### PR TITLE
[desktop] Electron 30

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^7",
         "@typescript-eslint/parser": "^7",
         "concurrently": "^8",
-        "electron": "^29",
+        "electron": "^30",
         "electron-builder": "^24",
         "electron-builder-notarize": "^1.5",
         "eslint": "^8",

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -127,15 +127,7 @@ const registerPrivilegedSchemes = () => {
         {
             scheme: "stream",
             privileges: {
-                // TODO(MR): Remove the commented bits if we don't end up
-                // needing them by the time the IPC refactoring is done.
-
-                // Prevent the insecure origin issues when fetching this
-                // secure: true,
-                // Allow the web fetch API in the renderer to use this scheme.
                 supportFetchAPI: true,
-                // Allow it to be used with video tags.
-                // stream: true,
             },
         },
     ]);

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -217,7 +217,25 @@ const watchReset = async () => {
 
 // - Upload
 
-const pathForFile = (file: File) => webUtils.getPathForFile(file);
+const pathForFile = (file: File) => {
+    const path = webUtils.getPathForFile(file);
+    // The path that we get back from `webUtils.getPathForFile` on Windows uses
+    // "/" as the path separator. Convert them to POSIX separators.
+    //
+    // Note that we do not have access to the path or the os module in the
+    // preload script, thus this hand rolled transformation.
+
+    // However that makes TypeScript fidgety since we it cannot find navigator,
+    // as we haven't included "lib": ["dom"] in our tsconfig to avoid making DOM
+    // APIs available to our main Node.js code. We could create a separate
+    // tsconfig just for the preload script, but for now let's go with a cast.
+    //
+    // @ts-expect-error navigator is not defined.
+    const platform = (navigator as { platform: string }).platform;
+    return platform.toLowerCase().includes("win")
+        ? path.split("\\").join("/")
+        : path;
+};
 
 const listZipItems = (zipPath: string) =>
     ipcRenderer.invoke("listZipItems", zipPath);

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -1199,10 +1199,10 @@ electron-updater@^6.1:
     semver "^7.3.8"
     tiny-typed-emitter "^2.1.0"
 
-electron@^29:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.3.1.tgz#87c82b2cd2c326f78f036499377a5448bea5d4bb"
-  integrity sha512-auge1/6RVqgUd6TgIq88wKdUCJi2cjESi3jy7d+6X4JzvBGprKBqMJ8JSSFpu/Px1YJrFUKAxfy6SC+TQf1uLw==
+electron@^30:
+  version "30.0.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-30.0.2.tgz#95ba019216bf8be9f3097580123e33ea37497733"
+  integrity sha512-zv7T+GG89J/hyWVkQsLH4Y/rVEfqJG5M/wOBIGNaDdqd8UV9/YZPdS7CuFeaIj0H9LhCt95xkIQNpYB/3svOkQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"

--- a/web/apps/photos/src/utils/native-stream.ts
+++ b/web/apps/photos/src/utils/native-stream.ts
@@ -93,39 +93,20 @@ export const writeStream = async (
     const params = new URLSearchParams({ path });
     const url = new URL(`stream://write?${params.toString()}`);
 
-    // TODO(MR): This doesn't currently work.
-    //
-    // Not sure what I'm doing wrong here; I've opened an issue upstream
-    // https://github.com/electron/electron/issues/41872
-    //
-    // A gist with a minimal reproduction
-    // https://gist.github.com/mnvr/e08d9f4876fb8400b7615347b4d268eb
-    //
-    // Meanwhile, write the complete body in one go (this'll eventually run into
-    // memory failures with large files - just a temporary stopgap to get the
-    // code to work).
-
-    /*
     // The duplex parameter needs to be set to 'half' when streaming requests.
     //
     // Currently browsers, and specifically in our case, since this code runs
     // only within our desktop (Electron) app, Chromium, don't support 'full'
     // duplex mode (i.e. streaming both the request and the response).
     // https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests
-    const req = new Request(`stream://write${path}`, {
+    const req = new Request(url, {
         // GET can't have a body
         method: "POST",
         body: stream,
-        // --@ts-expect-error TypeScript's libdom.d.ts does not include the
+        // @ts-expect-error TypeScript's libdom.d.ts does not include the
         // "duplex" parameter, e.g. see
         // https://github.com/node-fetch/node-fetch/issues/1769.
         duplex: "half",
-    });
-    */
-
-    const req = new Request(url, {
-        method: "POST",
-        body: await new Response(stream).blob(),
     });
 
     const res = await fetch(req);


### PR DESCRIPTION
Upgrade to Electron 30 to get the streaming request fix we need.

Also add a workaround to get POSIX paths from webUtils on Windows. For the test case, see this [Fiddle](https://gist.github.com/mnvr/91eaca21b0651926565274ee80f10ad5).
