### PR TITLE
[server] Fix uploads on self-hosted Docker when running on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set line endings of shell scripts to LF, even on Windows, otherwise execution
+# within Docker fails.
+*.sh text eol=lf


### PR DESCRIPTION
On our Discord @Degos ran into an issue where their uploads to the self hosted docker compose cluster were failing. On debugging, it was found that the line-endings in `server/scripts/compose/minio-provision.sh` were set to CRLF, causing the script to fail when run inside Docker. The minIO buckets never got provisioned, and so the uploads would fail with

    <Code>NoSuchBucket</Code>
    <Message>The specified bucket does not exist</Message>

![image](https://github.com/ente-io/ente/assets/24503581/37945ed3-3c52-4796-8092-47be6e4a85da)

To fix this, we add a new .gitattributes that enforces the LF for the scripts that run inside Docker. To (perhaps too preemptively) guard against similar issues in other scenarios, turn this on for all shell scripts.

Refs:
- https://stackoverflow.com/questions/29603737/bash-seamlessly-run-scripts-with-crlf-line-endings
- https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
