### PR TITLE
[web] Improve JPEG 2000 handling

### DIFF
--- a/web/apps/cast/src/services/render.ts
+++ b/web/apps/cast/src/services/render.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import { FILE_TYPE } from "@/media/file-type";
-import { isHEICExtension, isNonWebImageFileExtension } from "@/media/formats";
+import { isHEICExtension, needsJPEGConversion } from "@/media/formats";
 import { heicToJPEG } from "@/media/heic-convert";
 import { decodeLivePhoto } from "@/media/live-photo";
 import type {
@@ -258,8 +258,8 @@ const isFileEligible = (file: EnteFile) => {
     // extension. To detect the actual type, we need to sniff the MIME type, but
     // that requires downloading and decrypting the file first.
     const [, extension] = nameAndExtension(file.metadata.title);
-    if (extension && isNonWebImageFileExtension(extension)) {
-        // Of the known non-web types, we support HEIC.
+    if (extension && needsJPEGConversion(extension)) {
+        // On the web, we only support HEIC conversion.
         return isHEICExtension(extension);
     }
 

--- a/web/apps/photos/src/components/PhotoViewer/index.tsx
+++ b/web/apps/photos/src/components/PhotoViewer/index.tsx
@@ -14,11 +14,11 @@ import {
 } from "utils/file";
 
 import { FILE_TYPE } from "@/media/file-type";
-import { isNonWebImageFileExtension } from "@/media/formats";
+import { isHEICExtension, needsJPEGConversion } from "@/media/formats";
 import downloadManager from "@/new/photos/services/download";
 import type { LoadedLivePhotoSourceURL } from "@/new/photos/types/file";
 import { detectFileTypeInfo } from "@/new/photos/utils/detect-type";
-import { isNativeConvertibleToJPEG } from "@/new/photos/utils/file";
+import { isDesktop } from "@/next/app";
 import { lowercaseExtension } from "@/next/file";
 import { FlexWrapper } from "@ente/shared/components/Container";
 import EnteSpinner from "@ente/shared/components/EnteSpinner";
@@ -350,11 +350,16 @@ function PhotoViewer(props: Iprops) {
 
     function updateShowEditButton(file: EnteFile) {
         const extension = lowercaseExtension(file.metadata.title);
-        const isSupported =
-            !isNonWebImageFileExtension(extension) ||
-            // TODO: This condition doesn't sound correct when running in the
-            // web app?
-            isNativeConvertibleToJPEG(extension);
+        // Assume it is supported.
+        let isSupported = true;
+        if (needsJPEGConversion(extension)) {
+            // See if the file is on the whitelist of extensions that we know
+            // will not be directly renderable.
+            if (!isDesktop) {
+                // On the web, we only support HEIC conversion.
+                isSupported = isHEICExtension(extension);
+            }
+        }
         setShowEditButton(
             file.metadata.fileType === FILE_TYPE.IMAGE && isSupported,
         );

--- a/web/packages/media/formats.ts
+++ b/web/packages/media/formats.ts
@@ -1,29 +1,30 @@
 /**
- * Image file extensions that we know the browser is unlikely to have native
- * support for.
+ * List used by {@link needsJPEGConversion}.
  */
-const nonWebImageFileExtensions = [
-    "heic",
-    "rw2",
-    "tiff",
+const needsJPEGConversionExtensions = [
     "arw",
-    "cr3",
     "cr2",
-    "raf",
+    "cr3",
+    "dng",
+    "heic",
+    "jp2",
     "nef",
     "psd",
-    "dng",
+    "rw2",
     "tif",
+    "tiff",
 ];
 
 /**
  * Return `true` if {@link extension} is from amongst a known set of image file
- * extensions that we know that the browser is unlikely to have native support
- * for. If we want to display such files in the browser, we'll need to convert
- * them to some other format first.
+ * extensions that (a) we know that the browser is unlikely to support, and (b)
+ * which we should be able to convert to JPEG when running in our desktop app.
+ *
+ * These two are independent constraints, but we only return true if we satisfy
+ * both of them instead of having two disjoint lists.
  */
-export const isNonWebImageFileExtension = (extension: string) =>
-    nonWebImageFileExtensions.includes(extension.toLowerCase());
+export const needsJPEGConversion = (extension: string) =>
+    needsJPEGConversionExtensions.includes(extension.toLowerCase());
 
 /**
  * Return `true` if {@link extension} in for an HEIC-like file.

--- a/web/packages/media/formats.ts
+++ b/web/packages/media/formats.ts
@@ -27,6 +27,15 @@ export const needsJPEGConversion = (extension: string) =>
     needsJPEGConversionExtensions.includes(extension.toLowerCase());
 
 /**
+ * Return true if {@link extension} _might_ be supported by the user's browser.
+ *
+ * For example, JPEG 2000 (jp2) is supported by Safari, but not by Chrome or
+ * Firefox, and this function will return true for `jp2`.
+ */
+export const hasPartialBrowserSupport = (extension: string) =>
+    ["jp2"].includes(extension.toLowerCase());
+
+/**
  * Return `true` if {@link extension} in for an HEIC-like file.
  */
 export const isHEICExtension = (extension: string) => {


### PR DESCRIPTION
- Let supporting browsers (e.g. Safari) upload them.
- Let them be indexed by converting to JPEG.