### PR TITLE
[mob] Discard upload to deleted or others collection

### DIFF
--- a/mobile/lib/services/collections_service.dart
+++ b/mobile/lib/services/collections_service.dart
@@ -189,6 +189,23 @@ class CollectionsService {
     return result;
   }
 
+  bool allowUpload(int collectionID) {
+    final Collection? c = _collectionIDToCollections[collectionID];
+    if (c == null) {
+      _logger.info('discardUpload: collectionMissing $collectionID');
+      return false;
+    }
+    if (c.isDeleted) {
+      _logger.info('discardUpload: collectionDeleted $collectionID');
+      return false;
+    }
+    if (!c.isOwner(_config.getUserID()!)) {
+      _logger.info('discardUpload: notOwner $collectionID');
+      return false;
+    }
+    return true;
+  }
+
   Future<List<Collection>> getArchivedCollection() async {
     final allCollections = getCollectionsForUI();
     return allCollections

--- a/mobile/lib/utils/file_uploader.dart
+++ b/mobile/lib/utils/file_uploader.dart
@@ -401,6 +401,16 @@ class FileUploader {
       _logger.severe('Trying to upload file with missing localID');
       return file;
     }
+    if (!CollectionsService.instance.allowUpload(collectionID)) {
+      _logger.warning(
+        'Upload not allowed for collection $collectionID',
+      );
+      if (!file.isUploaded && file.generatedID != null) {
+        _logger.info("Deleting file entry for " + file.toString());
+        await FilesDB.instance.deleteByGeneratedID(file.generatedID!);
+      }
+      return file;
+    }
 
     final String lockKey = file.localID!;
 


### PR DESCRIPTION
## Description
On server, certain uploads are getting rejected because the upload is being made on a collection that's not owned by the user.
Still looking for the root cause where it's happening, this check during upload ensures that the client is not repeatitively trying to upload the file.

## Tests
