### PR TITLE
[meta] Add a special case for comments in the notifier workaround

### DIFF
--- a/infra/workers/github-discord-notifier/src/index.ts
+++ b/infra/workers/github-discord-notifier/src/index.ts
@@ -65,7 +65,10 @@ const handleRequest = async (request: Request, discordWebhookURL: string) => {
         // arrangement (we shouldn't be getting 429s forever), so just try to
         // see if we can extract a URL from something we recognize.
         let activityURL: string | undefined;
-        if (requestJSON["issue"]) {
+        if (requestJSON["comment"]) {
+            activityURL = requestJSON["comment"]["html_url"];
+        }
+        if (!activityURL && requestJSON["issue"]) {
             activityURL = requestJSON["issue"]["html_url"];
         }
         if (!activityURL && requestJSON["discussion"]) {


### PR DESCRIPTION
Discord still hasn't fixed the issue on their end, and having a top level link whenever a new comment is added is getting cumbersome, so add a handler for the common comments case too.

Tested and deployed.
