### PR TITLE
[infra] Limit the maximum size of the nginx stdout logs

### DIFF
--- a/infra/services/nginx/nginx.service
+++ b/infra/services/nginx/nginx.service
@@ -16,5 +16,6 @@ ExecStart=docker run --name nginx \
     -v /root/nginx/cert.pem:/etc/ssl/certs/cert.pem:ro \
     -v /root/nginx/key.pem:/etc/ssl/private/key.pem:ro \
     -v /root/nginx/conf.d:/etc/nginx/conf.d:ro \
+    --log-opt max-size=1g \
     nginx
 ExecReload=docker exec nginx nginx -s reload


### PR DESCRIPTION
nginx logs to stdout, which is captured by docker and put into a file at `/var/lib/docker/containers/<nginx-cont-id>/<id>-json.log`

By default, the size of this file is unbounded. Add a maximum limit of 1 GB to this.

References:
- https://docs.docker.com/config/containers/logging/local/
- https://stackoverflow.com/questions/31829587/docker-container-logs-taking-all-my-disk-space
