### PR TITLE
add human readable upload result to log file output

### DIFF
--- a/web/apps/photos/src/services/upload/uploadManager.ts
+++ b/web/apps/photos/src/services/upload/uploadManager.ts
@@ -567,8 +567,9 @@ class UploadManager {
         uploadResult: UPLOAD_RESULT,
         uploadedFile: EncryptedEnteFile | EnteFile | undefined,
     ) {
+        const key = UPLOAD_RESULT[uploadResult];
         log.info(
-            `Uploaded ${uploadableItem.fileName} with result ${uploadResult}`,
+            `Uploaded ${uploadableItem.fileName} with result ${uploadResult} (${key})`,
         );
         try {
             const electron = globalThis.electron;


### PR DESCRIPTION
## Description

Make the logfile more user friendly by adding a readable upload result string instead of just a number.

Before the logfile showed only a not human understandable number for the upload result:
`"Uploaded xyz.jpg with result 3"` 

This PR adds the key from the enum UPLOAD_RESULT to make it easy for a human to understand the result:
`"Uploaded xyz.jpg with result 3 (BLOCKED)"`

