### PR TITLE
[desktop] Fix duplicate file uploads when initializing a folder watch

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v1.7.1 (Unreleased)
 
+-   Support for passkeys as a second factor authentication mechanism.
 -   Remember the window size across app restarts.
 -   Revert changes to the Linux icon.
--   Fix an issue where deleted items in watched folders would not move to
+-   Fix an issue causing deleted items in watched folders to not move to
     uncategorized.
+-   Fix duplicate file uploads when initializing a folder watch (sometimes).
 
 ## v1.7.0
 

--- a/desktop/src/main/services/watch.ts
+++ b/desktop/src/main/services/watch.ts
@@ -23,6 +23,12 @@ export const createWatcher = (mainWindow: BrowserWindow) => {
     const folderPaths = folderWatches().map((watch) => watch.folderPath);
 
     const watcher = chokidar.watch(folderPaths, {
+        // Don't emit "add" events for matching paths when instantiating the
+        // watch (we do a full disk scan on launch on our own, and also getting
+        // the same events from the watcher causes duplicates).
+        ignoreInitial: true,
+        // Ask the watcher to wait for a the file size to stabilize before
+        // telling us about a new file. By default, it waits for 2 seconds.
         awaitWriteFinish: true,
     });
 


### PR DESCRIPTION
This didn't happen always, it was a race condition dependending on when the `this.eventQueue = []` in `syncWithDisk` happened.
