### PR TITLE
[mob] Passkeys: Don't show recover option on accounts page

### DIFF
--- a/auth/lib/ui/passkey_page.dart
+++ b/auth/lib/ui/passkey_page.dart
@@ -45,7 +45,6 @@ class _PasskeyPageState extends State<PasskeyPage> {
       "https://accounts.ente.io/passkeys/verify?"
       "passkeySessionID=${widget.sessionID}"
       "&redirect=enteauth://passkey"
-      "&recover=enteauth://passkey/recover"
       "&clientPackage=io.ente.auth",
       mode: LaunchMode.externalApplication,
     );

--- a/mobile/lib/ui/account/passkey_page.dart
+++ b/mobile/lib/ui/account/passkey_page.dart
@@ -44,7 +44,6 @@ class _PasskeyPageState extends State<PasskeyPage> {
       "https://accounts.ente.io/passkeys/verify?"
       "passkeySessionID=${widget.sessionID}"
       "&redirect=ente://passkey"
-      "&recover=ente://passkey/recover"
       "&clientPackage=io.ente.photos",
       mode: LaunchMode.externalApplication,
     );


### PR DESCRIPTION
Mobile app shows it on the waiting screen instead (accounts web app shows the recover option only when the recover query param is passed to it).

(Did not verify by running on mobile)

/cc @ua741 