### PR TITLE
[meta] Reduce the frequency of the sync translations cron

### DIFF
--- a/.github/workflows/auth-crowdin.yml
+++ b/.github/workflows/auth-crowdin.yml
@@ -9,8 +9,8 @@ on:
             - ".github/workflows/auth-crowdin.yml"
         branches: [main]
     schedule:
-        # See: [Note: Run every 24 hours]
-        - cron: "50 1 * * *"
+        # See: [Note: Run workflow on specific days of the week]
+        - cron: "50 1 * * 2,5"
     # Also allow manually running the workflow
     workflow_dispatch:
 

--- a/.github/workflows/mobile-crowdin.yml
+++ b/.github/workflows/mobile-crowdin.yml
@@ -9,8 +9,8 @@ on:
             - ".github/workflows/mobile-crowdin.yml"
         branches: [main]
     schedule:
-        # See: [Note: Run every 24 hours]
-        - cron: "40 1 * * *"
+        # See: [Note: Run workflow on specific days of the week]
+        - cron: "40 1 * * 2,5"
     # Also allow manually running the workflow
     workflow_dispatch:
 

--- a/.github/workflows/web-crowdin.yml
+++ b/.github/workflows/web-crowdin.yml
@@ -9,8 +9,14 @@ on:
             - ".github/workflows/web-crowdin.yml"
         branches: [main]
     schedule:
-        # See: [Note: Run every 24 hours]
-        - cron: "20 1 * * *"
+        # [Note: Run workflow on specific days of the week]
+        #
+        # The last (5th) component of the cron syntax denotes the day of the
+        # week, with 0 == SUN and 6 == SAT. So, for example, to run on every TUE
+        # and FRI, this can be set to `2,5`.
+        #
+        # See also: [Note: Run workflow every 24 hours]
+        - cron: "20 1 * * 2,5"
     # Also allow manually running the workflow
     workflow_dispatch:
 

--- a/.github/workflows/web-nightly.yml
+++ b/.github/workflows/web-nightly.yml
@@ -2,7 +2,7 @@ name: "Nightly (web)"
 
 on:
     schedule:
-        # [Note: Run every 24 hours]
+        # [Note: Run workflow every 24 hours]
         #
         # Run every 24 hours - First field is minute, second is hour of the day
         # This runs 23:15 UTC everyday - 1 and 15 are just arbitrary offset to


### PR DESCRIPTION
Every day is too much noise - we really only need this

- When a string gets changed in the source translation, in which case this workflow gets triggered automatically anyway.

- Before we do a new release (this doesn't automatically happen, but the workflow can be triggered manually if needed).

For now, reduce the frequency of the daily job to pull new translations from Crowdin: now it'll only happen on Tuesdays and Fridays (just an arbitrary choice).
