### PR TITLE
[web] Add Ubuntu section in getting started docs

### DIFF
--- a/docs/docs/self-hosting/troubleshooting/yarn.md
+++ b/docs/docs/self-hosting/troubleshooting/yarn.md
@@ -8,3 +8,6 @@ description: Fixing yarn install errors when trying to self host Ente
 If your `yarn install` is failing, make sure you are using Yarn Classic
 
 -   https://classic.yarnpkg.com/lang/en/docs/install
+
+For more details, see the [getting started
+instructions](https://github.com/ente-io/ente/blob/main/web/docs/new.md).

--- a/docs/docs/self-hosting/troubleshooting/yarn.md
+++ b/docs/docs/self-hosting/troubleshooting/yarn.md
@@ -9,5 +9,5 @@ If your `yarn install` is failing, make sure you are using Yarn Classic
 
 -   https://classic.yarnpkg.com/lang/en/docs/install
 
-For more details, see the [getting started
-instructions](https://github.com/ente-io/ente/blob/main/web/docs/new.md).
+For more details, see the
+[getting started instructions](https://github.com/ente-io/ente/blob/main/web/docs/new.md).

--- a/web/README.md
+++ b/web/README.md
@@ -32,8 +32,11 @@ yarn dev
 
 That's it. The web app will automatically hot reload when you make changes.
 
-If you're new to web development and unsure about how to get started, or are
-facing some problems when running the above steps, see [docs/new](docs/new.md).
+> [!TIP]
+>
+> If you're new to web development and unsure about how to get started, or are
+> facing some problems when running the above steps, see
+> [docs/new](docs/new.md).
 
 ## Other apps
 

--- a/web/README.md
+++ b/web/README.md
@@ -57,21 +57,22 @@ As a brief overview, this directory contains the following apps:
     your 2FA codes using this web app. For adding and editing your 2FA codes,
     please use the Ente Auth [mobile/desktop app](../auth/README.md) instead.
 
-These two are the public facing apps. There are other part of the code which are
+These are the public facing apps. There are other part of the code which are
 accessed as features within the main apps, but in terms of code are
 independently maintained and deployed:
 
 -   `apps/accounts`: Passkey support (Coming soon)
--   `apps/cast`: Chromecast support (Coming soon)
+-   `apps/cast`: Browser and Chromecast casting support.
+-   `apps/payments`: Handle subscription payments.
 
 > [!NOTE]
 >
-> This folder is supposed to contain all our web related code. Most of it is
-> already here, but some code which is being deployed from our other
-> repositories like the family portal (https://github.com/ente-io/families)
-> still needs to be brought here. Also, some of the Cloudflare workers we use
-> for fixing headers etc too. Hang tight, we're on it, will bring in the
-> remaining bits one by one.
+> Some older code is being deployed from our other repositories like the family
+> portal (https://github.com/ente-io/families) and still needs to be brought
+> here. Likewise, some of the Cloudflare workers we use for fixing headers etc.
+> We'll gradually bring all these into this monorepo one by one.
+
+The apps take use various `packages/` to share code amongst themselves.
 
 You might also find this [overview of dependencies](docs/dependencies.md)
 useful.

--- a/web/docs/README.md
+++ b/web/docs/README.md
@@ -7,3 +7,7 @@ If you just want to run Ente's web apps locally or develop them, you can do
 
 The docs in this directory provide more details that some developers might find
 useful.
+
+> [!TIP]
+>
+> To prepare your machine, see [new](new.md).

--- a/web/docs/new.md
+++ b/web/docs/new.md
@@ -1,26 +1,35 @@
 # Welcome!
 
-If you're new to this sort of stuff or coming back to it after mobile/backend
+If you're new to web stuff or coming back to it after mobile/backend
 development, here is a recommended workflow:
 
-1. Install VS Code.
+1. Install **VS Code**.
 
-2. Install the Prettier and ESLint extensions.
+2. Install the **Prettier** and **ESLint** extensions.
 
 3. Enable the VS Code setting to format on save.
 
-4. Install node on your machine `brew install node@20`. Our package manager,
-   `yarn` comes with it.
+4. Install **node** on your machine. There are myriad ways to do this, here are
+   some examples:
+
+    * macOS: `brew install node@20`
+
+    * Ubuntu: `sudo apt install nodejs npm && sudo npm i -g corepack`
+
+5. Enable corepack. This allows us to use the correct version of our package
+   manager (**Yarn**):
+
+    ```sh
+
+    corepack enable
+    ```
+
+   If now you run `yarn --version` in the web directory, you should be seeing a
+   1.22.xx version, otherwise your `yarn install` will fail.
+
+   ```sh
+   $ yarn --version
+   1.22.21
+   ```
 
 That's it. Enjoy coding!
-
-## Yarn
-
-Note that we use Yarn classic
-
-```
-$ yarn --version
-1.22.21
-```
-
-You should be seeing a 1.xx.xx version, otherwise your `yarn install` will fail.

--- a/web/docs/new.md
+++ b/web/docs/new.md
@@ -12,9 +12,9 @@ development, here is a recommended workflow:
 4. Install **node** on your machine. There are myriad ways to do this, here are
    some examples:
 
-    * macOS: `brew install node@20`
+    - macOS: `brew install node@20`
 
-    * Ubuntu: `sudo apt install nodejs npm && sudo npm i -g corepack`
+    - Ubuntu: `sudo apt install nodejs npm && sudo npm i -g corepack`
 
 5. Enable corepack. This allows us to use the correct version of our package
    manager (**Yarn**):
@@ -24,12 +24,12 @@ development, here is a recommended workflow:
     corepack enable
     ```
 
-   If now you run `yarn --version` in the web directory, you should be seeing a
-   1.22.xx version, otherwise your `yarn install` will fail.
+    If now you run `yarn --version` in the web directory, you should be seeing a
+    1.22.xx version, otherwise your `yarn install` will fail.
 
-   ```sh
-   $ yarn --version
-   1.22.21
-   ```
+    ```sh
+    $ yarn --version
+    1.22.21
+    ```
 
 That's it. Enjoy coding!


### PR DESCRIPTION
The `npm install -g corepack` was needed on Ubuntu 24 (See https://github.com/yarnpkg/berry/discussions/5060)