### PR TITLE
[desktop] Fix macOS universal binaries

### DIFF
--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -76,14 +76,13 @@ jobs:
               # behaviour of not overwriting the existing file named `ffmpeg`.
               run: |
                   rm -f node_modules/ffmpeg-static/ffmpeg
-                  npm rebuild --arch=arm64 -f ffmpeg-static
-                  mv node_modules/ffmpeg-static/ffmpeg node_modules/ffmpeg-static/ffmpeg-arm64
-                  npm rebuild --arch=x64 -f ffmpeg-static
-                  mv node_modules/ffmpeg-static/ffmpeg node_modules/ffmpeg-static/ffmpeg-x64
-                  cd node_modules/ffmpeg-static/
-                  lipo -create ffmpeg-arm64 ffmpeg-x64 -output ffmpeg
+                  npm_config_arch=arm64 yarn add --check-files ffmpeg-static
+                  mv node_modules/ffmpeg-static/ffmpeg ffmpeg-arm64
+                  npm_config_arch=x64 yarn add --check-files ffmpeg-static
+                  mv node_modules/ffmpeg-static/ffmpeg ffmpeg-x64
+                  lipo -create ffmpeg-arm64 ffmpeg-x64 -output node_modules/ffmpeg-static/ffmpeg
                   rm ffmpeg-arm64 ffmpeg-x64
-                  file ffmpeg     # print what we ended up with
+                  file node_modules/ffmpeg-static/ffmpeg  # print what we ended up with
 
             - name: Install libarchive-tools for pacman build
               if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
The previous approach worked, but we ran into some other issues

    Uncaught Exception:
    Error: Cannot find module 'ajv/dist/compile/codegen'
    Require stack:
    - /Applications/ente.app/Contents/Resources/app.asar/node_modules/ajv-formats/dist/limit.js

As an alternative, try to use the yarn equivalent(-ish).
