### PR TITLE
[auth] allow without backups use for windows

### DIFF
--- a/auth/lib/onboarding/view/onboarding_page.dart
+++ b/auth/lib/onboarding/view/onboarding_page.dart
@@ -219,9 +219,10 @@ class _OnboardingPageState extends State<OnboardingPage> {
   }
 
   Future<void> _optForOfflineMode() async {
-    bool canCheckBio = Platform.isMacOS || Platform.isLinux
-        ? true
-        : await LocalAuthentication().canCheckBiometrics;
+    bool canCheckBio = Platform.isMacOS ||
+        Platform.isLinux ||
+        Platform.isWindows ||
+        await LocalAuthentication().canCheckBiometrics;
     if (!canCheckBio) {
       showToast(
         context,


### PR DESCRIPTION
## Description

Windows client without pin/password should also be able to use the app, without backups as they can set app lock afterwards.

## Tests
