### PR TITLE
[server] Load museum.yaml after configuration.yaml

### DIFF
--- a/docs/docs/self-hosting/guides/configuring-s3.md
+++ b/docs/docs/self-hosting/guides/configuring-s3.md
@@ -81,6 +81,22 @@ Set the S3 bucket `endpoint` in `credentials.yaml` to a `yourserverip:3200` or
 some such IP/hostname that accessible from both where you are running the Ente
 clients (e.g. the mobile app) and also from within the Docker compose cluster.
 
+### Example
+
+An example `museum.yaml` when you're trying to connect to museum running on your computer from your
+phone on the same WiFi network:
+
+```
+s3:
+    are_local_buckets: true
+    b2-eu-cen:
+        key: test
+        secret: testtest
+        endpoint: http://<YOUR-WIFI-IP>:3200
+        region: eu-central-2
+        bucket: b2-eu-cen
+```
+
 ### 403 Forbidden
 
 If museum (`2`) is able to make a network connection to your S3 bucket (`3`) but

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -5,12 +5,13 @@
 #    load one of the files from the `configurations/` directory. If not present,
 #    then by default `local.yaml` (this file) will get loaded.
 #
-# 2. Then, museum will look for a file named `museum.yaml` in the current
-#    working directory. If found, this file will also be loaded, and entries
-#    specified therein will override the defaults specified here.
+# 2. If the "credentials-file" config option is set then museum will look for
+#    that file. If found, that file will also be loaded, and entries specified
+#    therein will override the defaults specified here.
 #
-# 3. If the "credentials-file" config option is set, then museum will also load
-#    that and merge it in.
+# 3. Then, museum will look for a file named `museum.yaml` (gitignored) in the
+#    current working directory. If found, this file will also be loaded and
+#    merged.
 #
 # 4. Config can be overridden with via environment variables (details below).
 #

--- a/server/pkg/utils/config/config.go
+++ b/server/pkg/utils/config/config.go
@@ -47,16 +47,16 @@ func ConfigureViper(environment string) error {
 		return err
 	}
 
-	err = mergeConfigFileIfExists("museum.yaml")
-	if err != nil {
-		return err
-	}
-
 	credentialsFile := viper.GetString("credentials-file")
 	if credentialsFile == "" {
 		credentialsFile = "credentials.yaml"
 	}
 	err = mergeConfigFileIfExists(credentialsFile)
+	if err != nil {
+		return err
+	}
+
+	err = mergeConfigFileIfExists("museum.yaml")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Since museum.yaml is gitignored, loading it the last makes it easier to do ad-hoc configuration changes without marking the git tree dirty.
