### PR TITLE
[meta] Prune gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-# Let folks use their custom .vscode settings
+# Let folks use their custom editor settings
 .vscode
+.idea
 
 # macOS
 .DS_Store
-.idea
-.ente.authenticator.db
-.ente.offline_authenticator.db


### PR DESCRIPTION
About the auth dbs, discussed in chat: These files got created once when debugging auth build for linux. They were probably accidental, so removing them for now (will add back if there is a workflow when they actively get recreated).
