### PR TITLE
[mob][photos] Request for ACCESS_MEDIA_LOCATION permission if not granted

### DIFF
--- a/mobile/lib/utils/file_uploader.dart
+++ b/mobile/lib/utils/file_uploader.dart
@@ -376,7 +376,13 @@ class FileUploader {
     if (Platform.isAndroid) {
       final bool hasPermission = await Permission.accessMediaLocation.isGranted;
       if (!hasPermission) {
-        throw NoMediaLocationAccessError();
+        final permissionStatus = await Permission.accessMediaLocation.request();
+        if (!permissionStatus.isGranted) {
+          _logger.severe(
+            "Media location access denied with permission status: ${permissionStatus.name}",
+          );
+          throw NoMediaLocationAccessError();
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

https://github.com/ente-io/ente/blob/a5d05decf299aa1677d88a42929d674b9c33d6d3/mobile/lib/utils/photo_manager_util.dart#L8

^passing true here should let the app have `ACCESS_MEDIA_LOCATION` permission. But looks like that isn't working for a small set of users. So, asking for permission explicitly.
