### PR TITLE
Stop unnecessary lint workflows from running on pushing tags

### DIFF
--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -1,12 +1,13 @@
 name: "Lint (auth)"
 
 on:
-    # Run on every push (this also covers pull requests)
+    # Run on every push to branches (this also covers pull requests)
     push:
+        # See: [Note: Specify branch when specifying a path filter]
+        branches: ["**"]
+        # Only run if something changes in these paths
         paths:
-            # - But only if something changes inside auth
             - "auth/**"
-            # - Or if the there is some change in workflow itself
             - ".github/workflows/auth-lint.yml"
 
 jobs:

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -3,10 +3,11 @@ name: "Lint (mobile)"
 on:
     # Run on every push (this also covers pull requests)
     push:
+        # See: [Note: Specify branch when specifying a path filter]
+        branches: ["**"]
+        # Only run if something changes in these paths
         paths:
-            # - But only if something changes inside mobile
             - "mobile/**"
-            # - Or if the there is some change in workflow itself
             - ".github/workflows/mobile-lint.yml"
 
 jobs:

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -3,10 +3,20 @@ name: "Lint (web)"
 on:
     # Run on every push (this also covers pull requests)
     push:
+        # [Note: Specify branch when specifying a path filter]
+        #
+        # Path filters are ignored for tag pushes, which causes this workflow to
+        # always run when we push a tag. Defining an explicit branch solves the
+        # issue. From GitHub's docs:
+        #
+        # > if you define both branches/branches-ignore and paths/paths-ignore,
+        # > the workflow will only run when both filters are satisfied.
+        #
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+        branches: ["**"]
+        # Only run if something changes in these paths
         paths:
-            # - But only if something changes inside web
             - "web/**"
-            # - Or if the there is some change in workflow itself
             - ".github/workflows/web-lint.yml"
 
 jobs:


### PR DESCRIPTION
Ref:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
- https://stackoverflow.com/questions/77667104/how-to-make-github-action-trigger-on-push-paths-and-push-tags
- https://github.com/orgs/community/discussions/26273