### PR TITLE
[web][error] Avoid using `in` operator on "string"

### DIFF
--- a/web/packages/shared/error/index.ts
+++ b/web/packages/shared/error/index.ts
@@ -18,7 +18,8 @@ export class ApiError extends Error {
 }
 
 export function isApiErrorResponse(object: any): object is ApiErrorResponse {
-    return object && "code" in object && "message" in object;
+    return object && typeof object != "string" && "code" in object
+      && "message" in object;
 }
 
 export const CustomError = {


### PR DESCRIPTION
## Description

HTTP 403 and probably other similar errors are Strings rather than Objects so using the `in` operator on them is not supported.

Ran into the following error while trying to set up a self-hosted Ente instance to evaluate the product.

```
[error] putFile to dataStore failed : TypeError: cannot use 'in' operator to search for "code" in "<?xml version=\"1..."
[ ... elided stacktrace ]
```

It's a 403 coming from Minio. (Any help with troubleshooting that would be awesome. I no longer have CORS errors and I can curl PUT files to the Minio instance.)

Going forward the error would be as originally intended:

```
[error] HTTP Service Error - {"url":"http://minio.ente.yorp.local/b2-eu-cen/1580559962386438/dd11ef2b-5814-415a-a5b5-82d713a9730b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20240829%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20240829T123350Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=721166d9f72ac8be9d1fa0e375f364b1d32d33010fe6c401acef6e749ef9847a","method":"put","httpStatus":403}: ApiError: client error
[ ... elided stacktrace ]
```
## Tests

Not sure what is desired here. The above error is what I actually got on my instance. If a unit test or similar is required I could use some help pointing out what framework to use.
