### PR TITLE
Request focus on the search box when clicked the search icon

### DIFF
--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -55,6 +55,9 @@ class _HomePageState extends State<HomePage> {
   final Logger _logger = Logger("HomePage");
   final scaffoldKey = GlobalKey<ScaffoldState>();
 
+  // Used to request focus on the search box when clicked the search icon
+  late FocusNode searchBoxFocusNode;
+
   final TextEditingController _textController = TextEditingController();
   final bool _autoFocusSearch =
       PreferenceService.instance.shouldAutoFocusOnSearchBar();
@@ -89,6 +92,8 @@ class _HomePageState extends State<HomePage> {
       setState(() {});
     });
     _showSearchBox = _autoFocusSearch;
+
+    searchBoxFocusNode = FocusNode();
   }
 
   void _loadCodes() {
@@ -158,6 +163,9 @@ class _HomePageState extends State<HomePage> {
     _triggerLogoutEvent?.cancel();
     _iconsChangedEvent?.cancel();
     _textController.removeListener(_applyFilteringAndRefresh);
+
+    searchBoxFocusNode.dispose();
+
     super.dispose();
   }
 
@@ -241,6 +249,7 @@ class _HomePageState extends State<HomePage> {
                     border: InputBorder.none,
                     focusedBorder: InputBorder.none,
                   ),
+                  focusNode: searchBoxFocusNode,
                 ),
           centerTitle: true,
           actions: <Widget>[
@@ -258,6 +267,12 @@ class _HomePageState extends State<HomePage> {
                       _searchText = "";
                     } else {
                       _searchText = _textController.text;
+
+                      // Request focus on the search box
+                      // For Windows only for now. "Platform.isWindows" can be removed if other platforms has been tested.
+                      if (Platform.isWindows) {
+                        searchBoxFocusNode.requestFocus();
+                      }
                     }
                     _applyFilteringAndRefresh();
                   },


### PR DESCRIPTION
## Description

Currently, on Windows, it is required two mouse clicks in order to focus the search box. 
1. Click the search icon 
3. Click the search box
4. Type keywords 


After this fix:
1. Click the search icon
4. Type keywords 

Before:
https://github.com/user-attachments/assets/a2f26d84-6c00-4ca6-ae94-cc004dd13f8f

After
https://github.com/user-attachments/assets/0950e7e9-4b90-4e70-b82c-de3f739d77c5


## Tests
- Tested on Windows 11 x64 (23H2 22631.3296).
- I added `Platform.isWindows`, as I could test on Windows only.
- Actually I saw this problem on one of my Android phone, but I am not able to build the apk to test it, should be due to my Android SDK issue.
- I don't have iOS devices 
