### PR TITLE
[web] Make it more apparent what the create albums button does

### DIFF
--- a/web/apps/photos/src/components/Collections/CollectionSelector/AddCollectionButton.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionSelector/AddCollectionButton.tsx
@@ -23,9 +23,7 @@ export default function AddCollectionButton({ showNextModal }: Iprops) {
             onClick={() => showNextModal()}
             coverFile={null}
         >
-            <AllCollectionTileText>
-                {t("CREATE_COLLECTION")}
-            </AllCollectionTileText>
+            <AllCollectionTileText>{t("create_albums")}</AllCollectionTileText>
             <ImageContainer>
                 <CenteredFlex>+</CenteredFlex>
             </ImageContainer>

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -41,6 +41,7 @@
     "REFERRAL_CODE_HINT": "How did you hear about Ente? (optional)",
     "REFERRAL_INFO": "We don't track app installs, It'd help us if you told us where you found us!",
     "PASSPHRASE_MATCH_ERROR": "Passwords don't match",
+    "create_albums": "Create albums",
     "CREATE_COLLECTION": "New album",
     "ENTER_ALBUM_NAME": "Album name",
     "CLOSE_OPTION": "Close (Esc)",


### PR DESCRIPTION
Change title of the button from "New album" to "Create albums" to indicate that it can be used to preserve albums.

See: https://github.com/ente-io/ente/issues/3067
