### PR TITLE
[web] Clear search bar state when value is falsey

### DIFF
--- a/web/apps/photos/src/components/Search/SearchBar/searchInput/index.tsx
+++ b/web/apps/photos/src/components/Search/SearchBar/searchInput/index.tsx
@@ -56,10 +56,8 @@ export default function SearchInput(props: Iprops) {
     const [value, setValue] = useState<SearchOption>(null);
     const appContext = useContext(AppContext);
     const handleChange = (value: SearchOption) => {
-        if (value) {
-            setValue(value);
-            setQuery(value.label);
-        }
+        setValue(value);
+        setQuery(value?.label);
 
         blur();
     };


### PR DESCRIPTION
Updates https://github.com/ente-io/ente/pull/1453 so that we also clear the existing state by calling the setFoo methods even when value is falsey.
