### PR TITLE
[desktop] Use latest version of our updated fork of the electron-builder action

### DIFF
--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -91,7 +91,7 @@ jobs:
               run: sudo apt-get install libarchive-tools
 
             - name: Build
-              uses: ente-io/action-electron-builder@v1.0.0
+              uses: ente-io/action-electron-builder
               with:
                   package_root: desktop
                   build_script_name: build:ci


### PR DESCRIPTION
So that it refs this commit
https://github.com/ente-io/action-electron-builder/commit/eff78a1d33bdab4c54ede0e5cdc71e0c2cf803e2
