### PR TITLE
[cli] Base64 Encode the CLI secrets

### DIFF
--- a/cli/pkg/secrets/key_holder.go
+++ b/cli/pkg/secrets/key_holder.go
@@ -18,6 +18,9 @@ type KeyHolder struct {
 }
 
 func NewKeyHolder(deviceKey []byte) *KeyHolder {
+	if len(deviceKey) != 32 {
+		panic(fmt.Sprintf("device key must be 32 bytes, found: %d bytes", len(deviceKey)))
+	}
 	return &KeyHolder{
 		AccountSecrets: make(map[string]*model.AccSecretInfo),
 		CollectionKeys: make(map[string][]byte),


### PR DESCRIPTION
## Description

Related to #1510 & [#3163](https://github.com/ente-io/ente/pull/3163)

This potential fix was only possible due to amazing investigation done by @shoetten

## Tests
Did basic sanity testing on local machine
