### PR TITLE
[desktop] Add a workaround for the SUID sandbox helper error on Linux

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -134,6 +134,15 @@ const registerPrivilegedSchemes = () => {
 };
 
 /**
+ * The Chromium sandbox causes the app to fail to run on various Linux
+ * distributions. Reproducible on Ubuntu 24.
+ *
+ * See: https://github.com/electron/electron/issues/17972
+ */
+const suidWorkaroundOnLinux = () =>
+    process.platform == "linux" && app.commandLine.appendSwitch("--no-sandbox");
+
+/**
  * Create an return the {@link BrowserWindow} that will form our app's UI.
  *
  * This window will show the HTML served from {@link rendererURL}.
@@ -356,6 +365,7 @@ const main = () => {
 
     initLogging();
     logStartupBanner();
+    suidWorkaroundOnLinux();
     // The order of the next two calls is important
     setupRendererServer();
     registerPrivilegedSchemes();


### PR DESCRIPTION
I am able to reproduce this on Ubuntu 24 ARM.

> The SUID sandbox helper binary was found, but is not configured correctly.

See:
- https://github.com/electron/electron/issues/17972
- https://stackoverflow.com/questions/63780918/building-electron-linux-distro-the-suid-sandbox-helper-binary-was-found-but-i
