### PR TITLE
[server] Stop exposing /metrics for self-hosted users

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -353,7 +353,7 @@ func main() {
 
 	p := ginprometheus.NewPrometheus("museum")
 	p.ReqCntURLLabelMappingFn = urlSanitizer
-	p.Use(server)
+	server.Use(p.HandlerFunc())
 
 	// note: the recover middleware must be in the last
 	server.Use(requestid.New(), middleware.Logger(urlSanitizer), cors(), gzip.Gzip(gzip.DefaultCompression), middleware.PanicRecover())


### PR DESCRIPTION
Doesn't impact Ente's production instances since this endpoint was disallowed on the load balancer, but instead of requiring the same for folks who are self hosting we modify the source to not expose /metrics on :8080 (they'll still be available on :2112).

Refs:
- https://github.com/zsais/go-gin-prometheus/blob/2199a42d96c1d40f249909ed2f27d42449c7fc94/middleware.go#L345
- https://github.com/ente-io/ente/discussions/2562
