### PR TITLE
[server] Use nanoId as reqID

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	b64 "encoding/base64"
 	"fmt"
+	"github.com/ente-io/museum/ente/base"
 	"github.com/ente-io/museum/pkg/controller/file_copy"
 	"github.com/ente-io/museum/pkg/controller/filedata"
 	"net/http"
@@ -361,7 +362,14 @@ func main() {
 	server.Use(p.HandlerFunc())
 
 	// note: the recover middleware must be in the last
-	server.Use(requestid.New(), middleware.Logger(urlSanitizer), cors(), gzip.Gzip(gzip.DefaultCompression), middleware.PanicRecover())
+
+	server.Use(requestid.New(
+		requestid.Config{
+			Generator: func() string {
+				return base.ServerReqID()
+			},
+		}),
+		middleware.Logger(urlSanitizer), cors(), gzip.Gzip(gzip.DefaultCompression), middleware.PanicRecover())
 
 	publicAPI := server.Group("/")
 	publicAPI.Use(rateLimiter.GlobalRateLimiter(), rateLimiter.APIRateLimitMiddleware(urlSanitizer))

--- a/server/ente/base/id.go
+++ b/server/ente/base/id.go
@@ -3,6 +3,7 @@ package base
 import (
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/matoous/go-nanoid/v2"
 )
 
@@ -27,4 +28,13 @@ func NewID(prefix string) (*string, error) {
 	}
 	result := fmt.Sprintf("%s_%s", prefix, id)
 	return &result, nil
+}
+
+func ServerReqID() string {
+	// Generate a nanoid with a custom alphabet and length of 22
+	id, err := NewID("ser")
+	if err != nil {
+		return "ser_" + uuid.New().String()
+	}
+	return *id
 }


### PR DESCRIPTION
## Description
Note: if the client has already attached reqID in header, that will be used. All mobile clients currently add uuid as reqID, will change it to use `mphoto`, `mauth` as nano id prefix, similarly `cli` for CLI.
## Tests
