### PR TITLE
[Photos] Allow for configuring a custom server

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -152,6 +152,8 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - permission_handler_apple (9.1.1):
+    - Flutter
   - photo_manager (2.0.0):
     - Flutter
     - FlutterMacOS
@@ -247,6 +249,7 @@ DEPENDENCIES:
   - open_mail_app (from `.symlinks/plugins/open_mail_app/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - photo_manager (from `.symlinks/plugins/photo_manager/ios`)
   - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - screen_brightness_ios (from `.symlinks/plugins/screen_brightness_ios/ios`)
@@ -353,6 +356,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   photo_manager:
     :path: ".symlinks/plugins/photo_manager/ios"
   receive_sharing_intent:
@@ -429,6 +434,7 @@ SPEC CHECKSUMS:
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
@@ -454,4 +460,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c1a8f198a245ed1f10e40b617efdb129b021b225
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/mobile/lib/core/configuration.dart
+++ b/mobile/lib/core/configuration.dart
@@ -16,6 +16,7 @@ import 'package:photos/db/files_db.dart';
 import 'package:photos/db/memories_db.dart';
 import 'package:photos/db/trash_db.dart';
 import 'package:photos/db/upload_locks_db.dart';
+import "package:photos/events/endpoint_updated_event.dart";
 import 'package:photos/events/signed_in_event.dart';
 import 'package:photos/events/user_logged_out_event.dart';
 import 'package:photos/models/key_attributes.dart';
@@ -69,6 +70,7 @@ class Configuration {
   static const hasSelectedAllFoldersForBackupKey =
       "has_selected_all_folders_for_backup";
   static const anonymousUserIDKey = "anonymous_user_id";
+  static const endPointKey = "endpoint";
 
   final kTempFolderDeletionTimeBuffer = const Duration(hours: 6).inMicroseconds;
 
@@ -390,7 +392,12 @@ class Configuration {
   }
 
   String getHttpEndpoint() {
-    return endpoint;
+    return _preferences.getString(endPointKey) ?? endpoint;
+  }
+
+  Future<void> setHttpEndpoint(String endpoint) async {
+    await _preferences.setString(endPointKey, endpoint);
+    Bus.instance.fire(EndpointUpdatedEvent());
   }
 
   String? getToken() {

--- a/mobile/lib/core/network/ente_interceptor.dart
+++ b/mobile/lib/core/network/ente_interceptor.dart
@@ -1,14 +1,12 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:photos/core/configuration.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
 class EnteRequestInterceptor extends Interceptor {
-  final SharedPreferences _preferences;
   final String enteEndpoint;
 
-  EnteRequestInterceptor(this._preferences, this.enteEndpoint);
+  EnteRequestInterceptor(this.enteEndpoint);
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
@@ -20,7 +18,7 @@ class EnteRequestInterceptor extends Interceptor {
     }
     // ignore: prefer_const_constructors
     options.headers.putIfAbsent("x-request-id", () => Uuid().v4().toString());
-    final String? tokenValue = _preferences.getString(Configuration.tokenKey);
+    final String? tokenValue = Configuration.instance.getToken();
     if (tokenValue != null) {
       options.headers.putIfAbsent("X-Auth-Token", () => tokenValue);
     }

--- a/mobile/lib/events/endpoint_updated_event.dart
+++ b/mobile/lib/events/endpoint_updated_event.dart
@@ -1,0 +1,3 @@
+import "package:photos/events/event.dart";
+
+class EndpointUpdatedEvent extends Event {}

--- a/mobile/lib/generated/intl/messages_en.dart
+++ b/mobile/lib/generated/intl/messages_en.dart
@@ -62,6 +62,8 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m13(provider) =>
       "Please contact us at support@ente.io to manage your ${provider} subscription.";
 
+  static String m69(endpoint) => "Connected to ${endpoint}";
+
   static String m14(count) =>
       "${Intl.plural(count, one: 'Delete ${count} item', other: 'Delete ${count} items')}";
 
@@ -502,6 +504,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "currentUsageIs":
             MessageLookupByLibrary.simpleMessage("Current usage is "),
         "custom": MessageLookupByLibrary.simpleMessage("Custom"),
+        "customEndpoint": m69,
         "darkTheme": MessageLookupByLibrary.simpleMessage("Dark"),
         "dayToday": MessageLookupByLibrary.simpleMessage("Today"),
         "dayYesterday": MessageLookupByLibrary.simpleMessage("Yesterday"),
@@ -562,6 +565,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "details": MessageLookupByLibrary.simpleMessage("Details"),
         "devAccountChanged": MessageLookupByLibrary.simpleMessage(
             "The developer account we use to publish ente on App Store has changed. Because of this, you will need to login again.\n\nOur apologies for the inconvenience, but this was unavoidable."),
+        "developerSettings":
+            MessageLookupByLibrary.simpleMessage("Developer settings"),
+        "developerSettingsWarning": MessageLookupByLibrary.simpleMessage(
+            "Are you sure that you want to modify Developer settings?"),
         "deviceCodeHint":
             MessageLookupByLibrary.simpleMessage("Enter the code"),
         "deviceFilesAutoUploading": MessageLookupByLibrary.simpleMessage(
@@ -627,6 +634,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "encryption": MessageLookupByLibrary.simpleMessage("Encryption"),
         "encryptionKeys":
             MessageLookupByLibrary.simpleMessage("Encryption keys"),
+        "endpointUpdatedMessage": MessageLookupByLibrary.simpleMessage(
+            "Endpoint updated successfully"),
         "endtoendEncryptedByDefault": MessageLookupByLibrary.simpleMessage(
             "End-to-end encrypted by default"),
         "enteCanEncryptAndPreserveFilesOnlyIfYouGrant":
@@ -781,6 +790,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Install manually"),
         "invalidEmailAddress":
             MessageLookupByLibrary.simpleMessage("Invalid email address"),
+        "invalidEndpoint":
+            MessageLookupByLibrary.simpleMessage("Invalid endpoint"),
+        "invalidEndpointMessage": MessageLookupByLibrary.simpleMessage(
+            "Sorry, the endpoint you entered is invalid. Please enter a valid endpoint and try again."),
         "invalidKey": MessageLookupByLibrary.simpleMessage("Invalid key"),
         "invalidRecoveryKey": MessageLookupByLibrary.simpleMessage(
             "The recovery key you entered is not valid. Please make sure it contains 24 words, and check the spelling of each.\n\nIf you entered an older recovery code, make sure it is 64 characters long, and check each of them."),
@@ -1220,6 +1233,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "sendEmail": MessageLookupByLibrary.simpleMessage("Send email"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Send invite"),
         "sendLink": MessageLookupByLibrary.simpleMessage("Send link"),
+        "serverEndpoint":
+            MessageLookupByLibrary.simpleMessage("Server endpoint"),
         "sessionExpired":
             MessageLookupByLibrary.simpleMessage("Session expired"),
         "setAPassword": MessageLookupByLibrary.simpleMessage("Set a password"),

--- a/mobile/lib/generated/l10n.dart
+++ b/mobile/lib/generated/l10n.dart
@@ -8473,6 +8473,76 @@ class S {
       args: [],
     );
   }
+
+  /// `Are you sure that you want to modify Developer settings?`
+  String get developerSettingsWarning {
+    return Intl.message(
+      'Are you sure that you want to modify Developer settings?',
+      name: 'developerSettingsWarning',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Developer settings`
+  String get developerSettings {
+    return Intl.message(
+      'Developer settings',
+      name: 'developerSettings',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Server endpoint`
+  String get serverEndpoint {
+    return Intl.message(
+      'Server endpoint',
+      name: 'serverEndpoint',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Invalid endpoint`
+  String get invalidEndpoint {
+    return Intl.message(
+      'Invalid endpoint',
+      name: 'invalidEndpoint',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Sorry, the endpoint you entered is invalid. Please enter a valid endpoint and try again.`
+  String get invalidEndpointMessage {
+    return Intl.message(
+      'Sorry, the endpoint you entered is invalid. Please enter a valid endpoint and try again.',
+      name: 'invalidEndpointMessage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Endpoint updated successfully`
+  String get endpointUpdatedMessage {
+    return Intl.message(
+      'Endpoint updated successfully',
+      name: 'endpointUpdatedMessage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Connected to {endpoint}`
+  String customEndpoint(Object endpoint) {
+    return Intl.message(
+      'Connected to $endpoint',
+      name: 'customEndpoint',
+      desc: '',
+      args: [endpoint],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/mobile/lib/l10n/intl_en.arb
+++ b/mobile/lib/l10n/intl_en.arb
@@ -1203,5 +1203,12 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "developerSettingsWarning": "Are you sure that you want to modify Developer settings?",
+  "developerSettings": "Developer settings",
+  "serverEndpoint": "Server endpoint",
+  "invalidEndpoint": "Invalid endpoint",
+  "invalidEndpointMessage": "Sorry, the endpoint you entered is invalid. Please enter a valid endpoint and try again.",
+  "endpointUpdatedMessage": "Endpoint updated successfully",
+  "customEndpoint": "Connected to {endpoint}"
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -189,8 +189,8 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
   // Start workers asynchronously. No need to wait for them to start
   Computer.shared().turnOn(workersCount: 4).ignore();
   CryptoUtil.init();
-  await NetworkClient.instance.init();
   await Configuration.instance.init();
+  await NetworkClient.instance.init();
   await UserService.instance.init();
   await EntityService.instance.init();
   LocationService.instance.init(preferences);

--- a/mobile/lib/ui/home/landing_page_widget.dart
+++ b/mobile/lib/ui/home/landing_page_widget.dart
@@ -19,7 +19,10 @@ import 'package:photos/ui/components/buttons/button_widget.dart';
 import 'package:photos/ui/components/dialog_widget.dart';
 import 'package:photos/ui/components/models/button_type.dart';
 import 'package:photos/ui/payment/subscription.dart';
+import "package:photos/ui/settings/developer_settings_page.dart";
+import "package:photos/ui/settings/developer_settings_widget.dart";
 import "package:photos/ui/settings/language_picker.dart";
+import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/navigation_util.dart";
 
 class LandingPageWidget extends StatefulWidget {
@@ -30,7 +33,10 @@ class LandingPageWidget extends StatefulWidget {
 }
 
 class _LandingPageWidgetState extends State<LandingPageWidget> {
+  static const kDeveloperModeTapCountThreshold = 7;
+
   double _featureIndex = 0;
+  int _developerModeTapCount = 0;
 
   @override
   void initState() {
@@ -40,7 +46,35 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: _getBody(), resizeToAvoidBottomInset: false);
+    return Scaffold(
+      body: GestureDetector(
+        onTap: () async {
+          _developerModeTapCount++;
+          if (_developerModeTapCount >= kDeveloperModeTapCountThreshold) {
+            _developerModeTapCount = 0;
+            final result = await showChoiceDialog(
+              context,
+              title: S.of(context).developerSettings,
+              firstButtonLabel: S.of(context).yes,
+              body: S.of(context).developerSettingsWarning,
+              isDismissible: false,
+            );
+            if (result?.action == ButtonAction.first) {
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (BuildContext context) {
+                    return const DeveloperSettingsPage();
+                  },
+                ),
+              );
+              setState(() {});
+            }
+          }
+        },
+        child: _getBody(),
+      ),
+      resizeToAvoidBottomInset: false,
+    );
   }
 
   Widget _getBody() {
@@ -131,6 +165,7 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
                 ),
               ),
             ),
+            const DeveloperSettingsWidget(),
             const Padding(
               padding: EdgeInsets.all(20),
             ),
@@ -195,7 +230,9 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
       // No key
       if (Configuration.instance.getKeyAttributes() == null) {
         // Never had a key
-        page =  const PasswordEntryPage(mode: PasswordEntryMode.set,);
+        page = const PasswordEntryPage(
+          mode: PasswordEntryMode.set,
+        );
       } else if (Configuration.instance.getKey() == null) {
         // Yet to decrypt the key
         page = const PasswordReentryPage();
@@ -223,7 +260,9 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
       // No key
       if (Configuration.instance.getKeyAttributes() == null) {
         // Never had a key
-        page =  const PasswordEntryPage(mode: PasswordEntryMode.set,);
+        page = const PasswordEntryPage(
+          mode: PasswordEntryMode.set,
+        );
       } else if (Configuration.instance.getKey() == null) {
         // Yet to decrypt the key
         page = const PasswordReentryPage();

--- a/mobile/lib/ui/home/landing_page_widget.dart
+++ b/mobile/lib/ui/home/landing_page_widget.dart
@@ -165,7 +165,9 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
                 ),
               ),
             ),
-            const DeveloperSettingsWidget(),
+            // const DeveloperSettingsWidget() does not refresh when the endpoint is changed
+            // ignore: prefer_const_constructors
+            DeveloperSettingsWidget(),
             const Padding(
               padding: EdgeInsets.all(20),
             ),

--- a/mobile/lib/ui/settings/developer_settings_page.dart
+++ b/mobile/lib/ui/settings/developer_settings_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import "package:photos/core/configuration.dart";
+import "package:photos/core/network/network.dart";
+import "package:photos/generated/l10n.dart";
+import "package:photos/ui/common/gradient_button.dart";
+import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/toast_util.dart";
+
+class DeveloperSettingsPage extends StatefulWidget {
+  const DeveloperSettingsPage({super.key});
+
+  @override
+  State<DeveloperSettingsPage> createState() => _DeveloperSettingsPageState();
+}
+
+class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
+  final _logger = Logger('DeveloperSettingsPage');
+  final _urlController = TextEditingController();
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _logger.info(
+      "Current endpoint is: ${Configuration.instance.getHttpEndpoint()}",
+    );
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(S.of(context).developerSettings),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _urlController,
+              decoration: InputDecoration(
+                labelText: S.of(context).serverEndpoint,
+                hintText: Configuration.instance.getHttpEndpoint(),
+              ),
+              autofocus: true,
+            ),
+            const SizedBox(height: 40),
+            GradientButton(
+              onTap: () async {
+                final url = _urlController.text;
+                _logger.info("Entered endpoint: $url");
+                try {
+                  final uri = Uri.parse(url);
+                  if ((uri.scheme == "http" || uri.scheme == "https")) {
+                    await _ping(url);
+                    await Configuration.instance.setHttpEndpoint(url);
+                    showToast(context, S.of(context).endpointUpdatedMessage);
+                    Navigator.of(context).pop();
+                  } else {
+                    throw const FormatException();
+                  }
+                } catch (e) {
+                  // ignore: unawaited_futures
+                  showErrorDialog(
+                    context,
+                    S.of(context).invalidEndpoint,
+                    S.of(context).invalidEndpointMessage,
+                  );
+                }
+              },
+              text: S.of(context).save,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _ping(String endpoint) async {
+    try {
+      final response =
+          await NetworkClient.instance.getDio().get('$endpoint/ping');
+      if (response.data['message'] != 'pong') {
+        throw Exception('Invalid response');
+      }
+    } catch (e) {
+      throw Exception('Error occurred: $e');
+    }
+  }
+}

--- a/mobile/lib/ui/settings/developer_settings_widget.dart
+++ b/mobile/lib/ui/settings/developer_settings_widget.dart
@@ -14,9 +14,9 @@ class DeveloperSettingsWidget extends StatelessWidget {
       return Padding(
         padding: const EdgeInsets.only(bottom: 20),
         child: Text(
-          S.of(context).customEndpoint(
-            "${endpointURI.host}:${endpointURI.port}",
-          ),
+          S
+              .of(context)
+              .customEndpoint("${endpointURI.host}:${endpointURI.port}"),
           style: Theme.of(context).textTheme.bodySmall,
         ),
       );

--- a/mobile/lib/ui/settings/developer_settings_widget.dart
+++ b/mobile/lib/ui/settings/developer_settings_widget.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import "package:photos/core/configuration.dart";
+import "package:photos/core/constants.dart";
+import "package:photos/generated/l10n.dart";
+
+class DeveloperSettingsWidget extends StatelessWidget {
+  const DeveloperSettingsWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final endpoint = Configuration.instance.getHttpEndpoint();
+    if (endpoint != kDefaultProductionEndpoint) {
+      final endpointURI = Uri.parse(endpoint);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 20),
+        child: Text(
+          S.of(context).customEndpoint(
+            "${endpointURI.host}:${endpointURI.port}",
+          ),
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      );
+    } else {
+      return const SizedBox.shrink();
+    }
+  }
+}

--- a/mobile/lib/ui/settings_page.dart
+++ b/mobile/lib/ui/settings_page.dart
@@ -18,6 +18,7 @@ import 'package:photos/ui/settings/account_section_widget.dart';
 import 'package:photos/ui/settings/app_version_widget.dart';
 import 'package:photos/ui/settings/backup/backup_section_widget.dart';
 import 'package:photos/ui/settings/debug_section_widget.dart';
+import "package:photos/ui/settings/developer_settings_widget.dart";
 import 'package:photos/ui/settings/general_section_widget.dart';
 import 'package:photos/ui/settings/inherited_settings_state.dart';
 import 'package:photos/ui/settings/security_section_widget.dart';
@@ -144,6 +145,7 @@ class SettingsPage extends StatelessWidget {
       contents.addAll([sectionSpacing, const DebugSectionWidget()]);
     }
     contents.add(const AppVersionWidget());
+    contents.add(const DeveloperSettingsWidget());
     contents.add(
       const Padding(
         padding: EdgeInsets.only(bottom: 60),


### PR DESCRIPTION
## Description
Users can now tap on the onboarding screen 7 times to bring up a page where they can configure the endpoint the app should be connecting to.
![photos-selfhost](https://github.com/ente-io/ente/assets/1161789/42fda09a-07e4-4c4e-a658-ec4a2d3f1848)

## Tests
- [x] Verified that production flows are working as expected
- [x] Verified that configuring the endpoint to a local instance lets you
  - [x] Connect to that instance
  - [x] Create an account
  - [x] Upload a photo
  - [x] Logout and log back in
