### PR TITLE
Change Auth mobile apps' names to "Ente Auth"

### DIFF
--- a/auth/android/app/src/main/AndroidManifest.xml
+++ b/auth/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
     <application android:name="${applicationName}"
-                 android:label="Auth"
+                 android:label="Ente Auth"
                  android:icon="@mipmap/launcher_icon"
                  android:usesCleartextTraffic="true"
                  android:requestLegacyExternalStorage="true"

--- a/auth/ios/Runner/Info.plist
+++ b/auth/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>
-		<string>auth</string>
+		<string>Ente Auth</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Description

Changed the name of the Auth mobile app to "Ente Auth" on both Android and iOS to make it consistent with the naming of Ente Photos and to also make it consistent on both platforms.