### PR TITLE
fix(mob): readd missing key in locals

### DIFF
--- a/mobile/lib/generated/intl/messages_cs.dart
+++ b/mobile/lib/generated/intl/messages_cs.dart
@@ -33,8 +33,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Add to hidden album"),
         "addViewers": m1,
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "autoLock": MessageLookupByLibrary.simpleMessage("Auto lock"),

--- a/mobile/lib/generated/intl/messages_de.dart
+++ b/mobile/lib/generated/intl/messages_de.dart
@@ -312,8 +312,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle": MessageLookupByLibrary.simpleMessage(
             "Authentifizierung erforderlich"),
         "appLock": MessageLookupByLibrary.simpleMessage("App-Sperre"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Wähle zwischen dem Standard-Sperrbildschirm deines Gerätes und einem eigenen Sperrbildschirm mit PIN oder Passwort."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_en.dart
+++ b/mobile/lib/generated/intl/messages_en.dart
@@ -301,8 +301,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Authentication required"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_es.dart
+++ b/mobile/lib/generated/intl/messages_es.dart
@@ -311,8 +311,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Autentificación requerida"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_fr.dart
+++ b/mobile/lib/generated/intl/messages_fr.dart
@@ -299,8 +299,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Authentification requise"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_it.dart
+++ b/mobile/lib/generated/intl/messages_it.dart
@@ -292,8 +292,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Autenticazione necessaria"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_ko.dart
+++ b/mobile/lib/generated/intl/messages_ko.dart
@@ -33,8 +33,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Add to hidden album"),
         "addViewers": m1,
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "autoLock": MessageLookupByLibrary.simpleMessage("Auto lock"),

--- a/mobile/lib/generated/intl/messages_nl.dart
+++ b/mobile/lib/generated/intl/messages_nl.dart
@@ -311,8 +311,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Verificatie vereist"),
         "appLock": MessageLookupByLibrary.simpleMessage("App-vergrendeling"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Kies tussen het standaard vergrendelingsscherm van uw apparaat en een aangepast vergrendelingsscherm met een pincode of wachtwoord."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_no.dart
+++ b/mobile/lib/generated/intl/messages_no.dart
@@ -35,8 +35,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Add to hidden album"),
         "addViewers": m1,
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "askDeleteReason": MessageLookupByLibrary.simpleMessage(

--- a/mobile/lib/generated/intl/messages_pl.dart
+++ b/mobile/lib/generated/intl/messages_pl.dart
@@ -310,8 +310,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Wymagane uwierzytelnienie"),
         "appLock": MessageLookupByLibrary.simpleMessage(
             "Blokada dostępu do aplikacji"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Wybierz między domyślnym ekranem blokady urządzenia a niestandardowym ekranem blokady z kodem PIN lub hasłem."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_pt.dart
+++ b/mobile/lib/generated/intl/messages_pt.dart
@@ -309,8 +309,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Autenticação necessária"),
         "appLock": MessageLookupByLibrary.simpleMessage("Bloqueio de app"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Escolha entre a tela de bloqueio padrão do seu dispositivo e uma tela de bloqueio personalizada com PIN ou senha."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_ru.dart
+++ b/mobile/lib/generated/intl/messages_ru.dart
@@ -305,8 +305,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Требуется аутентификация"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_tr.dart
+++ b/mobile/lib/generated/intl/messages_tr.dart
@@ -305,8 +305,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Kimlik doğrulaması gerekli"),
         "appLock": MessageLookupByLibrary.simpleMessage("App lock"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "Choose between your device\\\'s default lock screen and a custom lock screen with a PIN or password."),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/intl/messages_zh.dart
+++ b/mobile/lib/generated/intl/messages_zh.dart
@@ -271,8 +271,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("安卓, iOS, 网页端, 桌面端"),
         "androidSignInTitle": MessageLookupByLibrary.simpleMessage("需要身份验证"),
         "appLock": MessageLookupByLibrary.simpleMessage("应用锁"),
-        "appLockDescription": MessageLookupByLibrary.simpleMessage(
-            "在设备的默认锁定屏幕和带有 PIN 或密码的自定义锁定屏幕之间进行选择。"),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Choose between your device\'s default lock screen and a custom lock screen with a PIN or password."),
         "appVersion": m7,

--- a/mobile/lib/generated/l10n.dart
+++ b/mobile/lib/generated/l10n.dart
@@ -9225,16 +9225,6 @@ class S {
     );
   }
 
-  /// `To enable app lock, please setup device passcode or screen lock in your system settings.`
-  String get toEnableAppLockPleaseSetupDevicePasscodeOrScreen {
-    return Intl.message(
-      'To enable app lock, please setup device passcode or screen lock in your system settings.',
-      name: 'toEnableAppLockPleaseSetupDevicePasscodeOrScreen',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `Tap to unlock`
   String get tapToUnlock {
     return Intl.message(
@@ -9470,6 +9460,16 @@ class S {
     return Intl.message(
       'Choose between your device\'s default lock screen and a custom lock screen with a PIN or password.',
       name: 'appLockDescriptions',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `To enable app lock, please setup device passcode or screen lock in your system settings.`
+  String get toEnableAppLockPleaseSetupDevicePasscodeOrScreen {
+    return Intl.message(
+      'To enable app lock, please setup device passcode or screen lock in your system settings.',
+      name: 'toEnableAppLockPleaseSetupDevicePasscodeOrScreen',
       desc: '',
       args: [],
     );

--- a/mobile/lib/l10n/intl_en.arb
+++ b/mobile/lib/l10n/intl_en.arb
@@ -1312,8 +1312,6 @@
   "cl_panorama_viewer_description": "We've added support for viewing panorama photos with 360 degree views. The experience is immersive with motion-based navigation!",
   "cl_video_player_title": "Video Player",
   "cl_video_player_description": "Introducing a fresh new video player, with better playback controls and support for HDR videos.",
-  "appLockDescriptions": "Choose between your device's default lock screen and a custom lock screen with a PIN or password."
+  "appLockDescriptions": "Choose between your device's default lock screen and a custom lock screen with a PIN or password.",
+  "toEnableAppLockPleaseSetupDevicePasscodeOrScreen": "To enable app lock, please setup device passcode or screen lock in your system settings."
 }
-
-
-


### PR DESCRIPTION
## Description

The commit https://github.com/ente-io/ente/commit/7dd1804e2e4cd50982a1c50ba00b4bbc6267064d removed the key, this commit re-add's the key.
