### PR TITLE
[meta] Run PRs lint checks for pull requests from external forks

### DIFF
--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -1,9 +1,8 @@
 name: "Lint (auth)"
 
 on:
-    # Run on every push to a branch other than main that changes auth/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes auth/
+    pull_request:
         paths:
             - "auth/**"
             - ".github/workflows/auth-lint.yml"

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -1,9 +1,8 @@
 name: "Lint (desktop)"
 
 on:
-    # Run on every push to a branch other than main that changes desktop/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes desktop/
+    pull_request:
         paths:
             - "desktop/**"
             - ".github/workflows/desktop-lint.yml"

--- a/.github/workflows/docs-verify-build.yml
+++ b/.github/workflows/docs-verify-build.yml
@@ -4,9 +4,8 @@ name: "Verify build (docs)"
 # succeeding before we merge the PR into main.
 
 on:
-    # Run on every push to a branch other than main that changes docs/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes docs/
+    pull_request:
         paths:
             - "docs/**"
             - ".github/workflows/docs-verify-build.yml"

--- a/.github/workflows/infra-lint-staff.yml
+++ b/.github/workflows/infra-lint-staff.yml
@@ -1,9 +1,8 @@
 name: "Lint (staff)"
 
 on:
-    # Run on every push to a branch other than main that changes infra/staff/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes infra/staff/
+    pull_request:
         paths:
             - "infra/staff/**"
             - ".github/workflows/infra-deploy-staff.yml"

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -1,9 +1,8 @@
 name: "Lint (mobile)"
 
 on:
-    # Run on every push to a branch other than main that changes mobile/
-    push:
-        branches-ignore: [main, f-droid]
+    # Run on every pull request (open or push to it) that changes mobile/
+    pull_request:
         paths:
             - "mobile/**"
             - ".github/workflows/mobile-lint.yml"

--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -1,9 +1,8 @@
 name: "Lint (server)"
 
 on:
-    # Run on every push to a branch other than main that changes server/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes server/
+    pull_request:
         paths:
             - "server/**"
             - ".github/workflows/server-lint.yml"

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -1,9 +1,8 @@
 name: "Lint (web)"
 
 on:
-    # Run on every push to a branch other than main that changes web/
-    push:
-        branches-ignore: [main]
+    # Run on every pull request (open or push to it) that changes web/
+    pull_request:
         paths:
             - "web/**"
             - ".github/workflows/web-lint.yml"


### PR DESCRIPTION
Currently, for PRs opened by external contributors, the various lint checks don't run (sometimes causing code that fails basic lint checks to be committed to main).

<img width="796" alt="Screenshot 2024-08-26 at 21 56 01" src="https://github.com/user-attachments/assets/d7607c65-1849-4ec3-ae0e-011161015fce">

From my current understanding (I find the docs around this confusing - I'm not sure about this), we need to instead use "pull_request". Refs:

* https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
* https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

Note that even then, we will need a manual step to approve running the lints for first time contributors. Which is fine, at least we'll see the option, unlike right now where they just can't be run until the code hits main.

<img width="542" alt="Screenshot 2024-08-26 at 21 56 17" src="https://github.com/user-attachments/assets/d5281a04-c6f8-4bd6-b368-b4bd99b943ef">
