### PR TITLE
[server] Build ARM images when publishing to ghcr.io

### DIFF
--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -32,6 +32,8 @@ jobs:
                   image: server
                   registry: ghcr.io
                   enableBuildKit: true
+                  multiPlatform: true
+                  platform: linux/amd64,linux/arm64,linux/arm/v7
                   buildArgs: GIT_COMMIT=${{ inputs.commit }}
                   tags: ${{ inputs.commit }}, latest
                   username: ${{ github.actor }}


### PR DESCRIPTION
Untested yet, will test alongside the next publish

Requested in https://github.com/ente-io/ente/discussions/1305