### PR TITLE
[desktop] Attempts to improve large drag drops on Windows

### DIFF
--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -227,25 +227,13 @@ const watchRemoveListeners = () => {
 
 // - Upload
 
-const pathForFile = (file: File) => {
-    const path = webUtils.getPathForFile(file);
-    // The path that we get back from `webUtils.getPathForFile` on Windows uses
-    // "/" as the path separator. Convert them to POSIX separators.
-    //
-    // Note that we do not have access to the path or the os module in the
-    // preload script, thus this hand rolled transformation.
+// The path that we get back from `webUtils.getPathForFile` on Windows uses "\"
+// as the path separator. Convert them to POSIX separators.
 
-    // However that makes TypeScript fidgety since we it cannot find navigator,
-    // as we haven't included "lib": ["dom"] in our tsconfig to avoid making DOM
-    // APIs available to our main Node.js code. We could create a separate
-    // tsconfig just for the preload script, but for now let's go with a cast.
-    //
-    // @ts-expect-error navigator is not defined.
-    const platform = (navigator as { platform: string }).platform;
-    return platform.toLowerCase().includes("win")
-        ? path.split("\\").join("/")
-        : path;
-};
+const pathForFile =
+    process.platform == "win32"
+        ? (file: File) => webUtils.getPathForFile(file).replace(/\\/g, "/")
+        : (file: File) => webUtils.getPathForFile(file);
 
 const listZipItems = (zipPath: string) =>
     ipcRenderer.invoke("listZipItems", zipPath);

--- a/web/apps/photos/src/components/Upload/Uploader.tsx
+++ b/web/apps/photos/src/components/Upload/Uploader.tsx
@@ -880,8 +880,11 @@ function getImportSuggestion(
         return DEFAULT_IMPORT_SUGGESTION;
     }
 
-    const getCharCount = (str: string) => (str.match(/\//g) ?? []).length;
-    paths.sort((path1, path2) => getCharCount(path1) - getCharCount(path2));
+    const separatorCounts = new Map(
+        paths.map((s) => [s, s.match(/\//g)?.length ?? 0]),
+    );
+    const separatorCount = (s: string) => ensure(separatorCounts.get(s));
+    paths.sort((path1, path2) => separatorCount(path1) - separatorCount(path2));
     const firstPath = paths[0];
     const lastPath = paths[paths.length - 1];
 


### PR DESCRIPTION
Trying to diagnose a customer issue where they reported that the renderer was crashing when trying to drag and drop a 1TB folder on Windows. Fixing some things that popped out in the memory allocations or the CPU time when testing with a synthetic workflow (on macOS) - these may or may not fix their issue, but these are anyway improvements and will only make things better.
