### PR TITLE
[desktop] Fix broken nightly builds due to ajv

### DIFF
--- a/desktop/docs/dependencies.md
+++ b/desktop/docs/dependencies.md
@@ -95,6 +95,10 @@ Some extra ones specific to the code here are:
     for allowing us to set environment variables in a way that also works on
     Windows.
 
+-   We don't need `ajv`, but it is a transitive dependency which breaks the
+    build if we let its version be resolved via the yarn resolution mechanism.
+    Taking a direct dependency on it is the easiest workaround for now.
+
 ## Functionality
 
 ### Format conversion

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -45,6 +45,7 @@
         "@types/auto-launch": "^5.0.5",
         "@types/eslint__js": "^8.42.3",
         "@types/ffmpeg-static": "^3.0.3",
+        "ajv": "^8.17.1",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
         "electron": "^30.4.0",

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -531,7 +531,7 @@ ajv@^6.10.0, ajv@^6.12.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.6.3:
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.6.3:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==


### PR DESCRIPTION
I'm not sure why it started happening now. Earlier I thought it was because of this - https://github.com/ente-io/ente/pull/2969 - but that was a red-herring (I think!), instead this likely got triggered because of
https://github.com/ente-io/action-electron-builder/commit/eff78a1d33bdab4c54ede0e5cdc71e0c2cf803e2.

This change fixed the issue locally, will see if it works on CI too.

Workaround from:
https://github.com/ajv-validator/ajv/issues/2443#issuecomment-2147026958
