### PR TITLE
[server] nginx configuration improvements

### DIFF
--- a/infra/services/nginx/README.md
+++ b/infra/services/nginx/README.md
@@ -62,3 +62,12 @@ We can see this in the default configuration of nginx:
 This is a [handy tool](https://nginx-playground.wizardzines.com) to check the
 syntax of the configuration files. Alternatively, you can run `docker exec nginx
 nginx -t` on the instance to ask nginx to check the configuration.
+
+## Updating configuration
+
+Nginx configuration files can be changed without needing to restart anything.
+
+1. Update the configuration file at `/root/nginx/conf.d/museum.conf`
+2. Verify that there are no errors in the configuration by using `sudo docker
+   exec nginx nginx -t`.
+3. Ask nginx to reload the configuration `sudo systemctl reload nginx`.

--- a/server/scripts/deploy/README.md
+++ b/server/scripts/deploy/README.md
@@ -62,7 +62,7 @@ To bring up an additional museum node:
       sudo mkdir -p /root/museum/data/billing
       sudo mv *.json /root/museum/data/billing/
 
-* If not running behind Nginx, add the TLS credentials (otherwise add the to
+* If not running behind Nginx, add the TLS credentials (otherwise add them to
   Nginx)
 
       sudo tee /root/museum/credentials/tls.cert

--- a/server/scripts/deploy/museum.nginx.conf
+++ b/server/scripts/deploy/museum.nginx.conf
@@ -4,11 +4,15 @@
 upstream museum {
     # https://nginx.org/en/docs/http/ngx_http_upstream_module.html
     server host.docker.internal:8080 max_conns=50;
+
+    # Keep these many connections alive to upstream (requires HTTP/1.1)
+    keepalive 20;
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     ssl_certificate         /etc/ssl/certs/cert.pem;
     ssl_certificate_key     /etc/ssl/private/key.pem;
 
@@ -16,6 +20,8 @@ server {
 
     location / {
         proxy_pass http://museum;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- Use keepalives
- Update deprecated http2 syntax
- Document how to check config

Refs:
- https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives
- https://github.com/nginxinc/kubernetes-ingress/issues/4237
- https://stackoverflow.com/questions/65944578/how-to-get-nginx-running-in-docker-to-reload-nginx-conf-configuration
