### PR TITLE
[web][photos] Fix search icon layout & color

### DIFF
--- a/web/apps/photos/src/components/Search/SearchBar/searchInput/valueContainerWithIcon.tsx
+++ b/web/apps/photos/src/components/Search/SearchBar/searchInput/valueContainerWithIcon.tsx
@@ -33,7 +33,7 @@ export const ValueContainerWithIcon: SelectComponents<
 >["ValueContainer"] = (props) => (
     <ValueContainer {...props}>
         <FlexWrapper>
-            <Box className="icon" mr={1.5} color="stroke.muted">
+            <Box style={ { display: 'inline-flex' } } mr={1.5} color={(theme) => theme.colors.stroke.muted}>
                 {getIconByType(props.getValue()[0]?.type)}
             </Box>
             {props.children}


### PR DESCRIPTION
This fixes the search icon in the search box not being centered properly and also not having the muted color style.

The container is a flex-box layout which already tries to center its items. But due to the icons in MUI having a display of `inline-block`, our `Box` container also needs `display: inline-flex` to properly calculate the height. Now the box container is the same height as the icon and it gets centered correctly again.
This is the same methodology that the MUI native `IconButton` also uses
as a display value. See https://github.com/mui/material-ui/issues/33020#issuecomment-1149971549

Current web version:
![image](https://github.com/user-attachments/assets/44ca19e3-16c3-4349-9ecd-5089b3876f76)

Proposed fix:
![image](https://github.com/user-attachments/assets/1b707cf3-a9cb-44cb-99ae-4eb4d350f20e)


This also removes the `icon` CSS class from the Box container since it does not exist anyway. And we fixed the theme color not being applied. This was otherwise just passed as a raw string to the color property and now correctly uses the intended theme color.

Thanks!