### PR TITLE
[server] Optional SMTP authentication

### DIFF
--- a/server/pkg/utils/email/email.go
+++ b/server/pkg/utils/email/email.go
@@ -47,6 +47,10 @@ func sendViaSMTP(toEmails []string, fromName string, fromEmail string, subject s
 	smtpEmail := viper.GetString("smtp.email")
 
 	var emailMessage string
+	var auth smtp.Auth = nil
+	if smtpUsername != "" && smtpPassword != "" {
+		auth = smtp.PlainAuth("", smtpUsername, smtpPassword, smtpServer)
+	}
 
 	// Construct 'emailAddresses' with comma-separated email addresses
 	var emailAddresses string
@@ -94,7 +98,6 @@ func sendViaSMTP(toEmails []string, fromName string, fromEmail string, subject s
 
 	// Send the email to each recipient
 	for _, toEmail := range toEmails {
-		auth := smtp.PlainAuth("", smtpUsername, smtpPassword, smtpServer)
 		err := smtp.SendMail(smtpServer+":"+smtpPort, auth, fromEmail, []string{toEmail}, []byte(emailMessage))
 		if err != nil {
 			errMsg := err.Error()


### PR DESCRIPTION
## Description
When using a local relay server, not authentication is needed. To support this use-case authentication is only send to the server when an user and password are set in the configuration file.

See error message from https://github.com/ente-io/ente/discussions/3179
