### PR TITLE
docs: Fixed url to RUNNING.md in /server/README.md

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -38,7 +38,7 @@ And ping again
 This time you'll see the updated message.
 
 For more details about how to get museum up and running, see
-[RUNNING.md](/RUNNING.md).
+[RUNNING.md](/server/RUNNING.md).
 
 ## Architecture
 


### PR DESCRIPTION
## Description
The link to RUNNING.md in /server/README.md was wrong, just fixed it.

## Tests
N/A