### PR TITLE
[Server] Fix data cleanup pipeline for recovered account

### DIFF
--- a/server/pkg/controller/data_cleanup/controller.go
+++ b/server/pkg/controller/data_cleanup/controller.go
@@ -194,6 +194,8 @@ func (c *DeleteUserCleanupController) isDeleted(item *entity.DataCleanup) error 
 	if err == nil {
 		// user is not deleted, double check by verifying email is not empty
 		if u.Email != "" {
+			// todo: remove this logic after next deployment. This is to only handle cases
+			// where we have not removed scheduled delete entry for account post recovery.
 			remErr := c.Repo.RemoveScheduledDelete(context.Background(), item.UserID)
 			if remErr != nil {
 				return stacktrace.Propagate(remErr, "failed to remove scheduled delete entry")

--- a/server/pkg/controller/data_cleanup/controller.go
+++ b/server/pkg/controller/data_cleanup/controller.go
@@ -190,8 +190,15 @@ func (c *DeleteUserCleanupController) storageCheck(ctx context.Context, item *en
 }
 
 func (c *DeleteUserCleanupController) isDeleted(item *entity.DataCleanup) error {
-	_, err := c.UserRepo.Get(item.UserID)
+	u, err := c.UserRepo.Get(item.UserID)
 	if err == nil {
+		// user is not deleted, double check by verifying email is not empty
+		if u.Email != "" {
+			remErr := c.Repo.RemoveScheduledDelete(context.Background(), item.UserID)
+			if remErr != nil {
+				return stacktrace.Propagate(remErr, "failed to remove scheduled delete entry")
+			}
+		}
 		return stacktrace.Propagate(ente.NewBadRequestWithMessage("User ID is linked to undeleted account"), "")
 	}
 	if !errors.Is(err, ente.ErrUserDeleted) {

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -368,7 +368,15 @@ func (c *UserController) HandleAccountRecovery(ctx *gin.Context, req ente.Recove
 		return stacktrace.Propagate(err, "")
 	}
 	err = c.UserRepo.UpdateEmail(req.UserID, encryptedEmail, emailHash)
-	return stacktrace.Propagate(err, "failed to update email")
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to update email")
+	}
+	err = c.DataCleanupRepo.RemoveScheduledDelete(ctx, req.UserID)
+	if err != nil {
+		logrus.WithError(err).Error("failed to remove scheduled delete")
+		return stacktrace.Propagate(err, "")
+	}
+	return stacktrace.Propagate(err, "")
 }
 
 func (c *UserController) attachFreeSubscription(userID int64) (ente.Subscription, error) {


### PR DESCRIPTION
## Description
For accounts that were recovered post deletion (within x days), we were not removing the entry from data_cleanup cron.

The data_clean up cron anyways verify that the account is indeed deleted before proceeding with deletion, so it was not causing any harm, but the cron was logging error.

## Tests

- [x] Verify that data clean up entry is removed if the account is recovered
- [x] Verify that for existing data_cleanup entry for already recovered account, the entry is deleted from cron.
