### PR TITLE
[cli] fix Failed to encrypt invalid key #1510

### DIFF
--- a/cli/pkg/secrets/secret.go
+++ b/cli/pkg/secrets/secret.go
@@ -2,11 +2,13 @@ package secrets
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/ente-io/cli/utils/constants"
 	"log"
 	"os"
+
+	"github.com/ente-io/cli/utils/constants"
 
 	"github.com/zalando/go-keyring"
 )
@@ -44,14 +46,20 @@ func GetOrCreateClISecret() []byte {
 		if err != nil {
 			log.Fatal(fmt.Errorf("error generating key: %w", err))
 		}
-		secret = string(key)
-		keySetErr := keyring.Set(secretService, secretUser, string(secret))
+		secret = base64.StdEncoding.EncodeToString(key)
+		keySetErr := keyring.Set(secretService, secretUser, secret)
 		if keySetErr != nil {
 			log.Fatal(fmt.Errorf("error setting password in keyring: %w", keySetErr))
 		}
 
 	}
-	return []byte(secret)
+
+	result, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		log.Fatal(fmt.Errorf("error decoding secret: %w", err))
+	}
+
+	return result
 }
 
 // GetSecretFromSecretText reads the scecret from the secret text file.


### PR DESCRIPTION
## Description

This changes the encoding for the secret stored in the keyring to `base64`, so all characters will always be represented by one byte.  This fixes the CLI for linux users (see #1510 for more details).

Obviously this is not ideal, as it is breaking for all users who have a (working) version of the CLI installed already, but it worked as a workaround for me, so i thought i post it here for reference.