### PR TITLE
CLI: Allow setting secrets path via env var

### DIFF
--- a/cli/pkg/secrets/secret.go
+++ b/cli/pkg/secrets/secret.go
@@ -26,10 +26,15 @@ const (
 func GetOrCreateClISecret() []byte {
 	// get password
 	secret, err := keyring.Get(secretService, secretUser)
+
 	if err != nil {
 		if !errors.Is(err, keyring.ErrNotFound) {
+
+			if secretsFile := os.Getenv("ENTE_CLI_SECRETS_PATH"); secretsFile != "" {
+				return GetSecretFromSecretText(secretsFile)
+			}
 			if IsRunningInContainer() {
-				return GetSecretFromSecretText()
+				return GetSecretFromSecretText(fmt.Sprintf("%s.secret.txt", constants.CliDataPath))
 			} else {
 				log.Fatal(fmt.Errorf("error getting password from keyring: %w", err))
 			}
@@ -51,9 +56,7 @@ func GetOrCreateClISecret() []byte {
 
 // GetSecretFromSecretText reads the scecret from the secret text file.
 // If the file does not exist, it will be created and write random 32 byte secret to it.
-func GetSecretFromSecretText() []byte {
-	// Define the path to the secret text file
-	secretFilePath := fmt.Sprintf("%s.secret.txt", constants.CliDataPath)
+func GetSecretFromSecretText(secretFilePath string) []byte {
 
 	// Check if file exists
 	_, err := os.Stat(secretFilePath)


### PR DESCRIPTION
## Description

Adds a new enviroment variable `ENTE_CLI_SECRETS_PATH`, that allows specifying the path to a `secrets.txt` like the one used in the dockerized version. If no path is provided, the old behaviour is maintained.

The configuration variable and behaviour is analog to the already present `ENTE_CONFIG_PATH` variable, which allows specifying a configuration. 

This provides a solution for people running without gnome-keyring (https://github.com/ente-io/ente/issues/722 and https://github.com/ente-io/ente/issues/1328)
