### PR TITLE
[Auth] Adjust icons

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -181,8 +181,7 @@
     },
     {
       "title": "enom"   
-    },
-   
+    },   
     {
       "title": "Epic Games",
       "slug": "epic_games",
@@ -266,7 +265,7 @@
     {
       "title": "Itch",
       "slug": "itch_io",
-      "hex": "e7685e"
+      "hex": "000000"
     },
     {
       "title": "IVPN",


### PR DESCRIPTION
Removed extra line after "enom" and adjusted itch.io icon color to more closely match their recommended color in dark and light mode.
