### PR TITLE
[mob][photos] Fix exceptions from incorrect use of InheritedWidget

### DIFF
--- a/mobile/lib/ui/components/home_header_widget.dart
+++ b/mobile/lib/ui/components/home_header_widget.dart
@@ -86,8 +86,8 @@ class _HomeHeaderWidgetState extends State<HomeHeaderWidget> {
               unawaited(
                 routeToPage(
                   context,
-                  BackupFolderSelectionPage(
-                    buttonText: S.of(context).backup,
+                  const BackupFolderSelectionPage(
+                    isFirstBackup: false,
                   ),
                 ),
               );

--- a/mobile/lib/ui/home/loading_photos_widget.dart
+++ b/mobile/lib/ui/home/loading_photos_widget.dart
@@ -50,10 +50,9 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
           // ignore: unawaited_futures
           routeToPage(
             context,
-            BackupFolderSelectionPage(
+            const BackupFolderSelectionPage(
               isOnboarding: true,
-              //Move this from here?
-              buttonText: S.of(context).startBackup,
+              isFirstBackup: true,
             ),
           );
         }

--- a/mobile/lib/ui/home/loading_photos_widget.dart
+++ b/mobile/lib/ui/home/loading_photos_widget.dart
@@ -25,7 +25,7 @@ class LoadingPhotosWidget extends StatefulWidget {
 
 class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
   late StreamSubscription<SyncStatusUpdate> _firstImportEvent;
-  late StreamSubscription<LocalImportProgressEvent> _importProgressEvent;
+  StreamSubscription<LocalImportProgressEvent>? _importProgressEvent;
   int _currentPage = 0;
   late String _loadingMessage;
   final PageController _pageController = PageController(
@@ -38,7 +38,6 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
   @override
   void initState() {
     super.initState();
-    _loadingMessage = S.of(context).loadingYourPhotos;
     Future.delayed(const Duration(seconds: 60), () {
       oneMinuteOnScreen.value = true;
     });
@@ -53,19 +52,14 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
             context,
             BackupFolderSelectionPage(
               isOnboarding: true,
+              //Move this from here?
               buttonText: S.of(context).startBackup,
             ),
           );
         }
       }
     });
-    _importProgressEvent =
-        Bus.instance.on<LocalImportProgressEvent>().listen((event) {
-      _loadingMessage = S.of(context).processingImport(event.folderName);
-      if (mounted) {
-        setState(() {});
-      }
-    });
+
     _didYouKnowTimer =
         Timer.periodic(const Duration(seconds: 5), (Timer timer) {
       if (!mounted) {
@@ -86,9 +80,25 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_importProgressEvent != null) {
+      _importProgressEvent!.cancel();
+    } else {
+      _importProgressEvent =
+          Bus.instance.on<LocalImportProgressEvent>().listen((event) {
+        _loadingMessage = S.of(context).processingImport(event.folderName);
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    }
+  }
+
+  @override
   void dispose() {
     _firstImportEvent.cancel();
-    _importProgressEvent.cancel();
+    _importProgressEvent?.cancel();
     _didYouKnowTimer.cancel();
     oneMinuteOnScreen.dispose();
     super.dispose();
@@ -96,6 +106,9 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
 
   @override
   Widget build(BuildContext context) {
+    if (_importProgressEvent == null) {
+      _loadingMessage = S.of(context).loadingYourPhotos;
+    }
     _setupLoadingMessages(context);
     final isLightMode = Theme.of(context).brightness == Brightness.light;
     return Scaffold(

--- a/mobile/lib/ui/home/start_backup_hook_widget.dart
+++ b/mobile/lib/ui/home/start_backup_hook_widget.dart
@@ -49,8 +49,8 @@ class StartBackupHookWidget extends StatelessWidget {
                     // ignore: unawaited_futures
                     routeToPage(
                       context,
-                      BackupFolderSelectionPage(
-                        buttonText: S.of(context).startBackup,
+                      const BackupFolderSelectionPage(
+                        isFirstBackup: true,
                       ),
                     );
                   }

--- a/mobile/lib/ui/settings/backup/backup_folder_selection_page.dart
+++ b/mobile/lib/ui/settings/backup/backup_folder_selection_page.dart
@@ -19,14 +19,14 @@ import 'package:photos/ui/viewer/file/thumbnail_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
 
 class BackupFolderSelectionPage extends StatefulWidget {
+  final bool isFirstBackup;
   final bool isOnboarding;
-  final String buttonText;
 
   const BackupFolderSelectionPage({
-    required this.buttonText,
+    required this.isFirstBackup,
     this.isOnboarding = false,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<BackupFolderSelectionPage> createState() =>
@@ -173,7 +173,11 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
                               : () async {
                                   await updateFolderSettings();
                                 },
-                      child: Text(widget.buttonText),
+                      child: Text(
+                        widget.isFirstBackup
+                            ? S.of(context).startBackup
+                            : S.of(context).backup,
+                      ),
                     ),
                   ),
                   widget.isOnboarding

--- a/mobile/lib/ui/settings/backup/backup_section_widget.dart
+++ b/mobile/lib/ui/settings/backup/backup_section_widget.dart
@@ -42,8 +42,8 @@ class BackupSectionWidgetState extends State<BackupSectionWidget> {
         onTap: () async {
           await routeToPage(
             context,
-            BackupFolderSelectionPage(
-              buttonText: S.of(context).backup,
+            const BackupFolderSelectionPage(
+              isFirstBackup: false,
             ),
           );
         },

--- a/mobile/lib/ui/viewer/search/tab_empty_state.dart
+++ b/mobile/lib/ui/viewer/search/tab_empty_state.dart
@@ -38,8 +38,8 @@ class SearchTabEmptyState extends StatelessWidget {
                 // ignore: unawaited_futures
                 routeToPage(
                   context,
-                  BackupFolderSelectionPage(
-                    buttonText: S.of(context).backup,
+                  const BackupFolderSelectionPage(
+                    isFirstBackup: false,
                   ),
                 );
               },


### PR DESCRIPTION
## Description

- Avoid/fix potential and current issues caused due to calling `dependOnInheritedWidgetOfExactType<T>()` in initState (i.e, before the widget is build). 

