### PR TITLE
[cli] Fix typo with ente account url constant

### DIFF
--- a/cli/utils/constants/constants.go
+++ b/cli/utils/constants/constants.go
@@ -3,4 +3,4 @@ package constants
 const CliDataPath = "/cli-data/"
 
 const EnteApiUrl = "https://api.ente.io"
-const EnteAccountUrl = "https://account.ente.io"
+const EnteAccountUrl = "https://accounts.ente.io"


### PR DESCRIPTION
## Description
I noticed there was a typo in the EnteAccountUrl constant for the CLI, which resulted in an incorrect URL being generated when asking the user to verify their passkey.

## Tests
I didn't see tests in the project, but I did build the cli project and manually tested `cli.exe` by adding my ente account and verifying the URL that's generated is correct now.

```
Nick  ~\..\ente\cli  .\cli.exe account add
Enter app type (default: photos):
Use default app type: photos
Enter export directory: .\
Enter email address: redacted@pm.me
Enter OTP: 123456
Open this url in browser to verify passkey: https://accounts.ente.io/passkeys/verify?redacted
Press enter once you have completed the passkey verification
```