### PR TITLE
[web] Show ML option only on desktop

### DIFF
--- a/web/apps/photos/src/components/Sidebar/Preferences.tsx
+++ b/web/apps/photos/src/components/Sidebar/Preferences.tsx
@@ -8,6 +8,7 @@ import {
     type SupportedLocale,
 } from "@/base/i18n";
 import { MLSettings } from "@/new/photos/components/MLSettings";
+import { isMLSupported } from "@/new/photos/services/ml";
 import { EnteMenuItem } from "@ente/shared/components/Menu/EnteMenuItem";
 import ChevronRight from "@mui/icons-material/ChevronRight";
 import ScienceIcon from "@mui/icons-material/Science";
@@ -78,19 +79,21 @@ export const Preferences: React.FC<SettingsDrawerProps> = ({
                             endIcon={<ChevronRight />}
                             label={t("advanced")}
                         />
-                        <Box>
-                            <MenuSectionTitle
-                                title={t("labs")}
-                                icon={<ScienceIcon />}
-                            />
-                            <MenuItemGroup>
-                                <EnteMenuItem
-                                    endIcon={<ChevronRight />}
-                                    onClick={() => setOpenMLSettings(true)}
-                                    label={t("ml_search")}
+                        {isMLSupported && (
+                            <Box>
+                                <MenuSectionTitle
+                                    title={t("labs")}
+                                    icon={<ScienceIcon />}
                                 />
-                            </MenuItemGroup>
-                        </Box>
+                                <MenuItemGroup>
+                                    <EnteMenuItem
+                                        endIcon={<ChevronRight />}
+                                        onClick={() => setOpenMLSettings(true)}
+                                        label={t("ml_search")}
+                                    />
+                                </MenuItemGroup>
+                            </Box>
+                        )}
                     </Stack>
                 </Box>
             </Stack>


### PR DESCRIPTION
This had been accidentally left enabled on web. The ML wouldn't run, just the option was being shown.

Fixes https://github.com/ente-io/ente/issues/2944 