### PR TITLE
[auth] Verify that the custom icon JSON is valid as part of lint checks

### DIFF
--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -35,3 +35,6 @@ jobs:
             - run: flutter pub get
 
             - run: flutter analyze --no-fatal-infos
+
+            - name: Verify custom icon JSON
+              run: cat assets/custom-icons/_data/custom-icons.json | jq empty


### PR DESCRIPTION
## Tested by

Purposely opening this PR against a known bad state to verify that the check catches this issue. And it worked.

<img width="590" alt="Screenshot 2024-03-06 at 14 04 40" src="https://github.com/ente-io/ente/assets/24503581/e67bac5c-4191-4497-a771-b73f7c850379">

Have now rebased the PR of main, to also check that the verification succeeds in a known good state.