### PR TITLE
[web] Document the need for yarn classic

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -32,8 +32,8 @@ yarn dev
 
 That's it. The web app will automatically hot reload when you make changes.
 
-If you're new to web development and unsure about how to get started, see
-[docs/new](docs/new.md).
+If you're new to web development and unsure about how to get started,  or are
+facing some problems when running the above steps, see [docs/new](docs/new.md).
 
 ## Other apps
 

--- a/web/docs/new.md
+++ b/web/docs/new.md
@@ -13,3 +13,14 @@ development, here is a recommended workflow:
    `yarn` comes with it.
 
 That's it. Enjoy coding!
+
+### Yarn
+
+Note that we use Yarn classic
+
+```
+$ yarn --version
+1.22.21
+```
+
+You should be seeing a 1.xx.xx version, otherwise your `yarn install` will fail.


### PR DESCRIPTION
People often run into issues with `yarn install` because they're using a newer yarn. The situation is generally bad - we don't want to update to Yarn v4 yet because it is marked experimental and is not the default yarn that gets installed by node currently. We could add a `packageManager` field to our package.json, but this will only fail the build with a better (hopefully) error message, and will necessitate the user to `corepack_enable`.

I'm not sure what's the best approach right now to make the initial setup be seamless (I think we're using the approach that works for the maximum of all the alternatives, but I'm not sure). At least, let me add a note about it.

Ref:
* https://github.com/yarnpkg/berry/issues/5912