### PR TITLE
[web][meta] Ignore stale lint runs on PR push

### DIFF
--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -7,6 +7,11 @@ on:
             - "web/**"
             - ".github/workflows/web-lint.yml"
 
+# Cancel in-progress lint runs when a new commit is pushed.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     lint:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior
