### PR TITLE
[web] Allow thumbnail cache to be optional

### DIFF
--- a/web/apps/photos/src/services/download/index.ts
+++ b/web/apps/photos/src/services/download/index.ts
@@ -150,7 +150,7 @@ class DownloadManagerImpl {
         this.ensureInitialized();
 
         const key = file.id.toString();
-        const cached = await this.thumbnailCache.get(key);
+        const cached = await this.thumbnailCache?.get(key);
         if (cached) return new Uint8Array(await cached.arrayBuffer());
         if (localOnly) return null;
 


### PR DESCRIPTION
See: https://github.com/ente-io/ente/discussions/1449#discussioncomment-9255346

I'm not yet sure what was the case why it was not initialized, hoping to get some logs for the error when initializing the cache to see how we got to this state. But meanwhile, ensure that the code works even without the cache.
