### PR TITLE
[web] Fix CSS alignment issue on gallery page

### DIFF
--- a/web/packages/shared/components/EnteLogo.tsx
+++ b/web/packages/shared/components/EnteLogo.tsx
@@ -3,6 +3,7 @@ import { styled } from "@mui/material";
 const LogoImage = styled("img")`
     margin: 3px 0;
     pointer-events: none;
+    vertical-align: middle;
 `;
 
 export function EnteLogo(props) {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3316,7 +3316,7 @@ libsodium-wrappers@0.7.9:
   dependencies:
     libsodium "^0.7.0"
 
-libsodium@^0.7.0:
+libsodium@0.7.9, libsodium@^0.7.0:
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.9.tgz#4bb7bcbf662ddd920d8795c227ae25bbbfa3821b"
   integrity sha512-gfeADtR4D/CM0oRUviKBViMGXZDgnFdMKMzHsvBdqLBHd9ySi6EtYnmuhHVDDYgYpAO8eU8hEY+F8vIUAPh08A==


### PR DESCRIPTION
## Description
Ran ente.io locally on PC and found a CSS-alignment issue on the `http://localhost:3000/gallery` page.
The alignment issue was found when it was locally hosted and found when '/gallery' was in an empty state. 
The line - "Welcome to" followed by the image of 'ente' was not aligned.
It was fixed by adding the following line `vertical-align: middle;` to the styled component.

> Please find below images showing the off-alignment and the rectified image. 

> Thank you ! to the team for considering

## Tests
### Before
![Screenshot 2024-04-14 115356](https://github.com/ente-io/ente/assets/82031202/d733a8b3-702f-41df-9480-9692db6b8e86)
### After
![Screenshot 2024-04-14 115433](https://github.com/ente-io/ente/assets/82031202/0c5acc8e-0107-4b00-b7e0-d26a4369ed19)
