### PR TITLE
[crowdin] Invalidate existing translations when source strings change

### DIFF
--- a/.github/workflows/auth-crowdin.yml
+++ b/.github/workflows/auth-crowdin.yml
@@ -28,7 +28,7 @@ jobs:
                   base_path: "auth/"
                   config: "auth/crowdin.yml"
                   upload_sources: true
-                  upload_translations: true
+                  upload_translations: false
                   download_translations: true
                   localization_branch_name: crowdin-translations-auth
                   create_pull_request: true

--- a/.github/workflows/mobile-crowdin.yml
+++ b/.github/workflows/mobile-crowdin.yml
@@ -28,7 +28,7 @@ jobs:
                   base_path: "mobile/"
                   config: "mobile/crowdin.yml"
                   upload_sources: true
-                  upload_translations: true
+                  upload_translations: false
                   download_translations: true
                   localization_branch_name: crowdin-translations-mobile
                   create_pull_request: true

--- a/.github/workflows/web-crowdin.yml
+++ b/.github/workflows/web-crowdin.yml
@@ -34,7 +34,7 @@ jobs:
                   base_path: "web/"
                   config: "web/crowdin.yml"
                   upload_sources: true
-                  upload_translations: true
+                  upload_translations: false
                   download_translations: true
                   localization_branch_name: crowdin-translations-web
                   create_pull_request: true


### PR DESCRIPTION
Don't upload existing translation when syncing with Crowdin. This way, we let the existing translations be invalidated when we change the source string (this was not happening previously since we also upload the (older) translations when
we upload the changed source strings).

**Tested by**

Doing this on a different test branch, changing a source string, manually running the workflow against that branch, and verifying that the strings are getting reset in the PR that Crowdin' action opens.
