### PR TITLE
[server] Add a notice that minio is only for getting started

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -97,7 +97,7 @@ Overall, there are [three approaches](RUNNING.md) you can take:
 * Run without Docker
 
 Everything that you might needed to run museum is all in here, since this is the
-setup we ourselves use in production.
+code we ourselves use in production.
 
 > [!TIP]
 >

--- a/server/RUNNING.md
+++ b/server/RUNNING.md
@@ -46,6 +46,12 @@ Or open the MinIO dashboard at <http://localhost:3201> (user: test/password: tes
 
 > [!NOTE]
 >
+> While we've provided a MinIO based Docker compose file to make it easy for
+> people to get started, if you're running it in production we recommend using
+> an external S3.
+
+> [!NOTE]
+>
 > If something seems amiss, ensure that Docker has read access to the parent
 > folder so that it can access credentials.yaml and other local files. On macOS,
 > you can do this by going to System Settings > Security & Privacy > Files and


### PR DESCRIPTION
From our Discord, someone commented

> if minio's cautions about Single-Node, Single-Drive are to be taken seriously:
>
> "SNSD deployments use a zero-parity erasure coded backend that provides no
  added reliability or availability beyond what the underlying storage volume
  implements. These deployments are best suited for local testing and
  evaluation, or for small-scale data workloads that do not have availability or
  performance requirements."

MinIO was never meant as a production replacement, it was only to make it easy
for people to get started. So add a notice in the docs re this.
