### PR TITLE
[desktop] Build ARM64 variant of Windows

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,5 +1,15 @@
 appId: io.ente.bhari-frame
 artifactName: ${productName}-${version}-${arch}.${ext}
+files:
+    - app/**/*
+    - out
+extraFiles:
+    - from: build
+      to: resources
+win:
+    target:
+        - target: nsis
+          arch: [x64, arm64]
 nsis:
     deleteAppDataOnUninstall: true
 linux:
@@ -20,9 +30,3 @@ mac:
     category: public.app-category.photography
     hardenedRuntime: true
 afterSign: electron-builder-notarize
-extraFiles:
-    - from: build
-      to: resources
-files:
-    - app/**/*
-    - out


### PR DESCRIPTION
Fixes https://github.com/ente-io/ente/issues/1374

A customer reported that the app fails to run on Windows ARM. The error is coming when trying to load ONNX.

ONNX runtime supports Windows ARM, e.g. see
- https://www.jsdelivr.com/package/npm/onnxruntime-node?tab=files&path=bin%2Fnapi-v3%2Fwin32
- https://github.com/microsoft/onnxruntime/issues/18078

The issue then seems to be that we're not actually building for Windows ARM. I'm not sure about this (don't have a Windows ARM machine at hand), but my theory is that since we don't ask Electron Builder to build for win arm64, it doesn't copy the corresponding ONNX binary into the generated bundle.

Other refs:
- https://www.electron.build/cli.html
