### PR TITLE
[desktop] Prevent the desktop app from getting stuck on viewing openstreetmap info

### DIFF
--- a/web/apps/photos/src/components/PhotoViewer/FileInfo/MapBox.tsx
+++ b/web/apps/photos/src/components/PhotoViewer/FileInfo/MapBox.tsx
@@ -13,7 +13,7 @@ const L = runningInBrowser()
 
 const LAYER_TILE_URL = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
 const LAYER_TILE_ATTRIBUTION =
-    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+    '&copy; <a target="_blank" rel="noopener" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 const ZOOM_LEVEL = 16;
 
 const MapBoxContainer = styled("div")`


### PR DESCRIPTION
Open the link in a new tab. This prevents the desktop app from getting into a state where the user cannot navigate back.

Tested on the web app and desktop app.