### PR TITLE
[server] Return key attributes in the session-validity response

### DIFF
--- a/server/pkg/api/user.go
+++ b/server/pkg/api/user.go
@@ -185,10 +185,11 @@ func (h *UserHandler) GetRoadmapURLV2(c *gin.Context) {
 // GetSessionValidityV2 verifies the user's session token and returns if the user has set their keys or not
 func (h *UserHandler) GetSessionValidityV2(c *gin.Context) {
 	userID := auth.GetUserID(c.Request.Header)
-	_, err := h.UserController.GetAttributes(userID)
+	keyAttributes, err := h.UserController.GetAttributes(userID)
 	if err == nil {
 		c.JSON(http.StatusOK, gin.H{
 			"hasSetKeys": true,
+			"keyAttributes": keyAttributes,
 		})
 	} else {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
Smoke tested locally. Was also more thoroughly tested as part of https://github.com/ente-io/ente/pull/2230.