### PR TITLE
[desktop] Improve robustness of cluster disabling condition

### DIFF
--- a/web/packages/new/photos/services/ml/index.ts
+++ b/web/packages/new/photos/services/ml/index.ts
@@ -337,8 +337,8 @@ let last: SearchPerson[] | undefined;
  * WIP! Don't enable, dragon eggs are hatching here.
  */
 export const wipClusterEnable = async () => {
-    if (!isDevBuild || !(await isInternalUser())) return false;
     if (!process.env.NEXT_PUBLIC_ENTE_WIP_CL) return false;
+    if (!isDevBuild || !(await isInternalUser())) return false;
     return true;
 };
 


### PR DESCRIPTION
Otherwise the code reaches the isInternalUser on logout, triggered by the search service, and at a point when it does not have the auth token anymore. Doesn't impact production builds, but doesn't hurt to make the check more robust say for people who're trying dev builds.
