### PR TITLE
[Mob][Photos] Show video duration only on Gallery

### DIFF
--- a/mobile/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/lib/ui/viewer/file/thumbnail_widget.dart
@@ -26,6 +26,7 @@ import 'package:photos/utils/thumbnail_util.dart';
 class ThumbnailWidget extends StatefulWidget {
   final EnteFile file;
   final BoxFit fit;
+
   final bool shouldShowSyncStatus;
   final bool shouldShowArchiveStatus;
   final bool shouldShowPinIcon;
@@ -36,6 +37,10 @@ class ThumbnailWidget extends StatefulWidget {
   final int thumbnailSize;
   final bool shouldShowOwnerAvatar;
   final bool shouldShowFavoriteIcon;
+
+  ///On video thumbnails, shows the video duration if true. If false,
+  ///shows a centered play icon.
+  final bool shouldShowVideoDuration;
 
   ThumbnailWidget(
     this.file, {
@@ -51,6 +56,7 @@ class ThumbnailWidget extends StatefulWidget {
     this.serverLoadDeferDuration,
     this.thumbnailSize = thumbnailSmallSize,
     this.shouldShowFavoriteIcon = true,
+    this.shouldShowVideoDuration = false,
   }) : super(key: key ?? Key(file.tag));
 
   @override
@@ -142,8 +148,12 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       }
 
       if (widget.file.fileType == FileType.video) {
-        contentChildren
-            .add(VideoOverlayDuration(duration: widget.file.duration!));
+        if (widget.shouldShowVideoDuration) {
+          contentChildren
+              .add(VideoOverlayDuration(duration: widget.file.duration!));
+        } else {
+          contentChildren.add(const VideoOverlayIcon());
+        }
       } else if (widget.shouldShowLivePhotoOverlay &&
           widget.file.isLiveOrMotionPhoto) {
         contentChildren.add(const LivePhotoOverlayIcon());

--- a/mobile/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/lib/ui/viewer/file/thumbnail_widget.dart
@@ -27,6 +27,8 @@ class ThumbnailWidget extends StatefulWidget {
   final EnteFile file;
   final BoxFit fit;
 
+  /// Returns ThumbnailWidget without any overlay icons if true.
+  final bool rawThumbnail;
   final bool shouldShowSyncStatus;
   final bool shouldShowArchiveStatus;
   final bool shouldShowPinIcon;
@@ -46,6 +48,7 @@ class ThumbnailWidget extends StatefulWidget {
     this.file, {
     Key? key,
     this.fit = BoxFit.cover,
+    this.rawThumbnail = false,
     this.shouldShowSyncStatus = true,
     this.shouldShowLivePhotoOverlay = false,
     this.shouldShowArchiveStatus = false,
@@ -137,6 +140,9 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
     // If yes, parent thumbnail widget can be stateless
     Widget? content;
     if (image != null) {
+      if (widget.rawThumbnail) {
+        return image;
+      }
       final List<Widget> contentChildren = [image];
       if (widget.shouldShowFavoriteIcon) {
         if (FavoritesService.instance.isFavoriteCache(

--- a/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -55,6 +55,7 @@ class GalleryFileWidget extends StatelessWidget {
           ? thumbnailLargeSize
           : thumbnailSmallSize,
       shouldShowOwnerAvatar: !isFileSelected,
+      shouldShowVideoDuration: true,
     );
     return GestureDetector(
       onTap: () {

--- a/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
+++ b/mobile/lib/ui/viewer/people/cropped_face_image_view.dart
@@ -96,6 +96,7 @@ class CroppedFaceImageView extends StatelessWidget {
           }
           return ThumbnailWidget(
             enteFile,
+            rawThumbnail: true,
           );
         }
       },

--- a/mobile/lib/ui/viewer/search/result/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/person_face_widget.dart
@@ -76,6 +76,7 @@ class PersonFaceWidget extends StatelessWidget {
             return thumbnailFallback
                 ? ThumbnailWidget(
                     file,
+                    rawThumbnail: true,
                   )
                 : const EnteLoadingWidget();
           }
@@ -100,6 +101,7 @@ class PersonFaceWidget extends StatelessWidget {
             return thumbnailFallback
                 ? ThumbnailWidget(
                     file,
+                    rawThumbnail: true,
                   )
                 : const EnteLoadingWidget();
           }

--- a/mobile/lib/ui/viewer/search/result/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/person_face_widget.dart
@@ -74,7 +74,9 @@ class PersonFaceWidget extends StatelessWidget {
               log('Error getting cover face for person: ${snapshot.error}');
             }
             return thumbnailFallback
-                ? ThumbnailWidget(file)
+                ? ThumbnailWidget(
+                    file,
+                  )
                 : const EnteLoadingWidget();
           }
         },
@@ -96,7 +98,9 @@ class PersonFaceWidget extends StatelessWidget {
               log('Error getting cover face for person: ${snapshot.error}');
             }
             return thumbnailFallback
-                ? ThumbnailWidget(file)
+                ? ThumbnailWidget(
+                    file,
+                  )
                 : const EnteLoadingWidget();
           }
         },
@@ -188,7 +192,7 @@ class PersonFaceWidget extends StatelessWidget {
         stackTrace: s,
       );
       resetPool(fullFile: useFullFile);
-      if(fetchAttempt <= retryLimit) {
+      if (fetchAttempt <= retryLimit) {
         return getFaceCrop(fetchAttempt: fetchAttempt + 1);
       }
       return null;


### PR DESCRIPTION
## Description

- Show video duration overlay only on galleries
- In all other places, show a centred play button -- showing the overlay on some places wasn't looking good, like memories, when opening a video etc. So have replaced the overlay with a play button, just like before. 
- Pass optional parameter to get Thumbnail without any icons stacked over it.
