### PR TITLE
[mobile][photos] Reupload file if GPS data is missing

### DIFF
--- a/mobile/lib/services/local_sync_service.dart
+++ b/mobile/lib/services/local_sync_service.dart
@@ -20,6 +20,7 @@ import 'package:photos/services/app_lifecycle_service.dart';
 import "package:photos/services/ignored_files_service.dart";
 import 'package:photos/services/local/local_sync_util.dart';
 import "package:photos/utils/debouncer.dart";
+import "package:photos/utils/photo_manager_util.dart";
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:tuple/tuple.dart';
@@ -61,14 +62,7 @@ class LocalSyncService {
       return;
     }
     if (Platform.isAndroid && AppLifecycleService.instance.isForeground) {
-      final permissionState = await PhotoManager.requestPermissionExtend(
-        requestOption: const PermissionRequestOption(
-          androidPermission: AndroidPermission(
-            type: RequestType.common,
-            mediaLocation: true,
-          ),
-        ),
-      );
+      final permissionState = await requestPhotoMangerPermissions();
       if (permissionState != PermissionState.authorized) {
         _logger.severe(
           "sync requested with invalid permission",

--- a/mobile/lib/ui/components/home_header_widget.dart
+++ b/mobile/lib/ui/components/home_header_widget.dart
@@ -10,6 +10,7 @@ import 'package:photos/ui/components/buttons/icon_button_widget.dart';
 import "package:photos/ui/settings/backup/backup_folder_selection_page.dart";
 import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/navigation_util.dart";
+import "package:photos/utils/photo_manager_util.dart";
 
 class HomeHeaderWidget extends StatefulWidget {
   final Widget centerWidget;
@@ -48,14 +49,7 @@ class _HomeHeaderWidgetState extends State<HomeHeaderWidget> {
           onTap: () async {
             try {
               final PermissionState state =
-                  await PhotoManager.requestPermissionExtend(
-                requestOption: const PermissionRequestOption(
-                  androidPermission: AndroidPermission(
-                    type: RequestType.common,
-                    mediaLocation: true,
-                  ),
-                ),
-              );
+                  await requestPhotoMangerPermissions();
               await LocalSyncService.instance.onUpdatePermission(state);
             } on Exception catch (e) {
               Logger("HomeHeaderWidget").severe(

--- a/mobile/lib/ui/home/grant_permissions_widget.dart
+++ b/mobile/lib/ui/home/grant_permissions_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 import "package:photos/generated/l10n.dart";
 import 'package:photos/services/sync_service.dart';
+import "package:photos/utils/photo_manager_util.dart";
 import "package:styled_text/styled_text.dart";
 
 class GrantPermissionsWidget extends StatelessWidget {
@@ -91,14 +92,7 @@ class GrantPermissionsWidget extends StatelessWidget {
           key: const ValueKey("grantPermissionButton"),
           child: Text(S.of(context).grantPermission),
           onPressed: () async {
-            final state = await PhotoManager.requestPermissionExtend(
-              requestOption: const PermissionRequestOption(
-                androidPermission: AndroidPermission(
-                  type: RequestType.common,
-                  mediaLocation: true,
-                ),
-              ),
-            );
+            final state = await requestPhotoMangerPermissions();
             if (state == PermissionState.authorized ||
                 state == PermissionState.limited) {
               await SyncService.instance.onPermissionGranted(state);

--- a/mobile/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
+++ b/mobile/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
@@ -21,6 +21,7 @@ import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
 import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/photo_manager_util.dart";
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
 Future<dynamic> showAddPhotosSheet(
@@ -203,14 +204,7 @@ class AddPhotosPhotoWidget extends StatelessWidget {
       }
     } catch (e) {
       if (e is StateError) {
-        final PermissionState ps = await PhotoManager.requestPermissionExtend(
-          requestOption: const PermissionRequestOption(
-            androidPermission: AndroidPermission(
-              type: RequestType.common,
-              mediaLocation: true,
-            ),
-          ),
-        );
+        final PermissionState ps = await requestPhotoMangerPermissions();
         if (ps != PermissionState.authorized && ps != PermissionState.limited) {
           await showChoiceDialog(
             context,

--- a/mobile/lib/utils/photo_manager_util.dart
+++ b/mobile/lib/utils/photo_manager_util.dart
@@ -1,0 +1,12 @@
+import "package:photo_manager/photo_manager.dart";
+
+Future<PermissionState> requestPhotoMangerPermissions() {
+  return PhotoManager.requestPermissionExtend(
+    requestOption: const PermissionRequestOption(
+      androidPermission: AndroidPermission(
+        type: RequestType.common,
+        mediaLocation: true,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Description

- Fixes corrupt files (missing GPS data) that were uploaded due to [this issue](https://github.com/ente-io/ente/pull/1261)
- Refactor

## Tests

Tested and working
- Uploaded two file from a build that has missing permission for `ACCESS_MEDIA_LOCATION` and GPS data is missing.
- Created a new build with changes in this PR.
- Deleted the file from device. 
- Remote file has GPS data when checked from file info.