### PR TITLE
[web] Improve handling of cancelled sub updates

### DIFF
--- a/web/apps/photos/src/utils/billing/index.ts
+++ b/web/apps/photos/src/utils/billing/index.ts
@@ -31,6 +31,51 @@ enum RESPONSE_STATUS {
     fail = "fail",
 }
 
+export type PlanSelectionOutcome =
+    | "buyPlan"
+    | "updateSubscriptionToPlan"
+    | "cancelOnMobile"
+    | "contactSupport";
+
+/**
+ * Return the outcome that should happen when the user selects a paid plan on
+ * the plan selection screen.
+ *
+ * @param subscription Their current subscription details.
+ */
+export const planSelectionOutcome = (
+    subscription: Subscription | undefined,
+) => {
+    // This shouldn't happen, but we need this case to handle missing types.
+    if (!subscription) return "buyPlan";
+
+    // The user is a on a free plan and can buy the plan they selected.
+    if (subscription.productID == "free") return "buyPlan";
+
+    // Their existing subscription has expired. They can buy a new plan.
+    if (subscription.expiryTime < Date.now() * 1000) return "buyPlan";
+
+    // -- The user already has an active subscription to a paid plan.
+
+    // Using stripe
+    if (subscription.paymentProvider == "stripe") {
+        // Update their existing subscription to the new plan.
+        return "updateSubscriptionToPlan";
+    }
+
+    // Using one of the mobile app stores
+    if (
+        subscription.paymentProvider == "appstore" ||
+        subscription.paymentProvider == "playstore"
+    ) {
+        // They need to cancel first on the mobile app stores.
+        return "cancelOnMobile";
+    }
+
+    // Some other bespoke case. They should contact support.
+    return "contactSupport";
+};
+
 export function hasPaidSubscription(subscription: Subscription) {
     return (
         subscription &&

--- a/web/apps/photos/src/utils/billing/index.ts
+++ b/web/apps/photos/src/utils/billing/index.ts
@@ -13,8 +13,6 @@ import { getSubscriptionPurchaseSuccessMessage } from "utils/ui";
 import { getTotalFamilyUsage, isPartOfFamily } from "utils/user/family";
 
 const PAYMENT_PROVIDER_STRIPE = "stripe";
-const PAYMENT_PROVIDER_APPSTORE = "appstore";
-const PAYMENT_PROVIDER_PLAYSTORE = "playstore";
 const FREE_PLAN = "free";
 const THIRTY_DAYS_IN_MICROSECONDS = 30 * 24 * 60 * 60 * 1000 * 1000;
 
@@ -134,15 +132,6 @@ export function hasStripeSubscription(subscription: Subscription) {
     return (
         subscription.paymentProvider.length > 0 &&
         subscription.paymentProvider === PAYMENT_PROVIDER_STRIPE
-    );
-}
-
-export function hasMobileSubscription(subscription: Subscription) {
-    return (
-        hasPaidSubscription(subscription) &&
-        subscription.paymentProvider.length > 0 &&
-        (subscription.paymentProvider === PAYMENT_PROVIDER_APPSTORE ||
-            subscription.paymentProvider === PAYMENT_PROVIDER_PLAYSTORE)
     );
 }
 


### PR DESCRIPTION
This fixes an issue where a user with a cancelled _and_ expired subscription would try to purchase a plan, and would instead get redirected to the updated subscription flow in stripe (instead of the buy flow).

Smoke tested a few scenarios locally.