### PR TITLE
Fix failing workflow for photos internal release 

### DIFF
--- a/.github/workflows/mobile-internal-release.yml
+++ b/.github/workflows/mobile-internal-release.yml
@@ -54,4 +54,3 @@ jobs:
                   packageName: io.ente.photos
                   releaseFiles: mobile/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab
                   track: internal
-                  changesNotSentForReview: true

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,7 +12,7 @@ description: ente photos application
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 0.8.95+615
+version: 0.8.96+616
 publish_to: none
 
 environment:


### PR DESCRIPTION
`Error: Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set.`


