### PR TITLE
[server] Specify a default for apps.public-albums

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -73,8 +73,11 @@ http:
 
 # Specify the base endpoints for various apps
 apps:
-    public-albums: "https://albums.ente.io"
-
+    # Default is https://albums.ente.io
+    #
+    # If you're running a self hosted instance and wish to serve public links,
+    # set this to the URL where your albums web app is running.
+    public-albums:
 
 # Database connection parameters
 db:

--- a/server/pkg/repo/public_collection.go
+++ b/server/pkg/repo/public_collection.go
@@ -23,7 +23,7 @@ type PublicCollectionRepository struct {
 // NewPublicCollectionRepository ..
 func NewPublicCollectionRepository(db *sql.DB, albumHost string) *PublicCollectionRepository {
 	if albumHost == "" {
-		panic("albumHost can not be empty")
+		albumHost = "https://albums.ente.io"
 	}
 	return &PublicCollectionRepository{
 		DB:        db,


### PR DESCRIPTION
local.yaml is only loaded in the local environment, and will not be used in production. To avoid specifying it in both production and local configurations, use it as a default specified in the code instead (that's the pattern we're using in other places too from what I remember, maybe we should refactor that too, but that's a bigger task not tied to this change).

**Tested by**

On a local dev cluster

- [x] Not specifying anything and ensuring that the default is picked
- [x] Specifying an override in museum.yaml and verifying that is used instead
