### PR TITLE
[photos][mobile] Performance improvement

### DIFF
--- a/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -68,6 +68,7 @@ class GalleryFileWidget extends StatelessWidget {
             : _onLongPressNoSelectionLimit(context, file);
       },
       child: Stack(
+        clipBehavior: Clip.none,
         children: [
           ClipRRect(
             borderRadius: BorderRadius.circular(1),


### PR DESCRIPTION
## Description

Stack has `clipBehaviour = Clip.hardEdge` by default. This is necessary if content inside the stack is overflowing it's boundary and it has to be clipped. Clipping is expensive so it's worth removing it when it makes sense.

In this case of `GalleryFileWidget`, content doesn't overflow the Stack's boundary so the clip operation can be removed by setting `clipBehaviour = Clip.none`.
