### PR TITLE
[auth]: use correct value for compact mode in code widget

### DIFF
--- a/auth/lib/ui/code_widget.dart
+++ b/auth/lib/ui/code_widget.dart
@@ -53,7 +53,6 @@ class _CodeWidgetState extends State<CodeWidget> {
   late bool _shouldShowLargeIcon;
   late bool _hideCode;
   bool isMaskingEnabled = false;
-  bool isCompactMode = true;
   int _codeTimeStep = -1;
 
   @override
@@ -114,16 +113,17 @@ class _CodeWidgetState extends State<CodeWidget> {
     Widget getCardContents(AppLocalizations l10n) {
       return Stack(
         children: [
-          if (widget.code.isPinned)
-            Align(
-              alignment: Alignment.topRight,
-              child: CustomPaint(
-                painter: PinBgPainter(
-                  color: colorScheme.pinnedBgColor,
-                ),
-                size: isCompactMode ? const Size(24, 24) : const Size(39, 39),
+          Align(
+            alignment: Alignment.topRight,
+            child: CustomPaint(
+              painter: PinBgPainter(
+                color: colorScheme.pinnedBgColor,
               ),
+              size: widget.isCompactMode
+                  ? const Size(24, 24)
+                  : const Size(39, 39),
             ),
+          ),
           if (widget.code.isTrashed && kDebugMode)
             Align(
               alignment: Alignment.topLeft,
@@ -161,7 +161,7 @@ class _CodeWidgetState extends State<CodeWidget> {
                   ),
                 ],
               ),
-              isCompactMode
+              widget.isCompactMode
                   ? const SizedBox(height: 4)
                   : const SizedBox(height: 32),
             ],
@@ -171,7 +171,7 @@ class _CodeWidgetState extends State<CodeWidget> {
               alignment: Alignment.topRight,
               child: Padding(
                 padding: widget.isCompactMode
-                    ? const EdgeInsets.only(right: 2, top: 2)
+                    ? const EdgeInsets.only(right: 4, top: 4)
                     : const EdgeInsets.only(right: 6, top: 6),
                 child: SvgPicture.asset(
                   "assets/svg/pin-card.svg",
@@ -284,8 +284,8 @@ class _CodeWidgetState extends State<CodeWidget> {
               child: clippedCard(l10n),
             );
           }
-          final double slideSpace = isCompactMode ? 4 : 8;
-          double extendRatio = isCompactMode ? 0.70 : 0.90;
+          final double slideSpace = widget.isCompactMode ? 4 : 8;
+          double extendRatio = widget.isCompactMode ? 0.70 : 0.90;
           if (widget.code.isTrashed) {
             extendRatio = 0.50;
           }

--- a/auth/lib/ui/code_widget.dart
+++ b/auth/lib/ui/code_widget.dart
@@ -113,17 +113,18 @@ class _CodeWidgetState extends State<CodeWidget> {
     Widget getCardContents(AppLocalizations l10n) {
       return Stack(
         children: [
-          Align(
-            alignment: Alignment.topRight,
-            child: CustomPaint(
-              painter: PinBgPainter(
-                color: colorScheme.pinnedBgColor,
+          if (widget.code.isPinned)
+            Align(
+              alignment: Alignment.topRight,
+              child: CustomPaint(
+                painter: PinBgPainter(
+                  color: colorScheme.pinnedBgColor,
+                ),
+                size: widget.isCompactMode
+                    ? const Size(24, 24)
+                    : const Size(39, 39),
               ),
-              size: widget.isCompactMode
-                  ? const Size(24, 24)
-                  : const Size(39, 39),
             ),
-          ),
           if (widget.code.isTrashed && kDebugMode)
             Align(
               alignment: Alignment.topLeft,


### PR DESCRIPTION
## Description

In some place isCompactMode was using local value, which was never updated and was always true. Which resulted in components such as Pin icon background to display incorrect in size.

## Tests
