### PR TITLE
[meta] Split translation related workflows

### DIFF
--- a/.github/workflows/auth-crowdin-push.yml
+++ b/.github/workflows/auth-crowdin-push.yml
@@ -1,21 +1,16 @@
-name: "Sync Crowdin translations (auth)"
+name: "Push sources to Crowdin (auth)"
 
 on:
     push:
         branches: [main]
         paths:
             # Run workflow when auth's intl_en.arb is changed
-            - "mobile/lib/l10n/arb/app_en.arb"
+            - "auth/lib/l10n/arb/app_en.arb"
             # Or the workflow itself is changed
             - ".github/workflows/auth-crowdin.yml"
-    schedule:
-        # See: [Note: Run workflow on specific days of the week]
-        - cron: "50 1 * * 2"
-    # Also allow manually running the workflow
-    workflow_dispatch:
 
 jobs:
-    synchronize-with-crowdin:
+    push-sources-to-crowdin:
         runs-on: ubuntu-latest
 
         steps:
@@ -29,13 +24,7 @@ jobs:
                   config: "auth/crowdin.yml"
                   upload_sources: true
                   upload_translations: false
-                  download_translations: true
-                  localization_branch_name: translations/auth
-                  create_pull_request: true
-                  skip_untranslated_strings: true
-                  pull_request_title: "[auth] New translations"
-                  pull_request_body: "New translations from [Crowdin](https://crowdin.com/project/ente-authenticator-app)"
-                  pull_request_base_branch_name: "main"
+                  download_translations: false
                   project_id: 575169
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auth-crowdin-sync.yml
+++ b/.github/workflows/auth-crowdin-sync.yml
@@ -1,0 +1,35 @@
+name: "Sync Crowdin translations (auth)"
+
+on:
+    schedule:
+        # See: [Note: Run workflow on specific days of the week]
+        - cron: "50 1 * * 2"
+    # Also allow manually running the workflow.
+    workflow_dispatch:
+
+jobs:
+    synchronize-with-crowdin:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Crowdin's action
+              uses: crowdin/github-action@v2
+              with:
+                  base_path: "auth/"
+                  config: "auth/crowdin.yml"
+                  upload_sources: true
+                  upload_translations: false
+                  download_translations: true
+                  localization_branch_name: translations/auth
+                  create_pull_request: true
+                  skip_untranslated_strings: true
+                  pull_request_title: "[auth] New translations"
+                  pull_request_body: "New translations from [Crowdin](https://crowdin.com/project/ente-authenticator-app)"
+                  pull_request_base_branch_name: "main"
+                  project_id: 575169
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/mobile-crowdin-push.yml
+++ b/.github/workflows/mobile-crowdin-push.yml
@@ -1,4 +1,4 @@
-name: "Sync Crowdin translations (mobile)"
+name: "Push sources to Crowdin (mobile)"
 
 on:
     push:
@@ -8,14 +8,9 @@ on:
             - "mobile/lib/l10n/intl_en.arb"
             # Or the workflow itself is changed
             - ".github/workflows/mobile-crowdin.yml"
-    schedule:
-        # See: [Note: Run workflow on specific days of the week]
-        - cron: "40 1 * * 2"
-    # Also allow manually running the workflow
-    workflow_dispatch:
 
 jobs:
-    synchronize-with-crowdin:
+    push-sources-to-crowdin:
         runs-on: ubuntu-latest
 
         steps:
@@ -29,13 +24,7 @@ jobs:
                   config: "mobile/crowdin.yml"
                   upload_sources: true
                   upload_translations: false
-                  download_translations: true
-                  localization_branch_name: translations/mobile
-                  create_pull_request: true
-                  skip_untranslated_strings: true
-                  pull_request_title: "[mobile] New translations"
-                  pull_request_body: "New translations from [Crowdin](https://crowdin.com/project/ente-photos-app)"
-                  pull_request_base_branch_name: "main"
+                  download_translations: false
                   project_id: 574741
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mobile-crowdin-sync.yml
+++ b/.github/workflows/mobile-crowdin-sync.yml
@@ -1,0 +1,35 @@
+name: "Sync Crowdin translations (mobile)"
+
+on:
+    schedule:
+        # See: [Note: Run workflow on specific days of the week]
+        - cron: "40 1 * * 2"
+    # Also allow manually running the workflow.
+    workflow_dispatch:
+
+jobs:
+    synchronize-with-crowdin:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Crowdin's action
+              uses: crowdin/github-action@v2
+              with:
+                  base_path: "mobile/"
+                  config: "mobile/crowdin.yml"
+                  upload_sources: true
+                  upload_translations: false
+                  download_translations: true
+                  localization_branch_name: translations/mobile
+                  create_pull_request: true
+                  skip_untranslated_strings: true
+                  pull_request_title: "[mobile] New translations"
+                  pull_request_body: "New translations from [Crowdin](https://crowdin.com/project/ente-photos-app)"
+                  pull_request_base_branch_name: "main"
+                  project_id: 574741
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/web-crowdin-push-both.yml
+++ b/.github/workflows/web-crowdin-push-both.yml
@@ -1,6 +1,6 @@
 name: "Push Crowdin translations (web)"
 
-# This is a variant of web-crowdin.yml that uploads the translated strings in
+# This is a variant of web-crowdin-sync.yml that uploads the translated strings in
 # addition to the source strings.
 #
 # This allows us to change the strings in our source code for an automated
@@ -9,11 +9,11 @@ name: "Push Crowdin translations (web)"
 
 on:
     # Trigger manually, or using
-    # `gh workflow run web-crowdin-push.yml --ref <my-branch>`
+    # `gh workflow run web-crowdin-push-both.yml --ref <my-branch>`
     workflow_dispatch:
 
 jobs:
-    push-to-crowdin:
+    push-both-to-crowdin:
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/web-crowdin-sync.yml
+++ b/.github/workflows/web-crowdin-sync.yml
@@ -17,7 +17,7 @@ on:
         #
         # See also: [Note: Run workflow every 24 hours]
         - cron: "20 1 * * 2"
-    # Also allow manually running the workflow
+    # Also allow manually running the workflow.
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
1. Sources uploaded anytime the {mobile,auth}/lib/l10n/arb/app_en.arb changes in main.
2. Tuesday morning: Download translations from crowdin.

Step 2 can be done manually by running the workflows, e.g.

    gh workflow run auth-crowdin-push.yml
    gh workflow run mobile-crowdin-push.yml
