### PR TITLE
[desktop] --no-sandbox does not prevent the SUID abort when added from JS

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## v1.7.0 (Unreleased)
 
-v1.7 is a major rewrite to improve the security of our app. We have enabled
-sandboxing and disabled node integration for the renderer process. All this
-required restructuring our IPC mechanisms, which resulted in a lot of under the
-hood changes. The outcome is a more secure app that also uses the latest and
-greatest Electron recommendations.
+v1.7 is a major rewrite to improve the security of our app. In particular, the
+UI and the native parts of the app now run isolated from each other and
+communicate only using a predefined IPC boundary.
+
+Other highlights:
+
+-   View your photos on big screens and Chromecast devices by using the "Play
+    album on TV" option in the album menu.
+-   Support Brazilian Portuguese, German and Russian.
+-   Provide a checkbox to select all photos in a day.
+-   Fix a case where the dedup screen would not refresh after removing items.
 
 ## v1.6.63
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -134,15 +134,6 @@ const registerPrivilegedSchemes = () => {
 };
 
 /**
- * The Chromium sandbox causes the app to fail to run on various Linux
- * distributions. Reproducible on Ubuntu 24.
- *
- * See: https://github.com/electron/electron/issues/17972
- */
-const suidWorkaroundOnLinux = () =>
-    process.platform == "linux" && app.commandLine.appendSwitch("no-sandbox");
-
-/**
  * Create an return the {@link BrowserWindow} that will form our app's UI.
  *
  * This window will show the HTML served from {@link rendererURL}.
@@ -365,7 +356,6 @@ const main = () => {
 
     initLogging();
     logStartupBanner();
-    suidWorkaroundOnLinux();
     // The order of the next two calls is important
     setupRendererServer();
     registerPrivilegedSchemes();

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -140,7 +140,7 @@ const registerPrivilegedSchemes = () => {
  * See: https://github.com/electron/electron/issues/17972
  */
 const suidWorkaroundOnLinux = () =>
-    process.platform == "linux" && app.commandLine.appendSwitch("--no-sandbox");
+    process.platform == "linux" && app.commandLine.appendSwitch("no-sandbox");
 
 /**
  * Create an return the {@link BrowserWindow} that will form our app's UI.

--- a/docs/docs/photos/troubleshooting/desktop-install/index.md
+++ b/docs/docs/photos/troubleshooting/desktop-install/index.md
@@ -9,37 +9,6 @@ The latest version of the Ente Photos desktop app can be downloaded from
 [ente.io/download](https://ente.io/download). If you're having trouble, please
 see if any of the following cases apply.
 
-## AppImages on ARM64 Linux
-
-If you're on an ARM64 machine running Linux, and the AppImages doesn't do
-anything when you run it, you will need to run the following command on your
-machine:
-
-```sh
-sudo ln -s /usr/lib/aarch64-linux-gnu/libz.so{.1,}
-```
-
-It is possible that the exact path might be different on your machine. Briefly,
-what we need to do is create `libz.so` as an alias for `libz.so.1`. For more
-details, see the following bugs in upstream repositories:
-
--   libz.so cannot open shared object file on ARM64 -
-    [/github.com/AppImage/AppImageKit/issues/1092](https://github.com/AppImage/AppImageKit/issues/1092)
-
--   libz.so: cannot open shared object file with Ubuntu arm64 -
-    [github.com/electron-userland/electron-builder/issues/7835](https://github.com/electron-userland/electron-builder/issues/7835)
-
-## AppImage says it requires FUSE
-
-See
-[docs.appimage.org](https://docs.appimage.org/user-guide/troubleshooting/fuse.html#the-appimage-tells-me-it-needs-fuse-to-run).
-
-tl;dr; for example, on Ubuntu,
-
-```sh
-sudo apt install libfuse2
-```
-
 ## Windows
 
 If the app stops with an "A JavaScript error occurred in the main process - The
@@ -52,3 +21,55 @@ This is what the error looks like:
 
 You can install the Microsoft VC++ redistributable runtime from here:<br/>
 https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version
+
+## AppImages on ARM64 Linux
+
+If you're on an ARM64 machine running Linux, and the AppImages doesn't do
+anything when you run it, you will need to run the following command on your
+machine:
+
+```sh
+sudo ln -s /usr/lib/aarch64-linux-gnu/libz.so{.1,}
+```
+
+It is possible that the exact path might be different on your machine. Briefly,
+what we need to do is create `libz.so` as an alias for `libz.so.1`. For more
+details, see the following upstream issues:
+
+-   libz.so cannot open shared object file on ARM64 -
+    [AppImage/AppImageKit/issues/1092](https://github.com/AppImage/AppImageKit/issues/1092)
+
+-   libz.so: cannot open shared object file with Ubuntu arm64 -
+    [electron-userland/electron-builder/issues/7835](https://github.com/electron-userland/electron-builder/issues/7835)
+
+## AppImage says it requires FUSE
+
+See
+[docs.appimage.org](https://docs.appimage.org/user-guide/troubleshooting/fuse.html#the-appimage-tells-me-it-needs-fuse-to-run).
+
+tl;dr; for example, on Ubuntu,
+
+```sh
+sudo apt install libfuse2
+```
+
+## Linux SUID error
+
+On some Linux distributions, if you run the AppImage from the CLI, it might fail
+with the following error:
+
+> The SUID sandbox helper binary was found, but is not configured correctly.
+
+This happens when you try to run the AppImage from the command line. If you
+instead double click on the AppImage in your Files browser, then it should start
+properly.
+
+If you do want to run it from the command line, you can do so by passing the
+`--no-sandbox` flag when executing the AppImage. e.g.
+
+```sh
+./ente.AppImage --no-sandbox
+```
+
+For more details, see this upstream issue on
+[electron](https://github.com/electron/electron/issues/17972).


### PR DESCRIPTION
- Revert the workaround
- Document the behaviour I observed
- (Unrelated) Add the other CHANGELOG entries in preparation for the release

