### PR TITLE
[mob][photos][auth] Fix lockscreen not automatically appearing on opening app on iPad

### DIFF
--- a/auth/lib/ui/tools/app_lock.dart
+++ b/auth/lib/ui/tools/app_lock.dart
@@ -67,13 +67,13 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
 
   @override
   void initState() {
+    super.initState();
+
     WidgetsBinding.instance.addObserver(this);
 
     this._didUnlockForAppLaunch = !this.widget.enabled;
     this._isLocked = false;
     this._enabled = this.widget.enabled;
-
-    super.initState();
   }
 
   @override

--- a/auth/lib/ui/tools/lock_screen.dart
+++ b/auth/lib/ui/tools/lock_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:math';
 
 import 'package:ente_auth/core/configuration.dart';
@@ -40,10 +39,6 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
     invalidAttemptCount = _lockscreenSetting.getInvalidAttemptCount();
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      if (isNonMobileIOSDevice()) {
-        _logger.info('ignore init for non mobile iOS device');
-        return;
-      }
       _showLockScreen(source: "postFrameInit");
     });
     _platformBrightness =
@@ -188,14 +183,6 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
         ),
       ),
     );
-  }
-
-  bool isNonMobileIOSDevice() {
-    if (Platform.isAndroid) {
-      return false;
-    }
-    var shortestSide = MediaQuery.of(context).size.shortestSide;
-    return shortestSide > 600 ? true : false;
   }
 
   void _onLogoutTapped(BuildContext context) {

--- a/auth/lib/utils/lock_screen_settings.dart
+++ b/auth/lib/utils/lock_screen_settings.dart
@@ -24,7 +24,7 @@ class LockScreenSettings {
   static const keyHasMigratedLockScreenChanges =
       "ls_has_migrated_lock_screen_changes";
   final List<Duration> autoLockDurations = const [
-    Duration(seconds: 0),
+    Duration(milliseconds: 650),
     Duration(seconds: 5),
     Duration(seconds: 15),
     Duration(minutes: 1),

--- a/mobile/lib/utils/lock_screen_settings.dart
+++ b/mobile/lib/utils/lock_screen_settings.dart
@@ -22,7 +22,7 @@ class LockScreenSettings {
   late FlutterSecureStorage _secureStorage;
   late SharedPreferences _preferences;
   static const List<Duration> autoLockDurations = [
-    Duration(seconds: 0),
+    Duration(milliseconds: 650),
     Duration(seconds: 5),
     Duration(seconds: 15),
     Duration(minutes: 1),


### PR DESCRIPTION
## Description

Check commit message.

Since this removes a code block added to fix another bug (see #358 ), I've verified that the change in this PR doesn't resurface the old bug. From what I've observed, changing the `immediate` app lock time from 0 to 650ms stops the old bug from surfacing. 
