### PR TITLE
[mob][photos] Consider sample aspect ratio or pixel aspect ratio when parsing width and height of video used for calculating aspect ratio

### DIFF
--- a/mobile/lib/models/ffmpeg/ffprobe_keys.dart
+++ b/mobile/lib/models/ffmpeg/ffprobe_keys.dart
@@ -73,6 +73,7 @@ class FFProbeKeys {
   static const sideDataList = 'side_data_list';
   static const rotation = 'rotation';
   static const sideDataType = 'side_data_type';
+  static const sampleAspectRatio = 'sample_aspect_ratio';
 }
 
 class MediaStreamTypes {


### PR DESCRIPTION


## Description

Most videos have a [Pixel aspect ratio](https://en.wikipedia.org/wiki/Pixel_aspect_ratio#:~:text=The%20aspect%20ratio%20of%20the%20pixels%20themselves%20is%20known%20as,PAR%20%3D%20DAR%20%2F%20SAR) of 1:1. For the ones that do not have a PAR of 1:1, just using height and width from exif to calculate the aspect ratio of the video won't work. In such cases, `sample_aspect_ratio` should be considered. 

## Tests

Tested and working without bugs. 