### PR TITLE
[docs] Note boxes fix

### DIFF
--- a/docs/docs/auth/migration-guides/authy/index.md
+++ b/docs/docs/auth/migration-guides/authy/index.md
@@ -51,7 +51,9 @@ following in your terminal:
 Assuming the filename of the binary remains unmodified and the working directory
 of the terminal is the location of the binary, you should type this for MacOS:
 
-> [!NOTE] On Apple Silicon devices, Rosetta 2 may be required to run the binary.
+> [!NOTE]
+>
+> On Apple Silicon devices, Rosetta 2 may be required to run the binary.
 
 ```
 ./authy-export-darwin-amd64 authy_codes.txt
@@ -92,6 +94,7 @@ to ente Authenticator!
 ### Method 2.1: If the export worked, but the import didn't
 
 > [!NOTE]
+> 
 > This is intended only for users who successfully exported their codes using the
 > guide in method 2, but could not import it to ente Authenticator for whatever
 > reason. If the import was successful, or you haven't tried to import the codes

--- a/docs/docs/auth/migration-guides/authy/index.md
+++ b/docs/docs/auth/migration-guides/authy/index.md
@@ -91,10 +91,11 @@ to ente Authenticator!
 
 ### Method 2.1: If the export worked, but the import didn't
 
-> [!NOTE] This is intended only for users who successfully exported their codes
-> using the guide in method 2, but could not import it to ente Authenticator for
-> whatever reason. If the import was successful, or you haven't tried to import
-> the codes yet, ignore this section.
+> [!NOTE]
+> This is intended only for users who successfully exported their codes using the
+> guide in method 2, but could not import it to ente Authenticator for whatever
+> reason. If the import was successful, or you haven't tried to import the codes
+> yet, ignore this section.
 >
 > If the export itself failed, try using
 > [**method 1**](#method-1-use-neerajs-export-tool) instead.


### PR DESCRIPTION
## Description
This fixes note boxes having incorrect titles, like this one:
<img width="719" alt="image" src="https://github.com/ente-io/ente/assets/41323182/4072f774-f507-4161-98ff-86724c84c680">

## Tests
- [x] Tested fixes on a selfhosted instance
<img width="701" alt="image" src="https://github.com/ente-io/ente/assets/41323182/e0338c2b-c0c6-42b0-82a5-cba068f192e1">
<img width="699" alt="image" src="https://github.com/ente-io/ente/assets/41323182/0c839ec9-13fd-46cd-bbb7-7f0347b19a8e">
