### PR TITLE
[server] Minor tweaks to the new FileData API URLs

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -413,11 +413,11 @@ func main() {
 	privateAPI.GET("/files/preview/:fileID", fileHandler.GetThumbnail)
 	privateAPI.GET("/files/preview/v2/:fileID", fileHandler.GetThumbnail)
 
-	privateAPI.PUT("/files/data/", fileHandler.PutFileData)
-	privateAPI.POST("files/data/fetch", fileHandler.GetFilesData)
-	privateAPI.GET("files/data/fetch", fileHandler.GetFileData)
-	privateAPI.GET("/files/data/preview-upload-url/", fileHandler.GetPreviewUploadURL)
-	privateAPI.GET("/files/data/preview/", fileHandler.GetPreviewURL)
+	privateAPI.PUT("/files/data", fileHandler.PutFileData)
+	privateAPI.POST("/files/data/fetch", fileHandler.GetFilesData)
+	privateAPI.GET("/files/data/fetch", fileHandler.GetFileData)
+	privateAPI.GET("/files/data/preview-upload-url", fileHandler.GetPreviewUploadURL)
+	privateAPI.GET("/files/data/preview", fileHandler.GetPreviewURL)
 
 	privateAPI.POST("/files", fileHandler.CreateOrUpdate)
 	privateAPI.POST("/files/copy", fileHandler.CopyFiles)


### PR DESCRIPTION
- Start with leading slash for easier greppability
- Omit trailing slash for consistency

No production clients are using this yet, so should be safe.

Tested the two embedding related ones on localhost.