### PR TITLE
[server] Enhancements for self hosters

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -113,10 +113,7 @@ s3:
     #
     # 1. Disable SSL.
     #
-    # 2. Use "path" style S3 URLs where the bucket is part of the URL path, e.g.
-    #    http://localhost:3200/b2-eu-cen. By default the bucket name is part of
-    #    the (sub)domain, e.g. http://b2-eu-cen.localhost:3200/ and cannot be
-    #    resolved when running locally.
+    # 2. Use "path" style S3 URLs (see `use_path_style_urls` below).
     #
     # 3. Directly download the file during replication instead of going via the
     #    Cloudflare worker.
@@ -125,6 +122,17 @@ s3:
     #    not support them, specifically it doesn't support GLACIER).
     #
     #are_local_buckets: true
+    # Uncomment this to use "path" style S3 URLs.
+    #
+    # By default the bucket name is part of the (sub)domain, e.g.
+    # http://b2-eu-cen.localhost:3200/. If this is true, then we use "path"
+    # style S3 URLs where the bucket is part of the URL path, e.g.
+    # http://localhost:3200/b2-eu-cen.
+    #
+    # This is useful in scenarios when sub-domain based addressing cannot be
+    # resolved, e.g. when running a local instance, or when using MinIO as a
+    # production store.
+    #use_path_style_urls: true
 
 # Key used for encrypting customer emails before storing them in DB
 #

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -174,7 +174,7 @@ stripe:
 webauthn:
     rpid: "example.com"
     rporigins:
-      - "https://example.com:3005"
+        - "https://example.com:3005"
 
 # Roadmap SSO (optional)
 #
@@ -220,13 +220,17 @@ internal:
     # If provided, this external healthcheck url is periodically pinged.
     health-check-url:
     # Hardcoded verification codes, useful for logging in when developing.
-    hardcoded-ott:
-        emails:
-            - "example@example.org,123456"
-        # When running in a local environment, hardcode the verification code to
-        # 123456 for email addresses ending with @example.org
-        local-domain-suffix: "@example.org"
-        local-domain-value: 123456
+    #
+    # Uncomment this and set these to your email ID or domain so that you don't
+    # need to peek into the server logs for obtaining the OTP when trying to log
+    # into an instance you're developing on.
+    # hardcoded-ott:
+    #     emails:
+    #         - "example@example.org,123456"
+    #     # When running in a local environment, hardcode the verification code to
+    #     # 123456 for email addresses ending with @example.org
+    #     local-domain-suffix: "@example.org"
+    #     local-domain-value: 123456
     # List of user IDs that can use the admin API endpoints.
     admins: []
 

--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -104,6 +104,7 @@ func (config *S3Config) initialize() {
 	config.s3Configs = make(map[string]*aws.Config)
 	config.s3Clients = make(map[string]s3.S3)
 
+	usePathStyleURLs := viper.GetBool("s3.use_path_style_urls")
 	areLocalBuckets := viper.GetBool("s3.are_local_buckets")
 	config.areLocalBuckets = areLocalBuckets
 
@@ -115,6 +116,9 @@ func (config *S3Config) initialize() {
 				viper.GetString("s3."+dc+".secret"), ""),
 			Endpoint: aws.String(viper.GetString("s3." + dc + ".endpoint")),
 			Region:   aws.String(viper.GetString("s3." + dc + ".region")),
+		}
+		if usePathStyleURLs {
+			s3Config.S3ForcePathStyle = aws.Bool(true)
 		}
 		if areLocalBuckets {
 			s3Config.DisableSSL = aws.Bool(true)


### PR DESCRIPTION
- Disable the example.org domains in the default self-hosted configuration (saner default)
- Add a new flag to support S3 path style URLs without disabling SSL (needed for folks who want to run minio as their production S3, without disabling SSL)

**Tested by**

Running a local cluster with the following `museum.yaml` and verifying that the path style URLs are kicking in.

```
s3:
    use_path_style_urls: true
```