### PR TITLE
Add Dockerfile for the web app

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.dockerignore
+node_modules
+Dockerfile

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+FROM node:21-bookworm-slim as ente-builder
+
+WORKDIR /app
+
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+RUN yarn install
+
+ARG GIT_SHA=local
+ENV GIT_SHA=$GIT_SHA
+
+ENV NEXT_PUBLIC_ENTE_ENDPOINT=DOCKER_RUNTIME_REPLACE_ENDPOINT
+ENV NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=DOCKER_RUNTIME_REPLACE_ALBUMS_ENDPOINT
+
+RUN yarn build
+
+FROM nginx:1.25-alpine-slim
+
+COPY --from=ente-builder /app/apps/photos/out /usr/share/nginx/html
+
+COPY <<EOF /etc/nginx/conf.d/default.conf
+server {
+  listen 80 default_server;
+  root /usr/share/nginx/html;
+  location / {
+      try_files \$uri \$uri.html \$uri/ =404;
+  }
+  error_page 404 /404.html;
+  location = /404.html {
+      internal;
+  }
+}
+EOF
+
+ARG ENDPOINT="http://localhost:8080"
+ENV ENDPOINT "$ENDPOINT"
+
+ARG ALBUMS_ENDPOINT="http://localhost:8082"
+ENV ALBUMS_ENDPOINT "$ALBUMS_ENDPOINT"
+
+COPY <<EOF /docker-entrypoint.d/replace_ente_endpoints.sh
+echo "Replacing endpoints"
+echo "  Endpoint: \$ENDPOINT"
+echo "  Albums Endpoint: \$ALBUMS_ENDPOINT"
+
+replace_enpoints() {
+  sed -i -e 's,DOCKER_RUNTIME_REPLACE_ENDPOINT,'"\$ENDPOINT"',g' \$1
+  sed -i -e 's,DOCKER_RUNTIME_REPLACE_ALBUMS_ENDPOINT,'"\$ALBUMS_ENDPOINT"',g' \$1
+}
+for jsfile in `find '/usr/share/nginx/html' -type f -name '*.js'`
+do
+    replace_enpoints "\$jsfile"
+done
+EOF
+
+RUN chmod +x /docker-entrypoint.d/replace_ente_endpoints.sh

--- a/web/packages/next/next.config.base.js
+++ b/web/packages/next/next.config.base.js
@@ -13,7 +13,7 @@
 const { withSentryConfig } = require("@sentry/nextjs");
 const cp = require("child_process");
 
-const gitSHA = cp
+const gitSHA = process.env.GIT_SHA || cp
     .execSync("git rev-parse --short HEAD", {
         cwd: __dirname,
         encoding: "utf8",


### PR DESCRIPTION
## Description

A dockerfile for the web application to build and prepare a ready to deploy container with customizable endpoints.

API endpoints and Albums endpoints can be set a the execution of the container with two environment variables:
* `ENTPOINT` the museum endpoint
* `ALBUMS_ENDPOINT` another host that points to the same front-end.

By default the nginx base image expose port 80 so an image build with the given docker file can be used like this:

```bash
docker build -t ente-web web  --build-arg git_sha=AN_OPTIONNAL_GIT_SHA
docker run -p 8081:80 -p 8081:80 -e ENDPOINT=<your_museum_endpoint> -e ALBUMS_ENDPOINT=http://localhost:8082 ente-web
```

I had to modify `web/packages/next/next.config.base.js` in order to be able to set the GIT_SHA without calling git.
