### PR TITLE
[server] Allow a configurable sslmode

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -76,6 +76,9 @@ db:
     host: localhost
     port: 5432
     name: ente_db
+    # You might want to set this to "require" for production
+    # See https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
+    sslmode: disable
     # These can be specified here, or alternatively provided via the environment
     # as ENTE_DB_USER and ENTE_DB_PASSWORD.
     user:

--- a/server/pkg/utils/config/config.go
+++ b/server/pkg/utils/config/config.go
@@ -103,12 +103,13 @@ func doesFileExist(path string) (bool, error) {
 
 func GetPGInfo() string {
 	return fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=disable",
+		"password=%s dbname=%s sslmode=%s",
 		viper.GetString("db.host"),
 		viper.GetInt("db.port"),
 		viper.GetString("db.user"),
 		viper.GetString("db.password"),
-		viper.GetString("db.name"))
+		viper.GetString("db.name"),
+		viper.GetString("db.sslmode"))
 }
 
 func IsLocalEnvironment() bool {


### PR DESCRIPTION
Tested that

- [x] Existing defaults remain unchanged
- [x] Setting db.sslmode = require in museum.yaml is honoured (in the docker compose environment, that causes the db connection to fail as expected)
