### PR TITLE
Tweak speed for crons

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -855,14 +855,14 @@ func setupAndStartCrons(userAuthRepo *repo.UserAuthRepository, publicCollectionR
 		}
 	})
 
-	schedule(c, "@every 193s", func() {
+	schedule(c, "@every 2m", func() {
 		fileController.CleanupDeletedFiles()
 	})
 	schedule(c, "@every 101s", func() {
 		embeddingCtrl.CleanupDeletedEmbeddings()
 	})
 
-	schedule(c, "@every 120s", func() {
+	schedule(c, "@every 5m", func() {
 		trashController.DropFileMetadataCron()
 	})
 

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -54,6 +55,9 @@ const MaxFileSize = int64(1024 * 1024 * 1024 * 5)
 
 // MaxUploadURLsLimit indicates the max number of upload urls which can be request in one go
 const MaxUploadURLsLimit = 50
+const (
+	DeletedObjectQueueLock = "deleted_objects_queue_lock"
+)
 
 // Create adds an entry for a file in the respective tables
 func (c *FileController) Create(ctx context.Context, userID int64, file ente.File, userAgent string, app ente.App) (ente.File, error) {
@@ -600,7 +604,16 @@ func (c *FileController) CleanupDeletedFiles() {
 	defer func() {
 		c.cleanupCronRunning = false
 	}()
-	items, err := c.QueueRepo.GetItemsReadyForDeletion(repo.DeleteObjectQueue, 200)
+
+	lockStatus := c.LockController.TryLock(DeletedObjectQueueLock, time.MicrosecondsAfterHours(24))
+	if !lockStatus {
+		log.Warning(fmt.Sprintf("Failed to acquire lock %s", DeletedObjectQueueLock))
+		return
+	}
+	defer func() {
+		c.LockController.ReleaseLock(DeletedObjectQueueLock)
+	}()
+	items, err := c.QueueRepo.GetItemsReadyForDeletion(repo.DeleteObjectQueue, 2000)
 	if err != nil {
 		log.WithError(err).Error("Failed to fetch items from queue")
 		return

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -605,7 +605,7 @@ func (c *FileController) CleanupDeletedFiles() {
 		c.cleanupCronRunning = false
 	}()
 
-	lockStatus := c.LockController.TryLock(DeletedObjectQueueLock, time.MicrosecondsAfterHours(24))
+	lockStatus := c.LockController.TryLock(DeletedObjectQueueLock, time.MicrosecondsAfterHours(2))
 	if !lockStatus {
 		log.Warning(fmt.Sprintf("Failed to acquire lock %s", DeletedObjectQueueLock))
 		return

--- a/server/pkg/controller/object.go
+++ b/server/pkg/controller/object.go
@@ -55,7 +55,7 @@ func (c *ObjectController) RemoveComplianceHolds() {
 		c.complianceCronRunning = false
 	}()
 
-	lockStatus := c.LockController.TryLock(RemoveComplianceHoldsLock, time.MicrosecondsAfterHours(24))
+	lockStatus := c.LockController.TryLock(RemoveComplianceHoldsLock, time.MicrosecondsAfterHours(2))
 	if !lockStatus {
 		log.Warning(fmt.Sprintf("Failed to acquire lock %s", RemoveComplianceHoldsLock))
 		return


### PR DESCRIPTION
## Description
Speed up object deletion & slow down metadata scrubbing to reduce noisy errors because of pending deletion.

## Tests
