### PR TITLE
fix(auth/code): add option to view raw codes in case of parse fail

### DIFF
--- a/auth/lib/l10n/arb/app_en.arb
+++ b/auth/lib/l10n/arb/app_en.arb
@@ -442,5 +442,8 @@
   "deleteTagTitle": "Delete tag?",
   "deleteTagMessage": "Are you sure you want to delete this tag? This action is irreversible.",
   "somethingWentWrongParsingCode": "We were unable to parse {x} codes.",
-  "updateNotAvailable": "Update not available"
+  "updateNotAvailable": "Update not available",
+  "viewRawCodes": "View raw codes",
+  "rawCodes": "Raw codes",
+  "rawCodeData": "Raw code data"
 }

--- a/auth/lib/ui/code_error_widget.dart
+++ b/auth/lib/ui/code_error_widget.dart
@@ -1,8 +1,10 @@
 import 'package:ente_auth/ente_theme_data.dart';
 import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/common/gradient_button.dart';
 import 'package:ente_auth/ui/linear_progress_widget.dart';
+import 'package:ente_auth/ui/tools/debug/raw_codes_viewer.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:flutter/material.dart';
 
@@ -12,7 +14,7 @@ class CodeErrorWidget extends StatelessWidget {
     required this.errors,
   });
 
-  final int errors;
+  final List<Code> errors;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +72,7 @@ class CodeErrorWidget extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
               child: Text(
-                context.l10n.somethingWentWrongParsingCode(errors),
+                context.l10n.somethingWentWrongParsingCode(errors.length),
                 style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w500,
@@ -78,29 +80,54 @@ class CodeErrorWidget extends StatelessWidget {
               ),
             ),
             const Spacer(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                SizedBox(
-                  width: 102,
-                  height: 28,
-                  child: GradientButton(
-                    text: context.l10n.contactSupport,
-                    fontSize: 10,
-                    onTap: () async {
-                      await showErrorDialog(
-                        context,
-                        context.l10n.contactSupport,
-                        context.l10n
-                            .contactSupportViaEmailMessage("support@ente.io"),
-                      );
-                    },
-                    borderWidth: 0.6,
-                    borderRadius: 6,
+            Align(
+              alignment: Alignment.centerRight,
+              child: Wrap(
+                children: [
+                  SizedBox(
+                    width: 102,
+                    height: 28,
+                    child: GradientButton(
+                      text: context.l10n.viewRawCodes,
+                      fontSize: 10,
+                      onTap: () async {
+                        await showDialog(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return RawCodesViewer(
+                              errors.map((e) => e.rawData).join('\n'),
+                            );
+                          },
+                          barrierColor: Colors.black87,
+                          barrierDismissible: false,
+                        );
+                      },
+                      borderWidth: 0.6,
+                      borderRadius: 6,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 6),
-              ],
+                  const SizedBox(width: 12),
+                  SizedBox(
+                    width: 102,
+                    height: 28,
+                    child: GradientButton(
+                      text: context.l10n.contactSupport,
+                      fontSize: 10,
+                      onTap: () async {
+                        await showErrorDialog(
+                          context,
+                          context.l10n.contactSupport,
+                          context.l10n
+                              .contactSupportViaEmailMessage("support@ente.io"),
+                        );
+                      },
+                      borderWidth: 0.6,
+                      borderRadius: 6,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                ],
+              ),
             ),
             const SizedBox(height: 12),
           ],

--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -348,8 +348,8 @@ class _HomePageState extends State<HomePage> {
                     return CodeErrorWidget(
                       errors: _allCodes
                               ?.where((element) => element.hasError)
-                              .length ??
-                          0,
+                              .toList() ??
+                          [],
                     );
                   }
                   final newIndex = index - indexOffset;

--- a/auth/lib/ui/tools/debug/raw_codes_viewer.dart
+++ b/auth/lib/ui/tools/debug/raw_codes_viewer.dart
@@ -1,0 +1,45 @@
+import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/utils/platform_util.dart';
+import 'package:flutter/material.dart';
+
+class RawCodesViewer extends StatefulWidget {
+  final String rawData;
+  const RawCodesViewer(this.rawData, {super.key});
+
+  @override
+  State<RawCodesViewer> createState() => _RawCodesViewerState();
+}
+
+class _RawCodesViewerState extends State<RawCodesViewer> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        title: Text(context.l10n.rawCodeData),
+      ),
+      body: _getBody(),
+    );
+  }
+
+  Widget _getBody() {
+    return Container(
+      padding: const EdgeInsets.only(left: 12, top: 8, right: 12),
+      child: SingleChildScrollView(
+        child: SelectableRegion(
+          focusNode: FocusNode(),
+          selectionControls: PlatformUtil.selectionControls,
+          child: Text(
+            widget.rawData,
+            style: const TextStyle(
+              fontFeatures: [
+                FontFeature.tabularFigures(),
+              ],
+              height: 1.2,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

![Screenshot 2024-07-17 190450](https://github.com/user-attachments/assets/886fc943-8462-48c6-a713-bae7a606f034)


![image](https://github.com/user-attachments/assets/ee750d07-5901-4864-88c9-7166abd9f1d1)


## Tests
