### PR TITLE
[cli] Use the tag: qualifier to better filter the releases

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -3,8 +3,8 @@
 ## Install
 
 You can either download the binary from the [GitHub releases
-page](https://github.com/ente-io/ente/releases?q=cli&expanded=true) or build it
-yourself.
+page](https://github.com/ente-io/ente/releases?q=tag%3Acli-v0&expanded=true) or
+build it yourself.
 
 ### Build from source
 


### PR DESCRIPTION
@ua741 We still need to provide at least the major version, and we'll need to remember to update these links when the major version changes.

Ref:
- https://docs.github.com/en/repositories/releasing-projects-on-github/searching-a-repositorys-releases
