### PR TITLE
[web] Allow running the build outside of a git repository

### DIFF
--- a/docs/docs/self-hosting/guides/external-s3.md
+++ b/docs/docs/self-hosting/guides/external-s3.md
@@ -69,8 +69,6 @@ services:
     web:
         build:
             context: web
-            args:
-                GIT_SHA: local
         ports:
             - 8081:80
             - 8082:80
@@ -115,8 +113,6 @@ WORKDIR /app
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY . .
 RUN yarn install
-ARG GIT_SHA=local
-ENV GIT_SHA=$GIT_SHA
 ENV NEXT_PUBLIC_ENTE_ENDPOINT=DOCKER_RUNTIME_REPLACE_ENDPOINT
 ENV NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=DOCKER_RUNTIME_REPLACE_ALBUMS_ENDPOINT
 RUN yarn build

--- a/docs/docs/self-hosting/guides/external-s3.md
+++ b/docs/docs/self-hosting/guides/external-s3.md
@@ -160,7 +160,10 @@ RUN chmod +x /docker-entrypoint.d/replace_ente_endpoints.sh
 Create a `.credentials.env` file at the root of the project with the following
 content (here you need to set the correct value of each variable):
 
-```env
+<!-- The following code block should have language env, but vitepress currently
+doesn't support that language, so use sh as a reasonable fallback instead. -->
+
+```sh
 # run  `go run tools/gen-random-keys/main.go` in the server directory to generate the keys
 ENTE_KEY_ENCRYPTION=
 ENTE_KEY_HASH=

--- a/web/packages/next/next.config.base.js
+++ b/web/packages/next/next.config.base.js
@@ -12,12 +12,22 @@
 
 const cp = require("child_process");
 
-const gitSHA = cp
-    .execSync("git rev-parse --short HEAD", {
-        cwd: __dirname,
-        encoding: "utf8",
-    })
-    .trimEnd();
+/**
+ * Return the current commit ID if we're running inside a git repository.
+ */
+const gitSHA = () => {
+    // Allow the command to fail. gitSHA will be an empty string in such cases.
+    // This allows us to run the build even when we're outside of a git context.
+    const result = cp
+        .execSync("git rev-parse --short HEAD 2>/dev/null || true", {
+            cwd: __dirname,
+            encoding: "utf8",
+        })
+        .trimEnd();
+    // Convert empty strings (e.g. when the `|| true` part of the above execSync
+    // comes into play) to undefined.
+    return result ? result : undefined;
+};
 
 /**
  * Configuration for the Next.js build
@@ -42,7 +52,7 @@ const nextConfig = {
     // Add environment variables to the JavaScript bundle. They will be
     // available as `process.env.VAR_NAME` to our code.
     env: {
-        GIT_SHA: gitSHA,
+        GIT_SHA: gitSHA(),
     },
 
     // https://dev.to/marcinwosinek/how-to-add-resolve-fallback-to-webpack-5-in-nextjs-10-i6j

--- a/web/packages/shared/logging/web.ts
+++ b/web/packages/shared/logging/web.ts
@@ -74,9 +74,10 @@ export const logStartupMessage = async (appId: string) => {
     // TODO (MR): Remove the need to lowercase it, change the enum itself.
     const appIdL = appId.toLowerCase();
     const userID = (getData(LS_KEYS.USER) as User)?.id;
-    const buildId = isDevBuild ? "dev" : `git ${process.env.GIT_SHA}`;
+    const sha = process.env.GIT_SHA;
+    const buildId = isDevBuild ? "dev " : sha ? `git ${sha} ` : "";
 
-    addLogLine(`ente-${appIdL}-web ${buildId} uid ${userID}`);
+    addLogLine(`ente-${appIdL}-web ${buildId}uid ${userID}`);
 };
 
 function getLogs(): Log[] {


### PR DESCRIPTION
This was found useful by @Bramas when building a Dockerfile of the web app itself. See https://github.com/ente-io/ente/pull/1065.

Now, the GIT_SHA environment variable can just be undefined if we're not in a git repository, and the code using it deals with that case explicitly.

**Tested by**

Temporarily inverted the isDevBuild flag, then

1. Ran the build normally and verified that the SHA continued to appear in the logs.

2. Ran the build after copying to a standalone folder without an associated git repository and verified that the SHA was skipped without causing the build to fail.
