### PR TITLE
[worker] Log on all non-200 responses from upstream +1

### DIFF
--- a/infra/workers/cast-albums/src/index.ts
+++ b/infra/workers/cast-albums/src/index.ts
@@ -63,6 +63,9 @@ const handleGET = async (request: Request) => {
     let response = await fetch(
         `https://api.ente.io/cast/files${pathname}${fileID}?${params.toString()}`
     );
+
+    if (!response.ok) console.log("Upstream error", response.status);
+
     response = new Response(response.body, response);
     response.headers.set("Access-Control-Allow-Origin", "*");
     return response;

--- a/infra/workers/files/src/index.ts
+++ b/infra/workers/files/src/index.ts
@@ -93,6 +93,9 @@ const handleGET = async (request: Request) => {
             },
         }
     );
+
+    if (!response.ok) console.log("Upstream error", response.status);
+
     response = new Response(response.body, response);
     response.headers.set("Access-Control-Allow-Origin", "*");
     return response;

--- a/infra/workers/files/src/index.ts
+++ b/infra/workers/files/src/index.ts
@@ -32,20 +32,18 @@ const handleOPTIONS = (request: Request) => {
 };
 
 const isAllowedOrigin = (origin: string | null) => {
-    const desktopApp = "ente://app";
-    const allowedHostnames = [
-        "web.ente.io",
-        "photos.ente.io",
-        "photos.ente.sh",
-        "localhost",
-    ];
-
     if (!origin) return false;
     try {
         const url = new URL(origin);
-        return origin == desktopApp || allowedHostnames.includes(url.hostname);
+        const hostname = url.hostname;
+        return (
+            origin == "ente://app" /* desktop app */ ||
+            hostname.endsWith("ente.io") ||
+            hostname.endsWith("ente.sh") ||
+            hostname == "localhost"
+        );
     } catch {
-        // origin is likely an invalid URL
+        // `origin` is likely an invalid URL.
         return false;
     }
 };

--- a/infra/workers/public-albums/src/index.ts
+++ b/infra/workers/public-albums/src/index.ts
@@ -92,6 +92,9 @@ const handleGET = async (request: Request) => {
     let response = await fetch(
         `https://api.ente.io/public-collection/files${pathname}${fileID}?${params.toString()}`
     );
+
+    if (!response.ok) console.log("Upstream error", response.status);
+
     response = new Response(response.body, response);
     response.headers.set("Access-Control-Allow-Origin", "*");
     return response;

--- a/infra/workers/thumbnails/src/index.ts
+++ b/infra/workers/thumbnails/src/index.ts
@@ -81,6 +81,9 @@ const handleGET = async (request: Request) => {
     let response = await fetch(
         `https://api.ente.io/files/preview/${fileID}?${params.toString()}`
     );
+
+    if (!response.ok) console.log("Upstream error", response.status);
+
     response = new Response(response.body, response);
     response.headers.set("Access-Control-Allow-Origin", "*");
     return response;

--- a/infra/workers/thumbnails/src/index.ts
+++ b/infra/workers/thumbnails/src/index.ts
@@ -32,20 +32,18 @@ const handleOPTIONS = (request: Request) => {
 };
 
 const isAllowedOrigin = (origin: string | null) => {
-    const desktopApp = "ente://app";
-    const allowedHostnames = [
-        "web.ente.io",
-        "photos.ente.io",
-        "photos.ente.sh",
-        "localhost",
-    ];
-
     if (!origin) return false;
     try {
         const url = new URL(origin);
-        return origin == desktopApp || allowedHostnames.includes(url.hostname);
+        const hostname = url.hostname;
+        return (
+            origin == "ente://app" /* desktop app */ ||
+            hostname.endsWith("ente.io") ||
+            hostname.endsWith("ente.sh") ||
+            hostname == "localhost"
+        );
     } catch {
-        // origin is likely an invalid URL
+        // `origin` is likely an invalid URL.
         return false;
     }
 };

--- a/infra/workers/uploader/src/index.ts
+++ b/infra/workers/uploader/src/index.ts
@@ -39,20 +39,18 @@ const handleOPTIONS = (request: Request) => {
 };
 
 const isAllowedOrigin = (origin: string | null) => {
-    const desktopApp = "ente://app";
-    const allowedHostnames = [
-        "web.ente.io",
-        "photos.ente.io",
-        "photos.ente.sh",
-        "localhost",
-    ];
-
     if (!origin) return false;
     try {
         const url = new URL(origin);
-        return origin == desktopApp || allowedHostnames.includes(url.hostname);
+        const hostname = url.hostname;
+        return (
+            origin == "ente://app" /* desktop app */ ||
+            hostname.endsWith("ente.io") ||
+            hostname.endsWith("ente.sh") ||
+            hostname == "localhost"
+        );
     } catch {
-        // origin is likely an invalid URL
+        // `origin` is likely an invalid URL.
         return false;
     }
 };

--- a/infra/workers/uploader/src/index.ts
+++ b/infra/workers/uploader/src/index.ts
@@ -110,7 +110,7 @@ const handlePOSTOrPUT = async (request: Request) => {
             return new Response(null, { status: 404 });
     }
 
-    if (!response.ok) console.log("Request failed", response.status);
+    if (!response.ok) console.log("Upstream error", response.status);
 
     response = new Response(response.body, response);
     response.headers.set("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
- Allow albums.ente.io/sh
- Log on all non-200 responses from upstream
- Use an easier to grep label