### PR TITLE
Add alt names for some services

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -32,7 +32,10 @@
     },
     {
       "title": "Bloom Host",
-      "slug": "bloom_host"
+      "slug": "bloom_host",
+      "altNames": [
+        "Bloom Host Billing"
+      ]
     },
     {
       "title": "BorgBase",
@@ -345,7 +348,10 @@
       "hex": "FFFFFF"
     },
     {
-      "title": "Techlore"
+      "title": "Techlore",
+      "altNames": [
+        "Techlore Courses"
+      ]
     },
     {
       "title": "Termius",


### PR DESCRIPTION
## Description

This PR just adds some alternative names that could be used for the services "Bloom Host" and "Techlore".