### PR TITLE
[web] Fix shared albums

### DIFF
--- a/web/apps/photos/src/components/PhotoList/index.tsx
+++ b/web/apps/photos/src/components/PhotoList/index.tsx
@@ -718,6 +718,9 @@ export function PhotoList({
     };
 
     useEffect(() => {
+        // Nothing to do here if nothing is selected.
+        if (!galleryContext.selectedFile) return;
+
         const notSelectedFiles = displayFiles?.filter(
             (item) => !galleryContext.selectedFile[item.id],
         );


### PR DESCRIPTION
This flow probably got broken when the select-all-for-a-day functionality got added in https://github.com/ente-io/ente/pull/674 (haven't dug into this, I'm just guessing since that's where this all got touched).

Thank you to @Bramas on our Discord for pointing this out, and also providing the fix: https://github.com/ente-io/ente/compare/main...Bramas:ente:fix-error-on-shared-album

Tested by
---------

Run normal web app on one terminal

    NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=http://localhost:3002 yarn dev

Run the albums listener on another port (need to do this since we're running on localhost, and need to bind to a different origin):

    NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=http://localhost:3002 yarn dev:albums

Create a shared album, copy its public link, and verify that

- Before the fix we were getting an error (trying to access properties of `galleryContext.selectedFile`)
- After the fix the shared album is visible
