### PR TITLE
Minio Cold Storage

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -162,6 +162,12 @@ s3:
     #    not support them, specifically it doesn't support GLACIER).
     #
     #are_local_buckets: true
+
+    # Allow use of Minio (Configured with TLS) as cold storage, as Minio does not support glacier
+    # we need to disable the glacier storage class for using this, this allows a mixed used of 
+    # publicly available hot storage, and local hosted/private cold storage.
+    # minio_cold_storage: true
+
     # Uncomment this to use "path" style S3 URLs.
     #
     # By default the bucket name is part of the (sub)domain, e.g.

--- a/server/pkg/controller/replication3.go
+++ b/server/pkg/controller/replication3.go
@@ -196,7 +196,7 @@ func (c *ReplicationController3) createDestinations() {
 		Label:    "scaleway",
 		// should be true, except when running in a local cluster (since minio doesn't
 		// support specifying the GLACIER storage class).
-		IsGlacier: !config.AreLocalBuckets() || !config.MinioColdStorage(),
+		IsGlacier: !( !config.AreLocalBuckets() || !config.MinioColdStorage() ),
 	}
 }
 

--- a/server/pkg/controller/replication3.go
+++ b/server/pkg/controller/replication3.go
@@ -196,7 +196,7 @@ func (c *ReplicationController3) createDestinations() {
 		Label:    "scaleway",
 		// should be true, except when running in a local cluster (since minio doesn't
 		// support specifying the GLACIER storage class).
-		IsGlacier: !config.AreLocalBuckets(),
+		IsGlacier: !config.AreLocalBuckets() || !config.MinioColdStorage(),
 	}
 }
 

--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -41,6 +41,8 @@ type S3Config struct {
 	// Indicates if local minio buckets are being used. Enables various
 	// debugging workarounds; not tested/intended for production.
 	areLocalBuckets bool
+	// Indicates if want to use minio for cold storage, whilst using other (external) providers for hot storage
+	minioColdStorage bool
 
 	// FileDataConfig is the configuration for various file data.
 	// If for particular object type, the bucket is not specified, it will
@@ -273,4 +275,10 @@ func (config *S3Config) WasabiComplianceDC() string {
 // various workarounds for debugging locally; not meant for production use.
 func (config *S3Config) AreLocalBuckets() bool {
 	return config.areLocalBuckets
+}
+
+// Return true if we're using local minio buckets. This can then be used to add
+// various workarounds for debugging locally; not meant for production use.
+func (config *S3Config) MinioColdStorage() bool {
+	return config.minioColdStorage
 }


### PR DESCRIPTION
## Description
This PR is to allow use of Minio for cold storage, removing the GLACIER storage class that is usually set and is unsupported by Minio. 

By default if you set use "are_local_buckets" this breaks TLS on all buckets, so it is impossible to use public hot storage and self hosted cold storage. 

This option now allows for a hybrid approach. 

Note: TLS must be configured on the Minio instance.

## Tests
