### PR TITLE
[web] Make corepack happy

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -54,5 +54,6 @@
         "shx": "^0.3",
         "typescript": "^5"
     },
-    "productName": "ente"
+    "productName": "ente",
+    "packageManager": "yarn@1.22.21"
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -54,6 +54,6 @@
         "shx": "^0.3",
         "typescript": "^5"
     },
-    "productName": "ente",
-    "packageManager": "yarn@1.22.21"
+    "packageManager": "yarn@1.22.21",
+    "productName": "ente"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -45,5 +45,6 @@
         "eslint": "^8",
         "prettier": "^3",
         "typescript": "^5"
-    }
+    },
+    "packageManager": "yarn@1.22.21"
 }


### PR DESCRIPTION
Latest Node 20 (20.13.1) ships with an updated corepack which seems to insist
putting a package manager field in package.json
(https://github.com/nodejs/corepack/pull/413).

Let it have its way, hoping that this doesn't break someone's workflow
(depending on how they installed yarn without corepack or if they have a node
version that doesn't have corepack).
