### PR TITLE
[web] Fix race condition in initialization of search worker

### DIFF
--- a/web/apps/photos/src/utils/comlink/ComlinkSearchWorker.ts
+++ b/web/apps/photos/src/utils/comlink/ComlinkSearchWorker.ts
@@ -5,11 +5,13 @@ import { type DedicatedSearchWorker } from "worker/search.worker";
 
 class ComlinkSearchWorker {
     private comlinkWorkerInstance: Remote<DedicatedSearchWorker>;
+    private comlinkWorker: ComlinkWorker<typeof DedicatedSearchWorker>;
 
     async getInstance() {
         if (!this.comlinkWorkerInstance) {
-            this.comlinkWorkerInstance =
-                await getDedicatedSearchWorker().remote;
+            if (!this.comlinkWorker)
+                this.comlinkWorker = getDedicatedSearchWorker();
+            this.comlinkWorkerInstance = await this.comlinkWorker.remote;
         }
         return this.comlinkWorkerInstance;
     }


### PR DESCRIPTION
During app init, two worker instances would get created in some cases and two getInstances raced because of the await. This was causing the search results to be empty until the page is reloaded (since the files array was empty in the worker that got assigned, but the files would get set to the other worker instance that lost the race).
