### PR TITLE
feat(server): Add ability to configure sslmode

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -74,6 +74,7 @@ db:
     # as ENTE_DB_USER and ENTE_DB_PASSWORD.
     user:
     password:
+    sslmode: disable
 
 # Map of data centers
 #

--- a/server/pkg/utils/config/config.go
+++ b/server/pkg/utils/config/config.go
@@ -103,12 +103,13 @@ func doesFileExist(path string) (bool, error) {
 
 func GetPGInfo() string {
 	return fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=disable",
+		"password=%s dbname=%s sslmode=%s",
 		viper.GetString("db.host"),
 		viper.GetInt("db.port"),
 		viper.GetString("db.user"),
 		viper.GetString("db.password"),
-		viper.GetString("db.name"))
+		viper.GetString("db.name"),
+		viper.GetString("db.sslmode"))
 }
 
 func IsLocalEnvironment() bool {


### PR DESCRIPTION
## Description
This patch makes the sslmode for the postgres database configurable. It adds a new configuration option to for the database setup and removes the hardcoded value. This change is done to allow usage of hosted-databases that require TLS for connections, like ones created by the zalando postgres operator.

Alternatively one could use the Postgres standardised environment variables, but this would probably break the current behaviour.

References:
https://postgres-operator.readthedocs.io/en/latest/user/#connect-to-postgresql
https://www.postgresql.org/docs/current/libpq-envars.html#LIBPQ-ENVARS

## Tests
I didn't add any additional tests as there are also no tests for other database connect parameters.