### PR TITLE
Fix keyboard pop up when autofocus is turned on

### DIFF
--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -56,7 +56,7 @@ class _HomePageState extends State<HomePage> {
   final scaffoldKey = GlobalKey<ScaffoldState>();
 
   final TextEditingController _textController = TextEditingController();
-  final FocusNode searchInputFocusNode = FocusNode();
+  final bool _autoFocusSearch = PreferenceService.instance.shouldAutoFocusOnSearchBar();
   bool _showSearchBox = false;
   String _searchText = "";
   List<Code>? _allCodes;
@@ -87,18 +87,7 @@ class _HomePageState extends State<HomePage> {
     _iconsChangedEvent = Bus.instance.on<IconsChangedEvent>().listen((event) {
       setState(() {});
     });
-    _showSearchBox = PreferenceService.instance.shouldAutoFocusOnSearchBar();
-    if (_showSearchBox) {
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) {
-          // https://github.com/flutter/flutter/issues/20706#issuecomment-646328652
-          FocusScope.of(context).unfocus();
-          Timer(const Duration(milliseconds: 1), () {
-            FocusScope.of(context).requestFocus(searchInputFocusNode);
-          });
-        },
-      );
-    }
+    _showSearchBox = _autoFocusSearch;
   }
 
   void _loadCodes() {
@@ -240,8 +229,7 @@ class _HomePageState extends State<HomePage> {
               : TextField(
                   autocorrect: false,
                   enableSuggestions: false,
-                  focusNode: searchInputFocusNode,
-                  autofocus: _searchText.isEmpty,
+                  autofocus: _autoFocusSearch,
                   controller: _textController,
                   onChanged: (val) {
                     _searchText = val;


### PR DESCRIPTION
## Description

Keyboard didn't pop up when search-field was focused on startup. For more information see this issue: https://github.com/ente-io/ente/issues/279

## Tests

Created an build for my Android phone.
Outcome was as expected 
"Focus search on app start"  enabled did popped the keyboard out.
"Focus search on app start"  disabled did NOT popped the keyboard out and also didn't focused the search-textfield.


This is my first pull request to any open source project. So feel free to give some feedback!