### PR TITLE
[web] Indicate that hash comparision is also used in the detail message

### DIFF
--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -301,7 +301,7 @@
     "THUMBNAIL_GENERATION_FAILED_UPLOADS": "Thumbnail generation failed",
     "UNSUPPORTED_FILES": "Unsupported files",
     "SUCCESSFUL_UPLOADS": "Successful uploads",
-    "SKIPPED_INFO": "Skipped these as there are files with matching names in the same album",
+    "SKIPPED_INFO": "Skipped these as there are files with matching name and content in the same album",
     "UNSUPPORTED_INFO": "Ente does not support these file formats yet",
     "BLOCKED_UPLOADS": "Blocked uploads",
     "INPROGRESS_METADATA_EXTRACTION": "In progress",


### PR DESCRIPTION
Context: https://github.com/ente-io/ente/discussions/3070
