### PR TITLE
[web] Add passkeys related translations

### DIFF
--- a/web/apps/photos/public/locales/en-US/translation.json
+++ b/web/apps/photos/public/locales/en-US/translation.json
@@ -634,8 +634,21 @@
     "VISIT_CAST_ENTE_IO": "Visit cast.ente.io on the device you want to pair.",
     "CAST_AUTO_PAIR_FAILED": "Chromecast Auto Pair failed. Please try again.",
     "CACHE_DIRECTORY": "Cache folder",
-    "PASSKEYS": "Passkeys",
     "FREEHAND": "Freehand",
     "APPLY_CROP": "Apply Crop",
-    "PHOTO_EDIT_REQUIRED_TO_SAVE": "At least one transformation or color adjustment must be performed before saving."
+    "PHOTO_EDIT_REQUIRED_TO_SAVE": "At least one transformation or color adjustment must be performed before saving.",
+    "PASSKEYS": "Passkeys",
+    "DELETE_PASSKEY": "Delete passkey",
+    "DELETE_PASSKEY_CONFIRMATION": "Are you sure you want to delete this passkey? This action is irreversible.",
+    "RENAME_PASSKEY": "Rename passkey",
+    "ADD_PASSKEY": "Add passkey",
+    "ENTER_PASSKEY_NAME": "Enter passkey name",
+    "PASSKEYS_DESCRIPTION": "Passkeys are a modern and secure second-factor for your Ente account. They use on-device biometric authentication for convenience and security.",
+    "CREATED_AT": "Created at",
+    "PASSKEY_LOGIN_FAILED": "Passkey login failed",
+    "PASSKEY_LOGIN_URL_INVALID": "The login URL is invalid.",
+    "PASSKEY_LOGIN_ERRORED": "An error occurred while logging in with passkey.",
+    "TRY_AGAIN": "Try again",
+    "PASSKEY_FOLLOW_THE_STEPS_FROM_YOUR_BROWSER": "Follow the steps from your browser to continue logging in.",
+    "LOGIN_WITH_PASSKEY": "Login with passkey"
 }


### PR DESCRIPTION
Obtained these strings from https://github.com/ente-io/accounts-web/blob/33faadf83ea6c39732ffd185fc4716b006612684/apps/accounts/public/locales/en/translation.json#L632

I didn't have a way of exhaustively ensuring that all strings are covered, but I've tried to manually verify.

Once this is merged and translation files synced with Crowdin, I'll do another PR to update the `local/**/translation.json` files within apps/accounts.
