### PR TITLE
Clip with preprocessing inside ONNX on web

### DIFF
--- a/desktop/src/main/services/ml-worker.ts
+++ b/desktop/src/main/services/ml-worker.ts
@@ -202,8 +202,9 @@ const createInferenceSession = async (modelPath: string) => {
 };
 
 const cachedCLIPImageSession = makeCachedInferenceSession(
-    "mobileclip_s2_image.onnx",
+    "mobileclip_s2_image_opset18_rgba_sim.onnx",
     143061211 /* 143 MB */,
+    // TODO: manav: check above number, because I got 143093992 but might be calculating wrong
 );
 
 /**
@@ -211,10 +212,14 @@ const cachedCLIPImageSession = makeCachedInferenceSession(
  *
  * The embeddings are computed using ONNX runtime, with MobileCLIP as the model.
  */
-export const computeCLIPImageEmbedding = async (input: Float32Array) => {
+export const computeCLIPImageEmbedding = async (
+    input: Uint8ClampedArray,
+    inputShape: number[],
+) => {
     const session = await cachedCLIPImageSession();
+    const inputArray = new Uint8Array(input.buffer);
     const feeds = {
-        input: new ort.Tensor("float32", input, [1, 3, 256, 256]),
+        input: new ort.Tensor("uint8", inputArray, inputShape),
     };
     const t = Date.now();
     const results = await session.run(feeds);

--- a/desktop/src/main/services/ml-worker.ts
+++ b/desktop/src/main/services/ml-worker.ts
@@ -203,8 +203,7 @@ const createInferenceSession = async (modelPath: string) => {
 
 const cachedCLIPImageSession = makeCachedInferenceSession(
     "mobileclip_s2_image_opset18_rgba_sim.onnx",
-    143061211 /* 143 MB */,
-    // TODO: manav: check above number, because I got 143093992 but might be calculating wrong
+    143093992 /* 143 MB */,
 );
 
 /**

--- a/web/packages/base/types/ipc.ts
+++ b/web/packages/base/types/ipc.ts
@@ -558,7 +558,10 @@ export interface ElectronMLWorker {
      *
      * @returns A CLIP embedding (an array of 512 floating point values).
      */
-    computeCLIPImageEmbedding: (input: Float32Array) => Promise<Float32Array>;
+    computeCLIPImageEmbedding: (
+        input: Uint8ClampedArray,
+        inputShape: number[],
+    ) => Promise<Float32Array>;
 
     /**
      * Return a CLIP embedding of the given image if we already have the model

--- a/web/packages/base/types/ipc.ts
+++ b/web/packages/base/types/ipc.ts
@@ -553,8 +553,9 @@ export interface ElectronMLWorker {
      * See: [Note: Natural language search using CLIP]
      *
      * The input is a opaque float32 array representing the image. The layout
-     * and exact encoding of the input is specific to our implementation and the
-     * ML model (CLIP) we use.
+     * and exact encoding of the input is specific to the runtime (ONNX) and the
+     * ML model (a MobileCLIP variant) we use. In particular, the image
+     * pre-processing happens within our model itself.
      *
      * @returns A CLIP embedding (an array of 512 floating point values).
      */

--- a/web/packages/new/photos/services/ml/clip.ts
+++ b/web/packages/new/photos/services/ml/clip.ts
@@ -1,7 +1,6 @@
 import type { ElectronMLWorker } from "@/base/types/ipc";
 import type { ImageBitmapAndData } from "./blob";
 import { getCLIPIndexes } from "./db";
-import { pixelRGBBilinear } from "./image";
 import { dotProduct, norm } from "./math";
 import type { CLIPMatches } from "./worker-types";
 
@@ -116,50 +115,6 @@ const computeEmbedding = async (
     const { height, width, data: pixelData } = imageData;
     const inputShape = [height, width, 4]; // [H, W, C]
     return normalized(await electron.computeCLIPImageEmbedding(pixelData, inputShape));
-};
-
-/**
- * Convert {@link imageData} into the format that the MobileCLIP model expects.
- */
-const convertToCLIPInput = (imageData: ImageData) => {
-    const [requiredWidth, requiredHeight] = [256, 256];
-
-    const { width, height, data: pixelData } = imageData;
-
-    // Maintain aspect ratio.
-    const scale = Math.max(requiredWidth / width, requiredHeight / height);
-
-    // Perform antialiasing if downscaling.
-    const antialias = scale < 0.8;
-
-    const scaledWidth = Math.round(width * scale);
-    const scaledHeight = Math.round(height * scale);
-    const widthOffset = Math.max(0, scaledWidth - requiredWidth) / 2;
-    const heightOffset = Math.max(0, scaledHeight - requiredHeight) / 2;
-
-    const clipInput = new Float32Array(3 * requiredWidth * requiredHeight);
-
-    // Populate the Float32Array with normalized pixel values.
-    let pi = 0;
-    const cOffsetG = requiredHeight * requiredWidth; // ChannelOffsetGreen
-    const cOffsetB = 2 * requiredHeight * requiredWidth; // ChannelOffsetBlue
-    for (let h = 0 + heightOffset; h < scaledHeight - heightOffset; h++) {
-        for (let w = 0 + widthOffset; w < scaledWidth - widthOffset; w++) {
-            const { r, g, b } = pixelRGBBilinear(
-                w / scale,
-                h / scale,
-                pixelData,
-                width,
-                height,
-                antialias,
-            );
-            clipInput[pi] = r / 255.0;
-            clipInput[pi + cOffsetG] = g / 255.0;
-            clipInput[pi + cOffsetB] = b / 255.0;
-            pi++;
-        }
-    }
-    return clipInput;
 };
 
 const normalized = (embedding: Float32Array) => {

--- a/web/packages/new/photos/services/ml/clip.ts
+++ b/web/packages/new/photos/services/ml/clip.ts
@@ -112,9 +112,15 @@ const computeEmbedding = async (
     imageData: ImageData,
     electron: ElectronMLWorker,
 ): Promise<Float32Array> => {
+    // In contrast to the face detection model, the image pre-preprocessing
+    // happens within the model itself, using ONNX primitives. This is more
+    // performant and also saves us from having to reinvent (say) the
+    // antialising wheels.
     const { height, width, data: pixelData } = imageData;
     const inputShape = [height, width, 4]; // [H, W, C]
-    return normalized(await electron.computeCLIPImageEmbedding(pixelData, inputShape));
+    return normalized(
+        await electron.computeCLIPImageEmbedding(pixelData, inputShape),
+    );
 };
 
 const normalized = (embedding: Float32Array) => {

--- a/web/packages/new/photos/services/ml/clip.ts
+++ b/web/packages/new/photos/services/ml/clip.ts
@@ -113,8 +113,9 @@ const computeEmbedding = async (
     imageData: ImageData,
     electron: ElectronMLWorker,
 ): Promise<Float32Array> => {
-    const clipInput = convertToCLIPInput(imageData);
-    return normalized(await electron.computeCLIPImageEmbedding(clipInput));
+    const { height, width, data: pixelData } = imageData;
+    const inputShape = [height, width, 4]; // [H, W, C]
+    return normalized(await electron.computeCLIPImageEmbedding(pixelData, inputShape));
 };
 
 /**

--- a/web/packages/new/photos/services/ml/face.ts
+++ b/web/packages/new/photos/services/ml/face.ts
@@ -397,7 +397,6 @@ const convertToYOLOInputFloat32ChannelsFirst = (imageData: ImageData) => {
                           pixelData,
                           width,
                           height,
-                          false,
                       );
             yoloInput[pi] = r / 255.0;
             yoloInput[pi + channelOffsetGreen] = g / 255.0;

--- a/web/packages/new/photos/services/ml/image.ts
+++ b/web/packages/new/photos/services/ml/image.ts
@@ -7,7 +7,7 @@ import { clamp } from "./math";
 
 /**
  * Returns the pixel value (RGB) at the given coordinates ({@link fx},
- * {@link fy}) using bilinear interpolation (optionally anti-aliased).
+ * {@link fy}) using bilinear interpolation.
  */
 export function pixelRGBBilinear(
     fx: number,
@@ -15,7 +15,6 @@ export function pixelRGBBilinear(
     imageData: Uint8ClampedArray,
     imageWidth: number,
     imageHeight: number,
-    antialias: boolean,
 ) {
     // Clamp to image boundaries.
     fx = clamp(fx, 0, imageWidth - 1);
@@ -32,11 +31,10 @@ export function pixelRGBBilinear(
     const dy1 = 1.0 - dy;
 
     // Get the original pixels.
-    const getPixelRGBA = antialias ? pixelRGBABlurred : pixelRGBA;
-    const pixel1 = getPixelRGBA(imageData, imageWidth, imageHeight, x0, y0);
-    const pixel2 = getPixelRGBA(imageData, imageWidth, imageHeight, x1, y0);
-    const pixel3 = getPixelRGBA(imageData, imageWidth, imageHeight, x0, y1);
-    const pixel4 = getPixelRGBA(imageData, imageWidth, imageHeight, x1, y1);
+    const pixel1 = pixelRGBA(imageData, imageWidth, imageHeight, x0, y0);
+    const pixel2 = pixelRGBA(imageData, imageWidth, imageHeight, x1, y0);
+    const pixel3 = pixelRGBA(imageData, imageWidth, imageHeight, x0, y1);
+    const pixel4 = pixelRGBA(imageData, imageWidth, imageHeight, x1, y1);
 
     const bilinear = (val1: number, val2: number, val3: number, val4: number) =>
         Math.round(
@@ -71,32 +69,6 @@ const pixelRGBA = (
         b: ensure(imageData[index + 2]),
         a: ensure(imageData[index + 3]),
     };
-};
-
-const pixelRGBABlurred = (
-    imageData: Uint8ClampedArray,
-    width: number,
-    height: number,
-    x: number,
-    y: number,
-) => {
-    let r = 0,
-        g = 0,
-        b = 0;
-    for (let ky = 0; ky < gaussianKernelSize; ky++) {
-        for (let kx = 0; kx < gaussianKernelSize; kx++) {
-            const px = x - gaussianKernelRadius + kx;
-            const py = y - gaussianKernelRadius + ky;
-
-            const pixelRgbTuple = pixelRGBA(imageData, width, height, px, py);
-            const weight = gaussianKernel[ky]![kx]!;
-
-            r += pixelRgbTuple.r * weight;
-            g += pixelRgbTuple.g * weight;
-            b += pixelRgbTuple.b * weight;
-        }
-    }
-    return { r: Math.round(r), g: Math.round(g), b: Math.round(b), a: 255 };
 };
 
 /**
@@ -315,42 +287,3 @@ export const grayscaleIntMatrixFromNormalized2List = (
         }),
     );
 };
-
-const gaussianKernelSize = 5;
-const gaussianKernelRadius = Math.floor(gaussianKernelSize / 2);
-const gaussianSigma = 10.0;
-
-const create2DGaussianKernel = (size: number, sigma: number): number[][] => {
-    const kernel = Array(size)
-        .fill(0)
-        .map(() => Array(size).fill(0) as number[]);
-
-    let sum = 0.0;
-    const center = Math.floor(size / 2);
-
-    for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-            const dx = x - center;
-            const dy = y - center;
-            const g =
-                (1 / (2 * Math.PI * sigma * sigma)) *
-                Math.exp(-(dx * dx + dy * dy) / (2 * sigma * sigma));
-            kernel[y]![x] = g;
-            sum += g;
-        }
-    }
-
-    // Normalize the kernel.
-    for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-            kernel[y]![x]! /= sum;
-        }
-    }
-
-    return kernel;
-};
-
-const gaussianKernel: number[][] = create2DGaussianKernel(
-    gaussianKernelSize,
-    gaussianSigma,
-);


### PR DESCRIPTION
## Description

Switched to new clip ONNX model on web, where preprocessing is done inside ORT. This means it's more performant and more advanced image processing.

## Tests

Not tested at all! I'm sure I've made a small mistake somewhere, please review and test carefully. 
The only thing properly tested is the model itself, this approach is tested and passed on mobile.

Also, there's one "TODO: manav" pending, please check.