### PR TITLE
[auth][mob] Format longer codes with length > 6

### DIFF
--- a/auth/lib/ui/two_factor_authentication_page.dart
+++ b/auth/lib/ui/two_factor_authentication_page.dart
@@ -69,6 +69,7 @@ class _TwoFactorAuthenticationPageState
       ),
       borderRadius: BorderRadius.circular(15.0),
     );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisAlignment: MainAxisAlignment.center,
@@ -86,9 +87,10 @@ class _TwoFactorAuthenticationPageState
         Padding(
           padding: const EdgeInsets.fromLTRB(40, 0, 40, 0),
           child: PinPut(
-            fieldsCount: 6,
+            fieldsCount: 6, // Keep fieldsCount as it is for 6 characters
             onSubmit: (String code) {
-              _verifyTwoFactorCode(code);
+              _verifyTwoFactorCode(code.replaceAll(
+                  " ", "")); // Remove spaces before verification
             },
             onChanged: (String pin) {
               setState(() {
@@ -108,6 +110,9 @@ class _TwoFactorAuthenticationPageState
               border: InputBorder.none,
               counterText: '',
             ),
+            // Customize how the pin is displayed
+            separator: " ", // Add a space as separator
+            textStyle: TextStyle(fontSize: 24), // Adjust font size if needed
             autofocus: true,
           ),
         ),
@@ -119,7 +124,8 @@ class _TwoFactorAuthenticationPageState
           child: OutlinedButton(
             onPressed: _code.length == 6
                 ? () async {
-                    await _verifyTwoFactorCode(_code);
+                    await _verifyTwoFactorCode(_code.replaceAll(
+                        " ", "")); // Remove spaces before verification
                   }
                 : null,
             child: Text(l10n.verify),


### PR DESCRIPTION
## Description
This modification adds a space after every third character in the PinPut widget, making the 8-digit code visually separated into blocks of 3 characters. Additionally, it adjusts the verification logic to remove spaces from the code before verifying it.

## Tests

fixes #475 