### PR TITLE
[web/desktop] Make images on deduplicate selectable

### DIFF
--- a/web/apps/photos/src/components/PhotoFrame.tsx
+++ b/web/apps/photos/src/components/PhotoFrame.tsx
@@ -66,6 +66,7 @@ interface Props {
     setIsPhotoSwipeOpen?: (value: boolean) => void;
     isInHiddenSection?: boolean;
     setFilesDownloadProgressAttributesCreator?: SetFilesDownloadProgressAttributesCreator;
+    selectable?: boolean;
 }
 
 const PhotoFrame = ({
@@ -86,6 +87,7 @@ const PhotoFrame = ({
     setIsPhotoSwipeOpen,
     isInHiddenSection,
     setFilesDownloadProgressAttributesCreator,
+    selectable,
 }: Props) => {
     const [open, setOpen] = useState(false);
     const [currentIndex, setCurrentIndex] = useState<number>(0);
@@ -277,7 +279,7 @@ const PhotoFrame = ({
             file={item}
             updateURL={updateURL(index)}
             onClick={onThumbnailClick(index)}
-            selectable={enableDownload}
+            selectable={selectable}
             onSelect={handleSelect(
                 item.id,
                 item.ownerID === galleryContext.user?.id,

--- a/web/apps/photos/src/pages/deduplicate.tsx
+++ b/web/apps/photos/src/pages/deduplicate.tsx
@@ -196,6 +196,7 @@ export default function Deduplicate() {
                     activeCollectionID={ALL_SECTION}
                     fileToCollectionsMap={fileToCollectionsMap}
                     collectionNameMap={collectionNameMap}
+                    selectable={true}
                 />
             )}
             <DeduplicateOptions

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -1195,6 +1195,7 @@ export default function Gallery() {
                         setFilesDownloadProgressAttributesCreator={
                             setFilesDownloadProgressAttributesCreator
                         }
+                        selectable={true}
                     />
                 )}
                 {selected.count > 0 &&

--- a/web/apps/photos/src/pages/shared-albums.tsx
+++ b/web/apps/photos/src/pages/shared-albums.tsx
@@ -562,6 +562,7 @@ export default function PublicCollectionGallery() {
                     setFilesDownloadProgressAttributesCreator={
                         setFilesDownloadProgressAttributesCreator
                     }
+                    selectable={downloadEnabled}
                 />
                 {blockingLoad && (
                     <LoadingOverlay>


### PR DESCRIPTION
The duplicate images page has a image preselected but there is no checkbox available.
When unselecting this image there is no possibility to do a new selection.

This PR adds the same checkbox like on the gallery to select images on the deduplication page.