### PR TITLE
[web] Disable the Cloudflare upload proxy when connecting to a custom endpoint

### DIFF
--- a/web/apps/photos/.env.development
+++ b/web/apps/photos/.env.development
@@ -10,7 +10,7 @@
 #
 # Alternatively, these variables can be provided as environment variables, say:
 #
-#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_DIRECT_UPLOAD=true yarn dev:photos
+#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 yarn dev:photos
 #
 # Variables prefixed with NEXT_PUBLIC_ are made available when Next.js runs our
 # code in the browser (Behind the scenes, Next.js just hardcodes occurrences of
@@ -68,17 +68,6 @@
 # Enhancement: Consider moving that into the app/ folder in this repository.
 #
 # NEXT_PUBLIC_ENTE_FAMILY_PORTAL_ENDPOINT = http://localhost:3003
-
-# Set this to "true" to disable the upload of files via Cloudflare Workers.
-#
-# These workers were introduced as a way of make file uploads faster:
-# https://ente.io/blog/tech/making-uploads-faster/
-#
-# By default, that's the route we take. However, during development it can be
-# convenient to turn this flag on to directly upload to the S3-compatible URLs
-# returned by the ente API.
-#
-# NEXT_PUBLIC_ENTE_DIRECT_UPLOAD = true
 
 # The path of the JSON file which contains the expected results of our
 # integration tests. See `upload.test.ts` for more details.

--- a/web/apps/photos/.env.localhost
+++ b/web/apps/photos/.env.localhost
@@ -7,15 +7,14 @@
 #
 # Equivalent CLI command using environment variables would be
 #
-#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_DIRECT_UPLOAD=true yarn dev:photos
+#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 yarn dev:photos
 #
 
 NEXT_PUBLIC_ENTE_ENDPOINT = http://localhost:8080
-NEXT_PUBLIC_ENTE_DIRECT_UPLOAD = true
 
 # If you wish to preview how the shared albums work, you can use `yarn
 # dev:albums`. The equivalent CLI command using env vars would be
 #
-#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=http://localhost:3002 NEXT_PUBLIC_ENTE_DIRECT_UPLOAD=true yarn dev:albums
+#     NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=http://localhost:3002 yarn dev:albums
 
 NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT = http://localhost:3002

--- a/web/apps/photos/src/services/userService.ts
+++ b/web/apps/photos/src/services/userService.ts
@@ -338,8 +338,24 @@ export const updateMapEnabledStatus = async (newStatus: boolean) => {
     }
 };
 
+/**
+ * Return true to disable the upload of files via Cloudflare Workers.
+ *
+ * These workers were introduced as a way of make file uploads faster:
+ * https://ente.io/blog/tech/making-uploads-faster/
+ *
+ * By default, that's the route we take. However, during development or when
+ * self-hosting it can be convenient to turn this flag on to directly upload to
+ * the S3-compatible URLs returned by the ente API.
+ *
+ * Note the double negative (Enhancement: maybe remove the double negative,
+ * rename this to say getUseDirectUpload).
+ */
 export async function getDisableCFUploadProxyFlag(): Promise<boolean> {
-    if (process.env.NEXT_PUBLIC_ENTE_DIRECT_UPLOAD === "true") return true;
+    // If NEXT_PUBLIC_ENTE_ENDPOINT is set, that means we're not running a
+    // production deployment. Disable the Cloudflare upload proxy, and instead
+    // just directly use the upload URLs that museum gives us.
+    if (process.env.NEXT_PUBLIC_ENTE_ENDPOINT) return true;
 
     try {
         const featureFlags = (


### PR DESCRIPTION
This simplifies use cases like https://github.com/ente-io/ente/discussions/685#discussioncomment-8682588. There is one less thing for folks to do if they want to run locally or self-host.

## Tested by

Starting a local museum, then connecting to it from the web app

    NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 yarn dev

And uploading a photo.