### PR TITLE
[mob][photos] Use sqlite_async instead of sqlite3

### DIFF
--- a/mobile/lib/db/files_db.dart
+++ b/mobile/lib/db/files_db.dart
@@ -478,8 +478,8 @@ class FilesDB {
   }
 
   Future<EnteFile?> getFile(int generatedID) async {
-    final db = await instance.ffiDB;
-    final results = db.select(
+    final db = await instance.sqliteAsyncDB;
+    final results = await db.getAll(
       'SELECT * FROM $filesTable WHERE $columnGeneratedID = ?',
       [generatedID],
     );
@@ -490,8 +490,8 @@ class FilesDB {
   }
 
   Future<EnteFile?> getUploadedFile(int uploadedID, int collectionID) async {
-    final db = await instance.ffiDB;
-    final results = db.select(
+    final db = await instance.sqliteAsyncDB;
+    final results = await db.getAll(
       'SELECT * FROM $filesTable WHERE $columnUploadedFileID = ? AND $columnCollectionID = ?',
       [
         uploadedID,
@@ -505,8 +505,8 @@ class FilesDB {
   }
 
   Future<Set<int>> getUploadedFileIDs(int collectionID) async {
-    final db = await instance.ffiDB;
-    final results = db.select(
+    final db = await instance.sqliteAsyncDB;
+    final results = await db.getAll(
       'SELECT $columnUploadedFileID FROM $filesTable'
       ' WHERE $columnCollectionID = ? AND ($columnUploadedFileID IS NOT NULL AND $columnUploadedFileID IS NOT -1)',
       [
@@ -755,41 +755,6 @@ class FilesDB {
         'SELECT * FROM $filesTable WHERE $whereClause ORDER BY $columnCreationTime $order';
     final results = await db.getAll(
       query,
-    );
-
-    final files = convertToFiles(results);
-    return applyDBFilters(
-      files,
-      DBFilterOptions(ignoredCollectionIDs: ignoredCollectionIDs),
-    );
-  }
-
-  Future<List<EnteFile>> getFilesCreatedWithinDurationsSync(
-    List<List<int>> durations,
-    Set<int> ignoredCollectionIDs, {
-    int? visibility,
-    String order = 'ASC',
-  }) async {
-    if (durations.isEmpty) {
-      return <EnteFile>[];
-    }
-    final db = await instance.ffiDB;
-    String whereClause = "( ";
-    for (int index = 0; index < durations.length; index++) {
-      whereClause += "($columnCreationTime >= " +
-          durations[index][0].toString() +
-          " AND $columnCreationTime < " +
-          durations[index][1].toString() +
-          ")";
-      if (index != durations.length - 1) {
-        whereClause += " OR ";
-      } else if (visibility != null) {
-        whereClause += ' AND $columnMMdVisibility = $visibility';
-      }
-    }
-    whereClause += ")";
-    final results = db.select(
-      'select * from $filesTable where $whereClause order by $columnCreationTime $order',
     );
     final files = convertToFiles(results);
     return applyDBFilters(

--- a/mobile/lib/db/files_db.dart
+++ b/mobile/lib/db/files_db.dart
@@ -106,6 +106,7 @@ class FilesDB {
   static Future<sqlite3.Database>? _ffiDBFuture;
   static Future<sqlite_async.SqliteDatabase>? _sqliteAsyncDBFuture;
 
+  @Deprecated("Use ffiDB instead (sqlite_async)")
   Future<Database> get database async {
     // lazily instantiate the db the first time it is accessed
     _dbFuture ??= _initDatabase();

--- a/mobile/lib/services/memories_service.dart
+++ b/mobile/lib/services/memories_service.dart
@@ -107,7 +107,7 @@ class MemoriesService extends ChangeNotifier {
     }
     final ignoredCollections =
         CollectionsService.instance.archivedOrHiddenCollectionIds();
-    final files = await _filesDB.getFilesCreatedWithinDurationsSync(
+    final files = await _filesDB.getFilesCreatedWithinDurations(
       durations,
       ignoredCollections,
       visibility: visibleVisibility,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2039,7 +2039,7 @@ packages:
     source: hosted
     version: "0.3.0"
   sqlite3:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sqlite3
       sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -140,7 +140,6 @@ dependencies:
   shared_preferences: ^2.0.5
   sqflite: ^2.3.0
   sqflite_migration: ^0.3.0
-  sqlite3: ^2.1.0
   sqlite3_flutter_libs: ^0.5.20
   sqlite_async: ^0.6.1
   step_progress_indicator: ^1.0.2


### PR DESCRIPTION
## Description

Using both `sqlite_async` and `sqlite3` for querying at the same time was throwing this error:
`error: SqliteException(5): while executing, database is locked, database is locked (code 5)`

So, have used `sqlite_async` everywhere.

## Tests

- [x] Tested all changes