### PR TITLE
Update links to GitHub from within the apps

### DIFF
--- a/auth/docs/localization.md
+++ b/auth/docs/localization.md
@@ -4,7 +4,7 @@ If the feature requires adding new strings, you can do that by following these
 steps:
 
 1. Add a new entry inside
-   [app_en.arb](https://github.com/ente-io/auth/blob/main/lib/l10n/arb/app_en.arb)
+   [app_en.arb](https://github.com/ente-io/ente/blob/main/auth/lib/l10n/arb/app_en.arb)
    (remember to save!)
 
 2.  In your dart file, add the following import

--- a/auth/lib/core/constants.dart
+++ b/auth/lib/core/constants.dart
@@ -7,7 +7,7 @@ const String sentryDSN =
     "https://ed4ddd6309b847ba8849935e26e9b648@sentry.ente.io/9";
 const String sentryTunnel = "https://sentry-reporter.ente.io";
 const String roadmapURL = "https://roadmap.ente.io";
-const String githubIssuesUrl = "https://github.com/ente-io/auth/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc";
+const String githubDiscussionsUrl = "https://github.com/ente-io/ente/discussions";
 const int microSecondsInDay = 86400000000;
 const int android11SDKINT = 30;
 const int galleryLoadStartTime = -8000000000000000; // Wednesday, March 6, 1748

--- a/auth/lib/ui/settings/about_section_widget.dart
+++ b/auth/lib/ui/settings/about_section_widget.dart
@@ -36,7 +36,7 @@ class AboutSectionWidget extends StatelessWidget {
           trailingIcon: Icons.chevron_right_outlined,
           trailingIconIsMuted: true,
           onTap: () async {
-            launchUrl(Uri.parse("https://github.com/ente-io/auth"));
+            launchUrl(Uri.parse("https://github.com/ente-io/ente"));
           },
         ),
         sectionOptionSpacing,

--- a/auth/lib/ui/settings/support_section_widget.dart
+++ b/auth/lib/ui/settings/support_section_widget.dart
@@ -62,7 +62,7 @@ class _SupportSectionWidgetState extends State<SupportSectionWidget> {
           trailingIconIsMuted: true,
           onTap: () async {
             launchUrlString(
-              githubIssuesUrl,
+              githubDiscussionsUrl,
               mode: LaunchMode.externalApplication,
             );
           },

--- a/desktop/src/utils/menu.ts
+++ b/desktop/src/utils/menu.ts
@@ -64,7 +64,7 @@ export async function buildMenuBar(mainWindow: BrowserWindow): Promise<Menu> {
                     label: 'View Changelog',
                     click: () => {
                         shell.openExternal(
-                            'https://github.com/ente-io/photos-desktop/blob/main/CHANGELOG.md'
+                            'https://github.com/ente-io/ente/blob/main/desktop/CHANGELOG.md'
                         );
                     },
                 },

--- a/mobile/lib/core/constants.dart
+++ b/mobile/lib/core/constants.dart
@@ -8,7 +8,7 @@ const String sentryDSN =
 const String sentryDebugDSN =
     "https://ca5e686dd7f149d9bf94e620564cceba@sentry.ente.io/3";
 const String sentryTunnel = "https://sentry-reporter.ente.io";
-const String githubIssuesUrl = "https://github.com/ente-io/photos-app/issues";
+const String githubDiscussionsUrl = "https://github.com/ente-io/ente/discussions";
 const int microSecondsInDay = 86400000000;
 const int android11SDKINT = 30;
 const int jan011981Time = 347155200000000;

--- a/mobile/lib/ui/settings/about_section_widget.dart
+++ b/mobile/lib/ui/settings/about_section_widget.dart
@@ -37,7 +37,7 @@ class AboutSectionWidget extends StatelessWidget {
           trailingIconIsMuted: true,
           onTap: () async {
             // ignore: unawaited_futures
-            launchUrl(Uri.parse("https://github.com/ente-io/photos-app"));
+            launchUrl(Uri.parse("https://github.com/ente-io/ente"));
           },
         ),
         sectionOptionSpacing,

--- a/mobile/lib/ui/settings/support_section_widget.dart
+++ b/mobile/lib/ui/settings/support_section_widget.dart
@@ -57,7 +57,7 @@ class SupportSectionWidget extends StatelessWidget {
           onTap: () async {
             // ignore: unawaited_futures
             launchUrlString(
-              githubIssuesUrl,
+              githubDiscussionsUrl,
               mode: LaunchMode.externalApplication,
             );
           },

--- a/web/apps/auth/src/components/AuthFooter.tsx
+++ b/web/apps/auth/src/components/AuthFooter.tsx
@@ -12,7 +12,7 @@ export const AuthFooter = () => {
             }}
         >
             <p>{t("AUTH_DOWNLOAD_MOBILE_APP")}</p>
-            <a href="https://github.com/ente-io/auth#-download" download>
+            <a href="https://github.com/ente-io/ente/tree/main/auth#-download" download>
                 <Button color="accent">{t("DOWNLOAD")}</Button>
             </a>
         </div>

--- a/web/apps/cast/src/constants/urls.ts
+++ b/web/apps/cast/src/constants/urls.ts
@@ -13,7 +13,7 @@ export const FEEDBACK_EMAIL = "feedback@ente.io";
 
 export const DELETE_ACCOUNT_EMAIL = "account-deletion@ente.io";
 
-export const WEB_ROADMAP_URL = "https://github.com/ente-io/photos-web/issues";
+export const WEB_ROADMAP_URL = "https://github.com/ente-io/ente/discussions";
 
 export const DESKTOP_ROADMAP_URL =
-    "https://github.com/ente-io/photos-desktop/issues";
+    "https://github.com/ente-io/ente/discussions";

--- a/web/packages/shared/constants/urls.ts
+++ b/web/packages/shared/constants/urls.ts
@@ -13,9 +13,9 @@ export const FEEDBACK_EMAIL = "feedback@ente.io";
 
 export const DELETE_ACCOUNT_EMAIL = "account-deletion@ente.io";
 
-export const WEB_ROADMAP_URL = "https://github.com/ente-io/photos-web/issues";
+export const WEB_ROADMAP_URL = "https://github.com/ente-io/ente/discussions";
 
 export const DESKTOP_ROADMAP_URL =
-    "https://github.com/ente-io/photos-desktop/issues";
+    "https://github.com/ente-io/ente/discussions";
 
 export const CITIES_URL = "https://static.ente.io/world_cities.json";


### PR DESCRIPTION
The links within the apps still point to the old repositories. This PR updates them to point here instead.

> Thanks to @iAnonymous3000 and @s38b35M5 for pointing this out! 

Meanwhile I've set up redirects from the old repositories. Have done it for

- [x] web app (e.g. see https://github.com/ente-io/photos-web/issues/new/choose)
- [ ] mobile app
- [ ] desktop app