### PR TITLE
[desktop] Run the electron builder in the correct path

### DIFF
--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -71,6 +71,8 @@ jobs:
             - name: Build
               uses: ente-io/action-electron-builder@v1.0.0
               with:
+                  package_root: desktop
+
                   # GitHub token, automatically provided to the action
                   # (No need to define this secret in the repo settings)
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -34,22 +34,11 @@ The workflow is:
     git push origin photosd-v1.x.x
     ```
 
-3.  Head over to the releases repository, copy all relevant changes from the
-    source repository, commit and push the changes.
+3.  Head over to the releases repository and run the trigger script, passing it
+    the tag _without_ the `photosd-` prefix.
 
     ```sh
-    cp ../ente/desktop/CHANGELOG.md CHANGELOG.md
-    git add CHANGELOG.md
-    git commit -m 'Release v1.x.x'
-    git push origin main
-    ```
-
-4.  Tag this commit, but this time _don't_ use the `photosd-` prefix. Push the
-    tag to trigger the GitHub action.
-
-    ```sh
-    git tag v1.x.x
-    git push origin v1.x.x
+    ./.github/trigger-release.sh v1.x.x
     ```
 
 ## Post build


### PR DESCRIPTION
Also add a convenience script to the [photos-desktop repo](https://github.com/ente-io/photos-desktop/blob/main/.github/trigger-release.sh):

```sh
#!/bin/sh

set -o errexit

version="$1"
if test -z "$version"
then
    echo "usage: `basename $0` <version-including-v>"
    exit 1
fi

set -o xtrace

cp ../ente/desktop/CHANGELOG.md CHANGELOG.md
cp ../ente/desktop/.github/workflows/desktop-release.yml .github/workflows/
git add CHANGELOG.md .github/workflows/desktop-release.yml
git commit -m "$version"
git push origin main

git tag "$version"
git push origin "$version"
```