### PR TITLE
[web] Deploy to staging from staging/web branch if it exists

### DIFF
--- a/.github/workflows/web-deploy-staging.yml
+++ b/.github/workflows/web-deploy-staging.yml
@@ -1,5 +1,7 @@
 name: "Deploy staging (web)"
 
+# Builds the "staging/web" branch if it exists, "main" otherwise.
+
 on:
     schedule:
         # Run everyday at ~3:00 PM IST
@@ -18,9 +20,19 @@ jobs:
                 working-directory: web
 
         steps:
-            - name: Checkout code
+            - name: Determine branch to build
+              id: select-branch
+              run: |
+                  if git ls-remote --exit-code --heads https://github.com/ente-io/ente refs/heads/staging/web; then
+                      echo "branch=staging/web" >> $GITHUB_OUTPUT
+                  else
+                      echo "branch=main" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Checkout ${{ steps.select-branch.outputs.branch }}
               uses: actions/checkout@v4
               with:
+                  ref: ${{ steps.select-branch.outputs.branch }}
                   submodules: recursive
 
             - name: Setup node and enable yarn caching


### PR DESCRIPTION
This allows us to temporarily deploy arbitrary branches to staging by pushing to a staging/web branch. Removing that branch reverts to the existing and default behaviour of deploying main.

Untested (need to deploy and trigger)

Refs:

- https://github.com/NLnetLabs/krill/commit/942f6a9fe9b43c2ddcd5adec261964359133d8e0
- https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
- https://stackoverflow.com/questions/57819539/github-actions-how-to-share-a-calculated-value-between-job-steps
