### PR TITLE
[server] Stop making 32 bit ARM images

### DIFF
--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -33,7 +33,7 @@ jobs:
                   registry: ghcr.io
                   enableBuildKit: true
                   multiPlatform: true
-                  platform: linux/amd64,linux/arm64,linux/arm/v7
+                  platform: linux/amd64,linux/arm64
                   buildArgs: GIT_COMMIT=${{ inputs.commit }}
                   tags: ${{ inputs.commit }}, latest
                   username: ${{ github.actor }}


### PR DESCRIPTION
The code doesn't get tested or run and is likely not safe for 32 bits

> 941.0 pkg/utils/billing/billing.go:117:13: cannot use ente.FreePlanStorage
  (untyped int constant 5368709120) as int value in struct literal (overflows)
>
> https://github.com/ente-io/ente/actions/runs/9546167833/job/26308448952
