### PR TITLE
[server] Allow replication without Cloudflare worker

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -317,7 +317,7 @@ internal:
 replication:
     enabled: false
     # The Cloudflare worker to use to download files from the primary hot
-    # bucket. Must be specified if replication is enabled.
+    # bucket. If this isn't specified, files will be downloaded directly.
     worker-url:
     # Number of go routines to spawn for replication
     # This is not related to the worker-url above.

--- a/server/pkg/controller/replication3.go
+++ b/server/pkg/controller/replication3.go
@@ -87,10 +87,11 @@ func (c *ReplicationController3) StartReplication() error {
 
 	workerURL := viper.GetString("replication.worker-url")
 	if workerURL == "" {
-		return fmt.Errorf("replication.worker-url was not defined")
+		log.Infof("replication.worker-url was not defined, files will downloaded directly during replication")
+	} else {
+		log.Infof("Worker URL to download objects for replication v3 is: %s", workerURL)
 	}
 	c.workerURL = workerURL
-	log.Infof("Worker URL to download objects for replication v3 is: %s", workerURL)
 
 	c.createMetrics()
 	err := c.createTemporaryStorage()
@@ -414,7 +415,7 @@ func (c *ReplicationController3) downloadFromB2ViaWorker(objectKey string, file 
 	q.Add("src", presignedEncodedURL)
 	request.URL.RawQuery = q.Encode()
 
-	if c.S3Config.AreLocalBuckets() {
+	if c.S3Config.AreLocalBuckets() || c.workerURL == "" {
 		originalURL := request.URL
 		request, err = http.NewRequest("GET", presignedURL, nil)
 		if err != nil {


### PR DESCRIPTION
## Description
I recently started self hosting an instance of Ente. All went well until I tried to enable replication.

This PR adds an option that allows replication to be enabled without a Cloudflare worker, useful for self hosting.

## Tests
It doesn't look like there are any automated tests that I can add to, but let me know if I'm wrong. Otherwise, I tested this on my own instance and it's working as expected.