### PR TITLE
[web] Add required transitive dependency of MUI datepicker

### DIFF
--- a/web/apps/photos/package.json
+++ b/web/apps/photos/package.json
@@ -21,6 +21,7 @@
         "bs58": "^5.0.0",
         "chrono-node": "^2.2.6",
         "comlink": "^4.3.0",
+        "date-fns": "^2",
         "debounce": "^2.0.0",
         "density-clustering": "^1.3.0",
         "eventemitter3": "^4.0.7",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -211,6 +211,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.21.0":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
+  integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.24.0":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
@@ -1856,6 +1863,13 @@ data-view-byte-offset@^1.0.0:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+date-fns@^2:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 dayjs@^1.10.0:
   version "1.11.10"


### PR DESCRIPTION
Previously this was coming from react-datepicker that was otherwise unused and thus removed.

Use the same major version as we had previously.

Ref:
https://stackoverflow.com/questions/71037974/module-not-found-error-cant-resolve-date-fns-adddays-in-c-users
