### PR TITLE
[mob][photos] Generate face crops faster

### DIFF
--- a/mobile/lib/face/model/box.dart
+++ b/mobile/lib/face/model/box.dart
@@ -41,3 +41,23 @@ class FaceBox {
         'height': height,
       };
 }
+
+/// Bounding box of a face.
+///
+/// [xMin] and [yMin] are the coordinates of the top left corner of the box, and
+/// [width] and [height] are the width and height of the box.
+///
+/// One unit is equal to one pixel in the original image.
+class FaceBoxImage {
+  final int xMin;
+  final int yMin;
+  final int width;
+  final int height;
+
+  FaceBoxImage({
+    required this.xMin,
+    required this.yMin,
+    required this.width,
+    required this.height,
+  });
+}

--- a/mobile/lib/ui/viewer/file_details/face_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/face_widget.dart
@@ -20,7 +20,7 @@ import "package:photos/utils/face/face_box_crop.dart";
 import "package:photos/utils/thumbnail_util.dart";
 // import "package:photos/utils/toast_util.dart";
 
-const useGeneratedFaceCrops = false;
+const useGeneratedFaceCrops = true;
 
 class FaceWidget extends StatefulWidget {
   final EnteFile file;

--- a/mobile/lib/ui/viewer/file_details/face_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/face_widget.dart
@@ -267,7 +267,7 @@ class _FaceWidgetState extends State<FaceWidget> {
                 SizedBox(
                   width: 60,
                   height: 60,
-                  child: CroppedFaceImageView(
+                  child: CroppedFaceImgImageView(
                     enteFile: widget.file,
                     face: widget.face,
                   ),

--- a/mobile/lib/ui/viewer/file_details/face_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/face_widget.dart
@@ -288,7 +288,7 @@ class _FaceWidgetState extends State<FaceWidget> {
                         child: SizedBox(
                           width: 60,
                           height: 60,
-                          child: CroppedFaceImgImageView(
+                          child: CroppedFaceImageView(
                             enteFile: widget.file,
                             face: widget.face,
                           ),

--- a/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
+++ b/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
@@ -1,14 +1,11 @@
+import 'dart:developer' show log;
 import "dart:io" show File;
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import "package:image/image.dart" as img;
-import "package:logging/logging.dart";
 import "package:photos/face/model/face.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 import "package:photos/utils/file_util.dart";
-import "package:photos/utils/image_util.dart";
 
 class CroppedFaceInfo {
   final Image image;
@@ -24,7 +21,7 @@ class CroppedFaceInfo {
   });
 }
 
-class CroppedFaceImageView extends StatefulWidget {
+class CroppedFaceImageView extends StatelessWidget {
   final EnteFile enteFile;
   final Face face;
 
@@ -35,74 +32,85 @@ class CroppedFaceImageView extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  CroppedFaceImageViewState createState() => CroppedFaceImageViewState();
-}
-
-class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
-  ui.Image? _image;
-  final _logger = Logger("CroppedFaceImageView");
-
-  @override
-  void initState() {
-    super.initState();
-    _loadImage();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-    _image?.dispose();
-  }
-
-  Future<void> _loadImage() async {
-    final image = await getImage();
-    if (mounted) {
-      setState(() {
-        _image = image;
-      });
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return _image != null
-        ? LayoutBuilder(
-            builder: (context, constraints) {
-              return RawImage(
-                image: _image!,
+    return FutureBuilder(
+      future: getImage(),
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          return LayoutBuilder(
+            builder: ((context, constraints) {
+              final double imageAspectRatio = enteFile.width / enteFile.height;
+              final Image image = snapshot.data!;
+
+              final double viewWidth = constraints.maxWidth;
+              final double viewHeight = constraints.maxHeight;
+
+              final faceBox = face.detection.box;
+
+              final double relativeFaceCenterX =
+                  faceBox.xMin + faceBox.width / 2;
+              final double relativeFaceCenterY =
+                  faceBox.yMin + faceBox.height / 2;
+
+              const double desiredFaceHeightRelativeToWidget = 8 / 10;
+              final double scale =
+                  (1 / faceBox.height) * desiredFaceHeightRelativeToWidget;
+
+              final double widgetCenterX = viewWidth / 2;
+              final double widgetCenterY = viewHeight / 2;
+
+              final double widgetAspectRatio = viewWidth / viewHeight;
+              final double imageToWidgetRatio =
+                  imageAspectRatio / widgetAspectRatio;
+
+              double offsetX =
+                  (widgetCenterX - relativeFaceCenterX * viewWidth) * scale;
+              double offsetY =
+                  (widgetCenterY - relativeFaceCenterY * viewHeight) * scale;
+
+              if (imageAspectRatio < widgetAspectRatio) {
+                // Landscape Image: Adjust offsetX more conservatively
+                offsetX = offsetX * imageToWidgetRatio;
+              } else {
+                // Portrait Image: Adjust offsetY more conservatively
+                offsetY = offsetY / imageToWidgetRatio;
+              }
+              return ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.elliptical(16, 12)),
+                child: Transform.translate(
+                  offset: Offset(
+                    offsetX,
+                    offsetY,
+                  ),
+                  child: Transform.scale(
+                    scale: scale,
+                    child: image,
+                  ),
+                ),
               );
-            },
-          )
-        : ThumbnailWidget(widget.enteFile);
+            }),
+          );
+        } else {
+          if (snapshot.hasError) {
+            log('Error getting cover face for person: ${snapshot.error}');
+          }
+          return ThumbnailWidget(
+            enteFile,
+          );
+        }
+      },
+    );
   }
 
-  Future<ui.Image?> getImage() async {
-    try {
-      final faceBox = widget.face.detection.box;
-      final File? ioFile = await getFile(widget.enteFile);
-      if (ioFile == null) {
-        return null;
-      }
-
-      final image = await img.decodeImageFile(ioFile.path);
-
-      if (image == null) {
-        throw Exception("Failed decoding image file ${widget.enteFile.title}}");
-      }
-
-      final croppedImage = img.copyCrop(
-        image,
-        x: (image.width * faceBox.xMin).round(),
-        y: (image.height * faceBox.yMin).round(),
-        width: (image.width * faceBox.width).round(),
-        height: (image.height * faceBox.height).round(),
-        antialias: false,
-      );
-
-      return convertImageToFlutterUi(croppedImage);
-    } catch (e, s) {
-      _logger.severe("Error getting image", e, s);
+  Future<Image?> getImage() async {
+    final File? ioFile = await getFile(enteFile);
+    if (ioFile == null) {
       return null;
     }
+
+    final imageData = await ioFile.readAsBytes();
+    final image = Image.memory(imageData, fit: BoxFit.contain);
+
+    return image;
   }
 }

--- a/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
+++ b/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
@@ -1,7 +1,10 @@
 import "dart:io" show File;
 import 'dart:ui' as ui;
 
+import "package:computer/computer.dart";
 import 'package:flutter/material.dart';
+import "package:flutter/widgets.dart";
+import "package:flutter_image_compress/flutter_image_compress.dart";
 import "package:image/image.dart" as img;
 import "package:logging/logging.dart";
 import "package:photos/face/model/face.dart";
@@ -40,6 +43,7 @@ class CroppedFaceImageView extends StatefulWidget {
 
 class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
   ui.Image? _image;
+  final _computer = Computer.shared();
   final _logger = Logger("CroppedFaceImageView");
 
   @override
@@ -79,17 +83,32 @@ class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
   Future<ui.Image?> getImage() async {
     try {
       final faceBox = widget.face.detection.box;
+
       final File? ioFile = await getFile(widget.enteFile);
       if (ioFile == null) {
         return null;
       }
 
-      final image = await img.decodeImageFile(ioFile.path);
+      img.Image? image = await _computer
+          .compute(decodeImage, param: {"filePath": ioFile.path});
 
       if (image == null) {
-        throw Exception("Failed decoding image file ${widget.enteFile.title}}");
+        _logger.info(
+          "Failed to decode image ${widget.enteFile.title}. Compressing to jpg and decoding",
+        );
+        final compressedJPGImage =
+            await FlutterImageCompress.compressWithFile(ioFile.path);
+        image = await _computer.compute(
+          decodeJPGImage,
+          param: {"image": compressedJPGImage},
+        );
+
+        if (image == null) {
+          throw Exception("Failed to decode image");
+        }
       }
 
+      final stopwatch = Stopwatch()..start();
       final croppedImage = img.copyCrop(
         image,
         x: (image.width * faceBox.xMin).round(),
@@ -98,11 +117,22 @@ class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
         height: (image.height * faceBox.height).round(),
         antialias: false,
       );
-
+      _logger.info(
+        "Image crop took ${stopwatch.elapsedMilliseconds}ms ----------------",
+      );
+      stopwatch.stop();
       return convertImageToFlutterUi(croppedImage);
     } catch (e, s) {
       _logger.severe("Error getting image", e, s);
       return null;
     }
   }
+}
+
+Future<img.Image?> decodeImage(Map args) async {
+  return await img.decodeImageFile(args["filePath"]);
+}
+
+img.Image? decodeJPGImage(Map args) {
+  return img.decodeJpg(args["image"])!;
 }

--- a/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
+++ b/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
@@ -1,15 +1,14 @@
 import "dart:io" show File;
+import "dart:typed_data";
 import 'dart:ui' as ui;
 
-import "package:computer/computer.dart";
 import 'package:flutter/material.dart';
 import "package:flutter/widgets.dart";
-import "package:flutter_image_compress/flutter_image_compress.dart";
-import "package:image/image.dart" as img;
 import "package:logging/logging.dart";
 import "package:photos/face/model/face.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
+import "package:photos/utils/face/face_util.dart";
 import "package:photos/utils/file_util.dart";
 import "package:photos/utils/image_util.dart";
 
@@ -27,23 +26,22 @@ class CroppedFaceInfo {
   });
 }
 
-class CroppedFaceImageView extends StatefulWidget {
+class CroppedFaceImgImageView extends StatefulWidget {
   final EnteFile enteFile;
   final Face face;
 
-  const CroppedFaceImageView({
+  const CroppedFaceImgImageView({
     Key? key,
     required this.enteFile,
     required this.face,
   }) : super(key: key);
 
   @override
-  CroppedFaceImageViewState createState() => CroppedFaceImageViewState();
+  CroppedFaceImgImageViewState createState() => CroppedFaceImgImageViewState();
 }
 
-class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
+class CroppedFaceImgImageViewState extends State<CroppedFaceImgImageView> {
   ui.Image? _image;
-  final _computer = Computer.shared();
   final _logger = Logger("CroppedFaceImageView");
 
   @override
@@ -89,39 +87,9 @@ class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
         return null;
       }
 
-      img.Image? image = await _computer
-          .compute(decodeImage, param: {"filePath": ioFile.path});
+      final image = await generateImgFaceThumbnails(ioFile.path, [faceBox]);
 
-      if (image == null) {
-        _logger.info(
-          "Failed to decode image ${widget.enteFile.title}. Compressing to jpg and decoding",
-        );
-        final compressedJPGImage =
-            await FlutterImageCompress.compressWithFile(ioFile.path);
-        image = await _computer.compute(
-          decodeJPGImage,
-          param: {"image": compressedJPGImage},
-        );
-
-        if (image == null) {
-          throw Exception("Failed to decode image");
-        }
-      }
-
-      final stopwatch = Stopwatch()..start();
-      final croppedImage = img.copyCrop(
-        image,
-        x: (image.width * faceBox.xMin).round(),
-        y: (image.height * faceBox.yMin).round(),
-        width: (image.width * faceBox.width).round(),
-        height: (image.height * faceBox.height).round(),
-        antialias: false,
-      );
-      _logger.info(
-        "Image crop took ${stopwatch.elapsedMilliseconds}ms ----------------",
-      );
-      stopwatch.stop();
-      return convertImageToFlutterUi(croppedImage);
+      return convertImageToFlutterUi(image.first);
     } catch (e, s) {
       _logger.severe("Error getting image", e, s);
       return null;
@@ -129,10 +97,72 @@ class CroppedFaceImageViewState extends State<CroppedFaceImageView> {
   }
 }
 
-Future<img.Image?> decodeImage(Map args) async {
-  return await img.decodeImageFile(args["filePath"]);
+class CroppedFaceJpgImageView extends StatefulWidget {
+  final EnteFile enteFile;
+  final Face face;
+
+  const CroppedFaceJpgImageView({
+    Key? key,
+    required this.enteFile,
+    required this.face,
+  }) : super(key: key);
+
+  @override
+  CroppedFaceJpgImageViewState createState() => CroppedFaceJpgImageViewState();
 }
 
-img.Image? decodeJPGImage(Map args) {
-  return img.decodeJpg(args["image"])!;
+class CroppedFaceJpgImageViewState extends State<CroppedFaceJpgImageView> {
+  Uint8List? _image;
+  final _logger = Logger("CroppedFaceImageView");
+
+  @override
+  void initState() {
+    super.initState();
+    _loadImage();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  Future<void> _loadImage() async {
+    final image = await getImage();
+    if (mounted) {
+      setState(() {
+        _image = image;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _image != null
+        ? LayoutBuilder(
+            builder: (context, constraints) {
+              return Image.memory(
+                _image!,
+              );
+            },
+          )
+        : ThumbnailWidget(widget.enteFile);
+  }
+
+  Future<Uint8List?> getImage() async {
+    try {
+      final faceBox = widget.face.detection.box;
+
+      final File? ioFile = await getFile(widget.enteFile);
+      if (ioFile == null) {
+        return null;
+      }
+
+      final image = await generateJpgFaceThumbnails(ioFile.path, [faceBox]);
+
+      return image.first;
+    } catch (e, s) {
+      _logger.severe("Error getting image", e, s);
+      return null;
+    }
+  }
 }

--- a/mobile/lib/ui/viewer/search/result/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/person_face_widget.dart
@@ -124,7 +124,7 @@ class PersonFaceWidget extends StatelessWidget {
             return Stack(
               fit: StackFit.expand,
               children: [
-                CroppedFaceImgImageView(enteFile: file, face: face),
+                CroppedFaceImageView(enteFile: file, face: face),
               ],
             );
           } else {

--- a/mobile/lib/ui/viewer/search/result/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/person_face_widget.dart
@@ -90,7 +90,7 @@ class PersonFaceWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!useGeneratedFaceCrops) {
+    if (useGeneratedFaceCrops) {
       return FutureBuilder<Uint8List?>(
         future: getFaceCrop(),
         builder: (context, snapshot) {

--- a/mobile/lib/ui/viewer/search/result/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/person_face_widget.dart
@@ -69,7 +69,7 @@ class PersonFaceWidget extends StatelessWidget {
             return Stack(
               fit: StackFit.expand,
               children: [
-                CroppedFaceImageView(enteFile: file, face: face),
+                CroppedFaceImgImageView(enteFile: file, face: face),
               ],
             );
           } else {

--- a/mobile/lib/utils/face/face_box_crop.dart
+++ b/mobile/lib/utils/face/face_box_crop.dart
@@ -5,8 +5,8 @@ import "package:photos/core/cache/lru_map.dart";
 import "package:photos/face/model/box.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
+import "package:photos/utils/face/face_util.dart";
 import "package:photos/utils/file_util.dart";
-import "package:photos/utils/image_ml_isolate.dart";
 import "package:photos/utils/thumbnail_util.dart";
 import "package:pool/pool.dart";
 
@@ -37,7 +37,8 @@ Future<Map<String, Uint8List>?> getFaceCrops(
     faceBoxes.add(e.value);
   }
   final List<Uint8List> faceCrop =
-      await ImageMlIsolate.instance.generateFaceThumbnailsForImage(
+      // await ImageMlIsolate.instance.generateFaceThumbnailsForImage(
+      await generateJpgFaceThumbnails(
     imagePath,
     faceBoxes,
   );

--- a/mobile/lib/utils/face/face_util.dart
+++ b/mobile/lib/utils/face/face_util.dart
@@ -1,3 +1,4 @@
+import "dart:math";
 import "dart:typed_data";
 
 import "package:computer/computer.dart";
@@ -8,6 +9,7 @@ import "package:photos/face/model/box.dart";
 
 final _logger = Logger("FaceUtil");
 final _computer = Computer.shared();
+const _faceImageBufferFactor = 0.2;
 
 ///Convert img.Image to ui.Image and use RawImage to display.
 Future<List<img.Image>> generateImgFaceThumbnails(
@@ -74,13 +76,74 @@ Future<img.Image> decodeToImgImage(String imagePath) async {
 
 /// Returns an Image from 'package:image/image.dart'
 img.Image cropFaceBoxFromImage(img.Image image, FaceBox faceBox) {
+  final squareFaceBox = _getSquareFaceBoxImage(image, faceBox);
+  final squareFaceBoxWithBuffer =
+      _addBufferAroundFaceBox(squareFaceBox, _faceImageBufferFactor);
   return img.copyCrop(
     image,
-    x: (image.width * faceBox.xMin).round(),
-    y: (image.height * faceBox.yMin).round(),
-    width: (image.width * faceBox.width).round(),
-    height: (image.height * faceBox.height).round(),
+    x: squareFaceBoxWithBuffer.xMin,
+    y: squareFaceBoxWithBuffer.yMin,
+    width: squareFaceBoxWithBuffer.width,
+    height: squareFaceBoxWithBuffer.height,
     antialias: false,
+  );
+}
+
+/// Returns a square face box image from the original image with
+/// side length equal to the maximum of the width and height of the face box in
+/// the OG image.
+FaceBoxImage _getSquareFaceBoxImage(img.Image image, FaceBox faceBox) {
+  final width = (image.width * faceBox.width).round();
+  final height = (image.height * faceBox.height).round();
+  final side = max(width, height);
+  final xImage = (image.width * faceBox.xMin).round();
+  final yImage = (image.height * faceBox.yMin).round();
+
+  if (height >= width) {
+    final xImageAdj = (xImage - (height - width) / 2).round();
+    return FaceBoxImage(
+      xMin: xImageAdj,
+      yMin: yImage,
+      width: side,
+      height: side,
+    );
+  } else {
+    final yImageAdj = (yImage - (width - height) / 2).round();
+    return FaceBoxImage(
+      xMin: xImage,
+      yMin: yImageAdj,
+      width: side,
+      height: side,
+    );
+  }
+}
+
+///To add some buffer around the face box so that the face isn't cropped
+///too close to the face.
+FaceBoxImage _addBufferAroundFaceBox(
+  FaceBoxImage faceBoxImage,
+  double bufferFactor,
+) {
+  final heightBuffer = faceBoxImage.height * bufferFactor;
+  final widthBuffer = faceBoxImage.width * bufferFactor;
+  final xMinWithBuffer = faceBoxImage.xMin - widthBuffer;
+  final yMinWithBuffer = faceBoxImage.yMin - heightBuffer;
+  final widthWithBuffer = faceBoxImage.width + 2 * widthBuffer;
+  final heightWithBuffer = faceBoxImage.height + 2 * heightBuffer;
+  //Do not add buffer if the top left edge of the image is out of bounds
+  //after adding the buffer.
+  if (xMinWithBuffer < 0 || yMinWithBuffer < 0) {
+    return faceBoxImage;
+  }
+  //Another similar case that can be handled is when the bottom right edge
+  //of the image is out of bounds after adding the buffer. But the
+  //the visual difference is not as significant as when the top left edge
+  //is out of bounds, so we are not handling that case.
+  return FaceBoxImage(
+    xMin: xMinWithBuffer.round(),
+    yMin: yMinWithBuffer.round(),
+    width: widthWithBuffer.round(),
+    height: heightWithBuffer.round(),
   );
 }
 

--- a/mobile/lib/utils/face/face_util.dart
+++ b/mobile/lib/utils/face/face_util.dart
@@ -1,0 +1,101 @@
+import "dart:typed_data";
+
+import "package:computer/computer.dart";
+import "package:flutter_image_compress/flutter_image_compress.dart";
+import "package:image/image.dart" as img;
+import "package:logging/logging.dart";
+import "package:photos/face/model/box.dart";
+
+final _logger = Logger("FaceUtil");
+final _computer = Computer.shared();
+
+///Convert img.Image to ui.Image and use RawImage to display.
+Future<List<img.Image>> generateImgFaceThumbnails(
+  String imagePath,
+  List<FaceBox> faceBoxes,
+) async {
+  final faceThumbnails = <img.Image>[];
+
+  img.Image? image =
+      await _computer.compute(_decodeImageFile, param: {"filePath": imagePath});
+
+  if (image == null) {
+    _logger.info(
+      "Failed to decode image. Compressing to jpg and decoding",
+    );
+    final compressedJPGImage =
+        await FlutterImageCompress.compressWithFile(imagePath);
+    image = await _computer.compute(
+      _decodeJpg,
+      param: {"image": compressedJPGImage},
+    );
+
+    if (image == null) {
+      throw Exception("Failed to decode image");
+    }
+  }
+
+  for (FaceBox faceBox in faceBoxes) {
+    final croppedImage = cropFaceBoxFromImage(image, faceBox);
+    faceThumbnails.add(croppedImage);
+  }
+
+  return faceThumbnails;
+}
+
+Future<List<Uint8List>> generateJpgFaceThumbnails(
+  String imagePath,
+  List<FaceBox> faceBoxes,
+) async {
+  img.Image? image =
+      await _computer.compute(_decodeImageFile, param: {"filePath": imagePath});
+
+  if (image == null) {
+    _logger.info(
+      "Failed to decode image. Compressing to jpg and decoding",
+    );
+    final compressedJPGImage =
+        await FlutterImageCompress.compressWithFile(imagePath);
+    image = await _computer.compute(
+      _decodeJpg,
+      param: {"image": compressedJPGImage},
+    );
+
+    if (image == null) {
+      throw Exception("Failed to decode image");
+    }
+  }
+  final croppedImages = <img.Image>[];
+  for (FaceBox faceBox in faceBoxes) {
+    final croppedImage = cropFaceBoxFromImage(image, faceBox);
+    croppedImages.add(croppedImage);
+  }
+
+  return await _computer
+      .compute(_encodeImagesToJpg, param: {"images": croppedImages});
+}
+
+/// Returns an Image from 'package:image/image.dart'
+img.Image cropFaceBoxFromImage(img.Image image, FaceBox faceBox) {
+  return img.copyCrop(
+    image,
+    x: (image.width * faceBox.xMin).round(),
+    y: (image.height * faceBox.yMin).round(),
+    width: (image.width * faceBox.width).round(),
+    height: (image.height * faceBox.height).round(),
+    antialias: false,
+  );
+}
+
+List<Uint8List> _encodeImagesToJpg(Map args) {
+  final images = args["images"] as List<img.Image>;
+  return images.map((img.Image image) => img.encodeJpg(image)).toList();
+}
+
+Future<img.Image?> _decodeImageFile(Map args) async {
+  return await img.decodeImageFile(args["filePath"]);
+}
+
+img.Image? _decodeJpg(Map args) {
+  return img.decodeJpg(args["image"])!;
+}

--- a/mobile/lib/utils/image_util.dart
+++ b/mobile/lib/utils/image_util.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
+import 'package:image/image.dart' as img;
 
 Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   final completer = Completer<ImageInfo>();
@@ -13,4 +15,36 @@ Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   imageStream.addListener(listener);
   completer.future.whenComplete(() => imageStream.removeListener(listener));
   return completer.future;
+}
+
+Future<ui.Image> convertImageToFlutterUi(img.Image image) async {
+  if (image.format != img.Format.uint8 || image.numChannels != 4) {
+    final cmd = img.Command()
+      ..image(image)
+      ..convert(format: img.Format.uint8, numChannels: 4);
+    final rgba8 = await cmd.getImageThread();
+    if (rgba8 != null) {
+      image = rgba8;
+    }
+  }
+
+  final ui.ImmutableBuffer buffer =
+      await ui.ImmutableBuffer.fromUint8List(image.toUint8List());
+
+  final ui.ImageDescriptor id = ui.ImageDescriptor.raw(
+    buffer,
+    height: image.height,
+    width: image.width,
+    pixelFormat: ui.PixelFormat.rgba8888,
+  );
+
+  final ui.Codec codec = await id.instantiateCodec(
+    targetHeight: image.height,
+    targetWidth: image.width,
+  );
+
+  final ui.FrameInfo fi = await codec.getNextFrame();
+  final ui.Image uiImage = fi.image;
+
+  return uiImage;
 }

--- a/mobile/lib/utils/image_util.dart
+++ b/mobile/lib/utils/image_util.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
-import 'package:image/image.dart' as img;
 
 Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   final completer = Completer<ImageInfo>();
@@ -15,37 +13,4 @@ Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   imageStream.addListener(listener);
   completer.future.whenComplete(() => imageStream.removeListener(listener));
   return completer.future;
-}
-
-///https://github.com/brendan-duncan/image/blob/main/doc/flutter.md
-Future<ui.Image> convertImageToFlutterUi(img.Image image) async {
-  if (image.format != img.Format.uint8 || image.numChannels != 4) {
-    final cmd = img.Command()
-      ..image(image)
-      ..convert(format: img.Format.uint8, numChannels: 4);
-    final rgba8 = await cmd.getImageThread();
-    if (rgba8 != null) {
-      image = rgba8;
-    }
-  }
-
-  final ui.ImmutableBuffer buffer =
-      await ui.ImmutableBuffer.fromUint8List(image.toUint8List());
-
-  final ui.ImageDescriptor id = ui.ImageDescriptor.raw(
-    buffer,
-    height: image.height,
-    width: image.width,
-    pixelFormat: ui.PixelFormat.rgba8888,
-  );
-
-  final ui.Codec codec = await id.instantiateCodec(
-    targetHeight: image.height,
-    targetWidth: image.width,
-  );
-
-  final ui.FrameInfo fi = await codec.getNextFrame();
-  final ui.Image uiImage = fi.image;
-
-  return uiImage;
 }

--- a/mobile/lib/utils/image_util.dart
+++ b/mobile/lib/utils/image_util.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
+import 'package:image/image.dart' as img;
 
 Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   final completer = Completer<ImageInfo>();
@@ -13,4 +15,37 @@ Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
   imageStream.addListener(listener);
   completer.future.whenComplete(() => imageStream.removeListener(listener));
   return completer.future;
+}
+
+///https://github.com/brendan-duncan/image/blob/main/doc/flutter.md
+Future<ui.Image> convertImageToFlutterUi(img.Image image) async {
+  if (image.format != img.Format.uint8 || image.numChannels != 4) {
+    final cmd = img.Command()
+      ..image(image)
+      ..convert(format: img.Format.uint8, numChannels: 4);
+    final rgba8 = await cmd.getImageThread();
+    if (rgba8 != null) {
+      image = rgba8;
+    }
+  }
+
+  final ui.ImmutableBuffer buffer =
+      await ui.ImmutableBuffer.fromUint8List(image.toUint8List());
+
+  final ui.ImageDescriptor id = ui.ImageDescriptor.raw(
+    buffer,
+    height: image.height,
+    width: image.width,
+    pixelFormat: ui.PixelFormat.rgba8888,
+  );
+
+  final ui.Codec codec = await id.instantiateCodec(
+    targetHeight: image.height,
+    targetWidth: image.width,
+  );
+
+  final ui.FrameInfo fi = await codec.getNextFrame();
+  final ui.Image uiImage = fi.image;
+
+  return uiImage;
 }


### PR DESCRIPTION
## Description

Have written two new methods, `generateImgFaceThumbnails()` and `generateJpgFaceThumbnails()`.
Using `generateJpgFaceThumbnails()` now since it returns `Future<List<Uint8List>>` and is easier to integrate within the code base because the return type remains the same with the older `generateFaceThumbnailsForImage()`

There is performance improvement with `generateImgFaceThumbnails()`, but it's not very significant and it requires changes in codebase to work with it's return type `Future<List<Image>>` (`Image` from the `Image` package). Can consider using it if it feels necessary in future.

If multiple faces are being generated from the same image, the image can be decoded once and passed to `generateImgFaceThumbnails()` or `generateJpgFaceThumbnails()` to avoid repeated decoding of the same image. 

`generateImgFaceThumbnails()` and `generateJpgFaceThumbnails()` uses the isolates available from the pool of 4 spawned by `Computer` and processes multiple faces in parallel unlike `generateImgFaceThumbnails()`, which processes only one at a time.
