### PR TITLE
[web][photos] Fix infinite loop on half-logins

### DIFF
--- a/web/apps/photos/src/pages/index.tsx
+++ b/web/apps/photos/src/pages/index.tsx
@@ -17,6 +17,7 @@ import ElectronAPIs from "@ente/shared/electron";
 import { getAlbumsURL } from "@ente/shared/network/api";
 import { logError } from "@ente/shared/sentry";
 import localForage from "@ente/shared/storage/localForage";
+import { getToken } from "@ente/shared/storage/localStorage/helpers";
 import { getKey, SESSION_KEYS } from "@ente/shared/storage/sessionStorage";
 import isElectron from "is-electron";
 import { Trans } from "react-i18next";
@@ -145,18 +146,11 @@ export default function LandingPage() {
                 );
             }
         }
-        if (key) {
-            // if (appName === APPS.AUTH) {
-            //     await router.push(PAGES.AUTH);
-            // } else {
+        const token = getToken();
+        if (key && token) {
             await router.push(PAGES.GALLERY);
-            // }
         } else if (user?.email) {
             await router.push(PAGES.VERIFY);
-        } else {
-            // if (appName === APPS.AUTH) {
-            //     await router.push(PAGES.LOGIN);
-            // }
         }
         await initLocalForage();
         setLoading(false);

--- a/web/packages/accounts/pages/credentials.tsx
+++ b/web/packages/accounts/pages/credentials.tsx
@@ -35,6 +35,7 @@ import VerifyMasterPasswordForm, {
 } from "@ente/shared/components/VerifyMasterPasswordForm";
 import { getAccountsURL } from "@ente/shared/network/api";
 import {
+    getToken,
     isFirstLogin,
     setIsFirstLogin,
 } from "@ente/shared/storage/localStorage/helpers";
@@ -86,7 +87,8 @@ export default function Credentials({
                     );
                 }
             }
-            if (key) {
+            const token = getToken();
+            if (key && token) {
                 router.push(APP_HOMES.get(appName));
                 return;
             }


### PR DESCRIPTION
Fix an infinite loop of navigation under the following conditions: key is valid
but token is not present.

Fix is to match the condition used in both gallery

    if (!key || !token) {

and the root page.

They seemed to have diverged in commit c3304571a907f0d88b664f2d614f2cd443a600fa.

Was able to reproduce this when launching the desktop app such that the key was
picked up (possibly from a prior installation) from the secure keychain, but the
token was not found. I feel this is also a fix for a similar navigation loop
recently reported by QA but unreproducible so far.
