### PR TITLE
[mobile] Update passkeys URLs

### DIFF
--- a/auth/lib/services/passkey_service.dart
+++ b/auth/lib/services/passkey_service.dart
@@ -42,7 +42,7 @@ class PasskeyService {
   Future<void> openPasskeyPage(BuildContext context) async {
     try {
       final jwtToken = await getJwtToken();
-      final url = "https://accounts.ente.io/passkeys/handoff?token=$jwtToken";
+      final url = "https://accounts.ente.io/passkeys?token=$jwtToken";
       await launchUrlString(
         url,
         mode: LaunchMode.externalApplication,

--- a/auth/lib/ui/passkey_page.dart
+++ b/auth/lib/ui/passkey_page.dart
@@ -44,6 +44,7 @@ class _PasskeyPageState extends State<PasskeyPage> {
       "https://accounts.ente.io/passkeys/verify?"
       "passkeySessionID=${widget.sessionID}"
       "&redirect=enteauth://passkey"
+      "&recover=enteauth://passkey/recover"
       "&clientPackage=io.ente.auth",
       mode: LaunchMode.externalApplication,
     );

--- a/mobile/lib/services/passkey_service.dart
+++ b/mobile/lib/services/passkey_service.dart
@@ -42,7 +42,7 @@ class PasskeyService {
   Future<void> openPasskeyPage(BuildContext context) async {
     try {
       final jwtToken = await getJwtToken();
-      final url = "https://accounts.ente.io/passkeys/handoff?token=$jwtToken";
+      final url = "https://accounts.ente.io/passkeys?token=$jwtToken";
       await launchUrlString(
         url,
         mode: LaunchMode.externalApplication,

--- a/mobile/lib/ui/account/passkey_page.dart
+++ b/mobile/lib/ui/account/passkey_page.dart
@@ -44,6 +44,7 @@ class _PasskeyPageState extends State<PasskeyPage> {
       "https://accounts.ente.io/passkeys/verify?"
       "passkeySessionID=${widget.sessionID}"
       "&redirect=ente://passkey"
+      "&recover=ente://passkey/recover"
       "&clientPackage=io.ente.photos",
       mode: LaunchMode.externalApplication,
     );


### PR DESCRIPTION
We now explicitly pass a recover URL to the accounts app, and I've added some placeholder values. This URL will be opened when the user selects the "Recover passkey" option on the authentication failure screen.
