### PR TITLE
fix: fdroid icon background

### DIFF
--- a/auth/fdroid_flutter_icons.yaml
+++ b/auth/fdroid_flutter_icons.yaml
@@ -2,5 +2,4 @@ flutter_icons:
   android: "launcher_icon"
   image_path: "assets/generation-icons/icon-light.png"
   adaptive_icon_foreground: "assets/generation-icons/icon-light-adaptive-fg.png"
-  adaptive_icon_background: "#ffffff"
-
+  adaptive_icon_background: "assets/generation-icons/icon-light-adaptive-bg.png"


### PR DESCRIPTION
## Description

Fdroid icon for auth was white, whilst we have already moved to purple gradient. This PR adds the same adaptive background for fdroid as it is for normal build.

The below Fdroid build recipe regenerates the icons that's why it was not correct before:
https://gitlab.com/fdroid/fdroiddata/-/blob/3bbf65e8f0f056c5df9873bd683ab23f5f7de14c/metadata/io.ente.auth.yml#L58