### PR TITLE
Add altName back to T-Mobile icon that was previously removed from json

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -618,7 +618,8 @@
     {
       "title": "T-Mobile",
       "altNames": [
-        "T Mobile"
+        "T Mobile",
+        "T-Mobile ID"
       ]
     },    
     {


### PR DESCRIPTION
## Description

## Tests
