### PR TITLE
Specify which Google Takeout format is supported

### DIFF
--- a/web/apps/accounts/public/locales/de-DE/translation.json
+++ b/web/apps/accounts/public/locales/de-DE/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "",
     "UPLOAD_FILES": "Datei",
     "UPLOAD_DIRS": "Ordner",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "Du hast keine Duplikate, die gelöscht werden können",

--- a/web/apps/accounts/public/locales/en-US/translation.json
+++ b/web/apps/accounts/public/locales/en-US/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/accounts/public/locales/en/translation.json
+++ b/web/apps/accounts/public/locales/en/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/accounts/public/locales/es-ES/translation.json
+++ b/web/apps/accounts/public/locales/es-ES/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuración",
     "UPLOAD_FILES": "Archivo",
     "UPLOAD_DIRS": "Carpeta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicar archivos",
     "AUTHENTICATOR_SECTION": "Autenticación",
     "NO_DUPLICATES_FOUND": "No tienes archivos duplicados que puedan ser borrados",

--- a/web/apps/accounts/public/locales/fr-FR/translation.json
+++ b/web/apps/accounts/public/locales/fr-FR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Journaux de débugs",
     "UPLOAD_FILES": "Fichier",
     "UPLOAD_DIRS": "Dossier",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Déduplication de fichiers",
     "AUTHENTICATOR_SECTION": "Authentificateur",
     "NO_DUPLICATES_FOUND": "Vous n'avez aucun fichier dédupliqué pouvant être nettoyé",

--- a/web/apps/accounts/public/locales/nl-NL/translation.json
+++ b/web/apps/accounts/public/locales/nl-NL/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logboeken voor foutmeldingen",
     "UPLOAD_FILES": "Bestand",
     "UPLOAD_DIRS": "Map",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Dubbele bestanden verwijderen",
     "AUTHENTICATOR_SECTION": "Verificatie apparaat",
     "NO_DUPLICATES_FOUND": "Je hebt geen dubbele bestanden die kunnen worden gewist",

--- a/web/apps/accounts/public/locales/pt-BR/translation.json
+++ b/web/apps/accounts/public/locales/pt-BR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuração",
     "UPLOAD_FILES": "Arquivo",
     "UPLOAD_DIRS": "Pasta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Arquivos Deduplicados",
     "AUTHENTICATOR_SECTION": "Autenticação",
     "NO_DUPLICATES_FOUND": "Você não tem arquivos duplicados que possam ser limpos",

--- a/web/apps/accounts/public/locales/zh-CN/translation.json
+++ b/web/apps/accounts/public/locales/zh-CN/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "调试日志",
     "UPLOAD_FILES": "文件",
     "UPLOAD_DIRS": "文件夹",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "删除重复文件",
     "AUTHENTICATOR_SECTION": "身份验证器",
     "NO_DUPLICATES_FOUND": "您没有可以清除的重复文件",

--- a/web/apps/auth/public/locales/de-DE/translation.json
+++ b/web/apps/auth/public/locales/de-DE/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "Datei",
     "UPLOAD_DIRS": "Ordner",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "Du hast keine Duplikate, die gelöscht werden können",

--- a/web/apps/auth/public/locales/en-US/translation.json
+++ b/web/apps/auth/public/locales/en-US/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/es-ES/translation.json
+++ b/web/apps/auth/public/locales/es-ES/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuración",
     "UPLOAD_FILES": "Archivo",
     "UPLOAD_DIRS": "Carpeta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicar archivos",
     "AUTHENTICATOR_SECTION": "Autenticación",
     "NO_DUPLICATES_FOUND": "No tienes archivos duplicados que puedan ser borrados",

--- a/web/apps/auth/public/locales/fa-IR/translation.json
+++ b/web/apps/auth/public/locales/fa-IR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/fi-FI/translation.json
+++ b/web/apps/auth/public/locales/fi-FI/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/fr-FR/translation.json
+++ b/web/apps/auth/public/locales/fr-FR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Journaux de débugs",
     "UPLOAD_FILES": "Fichier",
     "UPLOAD_DIRS": "Dossier",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Déduplication de fichiers",
     "AUTHENTICATOR_SECTION": "Authentificateur",
     "NO_DUPLICATES_FOUND": "Vous n'avez aucun fichier dédupliqué pouvant être nettoyé",

--- a/web/apps/auth/public/locales/it-IT/translation.json
+++ b/web/apps/auth/public/locales/it-IT/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Cartella",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/nl-NL/translation.json
+++ b/web/apps/auth/public/locales/nl-NL/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logboeken voor foutmeldingen",
     "UPLOAD_FILES": "Bestand",
     "UPLOAD_DIRS": "Map",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Dubbele bestanden verwijderen",
     "AUTHENTICATOR_SECTION": "Verificatie apparaat",
     "NO_DUPLICATES_FOUND": "Je hebt geen dubbele bestanden die kunnen worden gewist",

--- a/web/apps/auth/public/locales/pt-BR/translation.json
+++ b/web/apps/auth/public/locales/pt-BR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuração",
     "UPLOAD_FILES": "Arquivo",
     "UPLOAD_DIRS": "Pasta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Arquivos Deduplicados",
     "AUTHENTICATOR_SECTION": "Autenticação",
     "NO_DUPLICATES_FOUND": "Você não tem arquivos duplicados que possam ser limpos",

--- a/web/apps/auth/public/locales/pt-PT/translation.json
+++ b/web/apps/auth/public/locales/pt-PT/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/ru-RU/translation.json
+++ b/web/apps/auth/public/locales/ru-RU/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/tr-TR/translation.json
+++ b/web/apps/auth/public/locales/tr-TR/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/auth/public/locales/zh-CN/translation.json
+++ b/web/apps/auth/public/locales/zh-CN/translation.json
@@ -418,7 +418,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "调试日志",
     "UPLOAD_FILES": "文件",
     "UPLOAD_DIRS": "文件夹",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "删除重复文件",
     "AUTHENTICATOR_SECTION": "身份验证器",
     "NO_DUPLICATES_FOUND": "您没有可以清除的重复文件",

--- a/web/apps/photos/public/locales/de-DE/translation.json
+++ b/web/apps/photos/public/locales/de-DE/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "",
     "UPLOAD_FILES": "Datei",
     "UPLOAD_DIRS": "Ordner",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "Du hast keine Duplikate, die gelöscht werden können",

--- a/web/apps/photos/public/locales/en-US/translation.json
+++ b/web/apps/photos/public/locales/en-US/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Debug logs",
     "UPLOAD_FILES": "File",
     "UPLOAD_DIRS": "Folder",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicate files",
     "AUTHENTICATOR_SECTION": "Authenticator",
     "NO_DUPLICATES_FOUND": "You've no duplicate files that can be cleared",

--- a/web/apps/photos/public/locales/es-ES/translation.json
+++ b/web/apps/photos/public/locales/es-ES/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuración",
     "UPLOAD_FILES": "Archivo",
     "UPLOAD_DIRS": "Carpeta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Deduplicar archivos",
     "AUTHENTICATOR_SECTION": "Autenticación",
     "NO_DUPLICATES_FOUND": "No tienes archivos duplicados que puedan ser borrados",

--- a/web/apps/photos/public/locales/fr-FR/translation.json
+++ b/web/apps/photos/public/locales/fr-FR/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Journaux de débugs",
     "UPLOAD_FILES": "Fichier",
     "UPLOAD_DIRS": "Dossier",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Déduplication de fichiers",
     "AUTHENTICATOR_SECTION": "Authentificateur",
     "NO_DUPLICATES_FOUND": "Vous n'avez aucun fichier dédupliqué pouvant être nettoyé",

--- a/web/apps/photos/public/locales/nl-NL/translation.json
+++ b/web/apps/photos/public/locales/nl-NL/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logboeken voor foutmeldingen",
     "UPLOAD_FILES": "Bestand",
     "UPLOAD_DIRS": "Map",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google takeout (ZIP)",
     "DEDUPLICATE_FILES": "Dubbele bestanden verwijderen",
     "AUTHENTICATOR_SECTION": "Verificatie apparaat",
     "NO_DUPLICATES_FOUND": "Je hebt geen dubbele bestanden die kunnen worden gewist",

--- a/web/apps/photos/public/locales/pt-BR/translation.json
+++ b/web/apps/photos/public/locales/pt-BR/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "Logs de depuração",
     "UPLOAD_FILES": "Arquivo",
     "UPLOAD_DIRS": "Pasta",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "Arquivos Deduplicados",
     "AUTHENTICATOR_SECTION": "Autenticação",
     "NO_DUPLICATES_FOUND": "Você não tem arquivos duplicados que possam ser limpos",

--- a/web/apps/photos/public/locales/zh-CN/translation.json
+++ b/web/apps/photos/public/locales/zh-CN/translation.json
@@ -416,7 +416,7 @@
     "DOWNLOAD_UPLOAD_LOGS": "调试日志",
     "UPLOAD_FILES": "文件",
     "UPLOAD_DIRS": "文件夹",
-    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout",
+    "UPLOAD_GOOGLE_TAKEOUT": "Google Takeout (ZIP)",
     "DEDUPLICATE_FILES": "删除重复文件",
     "AUTHENTICATOR_SECTION": "身份验证器",
     "NO_DUPLICATES_FOUND": "您没有可以清除的重复文件",


### PR DESCRIPTION
Currently, the upload menu says it accepts Google Takeout. Unfortunately, it's not clear to the user which format, ZIP or TGZ, is actually supported. This can lead a user to accidentally request Takeout in the wrong format, which is especially painful if the user has a large library that takes a long time to export.

Perhaps both ZIP and TGZ should be supported. At the very least, this change explicitly tells the user which format is supported, so they don't waste a day exporting the wrong format.