### PR TITLE
[web] Allow user to update subscriptions after cancel

### DIFF
--- a/web/apps/photos/src/components/pages/gallery/PlanSelector/card.tsx
+++ b/web/apps/photos/src/components/pages/gallery/PlanSelector/card.tsx
@@ -122,8 +122,8 @@ function PlanSelectorCard(props: Props) {
 
     async function onPlanSelect(plan: Plan) {
         if (
-            !hasPaidSubscription(subscription) ||
-            isSubscriptionCancelled(subscription)
+            !hasPaidSubscription(subscription) &&
+            !isSubscriptionCancelled(subscription)
         ) {
             try {
                 props.setLoading(true);


### PR DESCRIPTION
This fixes the issue reported by a user where they cancelled their subscription, then later on tried to upgrade, but were then redirected to the new subscription flow instead of the upgrade flow.

**Tested (on localhost):**

- [x] Buy new plan
- [x] Change existing plan
- [x] Change existing plan after cancelling