### PR TITLE
[web] Import the scaffolding to sync face embeddings from web_face_v2

### DIFF
--- a/web/apps/photos/src/pages/gallery/index.tsx
+++ b/web/apps/photos/src/pages/gallery/index.tsx
@@ -105,7 +105,7 @@ import { AppContext } from "pages/_app";
 import { clipService } from "services/clip-service";
 import { constructUserIDToEmailMap } from "services/collectionService";
 import downloadManager from "services/download";
-import { syncEmbeddings } from "services/embeddingService";
+import { syncEmbeddings, syncFileEmbeddings } from "services/embeddingService";
 import { syncEntities } from "services/entityService";
 import locationSearchService from "services/locationSearchService";
 import { getLocalTrashedFiles, syncTrash } from "services/trashService";
@@ -702,6 +702,10 @@ export default function Gallery() {
             await syncEntities();
             await syncMapEnabled();
             await syncEmbeddings();
+            const electron = globalThis.electron;
+            if (electron) {
+                await syncFileEmbeddings();
+            }
             if (clipService.isPlatformSupported()) {
                 void clipService.scheduleImageEmbeddingExtraction();
             }

--- a/web/apps/photos/src/services/embeddingService.ts
+++ b/web/apps/photos/src/services/embeddingService.ts
@@ -13,11 +13,14 @@ import type {
     PutEmbeddingRequest,
 } from "types/embedding";
 import { EnteFile } from "types/file";
-import { getLatestVersionEmbeddings,getLatestVersionFileEmbeddings } from "utils/embedding";
+import {
+    getLatestVersionEmbeddings,
+    getLatestVersionFileEmbeddings,
+} from "utils/embedding";
+import { FileML } from "utils/machineLearning/mldataMappers";
 import { getLocalCollections } from "./collectionService";
 import { getAllLocalFiles } from "./fileService";
 import { getLocalTrashedFiles } from "./trashService";
-import { FileML } from "utils/machineLearning/mldataMappers";
 
 const ENDPOINT = getEndpoint();
 
@@ -154,7 +157,7 @@ export const syncEmbeddings = async () => {
 export const syncFileEmbeddings = async () => {
     const models: EmbeddingModel[] = ["file-ml-clip-face"];
     try {
-        let allEmbeddings :FileML[] = await getFileMLEmbeddings();
+        let allEmbeddings: FileML[] = await getFileMLEmbeddings();
         const localFiles = await getAllLocalFiles();
         const hiddenAlbums = await getLocalCollections("hidden");
         const localTrashFiles = await getLocalTrashedFiles();
@@ -179,7 +182,6 @@ export const syncFileEmbeddings = async () => {
                 const newEmbeddings = await Promise.all(
                     response.diff.map(async (embedding) => {
                         try {
-                          
                             const worker =
                                 await ComlinkCryptoWorker.getInstance();
                             const fileKey = fileIdToKeyMap.get(
@@ -196,7 +198,7 @@ export const syncFileEmbeddings = async () => {
 
                             return {
                                 ...decryptedData,
-                                updatedAt: embedding.updatedAt
+                                updatedAt: embedding.updatedAt,
                             } as unknown as FileML;
                         } catch (e) {
                             let hasHiddenAlbums = false;
@@ -228,7 +230,6 @@ export const syncFileEmbeddings = async () => {
         log.error("Sync embeddings failed", e);
     }
 };
-
 
 export const getEmbeddingsDiff = async (
     sinceTime: number,
@@ -263,7 +264,7 @@ export const putEmbedding = async (
     try {
         const token = getToken();
         if (!token) {
-            log.info('putEmbedding failed: token not found');
+            log.info("putEmbedding failed: token not found");
             throw Error(CustomError.TOKEN_MISSING);
         }
         const resp = await HTTPService.put(

--- a/web/apps/photos/src/types/embedding.tsx
+++ b/web/apps/photos/src/types/embedding.tsx
@@ -5,7 +5,7 @@
  * embeddings on the server. However, we should be prepared to receive an
  * {@link EncryptedEmbedding} with a model value distinct from one of these.
  */
-export type EmbeddingModel = "onnx-clip";
+export type EmbeddingModel = "onnx-clip" |"file-ml-clip-face";
 
 export interface EncryptedEmbedding {
     fileID: number;
@@ -21,8 +21,9 @@ export interface Embedding
         EncryptedEmbedding,
         "encryptedEmbedding" | "decryptionHeader"
     > {
-    embedding: Float32Array;
+    embedding?: Float32Array;
 }
+
 
 export interface GetEmbeddingDiffResponse {
     diff: EncryptedEmbedding[];

--- a/web/apps/photos/src/types/embedding.tsx
+++ b/web/apps/photos/src/types/embedding.tsx
@@ -5,7 +5,7 @@
  * embeddings on the server. However, we should be prepared to receive an
  * {@link EncryptedEmbedding} with a model value distinct from one of these.
  */
-export type EmbeddingModel = "onnx-clip" |"file-ml-clip-face";
+export type EmbeddingModel = "onnx-clip" | "file-ml-clip-face";
 
 export interface EncryptedEmbedding {
     fileID: number;
@@ -23,7 +23,6 @@ export interface Embedding
     > {
     embedding?: Float32Array;
 }
-
 
 export interface GetEmbeddingDiffResponse {
     diff: EncryptedEmbedding[];

--- a/web/apps/photos/src/utils/embedding.ts
+++ b/web/apps/photos/src/utils/embedding.ts
@@ -1,7 +1,25 @@
 import { Embedding } from "types/embedding";
+import { FileML } from "./machineLearning/mldataMappers";
 
 export const getLatestVersionEmbeddings = (embeddings: Embedding[]) => {
     const latestVersionEntities = new Map<number, Embedding>();
+    embeddings.forEach((embedding) => {
+        if (!embedding?.fileID) {
+            return;
+        }
+        const existingEmbeddings = latestVersionEntities.get(embedding.fileID);
+        if (
+            !existingEmbeddings ||
+            existingEmbeddings.updatedAt < embedding.updatedAt
+        ) {
+            latestVersionEntities.set(embedding.fileID, embedding);
+        }
+    });
+    return Array.from(latestVersionEntities.values());
+};
+
+export const getLatestVersionFileEmbeddings = (embeddings: FileML[]) => {
+    const latestVersionEntities = new Map<number, FileML>();
     embeddings.forEach((embedding) => {
         if (!embedding?.fileID) {
             return;

--- a/web/apps/photos/src/utils/machineLearning/mldataMappers.ts
+++ b/web/apps/photos/src/utils/machineLearning/mldataMappers.ts
@@ -1,0 +1,263 @@
+import { Face, FaceDetection, Landmark, MlFileData } from "types/machineLearning";
+import { ClipEmbedding } from "types/machineLearning/data/clip";
+
+export interface FileML extends ServerFileMl {
+    updatedAt: number;
+}
+
+class ServerFileMl {
+    public fileID: number;
+    public height?: number;
+    public width?: number;
+    public faceEmbedding: ServerFaceEmbeddings;
+    public clipEmbedding?: ClipEmbedding;
+
+
+    public constructor(
+        fileID: number,
+        faceEmbedding: ServerFaceEmbeddings,
+        clipEmbedding?: ClipEmbedding,
+        height?: number,
+        width?: number,
+    ) {
+        this.fileID = fileID;
+        this.height = height;
+        this.width = width;
+        this.faceEmbedding = faceEmbedding;
+        this.clipEmbedding = clipEmbedding;
+    }
+
+    toJson(): string {
+        return JSON.stringify(this);
+    }
+
+    static fromJson(json: string): ServerFileMl {
+        return JSON.parse(json);
+    }
+}
+
+class ServerFaceEmbeddings {
+    public faces: ServerFace[];
+    public version: number;
+    public client?: string;
+    public error?: boolean;
+
+    public constructor(
+        faces: ServerFace[],
+        version: number,
+        client?: string,
+        error?: boolean,
+    ) {
+        this.faces = faces;
+        this.version = version;
+        this.client = client;
+        this.error = error;
+    }
+
+    toJson(): string {
+        return JSON.stringify(this);
+    }
+
+    static fromJson(json: string): ServerFaceEmbeddings {
+        return JSON.parse(json);
+    }
+}
+
+class ServerFace {
+    public fileID: number;
+    public faceID: string;
+    public embeddings: number[];
+    public detection: ServerDetection;
+    public score: number;
+    public blur: number;
+    public fileInfo?: ServerFileInfo;
+
+    public constructor(
+        fileID: number,
+        faceID: string,
+        embeddings: number[],
+        detection: ServerDetection,
+        score: number,
+        blur: number,
+        fileInfo?: ServerFileInfo,
+    ) {
+        this.fileID = fileID;
+        this.faceID = faceID;
+        this.embeddings = embeddings;
+        this.detection = detection;
+        this.score = score;
+        this.blur = blur;
+        this.fileInfo = fileInfo;
+    }
+
+    toJson(): string {
+        return JSON.stringify(this);
+    }
+
+    static fromJson(json: string): ServerFace {
+        return JSON.parse(json);
+    }
+}
+
+class ServerFileInfo {
+    public imageWidth?: number;
+    public imageHeight?: number;
+
+    public constructor(imageWidth?: number, imageHeight?: number) {
+        this.imageWidth = imageWidth;
+        this.imageHeight = imageHeight;
+    }
+}
+
+class ServerDetection {
+    public box: ServerFaceBox;
+    public landmarks: Landmark[];
+
+    public constructor(box: ServerFaceBox, landmarks: Landmark[]) {
+        this.box = box;
+        this.landmarks = landmarks;
+    }
+
+    toJson(): string {
+        return JSON.stringify(this);
+    }
+
+    static fromJson(json: string): ServerDetection {
+        return JSON.parse(json);
+    }
+}
+
+class ServerFaceBox {
+    public xMin: number;
+    public yMin: number;
+    public width: number;
+    public height: number;
+
+    public constructor(
+        xMin: number,
+        yMin: number,
+        width: number,
+        height: number,
+    ) {
+        this.xMin = xMin;
+        this.yMin = yMin;
+        this.width = width;
+        this.height = height;
+    }
+
+    toJson(): string {
+        return JSON.stringify(this);
+    }
+
+    static fromJson(json: string): ServerFaceBox {
+        return JSON.parse(json);
+    }
+}
+
+
+export function LocalFileMlDataToServerFileMl(
+    localFileMlData: MlFileData,
+): ServerFileMl {
+    if(localFileMlData.errorCount > 0 && localFileMlData.lastErrorMessage !== undefined) {
+        return null
+    }
+    const imageDimensions = localFileMlData.imageDimensions;
+    const fileInfo = new ServerFileInfo(
+        imageDimensions.width,
+        imageDimensions.height,
+    );
+    const faces: ServerFace[] = [];
+    for (let i = 0; i < localFileMlData.faces.length; i++) {
+        const face: Face = localFileMlData.faces[i];
+        const faceID = face.id;
+        const embedding = face.embedding;
+        const score = face.detection.probability;
+        const blur = face.blurValue;
+        const detection: FaceDetection = face.detection;
+        const box = detection.box;
+        const landmarks = detection.landmarks;
+        const newBox = new ServerFaceBox(
+            box.x,
+            box.y,
+            box.width,
+            box.height,
+        );
+        const newLandmarks: Landmark[] = [];
+        for (let j = 0; j < landmarks.length; j++) {
+            newLandmarks.push(
+                 {
+                    x: landmarks[j].x,
+                    y: landmarks[j].y,
+                 } as Landmark,
+                );
+        }
+        
+        const newFaceObject = new ServerFace(
+            localFileMlData.fileId,
+            faceID,
+            Array.from(embedding),
+            new ServerDetection(newBox, newLandmarks),
+            score,
+            blur,
+            fileInfo,
+        );
+        faces.push(newFaceObject);
+    }
+    const faceEmbeddings = new ServerFaceEmbeddings(faces, 1,localFileMlData.lastErrorMessage);
+    return new ServerFileMl(
+        localFileMlData.fileId,
+        faceEmbeddings,
+        null,
+        imageDimensions.height,
+        imageDimensions.width,
+    );
+}
+
+
+// // Not sure if this actually works
+// export function ServerFileMlToLocalFileMlData(
+//     serverFileMl: ServerFileMl,
+// ): MlFileData {
+//     const faces: Face[] = [];
+//     const mlVersion: number = serverFileMl.faceEmbeddings.version;
+//     const errorCount = serverFileMl.faceEmbeddings.error ? 1 : 0;
+//     for (let i = 0; i < serverFileMl.faceEmbeddings.faces.length; i++) {
+//         const face = serverFileMl.faceEmbeddings.faces[i];
+//         if(face.detection.landmarks.length === 0) {
+//             continue;
+//         }
+//         const detection = face.detection;
+//         const box = detection.box;
+//         const landmarks = detection.landmarks;
+//         const newBox = new FaceBox(
+//             box.xMin,
+//             box.yMin,
+//             box.width,
+//             box.height,
+//         );
+//         const newLandmarks: Landmark[] = [];
+//         for (let j = 0; j < landmarks.length; j++) {
+//             newLandmarks.push(
+//                 {
+//                  x:   landmarks[j].x,
+//                 y: landmarks[j].y,
+//         } as Landmark
+//             );
+//         }
+//         const newDetection = new Detection(newBox, newLandmarks);
+//         const newFace = {
+
+//         } as Face
+//         faces.push(newFace);
+//     }
+//     return {
+//         fileId: serverFileMl.fileID,
+//         imageDimensions: {
+//             width: serverFileMl.width,
+//             height: serverFileMl.height,
+//         },
+//         faces,
+//         mlVersion,
+//         errorCount,
+//     };
+// }

--- a/web/apps/photos/src/utils/machineLearning/mldataMappers.ts
+++ b/web/apps/photos/src/utils/machineLearning/mldataMappers.ts
@@ -1,4 +1,9 @@
-import { Face, FaceDetection, Landmark, MlFileData } from "types/machineLearning";
+import {
+    Face,
+    FaceDetection,
+    Landmark,
+    MlFileData,
+} from "types/machineLearning";
 import { ClipEmbedding } from "types/machineLearning/data/clip";
 
 export interface FileML extends ServerFileMl {
@@ -11,7 +16,6 @@ class ServerFileMl {
     public width?: number;
     public faceEmbedding: ServerFaceEmbeddings;
     public clipEmbedding?: ClipEmbedding;
-
 
     public constructor(
         fileID: number,
@@ -154,12 +158,14 @@ class ServerFaceBox {
     }
 }
 
-
 export function LocalFileMlDataToServerFileMl(
     localFileMlData: MlFileData,
 ): ServerFileMl {
-    if(localFileMlData.errorCount > 0 && localFileMlData.lastErrorMessage !== undefined) {
-        return null
+    if (
+        localFileMlData.errorCount > 0 &&
+        localFileMlData.lastErrorMessage !== undefined
+    ) {
+        return null;
     }
     const imageDimensions = localFileMlData.imageDimensions;
     const fileInfo = new ServerFileInfo(
@@ -176,22 +182,15 @@ export function LocalFileMlDataToServerFileMl(
         const detection: FaceDetection = face.detection;
         const box = detection.box;
         const landmarks = detection.landmarks;
-        const newBox = new ServerFaceBox(
-            box.x,
-            box.y,
-            box.width,
-            box.height,
-        );
+        const newBox = new ServerFaceBox(box.x, box.y, box.width, box.height);
         const newLandmarks: Landmark[] = [];
         for (let j = 0; j < landmarks.length; j++) {
-            newLandmarks.push(
-                 {
-                    x: landmarks[j].x,
-                    y: landmarks[j].y,
-                 } as Landmark,
-                );
+            newLandmarks.push({
+                x: landmarks[j].x,
+                y: landmarks[j].y,
+            } as Landmark);
         }
-        
+
         const newFaceObject = new ServerFace(
             localFileMlData.fileId,
             faceID,
@@ -203,7 +202,11 @@ export function LocalFileMlDataToServerFileMl(
         );
         faces.push(newFaceObject);
     }
-    const faceEmbeddings = new ServerFaceEmbeddings(faces, 1,localFileMlData.lastErrorMessage);
+    const faceEmbeddings = new ServerFaceEmbeddings(
+        faces,
+        1,
+        localFileMlData.lastErrorMessage,
+    );
     return new ServerFileMl(
         localFileMlData.fileId,
         faceEmbeddings,
@@ -212,7 +215,6 @@ export function LocalFileMlDataToServerFileMl(
         imageDimensions.width,
     );
 }
-
 
 // // Not sure if this actually works
 // export function ServerFileMlToLocalFileMlData(


### PR DESCRIPTION
This PR cherry picks Neeraj's ML related changes from the web_face_v2 branch.

Similar to https://github.com/ente-io/ente/pull/1399, this gets us one step closer to integrating ONNX-YOLO with our desktop app. But it is not currently in a usable state (The web app's functionality remains untouched).
