### PR TITLE
Clip fix unusable formats

### DIFF
--- a/mobile/lib/db/embeddings_db.dart
+++ b/mobile/lib/db/embeddings_db.dart
@@ -123,7 +123,9 @@ class EmbeddingsDB {
   List<Embedding> _convertToEmbeddings(List<Map<String, dynamic>> results) {
     final List<Embedding> embeddings = [];
     for (final result in results) {
-      embeddings.add(_getEmbeddingFromRow(result));
+      final embedding = _getEmbeddingFromRow(result);
+      if (embedding.isEmpty) continue;
+      embeddings.add(embedding);
     }
     return embeddings;
   }

--- a/mobile/lib/models/embedding.dart
+++ b/mobile/lib/models/embedding.dart
@@ -6,12 +6,22 @@ class Embedding {
   final List<double> embedding;
   int? updationTime;
 
+  bool get isEmpty => embedding.isEmpty;
+
   Embedding({
     required this.fileID,
     required this.model,
     required this.embedding,
     this.updationTime,
   });
+
+  factory Embedding.empty(int fileID, Model model) {
+    return Embedding(
+      fileID: fileID,
+      model: model,
+      embedding: <double>[],
+    );
+  }
 
   static List<double> decodeEmbedding(String embedding) {
     return List<double>.from(jsonDecode(embedding) as List);

--- a/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
+++ b/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
@@ -3,6 +3,7 @@ import "dart:collection";
 import "dart:math" show min;
 
 import "package:computer/computer.dart";
+import "package:flutter/services.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/cache/lru_map.dart";
 import "package:photos/core/configuration.dart";
@@ -333,6 +334,21 @@ class SemanticSearchService {
         file,
         embedding,
       );
+    } on FormatException catch (e, _) {
+      _logger.severe(
+        "Could not get embedding for $file because FormatException occured, storing empty result locally",
+        e,
+      );
+      final embedding = Embedding.empty(file.uploadedFileID!, _currentModel);
+      await EmbeddingsDB.instance.put(embedding);
+    } on PlatformException catch (e, s) {
+      _logger.severe(
+        "Could not get thumbnail for $file due to PlatformException related to thumbnails, storing empty result locally",
+        e,
+        s,
+      );
+      final embedding = Embedding.empty(file.uploadedFileID!, _currentModel);
+      await EmbeddingsDB.instance.put(embedding);
     } catch (e, s) {
       _logger.severe(e, s);
     }

--- a/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
+++ b/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
@@ -214,20 +214,6 @@ class SemanticSearchService {
     unawaited(_pollQueue());
   }
 
-  Future<void> _cacheThumbnails(List<EnteFile> files) async {
-    int counter = 0;
-    const batchSize = 100;
-    for (var i = 0; i < files.length;) {
-      final futures = <Future>[];
-      for (var j = 0; j < batchSize && i < files.length; j++, i++) {
-        futures.add(getThumbnail(files[i]));
-      }
-      await Future.wait(futures);
-      counter += futures.length;
-      _logger.info("$counter/${files.length} thumbnails cached");
-    }
-  }
-
   Future<List<int>> _getFileIDsToBeIndexed() async {
     final uploadedFileIDs = await getIndexableFileIDs();
     final embeddedFileIDs =


### PR DESCRIPTION
## Description

When a certain image format cannot be decoded, clip will store a local empty result instead of infinitely retrying.