### PR TITLE
[server] [cli] Fix docker "FROM AS" case warnings

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.17 as builder
+FROM golang:1.20-alpine3.17 AS builder
 RUN apk add --no-cache gcc musl-dev git build-base pkgconfig libsodium-dev
 
 ENV GOOS=linux

--- a/cli/Dockerfile-x86
+++ b/cli/Dockerfile-x86
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.17@sha256:9c2f89db6fda13c3c480749787f62fed5831699bb2c32881b8f327f1cf7bae42 as builder386
+FROM golang:1.20-alpine3.17@sha256:9c2f89db6fda13c3c480749787f62fed5831699bb2c32881b8f327f1cf7bae42 AS builder386
 RUN apt-get  update
 RUN apt-get  install -y gcc
 RUN apt-get  install -y git

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.17 as builder
+FROM golang:1.21-alpine3.17 AS builder
 RUN apk add --no-cache gcc musl-dev git build-base pkgconfig libsodium-dev
 
 ENV GOOS=linux


### PR DESCRIPTION
With the latest Docker update (27.0.3), it now warns about the "FROM" and "AS" in the Dockerfile not matching. E.g. when building the server docker image:

> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
