### PR TITLE
[server] Use the go.sum cache during CI lint

### DIFF
--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -21,7 +21,8 @@ jobs:
             - name: Setup go
               uses: actions/setup-go@v5
               with:
-                  go-version-file: "server/go.mod"
+                  go-version-file: server/go.mod
+                  cache-dependency-path: server/go.sum
                   cache: true
 
             - name: Install dependencies


### PR DESCRIPTION
Unrelated to the lint failures, I noticed that we were not using the go.sum file during the lint steps.