### PR TITLE
[cli] Documentation improvement

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -36,13 +36,20 @@ ente --help
 
 ### Accounts
 
-If you wish, you can add multiple accounts (your own and that of your family members) and export all data using this tool.
+If you wish, you can add multiple accounts (your own and that of your family
+members) and export all data using this tool.
 
 #### Add an account
 
 ```shell
 ente account add
 ```
+
+> [!NOTE]
+>
+> `ente account add` does not create new accounts, it just adds pre-existing
+> accounts to the list of accounts that the CLI knows about so that you can use
+> them for other actions.
 
 #### List accounts
 

--- a/docs/docs/self-hosting/guides/custom-server/index.md
+++ b/docs/docs/self-hosting/guides/custom-server/index.md
@@ -25,10 +25,13 @@ configure the endpoint the app should be connecting to.
 > You can download the CLI from
 > [here](https://github.com/ente-io/ente/releases?q=tag%3Acli-v0)
 
-Define a config.yaml and put it either in the same directory as CLI or path
-defined in env variable `ENTE_CLI_CONFIG_PATH`
+Define a config.yaml and put it either in the same directory as where you run
+the CLI from ("current working directory"), or in the path defined in env
+variable `ENTE_CLI_CONFIG_PATH`:
 
 ```yaml
 endpoint:
     api: "http://localhost:8080"
 ```
+
+(Another [example](https://github.com/ente-io/ente/blob/main/cli/config.yaml.example))


### PR DESCRIPTION
- Clarify that config.yaml needs to go to CWD
- Add a notice about ente account add (I think it is the second time someone got confused about this)

Maybe we can also print a notice or the help docs when `ente` is run without any arguments (just a thought for future changes)
