### PR TITLE
[server] Publish docker image - Part 2/2

### DIFF
--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -32,7 +32,7 @@ jobs:
                   image: server
                   registry: ghcr.io
                   enableBuildKit: true
-                  buildArgs: GIT_COMMIT=${GITHUB_SHA}
-                  tags: ${GITHUB_SHA}, latest
+                  buildArgs: GIT_COMMIT=$${ inputs.commit }}
+                  tags: ${{ inputs.commit }}, latest
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -32,7 +32,7 @@ jobs:
                   image: server
                   registry: ghcr.io
                   enableBuildKit: true
-                  buildArgs: GIT_COMMIT=$${ inputs.commit }}
+                  buildArgs: GIT_COMMIT=${{ inputs.commit }}
                   tags: ${{ inputs.commit }}, latest
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -16,7 +16,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout code @ ${{ inputs.commit }}
+            - name: Checkout code
               uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.commit }}
@@ -26,7 +26,8 @@ jobs:
               with:
                   dockerfile: server/Dockerfile
                   directory: server
-                  image: ghcr.io/ente-io/server
+                  # Resultant package name will be ghcr.io/ente-io/server
+                  image: server
                   registry: ghcr.io
                   enableBuildKit: true
                   buildArgs: GIT_COMMIT=${GITHUB_SHA}

--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -5,6 +5,8 @@ on:
     #
     # To obtain the commit from the currently deployed museum, do:
     # curl -s https://api.ente.io/ping | jq -r '.id'
+    #
+    # See server/docs/publish.md for more details.
     workflow_dispatch:
         inputs:
             commit:
@@ -13,7 +15,7 @@ on:
                 required: true
 
 jobs:
-    build:
+    publish:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/docs/docs/self-hosting/index.md
+++ b/docs/docs/self-hosting/index.md
@@ -24,6 +24,11 @@ cd ente/server
 docker compose up --build
 ```
 
+> [!TIP]
+>
+> You can also use a pre-built Docker image from `ghcr.io/ente-io/server` ([More
+> info](https://github.com/ente-io/ente/blob/main/server/docs/docker.md))
+
 Then in a separate terminal, you can run (e.g) the web client
 
 ```sh
@@ -42,7 +47,7 @@ For the mobile apps, you don't even need to build, and can install normal Ente
 apps and configure them to use your
 [custom self-hosted server](guides/custom-server/).
 
-> If you want to build from source, see the instructions
+> If you want to build the mobile apps from source, see the instructions
 > [here](guides/mobile-build).
 
 ## Next steps

--- a/server/README.md
+++ b/server/README.md
@@ -38,7 +38,13 @@ And ping again
 This time you'll see the updated message.
 
 For more details about how to get museum up and running, see
-[RUNNING.md](RUNNING.md).
+[RUNNING](RUNNING.md).
+
+> [!TIP]
+>
+> Also, there is a way to use our pre-built Docker images to directly start a
+> cluster without needing to clone this repository - see
+> [docs/docker](docs/docker.md).
 
 ## Architecture
 
@@ -84,10 +90,11 @@ And it is built with containerization in mind - both during development and
 deployment. Just use the provided Dockerfile, configure to taste and you're off
 to the races.
 
-> [!CAUTION]
->
-> We don't publish any official docker images (yet). For self-hosters, the
-> recommendation is to build your own image using the provided `Dockerfile`.
+Overall, there are [three approaches](RUNNING.md) you can take:
+
+* Run using Docker using a pre-built Docker image
+* Run using Docker but build an image from source
+* Run without Docker
 
 Everything that you might needed to run museum is all in here, since this is the
 setup we ourselves use in production.

--- a/server/RUNNING.md
+++ b/server/RUNNING.md
@@ -8,13 +8,14 @@ environment that doesn't clutter your machine.
 You can also run museum directly on your machine if you wish - it is a single
 static go binary.
 
-This document describes both these approaches, and also outlines configuration.
+This document describes these approaches, and also outlines configuration.
 
-- [Running using Docker](#docker)
-- [Running without Docker](#without-docker)
+- [Run using Docker using a pre-built Docker image](docs/docker.md)
+- [Run using Docker but build an image from source](#build-and-run-using-docker)
+- [Running without Docker](#run-without-docker)
 - [Configuration](#configuration)
 
-## Docker
+## Build and run using Docker
 
 Start the cluster
 
@@ -70,7 +71,7 @@ Each time museum gets rebuilt from source, a new image gets created but the old
 one is retained as a dangling image. You can use `docker image prune --force`,
 or `docker system prune` if that's fine with you, to remove these.
 
-## Without Docker
+## Running without Docker
 
 The museum binary can be run by using `go run cmd/museum/main.go`. But first,
 you'll need to prepare your machine for development. Here we give the steps,
@@ -132,7 +133,7 @@ pg_ctl -D /usr/local/var/postgres -l logfile start
 createuser -s postgres
 ```
 
-## Start museum
+### Start museum
 
 ```sh
 export ENTE_DB_USER=postgres
@@ -148,7 +149,7 @@ ENTE_DB_USER=ente_user
 air
 ```
 
-## Testing
+### Testing
 
 Set up a local database for testing. This is not required for running the server.
 Create a test database with the following name and credentials:

--- a/server/docs/docker.md
+++ b/server/docs/docker.md
@@ -10,7 +10,7 @@ require you to clone the repository or build any images.
     mkdir ente && cd ente
     ```
 
-2. Copy the starter compose.yaml (and two of its support files) from the
+2. Copy the starter compose.yaml and two of its support files from the
    repository onto your directory. You can do it by hand, or use (e.g.) curl
 
     ```sh
@@ -68,3 +68,7 @@ For each of these, it'll use the latest published Docker image.
 
 Alternatively, if you only want to run Ente's server, you can directly pull and
 run the image we publish to **`ghcr.io/ente-io/server`**.
+
+```sh
+docker pull ghcr.io/ente-io/server:latest
+```

--- a/server/docs/docker.md
+++ b/server/docs/docker.md
@@ -52,7 +52,7 @@ require you to clone the repository or build any images.
    touch museum.yaml
    ```
 
-4. That is all. You can now start everything.
+5. That is all. You can now start everything.
 
    ```sh
    docker compose up
@@ -66,9 +66,18 @@ This will start a cluster containing:
 
 For each of these, it'll use the latest published Docker image.
 
-Alternatively, if you only want to run Ente's server, you can directly pull and
-run the image we publish to **`ghcr.io/ente-io/server`**.
+You can do a quick smoke test by pinging the API:
 
 ```sh
-docker pull ghcr.io/ente-io/server:latest
+curl localhost:8080/ping
+```
+
+## Only the server
+
+Alternatively, if you have setup the database and object storage externally and
+only want to run Ente's server, you can skip the steps above and directly pull
+and run the image from **`ghcr.io/ente-io/server`**.
+
+```sh
+docker pull ghcr.io/ente-io/server
 ```

--- a/server/docs/publish.md
+++ b/server/docs/publish.md
@@ -34,4 +34,8 @@ Then, trigger the "Publish (server)" workflow, providing it the commit. You can
 trigger it either from GitHub's UI or using the `gh cli`. With the CLI, we can
 combine both these steps too.
 
-Once the workflow completes, the resultant image will be available at `ghcr.io/ente-io/server`.
+    gh workflow run server-publish.yml -F commit=`curl -s https://api.ente.io/ping | jq -r '.id'`
+
+Once the workflow completes, the resultant image will be available at
+`ghcr.io/ente-io/server`. The image will be tagged by the commit SHA. The latest
+image will also be tagged, well, "latest".


### PR DESCRIPTION
Part 2 (and final part) of https://github.com/ente-io/ente/pull/1218.

Completes https://github.com/ente-io/ente/discussions/673. The images are accessible at `ghcr.io/ente-io/server`, e.g.

```sh
docker pull ghcr.io/ente-io/server
```
