### PR TITLE
[web] Fix a warning about MUI component switch state on using the select all checkbox

### DIFF
--- a/web/apps/photos/src/components/PhotoList/index.tsx
+++ b/web/apps/photos/src/components/PhotoList/index.tsx
@@ -786,7 +786,7 @@ export function PhotoList({
                                 <Checkbox
                                     key={item.date}
                                     name={item.date}
-                                    checked={checkedDates[item.date]}
+                                    checked={!!checkedDates[item.date]}
                                     onChange={() =>
                                         onChangeSelectAllCheckBox(item.date)
                                     }
@@ -804,7 +804,7 @@ export function PhotoList({
                         <Checkbox
                             key={listItem.date}
                             name={listItem.date}
-                            checked={checkedDates[listItem.date]}
+                            checked={!!checkedDates[listItem.date]}
                             onChange={() =>
                                 onChangeSelectAllCheckBox(listItem.date)
                             }


### PR DESCRIPTION
The issue here was that since the checkbox property would get initialized to an undefined value, React would consider it to be uncontrolled. But later on we'd try to set a value, which'd cause React to complain.

Ref:
- Material-UI: A component is changing the uncontrolled checked state of SwitchBase to be controlled
  https://stackoverflow.com/questions/69259429/material-ui-a-component-is-changing-the-uncontrolled-checked-state-of-switchbas
