### PR TITLE
[desktop] Add a CORS workaround for uploads to arbitrary testing buckets

### DIFF
--- a/desktop/src/main/log.ts
+++ b/desktop/src/main/log.ts
@@ -70,8 +70,9 @@ const logInfo = (...params: unknown[]) => {
     const message = params
         .map((p) => (typeof p == "string" ? p : util.inspect(p)))
         .join(" ");
-    log.info(`[main] ${message}`);
-    if (isDev) console.log(`[info] ${message}`);
+    const m = `[info] ${message}`;
+    if (isDev) console.log(m);
+    log.info(`[main] ${m}`);
 };
 
 const logDebug = (param: () => unknown) => {


### PR DESCRIPTION
This workaround already existed in older versions (See `addAllowOriginHeader`), I had recently removed it, now putting it back.