### PR TITLE
[web] Fix for the staging deployment change

### DIFF
--- a/.github/workflows/web-deploy-staging.yml
+++ b/.github/workflows/web-deploy-staging.yml
@@ -22,6 +22,7 @@ jobs:
         steps:
             - name: Determine branch to build
               id: select-branch
+              working-directory: ${{ github.workspace }}
               run: |
                   if git ls-remote --exit-code --heads https://github.com/ente-io/ente refs/heads/staging/web; then
                       echo "branch=staging/web" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix for https://github.com/ente-io/ente/pull/2252

> Error: An error occurred trying to start process '/usr/bin/bash' with working
  directory '/home/runner/work/ente/ente/web'. No such file or directory
