### PR TITLE
[desktop] Fix desktop payments redirect

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -32,7 +32,7 @@ import { isDev } from "./main/util";
 /**
  * The URL where the renderer HTML is being served from.
  */
-export const rendererURL = "next://app";
+export const rendererURL = "ente://app";
 
 /**
  * We want to hide our window instead of closing it when the user presses the
@@ -63,7 +63,7 @@ export const allowWindowClose = (): void => {
  * production mode and `next dev` in development mode, whilst keeping the rest
  * of our code the same.
  *
- * It uses protocol handlers to serve files from the "next://app" protocol
+ * It uses protocol handlers to serve files from the "ente://" protocol.
  *
  * - In development this is proxied to http://localhost:3000
  * - In production it serves files from the `/out` directory

--- a/web/apps/payments/README.md
+++ b/web/apps/payments/README.md
@@ -73,8 +73,9 @@ stripe:
         key: stripe_dev_key
         webhook-secret: stripe_dev_webhook_secret
     whitelisted-redirect-urls:
-        - "http://localhost:3000/gallery"
-        - "http://192.168.1.2:3001/frameRedirect"
+        - http://localhost:3000/gallery
+        - http://localhost:3001/desktop-redirect
+        - http://192.168.1.2:3001/frameRedirect
     path:
         success: ?status=success&session_id={CHECKOUT_SESSION_ID}
         cancel: ?status=fail&reason=canceled

--- a/web/apps/payments/src/services/billing-service.ts
+++ b/web/apps/payments/src/services/billing-service.ts
@@ -9,6 +9,12 @@ import { loadStripe } from "@stripe/stripe-js";
  * redirect to the client or to some fallback URL.
  */
 export const parseAndHandleRequest = async () => {
+    // See: [Note: Intercept payments redirection to desktop app]
+    if (window.location.pathname == "/desktop-redirect") {
+        window.location.href = "ente://app";
+        return;
+    }
+
     try {
         const urlParams = new URLSearchParams(window.location.search);
         const productID = urlParams.get("productID");
@@ -291,6 +297,8 @@ const redirectToApp = (
     status: RedirectStatus,
     reason?: FailureReason,
 ) => {
+    // [Note: Intercept payments redirection to desktop app]
+    //
     // The desktop app passes "<our-origin>/desktop-redirect" as `redirectURL`.
     // This is just a placeholder, we want to intercept this and instead
     // redirect to the ente:// scheme protocol handler that is internally being

--- a/web/apps/payments/src/services/billing-service.ts
+++ b/web/apps/payments/src/services/billing-service.ts
@@ -11,7 +11,9 @@ import { loadStripe } from "@stripe/stripe-js";
 export const parseAndHandleRequest = async () => {
     // See: [Note: Intercept payments redirection to desktop app]
     if (window.location.pathname == "/desktop-redirect") {
-        window.location.href = "ente://app";
+        const desktopRedirectURL = new URL("ente://app/gallery");
+        desktopRedirectURL.search = new URL(window.location.href).search;
+        window.location.href = desktopRedirectURL.href;
         return;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/ente-io/ente/issues/1440

There were two issues:

- It was a backward incompatible change to change the scheme from ente:// to next://. Revert.

- We also need to setup a top level redirect when the user presses back without making any changes to their subscription.

**Tested by**

Running payments app and desktop app locally, and verifying that

- [x] Signing up for a new account, purchasing a plan and verifying that we went back to the app as expected
- [x] Existing account, after pressing back from the manage payments page we go back to the app as expected
