### PR TITLE
[web] Fix the upload tests

### DIFF
--- a/web/apps/photos/.env.development
+++ b/web/apps/photos/.env.development
@@ -68,7 +68,12 @@
 #
 # NEXT_PUBLIC_ENTE_FAMILY_PORTAL_ENDPOINT = http://localhost:3003
 
-# The path of the JSON file which contains the expected results of our
-# integration tests. See `upload.test.ts` for more details.
+# The JSON which describes the expected results of our integration tests. See
+# `upload.test.ts` for more details of the expected format.
 #
-# NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON_PATH = /path/to/dataset/expected.json
+# This is perhaps easier to specify as an environment variable, since then we
+# can directly read from the source file when running `yarn dev`. For example,
+#
+#    NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON=`cat path/to/expected.json` yarn dev
+#
+# NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON = {}

--- a/web/apps/photos/tests/upload.test.ts
+++ b/web/apps/photos/tests/upload.test.ts
@@ -100,13 +100,13 @@ const FILE_NAME_TO_JSON_NAME = [
 ];
 
 export async function testUpload() {
-    const jsonPath = process.env.NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON_PATH;
-    if (!jsonPath) {
+    const jsonString = process.env.NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON;
+    if (!jsonString) {
         throw Error(
-            "Please specify the NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON_PATH to run the upload tests",
+            "Please specify the NEXT_PUBLIC_ENTE_TEST_EXPECTED_JSON to run the upload tests",
         );
     }
-    const expectedState = await import(jsonPath);
+    const expectedState = JSON.parse(jsonString);
     if (!expectedState) {
         throw Error("upload test failed expectedState missing");
     }


### PR DESCRIPTION
The current approach wasn't working. Not sure what caused it to stop working,
but anyway that was an hacky import, as evidenced by the ungainly warning
webpack would print on `yarn dev`. So instead of taking the path, we just take
the JSON contents directly, sidestepping all that.

**Tested by**

Rerunning the upload tests
