### PR TITLE
[web] Passkey fixes

### DIFF
--- a/web/apps/photos/src/components/Sidebar/index.tsx
+++ b/web/apps/photos/src/components/Sidebar/index.tsx
@@ -14,6 +14,7 @@ import {
     ACCOUNTS_PAGES,
     PHOTOS_PAGES as PAGES,
 } from "@ente/shared/constants/pages";
+import ComlinkCryptoWorker from "@ente/shared/crypto";
 import { getRecoveryKey } from "@ente/shared/crypto/helpers";
 import {
     encryptToB64,
@@ -494,9 +495,10 @@ const UtilitySection: React.FC<UtilitySectionProps> = ({ closeSidebar }) => {
 
                 const resetSecret = await generateEncryptionKey();
 
+                const cryptoWorker = await ComlinkCryptoWorker.getInstance();
                 const encryptionResult = await encryptToB64(
                     resetSecret,
-                    recoveryKey,
+                    await cryptoWorker.fromHex(recoveryKey),
                 );
 
                 await configurePasskeyRecovery(

--- a/web/packages/accounts/services/passkey.ts
+++ b/web/packages/accounts/services/passkey.ts
@@ -29,7 +29,7 @@ export const isPasskeyRecoveryEnabled = async () => {
 
 export const configurePasskeyRecovery = async (
     secret: string,
-    userEncryptedSecret: string,
+    userSecretCipher: string,
     userSecretNonce: string,
 ) => {
     try {
@@ -39,7 +39,7 @@ export const configurePasskeyRecovery = async (
             `${getEndpoint()}/users/two-factor/passkeys/configure-recovery`,
             {
                 secret,
-                userEncryptedSecret,
+                userSecretCipher,
                 userSecretNonce,
             },
             {

--- a/web/packages/accounts/services/passkey.ts
+++ b/web/packages/accounts/services/passkey.ts
@@ -42,6 +42,7 @@ export const configurePasskeyRecovery = async (
                 userSecretCipher,
                 userSecretNonce,
             },
+            undefined,
             {
                 "X-Auth-Token": token,
             },

--- a/web/packages/accounts/services/passkey.ts
+++ b/web/packages/accounts/services/passkey.ts
@@ -1,6 +1,7 @@
 import log from "@/next/log";
 import { CustomError } from "@ente/shared/error";
 import HTTPService from "@ente/shared/network/HTTPService";
+import { getEndpoint } from "@ente/shared/network/api";
 import { getToken } from "@ente/shared/storage/localStorage/helpers";
 
 export const isPasskeyRecoveryEnabled = async () => {
@@ -8,7 +9,7 @@ export const isPasskeyRecoveryEnabled = async () => {
         const token = getToken();
 
         const resp = await HTTPService.get(
-            "/users/two-factor/recovery-status",
+            `${getEndpoint()}/users/two-factor/recovery-status`,
             {},
             {
                 "X-Auth-Token": token,
@@ -35,7 +36,7 @@ export const configurePasskeyRecovery = async (
         const token = getToken();
 
         const resp = await HTTPService.post(
-            "/users/two-factor/passkeys/configure-recovery",
+            `${getEndpoint()}/users/two-factor/passkeys/configure-recovery`,
             {
                 secret,
                 userEncryptedSecret,


### PR DESCRIPTION
@ua741 Not sure if passkey code is supposed to work on web yet, but I was doing an unrelated change and noticed that clicking passkeys didn't even try to redirect to accounts. I don't have a test setup for passkeys, so don't know if these changes are 100% correct, but at least now it redirects to accounts. Can test fully when doing final integration.

- Use correct origin for passkey API requests
- Fix key length error
- Fix param name to match server
- Pass the token instead of a query param
