### PR TITLE
[desktop] Specify an action version

### DIFF
--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -91,7 +91,7 @@ jobs:
               run: sudo apt-get install libarchive-tools
 
             - name: Build
-              uses: ente-io/action-electron-builder
+              uses: ente-io/action-electron-builder@eff78a1d33bdab4c54ede0e5cdc71e0c2cf803e2
               with:
                   package_root: desktop
                   build_script_name: build:ci


### PR DESCRIPTION
Apparently, specifying something after the @ is necessary. Without this, the action stopped working.

Updates https://github.com/ente-io/ente/pull/2976.