### PR TITLE
Correct the order for creating s3 presigned objects

### DIFF
--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -803,15 +803,15 @@ func (c *FileController) verifyFileAccess(actorUserID int64, fileID int64) error
 }
 
 func (c *FileController) getObjectURL(s3Client *s3.S3, dc string, bucket *string, objectKey string) (ente.UploadURL, error) {
+	err := c.ObjectCleanupCtrl.AddTempObjectKey(objectKey, dc)
+	if err != nil {
+		return ente.UploadURL{}, stacktrace.Propagate(err, "")
+	}
 	r, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket: bucket,
 		Key:    &objectKey,
 	})
 	url, err := r.Presign(PreSignedRequestValidityDuration)
-	if err != nil {
-		return ente.UploadURL{}, stacktrace.Propagate(err, "")
-	}
-	err = c.ObjectCleanupCtrl.AddTempObjectKey(objectKey, dc)
 	if err != nil {
 		return ente.UploadURL{}, stacktrace.Propagate(err, "")
 	}


### PR DESCRIPTION
*Note: I am still finding my way through the codebase. If this PR seems illogical LMK.*
## Description
In the current scenario, we first create a s3 object, presign it and then insert into the DB.
If this fails just before inserting into the db, we have a dangling object we don't cleanup.

But if we first insert it in DB, then it should work fine as background cleaner will be able to find it always.

Maybe this is needed for multipart uploads as well, but it may not be trivial to fix that.

## Tests
