### PR TITLE
[mob][photos] Mention OS with subject of logs sent when app is stuck on lockscreen for more than 15 seconds. This will let us identify OS when logs are not attached

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -186,7 +186,7 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
       if (!initComplete && !isBackground) {
         sendLogsForInit(
           "support@ente.io",
-          "Stuck on splash screen for >= 15 seconds",
+          "Stuck on splash screen for >= 15 seconds on ${Platform.operatingSystem}",
           null,
         );
       }


### PR DESCRIPTION
Tested if this breaks logs from getting sent. Good to go.
