### PR TITLE
[mob] Change share page copy

### DIFF
--- a/mobile/lib/generated/intl/messages_cs.dart
+++ b/mobile/lib/generated/intl/messages_cs.dart
@@ -35,6 +35,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "changeLocationOfSelectedItems": MessageLookupByLibrary.simpleMessage(
             "Change location of selected items?"),
         "contacts": MessageLookupByLibrary.simpleMessage("Contacts"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "deleteConfirmDialogBody": MessageLookupByLibrary.simpleMessage(
             "This account is linked to other ente apps, if you use any.\\n\\nYour uploaded data, across all ente apps, will be scheduled for deletion, and your account will be permanently deleted."),
         "descriptions": MessageLookupByLibrary.simpleMessage("Descriptions"),

--- a/mobile/lib/generated/intl/messages_de.dart
+++ b/mobile/lib/generated/intl/messages_de.dart
@@ -503,6 +503,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Konto erstellen"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Drücke lange um Fotos auszuwählen und klicke + um ein Album zu erstellen"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage":
             MessageLookupByLibrary.simpleMessage("Collage erstellen"),
         "createNewAccount":

--- a/mobile/lib/generated/intl/messages_en.dart
+++ b/mobile/lib/generated/intl/messages_en.dart
@@ -490,6 +490,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "createAccount": MessageLookupByLibrary.simpleMessage("Create account"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Long press to select photos and click + to create an album"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage": MessageLookupByLibrary.simpleMessage("Create collage"),
         "createNewAccount":
             MessageLookupByLibrary.simpleMessage("Create new account"),

--- a/mobile/lib/generated/intl/messages_es.dart
+++ b/mobile/lib/generated/intl/messages_es.dart
@@ -426,6 +426,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "createAccount": MessageLookupByLibrary.simpleMessage("Crear cuenta"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Mantenga presionado para seleccionar fotos y haga clic en + para crear un álbum"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createNewAccount":
             MessageLookupByLibrary.simpleMessage("Crear nueva cuenta"),
         "createOrSelectAlbum":

--- a/mobile/lib/generated/intl/messages_fr.dart
+++ b/mobile/lib/generated/intl/messages_fr.dart
@@ -494,6 +494,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Créer un compte"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Appuyez longuement pour sélectionner des photos et cliquez sur + pour créer un album"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage":
             MessageLookupByLibrary.simpleMessage("Créez un collage"),
         "createNewAccount":

--- a/mobile/lib/generated/intl/messages_it.dart
+++ b/mobile/lib/generated/intl/messages_it.dart
@@ -478,6 +478,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "createAccount": MessageLookupByLibrary.simpleMessage("Crea account"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Premi a lungo per selezionare le foto e fai clic su + per creare un album"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage":
             MessageLookupByLibrary.simpleMessage("Crea un collage"),
         "createNewAccount":

--- a/mobile/lib/generated/intl/messages_ko.dart
+++ b/mobile/lib/generated/intl/messages_ko.dart
@@ -35,6 +35,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "changeLocationOfSelectedItems": MessageLookupByLibrary.simpleMessage(
             "Change location of selected items?"),
         "contacts": MessageLookupByLibrary.simpleMessage("Contacts"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "deleteConfirmDialogBody": MessageLookupByLibrary.simpleMessage(
             "This account is linked to other ente apps, if you use any.\\n\\nYour uploaded data, across all ente apps, will be scheduled for deletion, and your account will be permanently deleted."),
         "descriptions": MessageLookupByLibrary.simpleMessage("Descriptions"),

--- a/mobile/lib/generated/intl/messages_nl.dart
+++ b/mobile/lib/generated/intl/messages_nl.dart
@@ -500,6 +500,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Account aanmaken"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Lang indrukken om foto\'s te selecteren en klik + om een album te maken"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage": MessageLookupByLibrary.simpleMessage("Creëer collage"),
         "createNewAccount":
             MessageLookupByLibrary.simpleMessage("Nieuw account aanmaken"),

--- a/mobile/lib/generated/intl/messages_no.dart
+++ b/mobile/lib/generated/intl/messages_no.dart
@@ -44,6 +44,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "confirmDeletePrompt": MessageLookupByLibrary.simpleMessage(
             "Ja, jeg ønsker å slette denne kontoen og all dataen dens permanent."),
         "contacts": MessageLookupByLibrary.simpleMessage("Contacts"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "deleteAccount": MessageLookupByLibrary.simpleMessage("Slett konto"),
         "deleteAccountFeedbackPrompt": MessageLookupByLibrary.simpleMessage(
             "Vi er lei oss for at du forlater oss. Gi oss gjerne en tilbakemelding så vi kan forbedre oss."),

--- a/mobile/lib/generated/intl/messages_pl.dart
+++ b/mobile/lib/generated/intl/messages_pl.dart
@@ -63,6 +63,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "contacts": MessageLookupByLibrary.simpleMessage("Contacts"),
         "continueLabel": MessageLookupByLibrary.simpleMessage("Kontynuuj"),
         "createAccount": MessageLookupByLibrary.simpleMessage("Stwórz konto"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createNewAccount":
             MessageLookupByLibrary.simpleMessage("Stwórz nowe konto"),
         "decrypting":

--- a/mobile/lib/generated/intl/messages_pt.dart
+++ b/mobile/lib/generated/intl/messages_pt.dart
@@ -499,6 +499,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Criar uma conta"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
             "Pressione e segure para selecionar fotos e clique em + para criar um álbum"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage": MessageLookupByLibrary.simpleMessage("Criar colagem"),
         "createNewAccount":
             MessageLookupByLibrary.simpleMessage("Criar nova conta"),

--- a/mobile/lib/generated/intl/messages_zh.dart
+++ b/mobile/lib/generated/intl/messages_zh.dart
@@ -421,6 +421,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "createAccount": MessageLookupByLibrary.simpleMessage("创建账户"),
         "createAlbumActionHint":
             MessageLookupByLibrary.simpleMessage("长按选择照片，然后点击 + 创建相册"),
+        "createCollaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Create collaborative link"),
         "createCollage": MessageLookupByLibrary.simpleMessage("创建拼贴"),
         "createNewAccount": MessageLookupByLibrary.simpleMessage("创建新账号"),
         "createOrSelectAlbum": MessageLookupByLibrary.simpleMessage("创建或选择相册"),

--- a/mobile/lib/generated/l10n.dart
+++ b/mobile/lib/generated/l10n.dart
@@ -8543,6 +8543,16 @@ class S {
       args: [endpoint],
     );
   }
+
+  /// `Create collaborative link`
+  String get createCollaborativeLink {
+    return Intl.message(
+      'Create collaborative link',
+      name: 'createCollaborativeLink',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/mobile/lib/l10n/intl_cs.arb
+++ b/mobile/lib/l10n/intl_cs.arb
@@ -16,5 +16,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_de.arb
+++ b/mobile/lib/l10n/intl_de.arb
@@ -1202,5 +1202,6 @@
   "descriptions": "Beschreibungen",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_en.arb
+++ b/mobile/lib/l10n/intl_en.arb
@@ -1210,5 +1210,6 @@
   "invalidEndpoint": "Invalid endpoint",
   "invalidEndpointMessage": "Sorry, the endpoint you entered is invalid. Please enter a valid endpoint and try again.",
   "endpointUpdatedMessage": "Endpoint updated successfully",
-  "customEndpoint": "Connected to {endpoint}"
+  "customEndpoint": "Connected to {endpoint}",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_es.arb
+++ b/mobile/lib/l10n/intl_es.arb
@@ -978,5 +978,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_fr.arb
+++ b/mobile/lib/l10n/intl_fr.arb
@@ -1159,5 +1159,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_it.arb
+++ b/mobile/lib/l10n/intl_it.arb
@@ -1121,5 +1121,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_ko.arb
+++ b/mobile/lib/l10n/intl_ko.arb
@@ -16,5 +16,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_nl.arb
+++ b/mobile/lib/l10n/intl_nl.arb
@@ -1197,5 +1197,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_no.arb
+++ b/mobile/lib/l10n/intl_no.arb
@@ -30,5 +30,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_pl.arb
+++ b/mobile/lib/l10n/intl_pl.arb
@@ -117,5 +117,6 @@
   "descriptions": "Descriptions",
   "addViewers": "{count, plural, zero {Add viewer} one {Add viewer} other {Add viewers}}",
   "addCollaborators": "{count, plural, zero {Add collaborator} one {Add collaborator} other {Add collaborators}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Long press an email to verify end to end encryption.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_pt.arb
+++ b/mobile/lib/l10n/intl_pt.arb
@@ -1203,5 +1203,6 @@
   "descriptions": "Descrições",
   "addViewers": "{count, plural, zero {Adicionar visualizador} one {Adicionar visualizador} other {Adicionar Visualizadores}}",
   "addCollaborators": "{count, plural, zero {Adicionar colaborador} one {Adicionar coloborador} other {Adicionar colaboradores}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "Pressione e segure um e-mail para verificar a criptografia de ponta a ponta."
+  "longPressAnEmailToVerifyEndToEndEncryption": "Pressione e segure um e-mail para verificar a criptografia de ponta a ponta.",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/l10n/intl_zh.arb
+++ b/mobile/lib/l10n/intl_zh.arb
@@ -1203,5 +1203,6 @@
   "descriptions": "描述",
   "addViewers": "{count, plural, zero {添加查看者} one {添加查看者} other {添加查看者}}",
   "addCollaborators": "{count, plural, zero {添加协作者} one {添加协作者} other {添加协作者}}",
-  "longPressAnEmailToVerifyEndToEndEncryption": "长按电子邮件以验证端到端加密。"
+  "longPressAnEmailToVerifyEndToEndEncryption": "长按电子邮件以验证端到端加密。",
+  "createCollaborativeLink": "Create collaborative link"
 }

--- a/mobile/lib/ui/sharing/share_collection_page.dart
+++ b/mobile/lib/ui/sharing/share_collection_page.dart
@@ -260,15 +260,15 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
           height: 24,
         ),
         MenuSectionTitle(
-          title: S.of(context).collaborativeLink,
+          title: S.of(context).collectPhotos,
           iconData: Icons.public,
         ),
         MenuItemWidget(
           captionedTextWidget: CaptionedTextWidget(
-            title: S.of(context).collectPhotos,
+            title: S.of(context).createCollaborativeLink,
             makeTextBold: true,
           ),
-          leadingIcon: Icons.download_sharp,
+          leadingIcon: Icons.people_alt_outlined,
           menuItemColor: getEnteColorScheme(context).fillFaint,
           showOnlyLoadingState: true,
           onTap: () async {


### PR DESCRIPTION
## Description

I thought the "Collect photos" line and the download icon in the share page looked very confusing:
![old_share_page_copy](https://github.com/ente-io/ente/assets/81471280/cb6a8415-e3a0-403e-abd3-e94b6256a572)

So I changed the icon and copy slightly:
![new_share_page_copy](https://github.com/ente-io/ente/assets/81471280/2480bb43-21fb-487a-af00-c473dbe7439c)


## Tests

Just a copy change, no tests.