### PR TITLE
[mob][photos] Kill the app on logging out from lockscreen

### DIFF
--- a/mobile/lib/ui/tools/lock_screen.dart
+++ b/mobile/lib/ui/tools/lock_screen.dart
@@ -213,6 +213,7 @@ class _LockScreenState extends State<LockScreen>
       isCritical: true,
       firstButtonOnTap: () async {
         await UserService.instance.logout(context);
+        Process.killPid(pid, ProcessSignal.sigkill);
       },
     );
   }


### PR DESCRIPTION
## Description 

If lockscreen is above some screens (like an album) and user logs out, the app goes back to that screen after logging out.
Killing the app right after logging out was the easiest fix.  