### PR TITLE
[web][photos] Fix web navbar button sizes

### DIFF
--- a/web/apps/photos/src/components/Upload/UploadButton.tsx
+++ b/web/apps/photos/src/components/Upload/UploadButton.tsx
@@ -17,7 +17,7 @@ const Wrapper = styled("div")<{ $disableShrink: boolean }>`
         !$disableShrink &&
         `@media (max-width: 624px) {
         & .mobile-button {
-            display: block;
+            display: inline-flex;
         }
         & .desktop-button {
             display: none;

--- a/web/apps/photos/src/components/pages/gallery/Navbar.tsx
+++ b/web/apps/photos/src/components/pages/gallery/Navbar.tsx
@@ -53,7 +53,7 @@ export function GalleryNavbar({
             ) : (
                 <>
                     {!isInSearchMode && (
-                        <IconButton onClick={openSidebar} sx={{ pl: 0 }}>
+                        <IconButton onClick={openSidebar}>
                             <MenuIcon />
                         </IconButton>
                     )}


### PR DESCRIPTION
Two minor style fixes for the nav bar. 

1. Sidebar 3-lines IconButton had its left padding set to 0, which causes issues.
2. Upload icon on mobile had the wrong height and thus weird ripple / hover effects.

Please see the respective commit for details & the reasoning.

How those currently look:
![image](https://github.com/user-attachments/assets/16466b61-dcf0-4647-953e-b680b53943e0)
![image](https://github.com/user-attachments/assets/63ccc4e6-97c2-4e39-8c76-6267bb0e8ae2)

How they look with the proposed fix:
![image](https://github.com/user-attachments/assets/9b1ba2c3-cabf-4ee7-b1e4-66ad3a09ec22)
![image](https://github.com/user-attachments/assets/82e0b49c-dc05-4ae9-a6c8-06efc8d364f3)


Thanks!