### PR TITLE
[web] Use the public link origin provided by the server

### DIFF
--- a/docs/docs/self-hosting/faq/sharing.md
+++ b/docs/docs/self-hosting/faq/sharing.md
@@ -41,3 +41,19 @@ NEXT_PUBLIC_ENTE_ENDPOINT=http://localhost:8080 \
     NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=http://localhost:3002 \
     yarn dev:albums
 ```
+
+If you also want to change the prefix (the origin) in the generated public
+links, to use your custom albums endpoint in the generated public link instead
+of albums.ente.io, set `apps.public-albums` property in museum's configuration
+
+For example, when running using the starter docker compose file, you can do this
+by creating a `museum.yaml` and defining the following configuration there:
+
+```yaml
+apps:
+    public-albums: http://localhost:3002
+```
+
+(For more details, see
+[local.yaml](https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml)
+in the server's source code).

--- a/web/apps/photos/.env
+++ b/web/apps/photos/.env
@@ -61,6 +61,9 @@
 # on port 3002 (using `yarn dev:albums`), we can connect to it and emulate the
 # production behaviour.
 #
+# Note: To use your custom albums endpoint in the generated public link, set the
+# `apps.public-albums` property in museum's configuration.
+#
 # Enhancement: Consider splitting this into a separate app/ in this repository.
 # That can also reduce bundle sizes and make it load faster.
 #

--- a/web/apps/photos/src/utils/collection/index.ts
+++ b/web/apps/photos/src/utils/collection/index.ts
@@ -1,7 +1,6 @@
 import { ensureElectron } from "@/next/electron";
 import log from "@/next/log";
 import { CustomError } from "@ente/shared/error";
-import { getAlbumsURL } from "@ente/shared/network/api";
 import { LS_KEYS, getData } from "@ente/shared/storage/localStorage";
 import { getUnixTimeInMicroSecondsWithDelta } from "@ente/shared/time";
 import { User } from "@ente/shared/user/types";
@@ -189,11 +188,6 @@ export function appendCollectionKeyToShareURL(
     }
 
     const sharableURL = new URL(url);
-    const albumsURL = new URL(getAlbumsURL());
-
-    sharableURL.protocol = albumsURL.protocol;
-    sharableURL.host = albumsURL.host;
-    sharableURL.pathname = albumsURL.pathname;
 
     const bytes = Buffer.from(collectionKey, "base64");
     sharableURL.hash = bs58.encode(bytes);


### PR DESCRIPTION
When implementing https://github.com/ente-io/ente/pull/1443 it was found that the Photos web app wasnt' using the sharedCollectionUrl prefix that is returned by the server. Instead, it was using NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT as the baseHost, while mobile client completely rely on the server for returning the correct hostUrl.

**Tested by**

Running against the modified server, and verifying that changes to apps.public-albums were being used.
