### PR TITLE
[photosd] Fix automatic move to uncategorized on watch folder deletions

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   Remember the window size across app restarts.
 -   Revert changes to the Linux icon.
+-   Fix an issue where deleted items in watched folders would not move to
+    uncategorized.
 
 ## v1.7.0
 

--- a/web/apps/photos/src/services/watch.ts
+++ b/web/apps/photos/src/services/watch.ts
@@ -270,10 +270,11 @@ class FolderWatcher {
             }
 
             const [removed, rest] = watch.syncedFiles.reduce(
-                ([removed, rest], { path }) => {
-                    (event.filePaths.includes(path) ? rest : removed).push(
-                        watch,
-                    );
+                ([removed, rest], syncedFile) => {
+                    (event.filePaths.includes(syncedFile.path)
+                        ? removed
+                        : rest
+                    ).push(syncedFile);
                     return [removed, rest];
                 },
                 [[], []],


### PR DESCRIPTION
This was a regression introduced in 1.7.0. On deleting a file on disk, the corresponding items are supposed to move to uncategorized.

> And if a file is deleted locally, then the corresponding Ente file will also be automatically moved to uncategorized.
>
> https://help.ente.io/photos/features/watch-folders
