### PR TITLE
[server] Increase HTTP request body size to prevent 413 Too Large errors

### DIFF
--- a/server/scripts/deploy/museum.nginx.conf
+++ b/server/scripts/deploy/museum.nginx.conf
@@ -18,6 +18,9 @@ server {
 
     server_name api.ente.io;
 
+    # Allow HTTP request body up to 4 MB (default is 1 MB).
+    client_max_body_size 4m;
+
     location / {
         proxy_pass http://museum;
         proxy_http_version 1.1;


### PR DESCRIPTION
Allow HTTP request body up to 4 MB. The default is 1 MB, which is too small for face embeddings for photos with more than a couple of hundred faces.

Roughly, each face embedding is 4KB, but encrypting and base-64-ing the embedding also has a 30% addition (just from one sample I saw), so this should allow photos with ~700 faces to go through.

Ref:
- https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
