### PR TITLE
[mob][photos] Improve UX on "Create new account" screen

### DIFF
--- a/mobile/lib/generated/intl/messages_cs.dart
+++ b/mobile/lib/generated/intl/messages_cs.dart
@@ -82,6 +82,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "noSystemLockFound":
             MessageLookupByLibrary.simpleMessage("No system lock found"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Password lock"),
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "pinLock": MessageLookupByLibrary.simpleMessage("PIN lock"),
         "reenterPassword":
             MessageLookupByLibrary.simpleMessage("Re-enter password"),

--- a/mobile/lib/generated/intl/messages_de.dart
+++ b/mobile/lib/generated/intl/messages_de.dart
@@ -1098,6 +1098,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Passwort erfolgreich geändert"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Passwort Sperre"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Wir speichern dieses Passwort nicht. Wenn du es vergisst, <underline>können wir deine Daten nicht entschlüsseln</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_en.dart
+++ b/mobile/lib/generated/intl/messages_en.dart
@@ -1054,6 +1054,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Password changed successfully"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Password lock"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "We don\'t store this password, so if you forget, <underline>we cannot decrypt your data</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_es.dart
+++ b/mobile/lib/generated/intl/messages_es.dart
@@ -1104,6 +1104,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Bloqueo por contraseña"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "No almacenamos esta contraseña, así que si la olvidas, <underline>no podemos descifrar tus datos</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_fr.dart
+++ b/mobile/lib/generated/intl/messages_fr.dart
@@ -1014,6 +1014,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Mot de passe verrou"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nous ne stockons pas ce mot de passe, donc si vous l\'oubliez, <underline>nous ne pouvons pas déchiffrer vos données</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_it.dart
+++ b/mobile/lib/generated/intl/messages_it.dart
@@ -981,6 +981,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Blocco con password"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Noi non memorizziamo la tua password, quindi se te la dimentichi, <underline>non possiamo decriptare i tuoi dati</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_ko.dart
+++ b/mobile/lib/generated/intl/messages_ko.dart
@@ -82,6 +82,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "noSystemLockFound":
             MessageLookupByLibrary.simpleMessage("No system lock found"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Password lock"),
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "pinLock": MessageLookupByLibrary.simpleMessage("PIN lock"),
         "reenterPassword":
             MessageLookupByLibrary.simpleMessage("Re-enter password"),

--- a/mobile/lib/generated/intl/messages_nl.dart
+++ b/mobile/lib/generated/intl/messages_nl.dart
@@ -1098,6 +1098,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Wachtwoord succesvol aangepast"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Wachtwoord slot"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Wij slaan dit wachtwoord niet op, dus als je het vergeet, kunnen <underline>we je gegevens niet ontsleutelen</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_no.dart
+++ b/mobile/lib/generated/intl/messages_no.dart
@@ -104,6 +104,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "noSystemLockFound":
             MessageLookupByLibrary.simpleMessage("No system lock found"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Password lock"),
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "pinLock": MessageLookupByLibrary.simpleMessage("PIN lock"),
         "reenterPassword":
             MessageLookupByLibrary.simpleMessage("Re-enter password"),

--- a/mobile/lib/generated/intl/messages_pl.dart
+++ b/mobile/lib/generated/intl/messages_pl.dart
@@ -1092,6 +1092,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Hasło zostało pomyślnie zmienione"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Blokada hasłem"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nie przechowujemy tego hasła, więc jeśli go zapomnisz, <underline>nie będziemy w stanie odszyfrować Twoich danych</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_pt.dart
+++ b/mobile/lib/generated/intl/messages_pt.dart
@@ -1089,6 +1089,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Bloqueio de senha"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Nós não salvamos essa senha, se você esquecer <underline> nós não poderemos descriptografar seus dados</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_ru.dart
+++ b/mobile/lib/generated/intl/messages_ru.dart
@@ -1089,6 +1089,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordLock":
             MessageLookupByLibrary.simpleMessage("Блокировка паролем"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Мы не храним этот пароль, поэтому если вы забудете его, <underline>мы не сможем расшифровать ваши данные</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_tr.dart
+++ b/mobile/lib/generated/intl/messages_tr.dart
@@ -1084,6 +1084,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Şifreniz başarılı bir şekilde değiştirildi"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("Sifre kilidi"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Şifrelerinizi saklamıyoruz, bu yüzden unutursanız, <underline>verilerinizi deşifre edemeyiz</underline>"),
         "paymentDetails":

--- a/mobile/lib/generated/intl/messages_zh.dart
+++ b/mobile/lib/generated/intl/messages_zh.dart
@@ -898,6 +898,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("密码修改成功"),
         "passwordLock": MessageLookupByLibrary.simpleMessage("密码锁"),
         "passwordStrength": m38,
+        "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
+            "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "我们不储存这个密码，所以如果忘记， <underline>我们将无法解密您的数据</underline>"),
         "paymentDetails": MessageLookupByLibrary.simpleMessage("付款明细"),

--- a/mobile/lib/generated/l10n.dart
+++ b/mobile/lib/generated/l10n.dart
@@ -9194,6 +9194,16 @@ class S {
       args: [],
     );
   }
+
+  /// `Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords`
+  String get passwordStrengthInfo {
+    return Intl.message(
+      'Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords',
+      name: 'passwordStrengthInfo',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/mobile/lib/l10n/intl_cs.arb
+++ b/mobile/lib/l10n/intl_cs.arb
@@ -47,5 +47,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_de.arb
+++ b/mobile/lib/l10n/intl_de.arb
@@ -1285,5 +1285,6 @@
   "videoInfo": "Video-Informationen",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_en.arb
+++ b/mobile/lib/l10n/intl_en.arb
@@ -1285,5 +1285,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_es.arb
+++ b/mobile/lib/l10n/intl_es.arb
@@ -1271,5 +1271,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_fr.arb
+++ b/mobile/lib/l10n/intl_fr.arb
@@ -1188,5 +1188,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_it.arb
+++ b/mobile/lib/l10n/intl_it.arb
@@ -1150,5 +1150,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_ko.arb
+++ b/mobile/lib/l10n/intl_ko.arb
@@ -47,5 +47,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_nl.arb
+++ b/mobile/lib/l10n/intl_nl.arb
@@ -1283,5 +1283,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_no.arb
+++ b/mobile/lib/l10n/intl_no.arb
@@ -61,5 +61,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_pl.arb
+++ b/mobile/lib/l10n/intl_pl.arb
@@ -1285,5 +1285,6 @@
   "videoInfo": "Informacje Wideo",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_pt.arb
+++ b/mobile/lib/l10n/intl_pt.arb
@@ -1283,5 +1283,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_ru.arb
+++ b/mobile/lib/l10n/intl_ru.arb
@@ -1270,5 +1270,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_tr.arb
+++ b/mobile/lib/l10n/intl_tr.arb
@@ -1282,5 +1282,6 @@
   "autoLockFeatureDescription": "Time after which the app locks after being put in the background",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/l10n/intl_zh.arb
+++ b/mobile/lib/l10n/intl_zh.arb
@@ -1285,5 +1285,6 @@
   "videoInfo": "视频详情",
   "hideContent": "Hide content",
   "hideContentDescriptionAndroid": "Hides app content in the app switcher and disables screenshots",
-  "hideContentDescriptionIos": "Hides app content in the app switcher"
+  "hideContentDescriptionIos": "Hides app content in the app switcher",
+  "passwordStrengthInfo": "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords"
 }

--- a/mobile/lib/ui/account/email_entry_page.dart
+++ b/mobile/lib/ui/account/email_entry_page.dart
@@ -49,6 +49,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
 
   @override
   void initState() {
+    super.initState();
     _email = _config.getEmail();
     _password1FocusNode.addListener(() {
       setState(() {
@@ -60,7 +61,6 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
         _password2InFocus = _password2FocusNode.hasFocus;
       });
     });
-    super.initState();
   }
 
   @override
@@ -164,7 +164,6 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                       suffixIcon: _emailIsValid
                           ? Icon(
                               Icons.check,
-                              size: 20,
                               color: Theme.of(context)
                                   .inputDecorationTheme
                                   .focusedBorder!
@@ -309,7 +308,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                     onChanged: (cnfPassword) {
                       setState(() {
                         _cnfPassword = cnfPassword;
-                        if (_password != null || _password != '') {
+                        if (_password != null && _password != '') {
                           _passwordsMatch = _password == _cnfPassword;
                         }
                       });
@@ -317,7 +316,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                   ),
                 ),
                 Opacity(
-                  opacity: (_password != '') && _password1InFocus ? 1 : 0,
+                  opacity: (_password != null && _password != '') ? 1 : 0,
                   child: Padding(
                     padding:
                         const EdgeInsets.symmetric(horizontal: 24, vertical: 8),

--- a/mobile/lib/ui/account/email_entry_page.dart
+++ b/mobile/lib/ui/account/email_entry_page.dart
@@ -343,9 +343,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                           onTap: () {
                             showInfoDialog(
                               context,
-                              title: "",
-                              body:
-                                  "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords",
+                              body: S.of(context).passwordStrengthInfo,
                             );
                           },
                         ),

--- a/mobile/lib/ui/account/email_entry_page.dart
+++ b/mobile/lib/ui/account/email_entry_page.dart
@@ -15,7 +15,7 @@ import 'package:step_progress_indicator/step_progress_indicator.dart';
 import "package:styled_text/styled_text.dart";
 
 class EmailEntryPage extends StatefulWidget {
-  const EmailEntryPage({Key? key}) : super(key: key);
+  const EmailEntryPage({super.key});
 
   @override
   State<EmailEntryPage> createState() => _EmailEntryPageState();
@@ -52,16 +52,23 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
   void initState() {
     super.initState();
     _email = _config.getEmail();
-    _password1FocusNode.addListener(() {
-      setState(() {
-        _password1InFocus = _password1FocusNode.hasFocus;
-      });
-    });
-    _password2FocusNode.addListener(() {
-      setState(() {
-        _password2InFocus = _password2FocusNode.hasFocus;
-      });
-    });
+    _password1FocusNode.addListener(
+      _password1FocusListener,
+    );
+    _password2FocusNode.addListener(
+      _password2FocusListener,
+    );
+  }
+
+  @override
+  void dispose() {
+    _password1FocusNode.removeListener(_password1FocusListener);
+    _password2FocusNode.removeListener(_password2FocusListener);
+    _password1FocusNode.dispose();
+    _password2FocusNode.dispose();
+    _passwordController1.dispose();
+    _passwordController2.dispose();
+    super.dispose();
   }
 
   @override
@@ -323,31 +330,33 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                       horizontal: 24,
                       vertical: 8,
                     ),
-                    child: Row(
-                      children: [
-                        Text(
-                          S.of(context).passwordStrength(passwordStrengthText),
-                          style: TextStyle(
-                            color: passwordStrengthColor,
-                            fontWeight: FontWeight.w500,
-                            fontSize: 12,
+                    child: GestureDetector(
+                      onTap: () {
+                        showInfoDialog(
+                          context,
+                          body: S.of(context).passwordStrengthInfo,
+                        );
+                      },
+                      child: Row(
+                        children: [
+                          Text(
+                            S
+                                .of(context)
+                                .passwordStrength(passwordStrengthText),
+                            style: TextStyle(
+                              color: passwordStrengthColor,
+                              fontWeight: FontWeight.w500,
+                              fontSize: 12,
+                            ),
                           ),
-                        ),
-                        const SizedBox(width: 8),
-                        GestureDetector(
-                          child: Icon(
+                          const SizedBox(width: 8),
+                          Icon(
                             Icons.info_outline,
                             size: 16,
                             color: getEnteColorScheme(context).fillStrong,
                           ),
-                          onTap: () {
-                            showInfoDialog(
-                              context,
-                              body: S.of(context).passwordStrengthInfo,
-                            );
-                          },
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -541,6 +550,18 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
         ],
       ),
     );
+  }
+
+  void _password1FocusListener() {
+    setState(() {
+      _password1InFocus = _password1FocusNode.hasFocus;
+    });
+  }
+
+  void _password2FocusListener() {
+    setState(() {
+      _password2InFocus = _password2FocusNode.hasFocus;
+    });
   }
 
   bool _isFormValid() {

--- a/mobile/lib/ui/account/email_entry_page.dart
+++ b/mobile/lib/ui/account/email_entry_page.dart
@@ -9,6 +9,7 @@ import 'package:photos/services/user_service.dart';
 import "package:photos/theme/ente_theme.dart";
 import 'package:photos/ui/common/dynamic_fab.dart';
 import 'package:photos/ui/common/web_page.dart';
+import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/toast_util.dart";
 import 'package:step_progress_indicator/step_progress_indicator.dart';
 import "package:styled_text/styled_text.dart";
@@ -318,15 +319,37 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                 Opacity(
                   opacity: (_password != null && _password != '') ? 1 : 0,
                   child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-                    child: Text(
-                      S.of(context).passwordStrength(passwordStrengthText),
-                      style: TextStyle(
-                        color: passwordStrengthColor,
-                        fontWeight: FontWeight.w500,
-                        fontSize: 12,
-                      ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 8,
+                    ),
+                    child: Row(
+                      children: [
+                        Text(
+                          S.of(context).passwordStrength(passwordStrengthText),
+                          style: TextStyle(
+                            color: passwordStrengthColor,
+                            fontWeight: FontWeight.w500,
+                            fontSize: 12,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        GestureDetector(
+                          child: Icon(
+                            Icons.info_outline,
+                            size: 16,
+                            color: getEnteColorScheme(context).fillStrong,
+                          ),
+                          onTap: () {
+                            showInfoDialog(
+                              context,
+                              title: "",
+                              body:
+                                  "Password strength is calculated considering the length of the password, used characters, and whether or not the password appears in the top 10,000 most used passwords",
+                            );
+                          },
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/mobile/lib/utils/dialog_util.dart
+++ b/mobile/lib/utils/dialog_util.dart
@@ -19,9 +19,9 @@ typedef DialogBuilder = DialogWidget Function(BuildContext context);
 
 ///Will return null if dismissed by tapping outside
 Future<ButtonResult?> showInfoDialog(
-  BuildContext context,
-  String title,
-  String? body, {
+  BuildContext context, {
+  String title = "",
+  String? body,
   IconData icon = Icons.info_outline_rounded,
   bool isDismissable = true,
 }) async {

--- a/mobile/lib/utils/dialog_util.dart
+++ b/mobile/lib/utils/dialog_util.dart
@@ -18,6 +18,31 @@ import "package:photos/utils/email_util.dart";
 typedef DialogBuilder = DialogWidget Function(BuildContext context);
 
 ///Will return null if dismissed by tapping outside
+Future<ButtonResult?> showInfoDialog(
+  BuildContext context,
+  String title,
+  String? body, {
+  IconData icon = Icons.info_outline_rounded,
+  bool isDismissable = true,
+}) async {
+  return showDialogWidget(
+    context: context,
+    title: title,
+    body: body,
+    icon: icon,
+    isDismissible: isDismissable,
+    buttons: [
+      ButtonWidget(
+        buttonType: ButtonType.secondary,
+        labelText: S.of(context).ok,
+        isInAlert: true,
+        buttonAction: ButtonAction.first,
+      ),
+    ],
+  );
+}
+
+///Will return null if dismissed by tapping outside
 Future<ButtonResult?> showErrorDialog(
   BuildContext context,
   String title,


### PR DESCRIPTION
## Description

Since the app doesn't let a user create an account with a weak password and since isn't clear for the user how the app classifies a password as "Weak", "Moderate" or "Strong", users would find it hard to come up with a moderate or strong password. Also, the app wasn't surfacing the strength every time. 

All these UX issues have been fixed in this PR. 
 
Before: 

https://github.com/user-attachments/assets/c9630c44-4591-4bdd-a05d-8098ff5afef8

After:

https://github.com/user-attachments/assets/a9c1abfa-de1e-44c6-9f7e-157abe4f8de3


## Tests

Tested new account creation flow, did not find any regressions and can't think of any that could have been introduced. 


