### PR TITLE
[server] Add a workaround for Safari to recognize Yubikeys

### DIFF
--- a/server/pkg/repo/passkey/passkey.go
+++ b/server/pkg/repo/passkey/passkey.go
@@ -47,7 +47,9 @@ func (u *PasskeyUser) WebAuthnName() string {
 }
 
 func (u *PasskeyUser) WebAuthnDisplayName() string {
-	return u.Name
+	// Safari requires a display name to be set, otherwise it does not recognize
+	// security keys.
+	return u.Email
 }
 
 func (u *PasskeyUser) WebAuthnCredentials() []webauthn.Credential {


### PR DESCRIPTION
Safari just doesn't recognize the Yubikey (macOS/iOS, NFC/USB, doesn't matter) if display name is set to the empty string. Safari's long description doesn't care to mention this requirement:
https://webkit.org/blog/11312/meet-face-id-and-touch-id-for-the-web/

Tested on localhost with Safari macOS. Will test on iOS post deployment.
