### PR TITLE
[web] Show select-all-for-day checkmark only when there is a selection

### DIFF
--- a/web/apps/photos/src/components/PhotoList/index.tsx
+++ b/web/apps/photos/src/components/PhotoList/index.tsx
@@ -780,23 +780,28 @@ export function PhotoList({
         listItem: TimeStampListItem,
         isScrolling: boolean,
     ) => {
+        // Enhancement: This logic doesn't work on the shared album screen, the
+        // galleryContext.selectedFile is always null there.
+        const haveSelection = (galleryContext.selectedFile?.count ?? 0) > 0;
         switch (listItem.itemType) {
             case ITEM_TYPE.TIME:
                 return listItem.dates ? (
                     listItem.dates
                         .map((item) => [
                             <DateContainer key={item.date} span={item.span}>
-                                <Checkbox
-                                    key={item.date}
-                                    name={item.date}
-                                    checked={!!checkedDates[item.date]}
-                                    onChange={() =>
-                                        onChangeSelectAllCheckBox(item.date)
-                                    }
-                                    size="small"
-                                    sx={{ pl: 0 }}
-                                    disableRipple={true}
-                                />
+                                {haveSelection && (
+                                    <Checkbox
+                                        key={item.date}
+                                        name={item.date}
+                                        checked={!!checkedDates[item.date]}
+                                        onChange={() =>
+                                            onChangeSelectAllCheckBox(item.date)
+                                        }
+                                        size="small"
+                                        sx={{ pl: 0 }}
+                                        disableRipple={true}
+                                    />
+                                )}
                                 {item.date}
                             </DateContainer>,
                             <div key={`${item.date}-gap`} />,
@@ -804,17 +809,19 @@ export function PhotoList({
                         .flat()
                 ) : (
                     <DateContainer span={columns}>
-                        <Checkbox
-                            key={listItem.date}
-                            name={listItem.date}
-                            checked={!!checkedDates[listItem.date]}
-                            onChange={() =>
-                                onChangeSelectAllCheckBox(listItem.date)
-                            }
-                            size="small"
-                            sx={{ pl: 0 }}
-                            disableRipple={true}
-                        />
+                        {haveSelection && (
+                            <Checkbox
+                                key={listItem.date}
+                                name={listItem.date}
+                                checked={!!checkedDates[listItem.date]}
+                                onChange={() =>
+                                    onChangeSelectAllCheckBox(listItem.date)
+                                }
+                                size="small"
+                                sx={{ pl: 0 }}
+                                disableRipple={true}
+                            />
+                        )}
                         {listItem.date}
                     </DateContainer>
                 );


### PR DESCRIPTION
For now, this at least makes it less obtrusive. Once I have cleaned up the state handling around selection (to better integrate this with the rest of the selection state so that there are no discrepancies), can revisit the UI - e.g. show it only on hover, or reduce the size of the checkbox / give it a rounded look etc to make it look even less obstrusive.