### PR TITLE
[meta] Omit unnecessary reruns of workflows when deploying

### DIFF
--- a/.github/workflows/auth-crowdin.yml
+++ b/.github/workflows/auth-crowdin.yml
@@ -2,12 +2,12 @@ name: "Sync Crowdin translations (auth)"
 
 on:
     push:
+        branches: [main]
         paths:
             # Run workflow when auth's intl_en.arb is changed
             - "mobile/lib/l10n/arb/app_en.arb"
             # Or the workflow itself is changed
             - ".github/workflows/auth-crowdin.yml"
-        branches: [main]
     schedule:
         # See: [Note: Run workflow on specific days of the week]
         - cron: "50 1 * * 2,5"

--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -3,7 +3,7 @@ name: "Lint (auth)"
 on:
     # Run on every push to a branch other than main that changes auth/
     push:
-        branches-ignore: [main]
+        branches-ignore: [main, "deploy/**"]
         paths:
             - "auth/**"
             - ".github/workflows/auth-lint.yml"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -3,7 +3,7 @@ name: "Deploy (docs)"
 on:
     # Run on every push to main that changes docs/
     push:
-        branches: [main]
+        branches-ignore: [main, "deploy/**"]
         paths:
             - "docs/**"
             - ".github/workflows/docs-deploy.yml"

--- a/.github/workflows/docs-verify-build.yml
+++ b/.github/workflows/docs-verify-build.yml
@@ -6,7 +6,7 @@ name: "Verify build (docs)"
 on:
     # Run on every push to a branch other than main that changes docs/
     push:
-        branches-ignore: [main]
+        branches-ignore: [main, "deploy/**"]
         paths:
             - "docs/**"
             - ".github/workflows/docs-verify-build.yml"

--- a/.github/workflows/mobile-crowdin.yml
+++ b/.github/workflows/mobile-crowdin.yml
@@ -2,12 +2,12 @@ name: "Sync Crowdin translations (mobile)"
 
 on:
     push:
+        branches: [main]
         paths:
             # Run workflow when mobiles's intl_en.arb is changed
             - "mobile/lib/l10n/intl_en.arb"
             # Or the workflow itself is changed
             - ".github/workflows/mobile-crowdin.yml"
-        branches: [main]
     schedule:
         # See: [Note: Run workflow on specific days of the week]
         - cron: "40 1 * * 2,5"

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -3,7 +3,7 @@ name: "Lint (mobile)"
 on:
     # Run on every push to a branch other than main that changes mobile/
     push:
-        branches-ignore: [main, f-droid]
+        branches-ignore: [main, f-droid, "deploy/**"]
         paths:
             - "mobile/**"
             - ".github/workflows/mobile-lint.yml"

--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -3,7 +3,7 @@ name: "Lint (server)"
 on:
     # Run on every push to a branch other than main that changes server/
     push:
-        branches-ignore: [main]
+        branches-ignore: [main, "deploy/**"]
         paths:
             - "server/**"
             - ".github/workflows/server-lint.yml"

--- a/.github/workflows/web-crowdin.yml
+++ b/.github/workflows/web-crowdin.yml
@@ -2,12 +2,12 @@ name: "Sync Crowdin translations (web)"
 
 on:
     push:
+        branches: [main]
         paths:
             # Run workflow when web's en-US/translation.json is changed
             - "web/apps/photos/public/locales/en-US/translation.json"
             # Or the workflow itself is changed
             - ".github/workflows/web-crowdin.yml"
-        branches: [main]
     schedule:
         # [Note: Run workflow on specific days of the week]
         #

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -3,7 +3,7 @@ name: "Lint (web)"
 on:
     # Run on every push to a branch other than main that changes web/
     push:
-        branches-ignore: [main]
+        branches-ignore: [main, "deploy/**"]
         paths:
             - "web/**"
             - ".github/workflows/web-lint.yml"


### PR DESCRIPTION
When we merge main into a deploy/* branch (e.g. https://github.com/ente-io/ente/pull/1147), all changes get pulled in not just the one related to that deployment, and this causes almost all of the path based workflows to run again unnecessarily. Exclude the various "deploy/**" branches to stop these unnecessary workflows from being triggered.
