### PR TITLE
[desktop] Pull existing embeddings first before starting on indexing

### DIFF
--- a/web/packages/new/photos/services/ml/embedding.ts
+++ b/web/packages/new/photos/services/ml/embedding.ts
@@ -309,26 +309,39 @@ const putEmbedding = async (
     ensureOk(res);
 };
 
+interface PullEmbeddingsResult {
+    /**
+     * Derived data indexed by the file id whose data this is.
+     */
+    items: Map<number, RemoteDerivedData>;
+    /**
+     * The latest {@link updatedAt} epoch milliseconds from all the derived data
+     * in {@link items}.
+     */
+    latestUpdatedAt: number;
+}
+
 /**
- * Fetch new {@link model} embeddings since the given {@link sinceTime}.
+ * Fetch derived data that has been created or updated since the given
+ * {@link sinceTime}.
  *
  * This allows a client to perform a quick "diff" and get embeddings that has
- * changed (created or updated) since the last time it checked. By fetching
- * these all upfront instead of doing them one by one during the indexing, we
- * can speed up the initial sync of existing embeddings on a new client.
- *
- * @param model The {@link EmbeddingModel} which we want.
+ * changed since the last time it checked. By fetching these all upfront instead
+ * of doing them one by one during the indexing, we can speed up the initial
+ * sync of existing embeddings on a new client.
  *
  * @param sinceTime Epoch milliseconds. We use this to ask remote to provide us
- * embeddings whose {@link updatedAt} is more than the given value. If not
+ * derived data whose {@link updatedAt} is more than the given value. If not
  * specified, then we'll start from the beginning.
  *
- * @param limit The maximum number of files to provide in the response.
+ * @param limit An advisory limit on the number of items to return.
  *
- * @returns a list of {@link RemoteEmbedding}, and the latest {@link updatedAt}
- * from amongst all embeddings that were fetched. The caller should persist that
- * and use it in subsequent calls to {@link pullEmbeddings} to resume pulling
- * from the current checkpoint.
+ * @returns a map of {@link RemoteDerivedData} indexed by the id of the file
+ * whose derived data it is, and the latest {@link updatedAt} from amongst all
+ * the data that was fetched.
+ *
+ * The caller should persist the returned timestamp for use in subsequent calls
+ * to {@link pullEmbeddings} to resume pulling from the current checkpoint.
  *
  * Returns undefined if nothing more is left to pull.
  */
@@ -336,8 +349,9 @@ const pullEmbeddings = async (
     model: EmbeddingModel,
     sinceTime: number | undefined,
     limit: number,
-) => {
-    getIndexedFiles(model)
+): Promise<PullEmbeddingsResult | undefined> => {
+    return undefined;
+    // getIndexedFiles(model)
 };
 
 /** A single entry in the response of {@link getIndexedFiles}. */

--- a/web/packages/new/photos/services/ml/embedding.ts
+++ b/web/packages/new/photos/services/ml/embedding.ts
@@ -350,7 +350,31 @@ const pullEmbeddings = async (
     sinceTime: number | undefined,
     limit: number,
 ): Promise<PullEmbeddingsResult | undefined> => {
-    return undefined;
+    // If since time is not provided, start at 0 (the beginning).
+    let latestUpdatedAt = sinceTime ?? 0;
+
+    // See if anything changed since then.
+    const indexedFiles = await getIndexedFiles(
+        "derived",
+        latestUpdatedAt,
+        limit,
+    );
+
+    // Nope. Nothing more is left to do.
+    if (!indexedFiles.length) return undefined;
+
+    // Find the latest from amongst the given updatedAt. This'll serve as our
+    // checkpoint for the next pull.
+    latestUpdatedAt = indexedFiles.reduce(
+        (max, { updatedAt }) => Math.max(max, updatedAt),
+        latestUpdatedAt,
+    );
+
+    // Fetch the embeddings for these guys. In rare cases, remote might return a
+    // partial response, but that will not have any lasting impact since we
+    // anyways refetch the derived data before attempting indexing.
+    const items = await fetchDerivedData()
+
     // getIndexedFiles(model)
 };
 

--- a/web/packages/new/photos/services/ml/worker.ts
+++ b/web/packages/new/photos/services/ml/worker.ts
@@ -306,6 +306,11 @@ export class MLWorker {
 
 expose(MLWorker);
 
+/**
+ * Pull embeddings from remote.
+ *
+ * Return true atleast one embedding was pulled.
+ */
 // eslint-disable-next-line @typescript-eslint/require-await
 const pull = async () => {
     return "";

--- a/web/packages/new/photos/services/ml/worker.ts
+++ b/web/packages/new/photos/services/ml/worker.ts
@@ -500,6 +500,9 @@ const indexNextBatch = async (
         await wait(0);
     }
 
+    // Wait for the pending tasks to drain out.
+    await Promise.all(tasks);
+
     // Return true if nothing failed.
     return allSuccess;
 };


### PR DESCRIPTION
Speeds up the initial sync on a new client.