### PR TITLE
[mob][photos] Modify the code to use XFile.fromData(bytes) instead of saving the image to a file for share link placeholder

### DIFF
--- a/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -1,5 +1,4 @@
 import "dart:async";
-import "dart:io";
 
 import 'package:fast_base58/fast_base58.dart';
 import "package:flutter/cupertino.dart";
@@ -7,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import "package:logging/logging.dart";
 import "package:modal_bottom_sheet/modal_bottom_sheet.dart";
-import "package:path_provider/path_provider.dart";
 import 'package:photos/core/configuration.dart';
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/people_changed_event.dart";
@@ -78,7 +76,7 @@ class _FileSelectionActionsWidgetState
   late CollectionActions collectionActions;
   late bool isCollectionOwner;
   final ScreenshotController screenshotController = ScreenshotController();
-  late String? placeholderPath;
+  late Uint8List? placeholderBytes;
   // _cachedCollectionForSharedLink is primarily used to avoid creating duplicate
   // links if user keeps on creating Create link button after selecting
   // few files. This link is reset on any selection changed;
@@ -610,23 +608,7 @@ class _FileSelectionActionsWidgetState
     }
   }
 
-  Future<String> saveImage(Uint8List bytes) async {
-    String path = "";
-    try {
-      final Directory root = await getTemporaryDirectory();
-      final String directoryPath = '${root.path}/enteTempFiles';
-      final DateTime timeStamp = DateTime.now();
-      await Directory(directoryPath).create(recursive: true);
-      final String filePath = '$directoryPath/$timeStamp.jpg';
-      final file = await File(filePath).writeAsBytes(bytes);
-      path = file.path;
-    } catch (e) {
-      _logger.severe("Failed to save placeholder image", e);
-    }
-    return path;
-  }
-
-  Future<String?> _createPlaceholder(
+  Future<Uint8List?> _createPlaceholder(
     List<EnteFile> ownedSelectedFiles,
   ) async {
     final Widget imageWidget = LinkPlaceholder(
@@ -640,10 +622,7 @@ class _FileSelectionActionsWidgetState
       targetSize: MediaQuery.sizeOf(context),
       delay: const Duration(milliseconds: 100),
     );
-
-    final String onCreatedPlaceholderPath =
-        await saveImage(bytesOfImageToWidget);
-    return onCreatedPlaceholderPath;
+    return bytesOfImageToWidget;
   }
 
   Future<void> _onSendLinkTapped() async {
@@ -664,7 +643,7 @@ class _FileSelectionActionsWidgetState
         .createSharedCollectionLink(context, split.ownedByCurrentUser);
 
     final List<EnteFile> ownedSelectedFiles = split.ownedByCurrentUser;
-    placeholderPath = await _createPlaceholder(ownedSelectedFiles);
+    placeholderBytes = await _createPlaceholder(ownedSelectedFiles);
     await dialog.hide();
     await _sendLink();
     widget.selectedFiles.clearAll();
@@ -778,23 +757,11 @@ class _FileSelectionActionsWidgetState
           "${_cachedCollectionForSharedLink!.publicURLs?.first?.url}#$collectionKey";
       unawaited(Clipboard.setData(ClipboardData(text: url)));
       await shareImageAndUrl(
-        placeholderPath!,
+        placeholderBytes!,
         url,
         context: context,
         key: sendLinkButtonKey,
       );
-      if (placeholderPath != null) {
-        final file = File(placeholderPath!);
-        try {
-          if (file.existsSync()) {
-            file.deleteSync();
-          }
-        } catch (e) {
-          _logger.warning("Failed to delete the file: $e");
-        } finally {
-          placeholderPath = null;
-        }
-      }
     }
   }
 

--- a/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -76,7 +76,7 @@ class _FileSelectionActionsWidgetState
   late CollectionActions collectionActions;
   late bool isCollectionOwner;
   final ScreenshotController screenshotController = ScreenshotController();
-  late Uint8List? placeholderBytes;
+  late Uint8List placeholderBytes;
   // _cachedCollectionForSharedLink is primarily used to avoid creating duplicate
   // links if user keeps on creating Create link button after selecting
   // few files. This link is reset on any selection changed;
@@ -756,7 +756,7 @@ class _FileSelectionActionsWidgetState
           "${_cachedCollectionForSharedLink!.publicURLs?.first?.url}#$collectionKey";
       unawaited(Clipboard.setData(ClipboardData(text: url)));
       await shareImageAndUrl(
-        placeholderBytes!,
+        placeholderBytes,
         url,
         context: context,
         key: sendLinkButtonKey,

--- a/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -608,19 +608,18 @@ class _FileSelectionActionsWidgetState
     }
   }
 
-  Future<Uint8List?> _createPlaceholder(
+  Future<Uint8List> _createPlaceholder(
     List<EnteFile> ownedSelectedFiles,
   ) async {
     final Widget imageWidget = LinkPlaceholder(
       files: ownedSelectedFiles,
     );
-    await Future.delayed(const Duration(milliseconds: 200));
-    final double pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    final double pixelRatio = MediaQuery.devicePixelRatioOf(context);
     final bytesOfImageToWidget = await screenshotController.captureFromWidget(
       imageWidget,
       pixelRatio: pixelRatio,
       targetSize: MediaQuery.sizeOf(context),
-      delay: const Duration(milliseconds: 100),
+      delay: const Duration(milliseconds: 300),
     );
     return bytesOfImageToWidget;
   }

--- a/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -614,7 +614,7 @@ class _FileSelectionActionsWidgetState
     final Widget imageWidget = LinkPlaceholder(
       files: ownedSelectedFiles,
     );
-    await Future.delayed(const Duration(milliseconds: 100));
+    await Future.delayed(const Duration(milliseconds: 200));
     final double pixelRatio = MediaQuery.of(context).devicePixelRatio;
     final bytesOfImageToWidget = await screenshotController.captureFromWidget(
       imageWidget,

--- a/mobile/lib/utils/share_util.dart
+++ b/mobile/lib/utils/share_util.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import "dart:io";
+import "dart:typed_data";
 
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
@@ -228,15 +229,20 @@ void shareSelected(
 }
 
 Future<void> shareImageAndUrl(
-  String imagePath,
+  Uint8List imageBytes,
   String url, {
   BuildContext? context,
   GlobalKey? key,
 }) async {
   final sharePosOrigin = _sharePosOrigin(context, key);
-
   await Share.shareXFiles(
-    [XFile(imagePath)],
+    [
+      XFile.fromData(
+        imageBytes,
+        name: 'placeholder_image.png',
+        mimeType: 'image/png',
+      ),
+    ],
     text: url,
     sharePositionOrigin: sharePosOrigin,
   );


### PR DESCRIPTION
1. Modified the` _createPlaceholder` function to return the image bytes instead of the image path, changed the return type to `Future<Uint8List?>`
2. Remove the call to `saveImage` on saving the image to a temporary directory
3. Modified the `shareImageAndUrl` function:
4. Replaced the usage of XFile(imagePath) with XFile.fromData(imageBytes).
5. Added metadata to the `XFile.fromData` method call, specifying the name and mimeType for better file identification during sharing.