### PR TITLE
[desktop] Cache the handle to the zip files to improve metadata parsing speed

### DIFF
--- a/desktop/docs/dependencies.md
+++ b/desktop/docs/dependencies.md
@@ -128,3 +128,6 @@ watcher for the watch folders functionality.
 
 [node-stream-zip](https://github.com/antelle/node-stream-zip) is used for
 reading of large ZIP files (e.g. during imports of Google Takeout ZIPs).
+
+[lru-cache](https://github.com/isaacs/node-lru-cache) is used to cache file ZIP
+handles to avoid reopening them for every operation.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,6 +34,7 @@
         "ffmpeg-static": "^5.2",
         "html-entities": "^2.5",
         "jpeg-js": "^0.4",
+        "lru-cache": "^10.2",
         "next-electron-server": "^1",
         "node-stream-zip": "^1.15",
         "onnxruntime-node": "^1.18"

--- a/desktop/src/main/services/logout.ts
+++ b/desktop/src/main/services/logout.ts
@@ -3,6 +3,7 @@ import log from "../log";
 import { clearConvertToMP4Results } from "../stream";
 import { clearStores } from "./store";
 import { watchReset } from "./watch";
+import { clearOpenZipCache } from "./zip";
 
 /**
  * Perform the native side logout sequence.
@@ -29,5 +30,10 @@ export const logout = (watcher: FSWatcher) => {
         clearStores();
     } catch (e) {
         ignoreError("native stores", e);
+    }
+    try {
+        clearOpenZipCache();
+    } catch (e) {
+        ignoreError("zip cache", e);
     }
 };

--- a/desktop/src/main/services/upload.ts
+++ b/desktop/src/main/services/upload.ts
@@ -5,6 +5,7 @@ import { existsSync } from "original-fs";
 import type { PendingUploads, ZipItem } from "../../types/ipc";
 import log from "../log";
 import { uploadStatusStore } from "../stores/upload-status";
+import { clearOpenZipCache } from "./zip";
 
 export const listZipItems = async (zipPath: string): Promise<ZipItem[]> => {
     const zip = new StreamZip.async({ file: zipPath });
@@ -152,4 +153,7 @@ export const markUploadedZipItems = (
     uploadStatusStore.set("zipItems", updated);
 };
 
-export const clearPendingUploads = () => uploadStatusStore.clear();
+export const clearPendingUploads = () => {
+    uploadStatusStore.clear();
+    clearOpenZipCache();
+};

--- a/desktop/src/main/services/zip.ts
+++ b/desktop/src/main/services/zip.ts
@@ -6,11 +6,7 @@ const _cache = new LRUCache<string, StreamZip.StreamZipAsync>({
     max: 50,
     disposeAfter: (zip, zipPath) => {
         if (_refCount.has(zipPath)) {
-            // Add it back again. The `noDisposeOnSet` flag prevents dispose
-            // from being called again. From my understanding, it shouldn't
-            // matter in our case, but I've kept it here to match the
-            // recommended example:
-            // https://github.com/isaacs/node-lru-cache/issues/151#issuecomment-1033206697
+            // Add it back again.
             _cache.set(zipPath, zip);
         } else {
             void zip.close();

--- a/desktop/src/main/services/zip.ts
+++ b/desktop/src/main/services/zip.ts
@@ -1,0 +1,38 @@
+import { LRUCache } from "lru-cache";
+import StreamZip from "node-stream-zip";
+
+const _cache = new LRUCache<string, StreamZip.StreamZipAsync>({ max: 50 });
+
+/**
+ * Cached `StreamZip.async`s
+ *
+ * This function uses an LRU cache to cache handles to zip files indexed by
+ * their path.
+ *
+ * To clear the cache (which is a good idea to avoid having open file handles
+ * lying around), use {@link clearOpenZipCache}.
+ *
+ * Why was this needed
+ * -------------------
+ *
+ * Caching the StreamZip file handles _significantly_ (hours => seconds)
+ * improves the performance of the metadata parsing step during import of large
+ * Google Takeout zips.
+ *
+ * In ad-hoc tests, it seems that beyond a certain zip size (few GBs), reopening
+ * the handle to a stream zip overshadows the time taken to read the individual
+ * JSONs.
+ */
+export const openZip = (zipPath: string) => {
+    let result = _cache.get(zipPath);
+    if (!result) {
+        result = new StreamZip.async({ file: zipPath });
+        _cache.set(zipPath, result);
+    }
+    return result;
+};
+
+/**
+ * Clear any entries previously cached by {@link openZip}.
+ */
+export const clearOpenZipCache = () => _cache.clear();

--- a/desktop/src/main/services/zip.ts
+++ b/desktop/src/main/services/zip.ts
@@ -5,7 +5,7 @@ import StreamZip from "node-stream-zip";
 const _cache = new LRUCache<string, StreamZip.StreamZipAsync>({
     max: 50,
     disposeAfter: (zip, zipPath) => {
-        if (isInUse(zipPath)) {
+        if (_refCount.has(zipPath)) {
             // Add it back again. The `noDisposeOnSet` flag prevents dispose
             // from being called again. From my understanding, it shouldn't
             // matter in our case, but I've kept it here to match the
@@ -20,8 +20,6 @@ const _cache = new LRUCache<string, StreamZip.StreamZipAsync>({
 
 /** Reference count. */
 const _refCount = new Map<string, number>();
-
-const isInUse = (zipPath: string) => (_refCount.get(zipPath) ?? 0) > 0;
 
 /**
  * Cached `StreamZip.async`s

--- a/desktop/src/main/utils/temp.ts
+++ b/desktop/src/main/utils/temp.ts
@@ -1,10 +1,10 @@
 import { app } from "electron/main";
-import StreamZip from "node-stream-zip";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZipItem } from "../../types/ipc";
 import log from "../log";
+import { markClosableZip, openZip } from "../services/zip";
 import { ensure } from "./common";
 
 /**
@@ -128,9 +128,9 @@ export const makeFileForDataOrPathOrZipItem = async (
         } else {
             writeToTemporaryFile = async () => {
                 const [zipPath, entryName] = dataOrPathOrZipItem;
-                const zip = new StreamZip.async({ file: zipPath });
+                const zip = openZip(zipPath);
                 await zip.extract(entryName, path);
-                await zip.close();
+                markClosableZip(zipPath);
             };
         }
     }

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -2259,7 +2259,7 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^10.2.0:
+lru-cache@^10.2, lru-cache@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==

--- a/web/packages/next/types/ipc.ts
+++ b/web/packages/next/types/ipc.ts
@@ -567,6 +567,9 @@ export interface Electron {
 
     /**
      * Clear any pending uploads.
+     *
+     * This is also taken by the Node.js layer as a signal to clear any cached
+     * state it has kept around to speed up the upload.
      */
     clearPendingUploads: () => Promise<void>;
 }


### PR DESCRIPTION
This should _significantly_ (hours => seconds) improve the performance of the metadata parsing step during import of large Google Takeout zips, and bring them to par as if the user had drag-and-dropped the unzipped folder instead.

In my monkey tests, it seems that beyond a certain zip size (few GBs), reopening the handle to a stream zip overshadows the time taken to read the individual JSONs. This effect seems to grow very big for big zips to a point where the metadata parsing step takes hours.

But note that I'm only testing this on synthetic exemplars I've created. After merging it'll also need testing on more realistic huge takeout examples.