### PR TITLE
[workflow] Retain the PlayStore AAB as a workflow artifact

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -80,6 +80,15 @@ jobs:
                   SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
                   SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
+            # Retain the PlayStore AAB as an workflow artifact so that it can be
+            # used in case the subsequent upload to PlayStore fails for some
+            # temporary reason
+            - name: Retain PlayStore AAB as an artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: app-playstore-release.aab
+                  path: auth/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab
+
             - name: Install dependencies for desktop build
               run: |
                   sudo apt-get update -y


### PR DESCRIPTION
Reasoning in the workflow comment.

While this wouldn't have helped in cases like the recent workflow failure (https://github.com/ente-io/ente/actions/runs/8211812037/job/22461255230), it is maybe a good idea to attach the AAB to the workflow artifacts so that we can get at the binary if needed.

I'm not fully sure if we need this though. So we can close this PR too - I just wanted to figure how to do this if we need to make this amendment later.

## Tests

Untested. I validated the YAML though.

    yq eval .github/workflows/auth-release.yml
