### PR TITLE
[meta] Reintroduce .vscode in the mobile gitignores

### DIFF
--- a/auth/.gitignore
+++ b/auth/.gitignore
@@ -9,6 +9,9 @@
 .history
 .svn/
 
+# Editors
+.vscode/
+
 # IntelliJ related
 *.iml
 *.ipr

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -9,6 +9,9 @@
 .history
 .svn/
 
+# Editors
+.vscode/
+
 # IntelliJ related
 *.iml
 *.ipr
@@ -25,7 +28,6 @@
 .pub/
 /build/
 
-
 # Web related
 lib/generated_plugin_registrant.dart
 
@@ -36,7 +38,6 @@ android/key.properties
 android/app/.settings/*
 android/.settings/
 .env
-
 
 fastlane/report.xml
 TensorFlowLiteC.framework


### PR DESCRIPTION
The intent had always been to have the individual project gitignores be self contained. In my previous PR (https://github.com/ente-io/ente/pull/516) I'd for some reason not followed this: correcting my mistake now. .vscode is gitignored both at the top level and at the individual project levels (as it was originally).
