### PR TITLE
[sever][replication] Avoid long running txn during replication

### DIFF
--- a/server/pkg/repo/object.go
+++ b/server/pkg/repo/object.go
@@ -200,8 +200,8 @@ func (repo *ObjectRepository) DoesObjectOrTempObjectExist(objectKey string) (boo
 //
 // Unknown objects (i.e. objectKeys for which there are no entries) are
 // considered as deleted.
-func (repo *ObjectRepository) GetObjectState(tx *sql.Tx, objectKey string) (ObjectState ente.ObjectState, err error) {
-	row := tx.QueryRow(`
+func (repo *ObjectRepository) GetObjectState(objectKey string) (ObjectState ente.ObjectState, err error) {
+	row := repo.DB.QueryRow(`
 	SELECT ok.is_deleted, u.encrypted_email IS NULL AS is_user_deleted, ok.size
 	FROM object_keys ok
 	JOIN files f ON ok.file_id = f.file_id


### PR DESCRIPTION
## Description
Going forward, we pick a row for replication, and immediately mark replication attempt. Once that's done, we try to replicate the object, and update it's status without any transaction.

The initial locking and marking the replication attempt should ideally ensure that no other worker will pick up the row for replication for next 24hours.

## Tests
