### PR TITLE
[mob](panorama): add back button to viewer screen

### DIFF
--- a/mobile/lib/ui/viewer/file/panorama_viewer_screen.dart
+++ b/mobile/lib/ui/viewer/file/panorama_viewer_screen.dart
@@ -127,6 +127,7 @@ class _PanoramaViewerScreenState extends State<PanoramaViewerScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: isVisible ? AppBar() : null,
       body: Stack(
         children: [
           Panorama(


### PR DESCRIPTION
## Description

Add back button to Panorama screen which will disappear as soon as timer expires i.e. 5 seconds and reappear on screen tap.

## Tests
