### PR TITLE
[desktop] Speed up reconciliation 

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -31,6 +31,7 @@ import {
 import { ffmpegExec } from "./services/ffmpeg";
 import {
     fsExists,
+    fsFindFiles,
     fsIsDir,
     fsMkdirIfNeeded,
     fsReadTextFile,
@@ -63,7 +64,6 @@ import {
 } from "./services/upload";
 import {
     watchAdd,
-    watchFindFiles,
     watchGet,
     watchRemove,
     watchUpdateIgnoredFiles,
@@ -153,6 +153,10 @@ export const attachIPCHandlers = () => {
     );
 
     ipcMain.handle("fsIsDir", (_, dirPath: string) => fsIsDir(dirPath));
+
+    ipcMain.handle("fsFindFiles", (_, folderPath: string) =>
+        fsFindFiles(folderPath),
+    );
 
     // - Conversion
 
@@ -261,10 +265,6 @@ export const attachFSWatchIPCHandlers = (watcher: FSWatcher) => {
         "watchUpdateIgnoredFiles",
         (_, ignoredFiles: FolderWatch["ignoredFiles"], folderPath: string) =>
             watchUpdateIgnoredFiles(ignoredFiles, folderPath),
-    );
-
-    ipcMain.handle("watchFindFiles", (_, folderPath: string) =>
-        watchFindFiles(folderPath),
     );
 };
 

--- a/desktop/src/main/services/fs.ts
+++ b/desktop/src/main/services/fs.ts
@@ -4,6 +4,7 @@
 
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 
 export const fsExists = (path: string) => existsSync(path);
 
@@ -27,4 +28,18 @@ export const fsIsDir = async (dirPath: string) => {
     if (!existsSync(dirPath)) return false;
     const stat = await fs.stat(dirPath);
     return stat.isDirectory();
+};
+
+export const fsFindFiles = async (dirPath: string) => {
+    const items = await fs.readdir(dirPath, { withFileTypes: true });
+    let paths: string[] = [];
+    for (const item of items) {
+        const itemPath = path.posix.join(dirPath, item.name);
+        if (item.isFile()) {
+            paths.push(itemPath);
+        } else if (item.isDirectory()) {
+            paths = [...paths, ...(await fsFindFiles(itemPath))];
+        }
+    }
+    return paths;
 };

--- a/desktop/src/main/services/watch.ts
+++ b/desktop/src/main/services/watch.ts
@@ -1,7 +1,5 @@
 import chokidar, { type FSWatcher } from "chokidar";
 import { BrowserWindow } from "electron/main";
-import fs from "node:fs/promises";
-import path from "node:path";
 import { FolderWatch, type CollectionMapping } from "../../types/ipc";
 import log from "../log";
 import { watchStore } from "../stores/watch";
@@ -141,20 +139,6 @@ export const watchUpdateIgnoredFiles = (
             return watch;
         }),
     );
-};
-
-export const watchFindFiles = async (dirPath: string) => {
-    const items = await fs.readdir(dirPath, { withFileTypes: true });
-    let paths: string[] = [];
-    for (const item of items) {
-        const itemPath = path.posix.join(dirPath, item.name);
-        if (item.isFile()) {
-            paths.push(itemPath);
-        } else if (item.isDirectory()) {
-            paths = [...paths, ...(await watchFindFiles(itemPath))];
-        }
-    }
-    return paths;
 };
 
 /**

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -216,8 +216,8 @@ const watchOnRemoveDir = (f: (path: string, watch: FolderWatch) => void) => {
     );
 };
 
-const watchFindFiles = (folderPath: string) =>
-    ipcRenderer.invoke("watchFindFiles", folderPath);
+const fsFindFiles = (folderPath: string) =>
+    ipcRenderer.invoke("fsFindFiles", folderPath);
 
 const watchRemoveListeners = () => {
     ipcRenderer.removeAllListeners("watchAddFile");
@@ -340,6 +340,7 @@ contextBridge.exposeInMainWorld("electron", {
         readTextFile: fsReadTextFile,
         writeFile: fsWriteFile,
         isDir: fsIsDir,
+        findFiles: fsFindFiles,
     },
 
     // - Conversion
@@ -366,7 +367,6 @@ contextBridge.exposeInMainWorld("electron", {
         onAddFile: watchOnAddFile,
         onRemoveFile: watchOnRemoveFile,
         onRemoveDir: watchOnRemoveDir,
-        findFiles: watchFindFiles,
     },
 
     // - Upload

--- a/web/apps/photos/src/components/WatchFolder.tsx
+++ b/web/apps/photos/src/components/WatchFolder.tsx
@@ -82,7 +82,7 @@ export const WatchFolder: React.FC<WatchFolderProps> = ({ open, onClose }) => {
     };
 
     const selectCollectionMappingAndAddWatch = async (path: string) => {
-        const filePaths = await ensureElectron().watch.findFiles(path);
+        const filePaths = await ensureElectron().fs.findFiles(path);
         if (areAllInSameDirectory(filePaths)) {
             addWatch(path, "root");
         } else {

--- a/web/apps/photos/src/services/watch.ts
+++ b/web/apps/photos/src/services/watch.ts
@@ -561,7 +561,7 @@ const deduceEvents = async (watches: FolderWatch[]): Promise<WatchEvent[]> => {
     for (const watch of watches) {
         const folderPath = watch.folderPath;
 
-        const filePaths = await electron.watch.findFiles(folderPath);
+        const filePaths = await electron.fs.findFiles(folderPath);
 
         // Files that are on disk but not yet synced.
         for (const filePath of pathsToUpload(filePaths, watch))

--- a/web/packages/next/types/ipc.ts
+++ b/web/packages/next/types/ipc.ts
@@ -234,6 +234,18 @@ export interface Electron {
          * directory.
          */
         isDir: (dirPath: string) => Promise<boolean>;
+
+        /**
+         * Return the paths of all the files under the given folder.
+         *
+         * This function walks the directory tree starting at {@link folderPath}
+         * and returns a list of the absolute paths of all the files that exist
+         * therein. It will recursively traverse into nested directories, and
+         * return the absolute paths of the files there too.
+         *
+         * The returned paths are guaranteed to use POSIX separators ('/').
+         */
+        findFiles: (folderPath: string) => Promise<string[]>;
     };
 
     // - Conversion
@@ -479,18 +491,6 @@ export interface Electron {
          * The path is guaranteed to use POSIX separators ('/').
          */
         onRemoveDir: (f: (path: string, watch: FolderWatch) => void) => void;
-
-        /**
-         * Return the paths of all the files under the given folder.
-         *
-         * This function walks the directory tree starting at {@link folderPath}
-         * and returns a list of the absolute paths of all the files that exist
-         * therein. It will recursively traverse into nested directories, and
-         * return the absolute paths of the files there too.
-         *
-         * The returned paths are guaranteed to use POSIX separators ('/').
-         */
-        findFiles: (folderPath: string) => Promise<string[]>;
     };
 
     // - Upload


### PR DESCRIPTION
- Do an upfront directory listing.
- Avoid JSON parsing (the various LivePhoto functions we were callling were internally doing it), and even when we have to, don't do it twice (I tested, the JSON parsing does have a noticeable impact)

@ua741 Monkey testing shows it to be _*almost_ O(1) compared to the earlier O(n). _*almost_ is with many caveats:
- The recursive ls is still multi-second (takes ~5s for 300k files on my SSD)
- The loop is now almost instantaneous for people who don't have live photos or have already synced, but there is still one JSON parse (in the else branch) that'll run for initial exports or people with many live photos
