### PR TITLE
[web] Faster and noUncheckedIndexedAccess compliant Uint8Array merging

### DIFF
--- a/web/apps/cast/tsconfig.json
+++ b/web/apps/cast/tsconfig.json
@@ -1,12 +1,9 @@
 {
     "extends": "@/build-config/tsconfig-next.json",
     "compilerOptions": {
-        /* Set the base directory from which to resolve bare module names */
+        /* Set the base directory from which to resolve bare module names. */
         "baseUrl": "./src",
-
-        /* TODO(MR): Enable this */
-        "noUncheckedIndexedAccess": false,
-        /* MUI doesn't play great with exactOptionalPropertyTypes currently. */
+        /* MUI doesn't work with exactOptionalPropertyTypes yet. */
         "exactOptionalPropertyTypes": false
     },
     "include": [

--- a/web/packages/shared/crypto/internal/libsodium.ts
+++ b/web/packages/shared/crypto/internal/libsodium.ts
@@ -22,11 +22,11 @@ export async function decryptChaChaOneShot(
     return pullResult.message;
 }
 
-export async function decryptChaCha(
+export const decryptChaCha = async (
     data: Uint8Array,
     header: Uint8Array,
     key: string,
-) {
+) => {
     await sodium.ready;
     const pullState = sodium.crypto_secretstream_xchacha20poly1305_init_pull(
         header,
@@ -36,7 +36,7 @@ export async function decryptChaCha(
         ENCRYPTION_CHUNK_SIZE +
         sodium.crypto_secretstream_xchacha20poly1305_ABYTES;
     let bytesRead = 0;
-    const decryptedData = [];
+    const decryptedChunks = [];
     let tag = sodium.crypto_secretstream_xchacha20poly1305_TAG_MESSAGE;
     while (tag !== sodium.crypto_secretstream_xchacha20poly1305_TAG_FINAL) {
         let chunkSize = decryptionChunkSize;
@@ -51,14 +51,12 @@ export async function decryptChaCha(
         if (!pullResult.message) {
             throw new Error(CustomError.PROCESSING_FAILED);
         }
-        for (let index = 0; index < pullResult.message.length; index++) {
-            decryptedData.push(pullResult.message[index]);
-        }
+        decryptedChunks.push(pullResult.message);
         tag = pullResult.tag;
         bytesRead += chunkSize;
     }
-    return Uint8Array.from(decryptedData);
-}
+    return mergeUint8Arrays(decryptedChunks);
+};
 
 export async function initChunkDecryption(header: Uint8Array, key: Uint8Array) {
     await sodium.ready;
@@ -112,7 +110,7 @@ export async function encryptChaChaOneShot(data: Uint8Array, key: string) {
     };
 }
 
-export async function encryptChaCha(data: Uint8Array) {
+export const encryptChaCha = async (data: Uint8Array) => {
     await sodium.ready;
 
     const uintkey: Uint8Array =
@@ -150,7 +148,7 @@ export async function encryptChaCha(data: Uint8Array) {
             decryptionHeader: await toB64(header),
         },
     };
-}
+};
 
 export async function initChunkEncryption() {
     await sodium.ready;

--- a/web/packages/utils/array.ts
+++ b/web/packages/utils/array.ts
@@ -28,3 +28,21 @@ export const firstNonEmpty = (ss: (string | undefined)[]) => {
     for (const s of ss) if (s && s.length > 0) return s;
     return undefined;
 };
+
+/**
+ * Merge the given array of {@link Uint8Array}s in order into a single
+ * {@link Uint8Array}.
+ *
+ * @param as An array of {@link Uint8Array}.
+ */
+export const mergeUint8Arrays = (as: Uint8Array[]) => {
+    // A longer but better performing replacement of
+    //
+    //     new Uint8Array(as.reduce((acc, x) => acc.concat(...x), []))
+    //
+
+    const len = as.reduce((len, xs) => len + xs.length, 0);
+    const result = new Uint8Array(len);
+    as.reduce((n, xs) => (result.set(xs, n), n + xs.length), 0);
+    return result;
+};


### PR DESCRIPTION
The script I used for testing - 10-100x faster, and the faster the longer the arrays. Note that speed was not the primary motivator for this change, I just wanted to enable `noUncheckedIndexedAccess`

```js
//zs = [...Array(10).keys()].map(() => Uint8Array.from(Array(100000).keys()));                                                    
zs = [...Array(100).keys()].map(() => Uint8Array.from(Array(1000).keys()));

const m0 = (as) => new Uint8Array(as.reduce((acc, x) => acc.concat(...x), []));

const mergeUint8Arrays = (as) => {
    const len = as.reduce((len, xs) => len + xs.length, 0);
    const result = new Uint8Array(len);
    as.reduce((n, xs) => (result.set(xs, n), n + xs.length), 0);
    return result;
};

s = performance.now();
a = m0(zs);
e = performance.now();
console.log(e - s, "ms", a.length, "m0");
//console.log(a);                                                                                                                 

s = performance.now();
b = mergeUint8Arrays(zs);
e = performance.now();
console.log(e - s, "ms", b.length, "merge");
//console.log(b);                                                                                                                 

console.log(JSON.stringify(a) === JSON.stringify(b))
```