### PR TITLE
Ente Auth: Add support for Steam domain (steampowered.com) as an issuer

### DIFF
--- a/auth/lib/models/code.dart
+++ b/auth/lib/models/code.dart
@@ -128,7 +128,7 @@ class Code {
       final code = Code(
         _getAccount(uri),
         issuer,
-        _getDigits(uri, issuer),
+        _getDigits(uri),
         _getPeriod(uri),
         getSanitizedSecret(uri.queryParameters['secret']!),
         _getAlgorithm(uri),
@@ -201,11 +201,11 @@ class Code {
     }
   }
 
-  static int _getDigits(Uri uri, String issuer) {
+  static int _getDigits(Uri uri) {
     try {
       return int.parse(uri.queryParameters['digits']!);
     } catch (e) {
-      if (issuer.toLowerCase() == "steam" || issuer.toLowerCase().contains('steampowered.com')) {
+      if (uri.host == "steam") {
         return steamDigits;
       }
       return defaultDigits;

--- a/auth/lib/models/code.dart
+++ b/auth/lib/models/code.dart
@@ -205,7 +205,7 @@ class Code {
     try {
       return int.parse(uri.queryParameters['digits']!);
     } catch (e) {
-      if (issuer.toLowerCase() == "steam") {
+      if (issuer.toLowerCase() == "steam" || issuer.toLowerCase().contains('steampowered.com')) {
         return steamDigits;
       }
       return defaultDigits;

--- a/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
+++ b/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
@@ -240,7 +240,7 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
       final account = _accountController.text.trim();
       final issuer = _issuerController.text.trim();
       final secret = _secretController.text.trim().replaceAll(' ', '');
-      final isStreamCode = issuer.toLowerCase() == "steam";
+      final isStreamCode = issuer.toLowerCase() == "steam" || issuer.toLowerCase().contains('steampowered.com');
       if (widget.code != null && widget.code!.secret != secret) {
         ButtonResult? result = await showChoiceActionSheet(
           context,

--- a/auth/lib/utils/totp_util.dart
+++ b/auth/lib/utils/totp_util.dart
@@ -4,7 +4,7 @@ import 'package:otp/otp.dart' as otp;
 import 'package:steam_totp/steam_totp.dart';
 
 String getOTP(Code code) {
-  if (['steam', 'steampowered.com'].contains(code.issuer.toLowerCase())) {
+  if (code.type == Type.steam) {
     return _getSteamCode(code);
   }
   if (code.type == Type.hotp) {
@@ -39,7 +39,7 @@ String _getSteamCode(Code code, [bool isNext = false]) {
 }
 
 String getNextTotp(Code code) {
-  if (['steam', 'steampowered.com'].contains(code.issuer.toLowerCase())) {
+  if (code.type == Type.steam) {
     return _getSteamCode(code, true);
   }
   return otp.OTP.generateTOTPCodeString(

--- a/auth/lib/utils/totp_util.dart
+++ b/auth/lib/utils/totp_util.dart
@@ -4,7 +4,7 @@ import 'package:otp/otp.dart' as otp;
 import 'package:steam_totp/steam_totp.dart';
 
 String getOTP(Code code) {
-  if (code.issuer.toLowerCase() == 'steam') {
+  if (['steam', 'steampowered.com'].contains(code.issuer.toLowerCase())) {
     return _getSteamCode(code);
   }
   if (code.type == Type.hotp) {
@@ -39,7 +39,7 @@ String _getSteamCode(Code code, [bool isNext = false]) {
 }
 
 String getNextTotp(Code code) {
-  if (code.issuer.toLowerCase() == 'steam') {
+  if (['steam', 'steampowered.com'].contains(code.issuer.toLowerCase())) {
     return _getSteamCode(code, true);
   }
   return otp.OTP.generateTOTPCodeString(


### PR DESCRIPTION
## Description
I don't think I'm the only one using website domains as issuers of TOTP codes. This change will add support for the Steam domain (steampowered.com) as an issuer.