### PR TITLE
[server] Reduce DB healthcheck interval in starter Docker compose template

### DIFF
--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -49,9 +49,8 @@ services:
           "-U",
           "pguser"
         ]
-      interval: 1s
-      timeout: 5s
-      retries: 20
+      start_period: 40s
+      start_interval: 1s
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
The museum container depends on the postgres container being up and the DB being ready to accept connections. To enforce this dependency, we use the healthcheck attribute.

See: https://docs.docker.com/compose/startup-order/

The value of the healthcheck interval was set to 1s since the default (30s) caused each `docker compose up` to require at least 30 seconds on each startup, which was prohibitive. The downside is that the healthchecks continue to run beyond the startup phase too, and for small VMs, this caused a lot of unnecessary CPU usage.

Thankfully, now Docker has a new option for a different healthcheck during the start phase:

> start interval is the time between health checks during the start period. This
  option requires Docker Engine version 25.0 or later.

They were added in Docker compose 2.20.2, released an year ago (2023-07-19).

https://docs.docker.com/compose/release-notes/#2202
