### PR TITLE
Update ente.io/faq => help.ente.io where possible

### DIFF
--- a/desktop/src/utils/menu.ts
+++ b/desktop/src/utils/menu.ts
@@ -187,8 +187,8 @@ export async function buildMenuBar(mainWindow: BrowserWindow): Promise<Menu> {
             label: "Help",
             submenu: [
                 {
-                    label: "FAQ",
-                    click: () => shell.openExternal("https://ente.io/faq/"),
+                    label: "Ente Help",
+                    click: () => shell.openExternal("https://help.ente.io/photos/"),
                 },
                 { type: "separator" },
                 {

--- a/mobile/lib/ui/growth/referral_screen.dart
+++ b/mobile/lib/ui/growth/referral_screen.dart
@@ -255,7 +255,7 @@ class ReferralWidget extends StatelessWidget {
               context,
               WebPage(
                 S.of(context).faq,
-                "https://ente.io/faq/general/referral-program",
+                "https://help.ente.io/photos/features/referral-program/",
               ),
             );
           },

--- a/mobile/lib/ui/settings/account_section_widget.dart
+++ b/mobile/lib/ui/settings/account_section_widget.dart
@@ -150,7 +150,7 @@ class AccountSectionWidget extends StatelessWidget {
           trailingIconIsMuted: true,
           onTap: () async {
             // ignore: unawaited_futures
-            launchUrlString("https://ente.io/faq/migration/out-of-ente/");
+            launchUrlString("https://help.ente.io/photos/migration/export/");
           },
         ),
         sectionOptionSpacing,

--- a/server/mail-templates/mobile_app_first_upload.html
+++ b/server/mail-templates/mobile_app_first_upload.html
@@ -302,7 +302,7 @@
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                    href="https://ente.io/about">About</a>
                                                                                    <a style="color: grey; font-size: 14px; margin-left: 12px;"
-                                                                                   href="https://ente.io/faq">FAQ</a>
+                                                                                   href="https://help.ente.io/">Help</a>
                                                                                    <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                    href="https://twitter.com/enteio">Twitter</a>
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"

--- a/server/mail-templates/subscription_ended.html
+++ b/server/mail-templates/subscription_ended.html
@@ -214,7 +214,7 @@
                                                                                                 <div
                                                                                                     style="font-family: inherit; text-align: inherit">
                                                                                                     <span
-                                                                                                        style="font-family: helvetica, sans-serif">If you still have data stored in ente, we encourage you to follow the steps outlined here to export your data: <a href="https://ente.io/faq/migration/out-of-ente">ente.io/faq/migration/out-of-ente</a>.</span>
+                                                                                                        style="font-family: helvetica, sans-serif">If you still have data stored in ente, we encourage you to follow the steps outlined here to export your data: <a href="https://help.ente.io/photos/migration/export/">help.ente.io/photos/migration/export</a>.</span>
                                                                                                 </div>
                                                                                                 <div
                                                                                                     style="font-family: inherit; text-align: inherit">

--- a/server/mail-templates/successful_referral.html
+++ b/server/mail-templates/successful_referral.html
@@ -253,7 +253,7 @@
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                    href="https://ente.io/about">About</a>
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"
-                                                                                   href="https://ente.io/faq">FAQ</a>
+                                                                                   href="https://help.ente.io/">Help</a>
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                    href="https://twitter.com/enteio">Twitter</a>
                                                                                 <a style="color: grey; font-size: 14px; margin-left: 12px;"

--- a/server/mail-templates/web_app_first_upload.html
+++ b/server/mail-templates/web_app_first_upload.html
@@ -417,7 +417,7 @@
                                                                                     <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                        href="https://ente.io/about">About</a>
                                                                                        <a style="color: grey; font-size: 14px; margin-left: 12px;"
-                                                                                       href="https://ente.io/faq">FAQ</a>
+                                                                                       href="https://help.ente.io/">Help</a>
                                                                                        <a style="color: grey; font-size: 14px; margin-left: 12px;"
                                                                                        href="https://twitter.com/enteio">Twitter</a>
                                                                                     <a style="color: grey; font-size: 14px; margin-left: 12px;"


### PR DESCRIPTION
On desktop, now there Help menu will have an "Ente Help" option instead of "FAQ".

<img width="222" alt="Screenshot 2024-03-25 at 19 35 33" src="https://github.com/ente-io/ente/assets/24503581/f061419d-7587-4438-b055-927a9cc8f42f">

The only place remaining after this is the sidebar on mobile (`support_section_widget.dart`), but I wasn't sure of what string to use (and how to add it to the localized strings for mobile) so I've left it unchanged.
