### PR TITLE
[mob][photos] Remove legacy code in detail page

### DIFF
--- a/mobile/lib/services/home_widget_service.dart
+++ b/mobile/lib/services/home_widget_service.dart
@@ -139,10 +139,10 @@ class HomeWidgetService {
         iOSName: 'SlideshowWidget',
       );
       _logger.info(
-        ">>> OG size of SlideshowWidget image: ${width} x $height",
+        ">>> OG size of SlideshowWidget image: $width x $height",
       );
       _logger.info(
-        ">>> SlideshowWidget image rendered with size ${cacheWidth} x $cacheHeight",
+        ">>> SlideshowWidget image rendered with size $cacheWidth x $cacheHeight",
       );
     } catch (e) {
       _logger.severe("Error rendering widget", e);
@@ -217,7 +217,7 @@ class HomeWidgetService {
     if (res == null) return;
 
     final page = DetailPage(
-      DetailPageConfiguration(List.unmodifiable([res]), null, 0, "collection"),
+      DetailPageConfiguration(List.unmodifiable([res]), 0, "collection"),
     );
     routeToPage(context, page, forceCustomPageRoute: true).ignore();
   }

--- a/mobile/lib/ui/home/home_gallery_widget.dart
+++ b/mobile/lib/ui/home/home_gallery_widget.dart
@@ -13,6 +13,7 @@ import 'package:photos/services/collections_service.dart';
 import "package:photos/services/filter/db_filters.dart";
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class HomeGalleryWidget extends StatelessWidget {
@@ -21,11 +22,11 @@ class HomeGalleryWidget extends StatelessWidget {
   final SelectedFiles selectedFiles;
 
   const HomeGalleryWidget({
-    Key? key,
+    super.key,
     this.header,
     this.footer,
     required this.selectedFiles,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -85,14 +86,16 @@ class HomeGalleryWidget extends StatelessWidget {
       reloadDebounceTime: const Duration(seconds: 2),
       reloadDebounceExecutionInterval: const Duration(seconds: 5),
     );
-    return SelectionState(
-      selectedFiles: selectedFiles,
-      child: Stack(
-        alignment: Alignment.bottomCenter,
-        children: [
-          gallery,
-          FileSelectionOverlayBar(GalleryType.homepage, selectedFiles),
-        ],
+    return GalleryFilesState(
+      child: SelectionState(
+        selectedFiles: selectedFiles,
+        child: Stack(
+          alignment: Alignment.bottomCenter,
+          children: [
+            gallery,
+            FileSelectionOverlayBar(GalleryType.homepage, selectedFiles),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/ui/map/map_pull_up_gallery.dart
+++ b/mobile/lib/ui/map/map_pull_up_gallery.dart
@@ -15,6 +15,7 @@ import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/viewer/actions/file_selection_overlay_bar.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class MapPullUpGallery extends StatefulWidget {
@@ -29,8 +30,8 @@ class MapPullUpGallery extends StatefulWidget {
     this.visibleImages,
     this.bottomSheetDraggableAreaHeight,
     this.bottomUnsafeArea, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<MapPullUpGallery> createState() => _MapPullUpGalleryState();
@@ -49,40 +50,42 @@ class _MapPullUpGalleryState extends State<MapPullUpGallery> {
     Widget? cachedScrollableContent;
 
     return DeferredPointerHandler(
-      child: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          clipBehavior: Clip.none,
-          children: [
-            DraggableScrollableSheet(
-              expand: false,
-              initialChildSize: initialChildSize,
-              minChildSize: initialChildSize,
-              maxChildSize: 0.8,
-              snap: true,
-              snapSizes: const [0.5],
-              builder: (context, scrollController) {
-                //Must use cached widget here to avoid rebuilds when DraggableScrollableSheet
-                //is snapped to it's initialChildSize
-                cachedScrollableContent ??=
-                    cacheScrollableContent(scrollController, context, logger);
-                return cachedScrollableContent!;
-              },
-            ),
-            DeferPointer(
-              //This is to make the FileSelectionOverlayBar respect SafeArea
-              child: MediaQuery(
-                data: MediaQueryData.fromView(View.of(context)),
-                child: FileSelectionOverlayBar(
-                  GalleryType.searchResults,
-                  _selectedFiles,
-                  backgroundColor:
-                      getEnteColorScheme(context).backgroundElevated2,
+      child: GalleryFilesState(
+        child: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            clipBehavior: Clip.none,
+            children: [
+              DraggableScrollableSheet(
+                expand: false,
+                initialChildSize: initialChildSize,
+                minChildSize: initialChildSize,
+                maxChildSize: 0.8,
+                snap: true,
+                snapSizes: const [0.5],
+                builder: (context, scrollController) {
+                  //Must use cached widget here to avoid rebuilds when DraggableScrollableSheet
+                  //is snapped to it's initialChildSize
+                  cachedScrollableContent ??=
+                      cacheScrollableContent(scrollController, context, logger);
+                  return cachedScrollableContent!;
+                },
+              ),
+              DeferPointer(
+                //This is to make the FileSelectionOverlayBar respect SafeArea
+                child: MediaQuery(
+                  data: MediaQueryData.fromView(View.of(context)),
+                  child: FileSelectionOverlayBar(
+                    GalleryType.searchResults,
+                    _selectedFiles,
+                    backgroundColor:
+                        getEnteColorScheme(context).backgroundElevated2,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/tools/collage/collage_save_button.dart
+++ b/mobile/lib/ui/tools/collage/collage_save_button.dart
@@ -59,7 +59,7 @@ class SaveCollageButton extends StatelessWidget {
             replacePage(
               context,
               DetailPage(
-                DetailPageConfiguration([newFile], null, 0, "collage"),
+                DetailPageConfiguration([newFile], 0, "collage"),
               ),
               result: true,
             );

--- a/mobile/lib/ui/tools/deduplicate_page.dart
+++ b/mobile/lib/ui/tools/deduplicate_page.dart
@@ -22,7 +22,7 @@ import 'package:photos/utils/navigation_util.dart';
 class DeduplicatePage extends StatefulWidget {
   final List<DuplicateFiles> duplicates;
 
-  const DeduplicatePage(this.duplicates, {Key? key}) : super(key: key);
+  const DeduplicatePage(this.duplicates, {super.key});
 
   @override
   State<DeduplicatePage> createState() => _DeduplicatePageState();
@@ -442,7 +442,6 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
           DetailPage(
             DetailPageConfiguration(
               files,
-              null,
               files.indexOf(file),
               "deduplicate_",
               mode: DetailPageMode.minimalistic,
@@ -459,7 +458,6 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
           DetailPage(
             DetailPageConfiguration(
               files,
-              null,
               files.indexOf(file),
               "deduplicate_",
               mode: DetailPageMode.minimalistic,

--- a/mobile/lib/ui/tools/editor/image_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/image_editor_page.dart
@@ -377,14 +377,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       showShortToast(context, S.of(context).editsSaved);
       _logger.info("Original file " + widget.originalFile.toString());
       _logger.info("Saved edits to file " + newFile.toString());
-      final existingFiles = widget.detailPageConfig.files;
-
-      final files = existingFiles;
-      // final files = (await widget.detailPageConfig.asyncLoader!(
-      //   existingFiles[existingFiles.length - 1].creationTime!,
-      //   existingFiles[0].creationTime!,
-      // ))
-      //     .files;
+      final files = widget.detailPageConfig.files;
 
       // the index could be -1 if the files fetched doesn't contain the newly
       // edited files

--- a/mobile/lib/ui/tools/editor/image_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/image_editor_page.dart
@@ -378,11 +378,14 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       _logger.info("Original file " + widget.originalFile.toString());
       _logger.info("Saved edits to file " + newFile.toString());
       final existingFiles = widget.detailPageConfig.files;
-      final files = (await widget.detailPageConfig.asyncLoader!(
-        existingFiles[existingFiles.length - 1].creationTime!,
-        existingFiles[0].creationTime!,
-      ))
-          .files;
+
+      final files = existingFiles;
+      // final files = (await widget.detailPageConfig.asyncLoader!(
+      //   existingFiles[existingFiles.length - 1].creationTime!,
+      //   existingFiles[0].creationTime!,
+      // ))
+      //     .files;
+
       // the index could be -1 if the files fetched doesn't contain the newly
       // edited files
       int selectionIndex =

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -262,13 +262,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
             showShortToast(context, S.of(context).editsSaved);
             _logger.info("Original file " + widget.file.toString());
             _logger.info("Saved edits to file " + newFile.toString());
-            final existingFiles = widget.detailPageConfig.files;
-            final files = existingFiles;
-            // final files = (await widget.detailPageConfig.asyncLoader!(
-            //   existingFiles[existingFiles.length - 1].creationTime!,
-            //   existingFiles[0].creationTime!,
-            // ))
-            //     .files;
+            final files = widget.detailPageConfig.files;
 
             // the index could be -1 if the files fetched doesn't contain the newly
             // edited files

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -263,11 +263,13 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
             _logger.info("Original file " + widget.file.toString());
             _logger.info("Saved edits to file " + newFile.toString());
             final existingFiles = widget.detailPageConfig.files;
-            final files = (await widget.detailPageConfig.asyncLoader!(
-              existingFiles[existingFiles.length - 1].creationTime!,
-              existingFiles[0].creationTime!,
-            ))
-                .files;
+            final files = existingFiles;
+            // final files = (await widget.detailPageConfig.asyncLoader!(
+            //   existingFiles[existingFiles.length - 1].creationTime!,
+            //   existingFiles[0].creationTime!,
+            // ))
+            //     .files;
+
             // the index could be -1 if the files fetched doesn't contain the newly
             // edited files
             int selectionIndex = files

--- a/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -577,7 +577,6 @@ class _FileSelectionActionsWidgetState
       final page = DetailPage(
         DetailPageConfiguration(
           selectedFiles,
-          null,
           0,
           "guest_view",
         ),

--- a/mobile/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -6,6 +6,7 @@ import 'package:photos/models/selected_files.dart';
 import "package:photos/theme/effects.dart";
 import "package:photos/theme/ente_theme.dart";
 import 'package:photos/ui/components/bottom_action_bar/bottom_action_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class FileSelectionOverlayBar extends StatefulWidget {
@@ -23,8 +24,8 @@ class FileSelectionOverlayBar extends StatefulWidget {
     this.backgroundColor,
     this.person,
     this.clusterID,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<FileSelectionOverlayBar> createState() =>
@@ -136,6 +137,7 @@ class _SelectAllButtonState extends State<SelectAllButton> {
   @override
   Widget build(BuildContext context) {
     final selectionState = SelectionState.of(context);
+    final allGalleryFiles = GalleryFilesState.of(context).galleryFiles;
     assert(
       selectionState != null,
       "SelectionState not found in context, SelectionState should be an ancestor of FileSelectionOverlayBar",
@@ -147,8 +149,9 @@ class _SelectAllButtonState extends State<SelectAllButton> {
           if (_allSelected) {
             selectionState.selectedFiles.clearAll();
           } else {
-            selectionState.selectedFiles
-                .selectAll(selectionState.allGalleryFiles!.toSet());
+            selectionState.selectedFiles.selectAll(
+              allGalleryFiles.toSet(),
+            );
           }
           _allSelected = !_allSelected;
         });
@@ -181,7 +184,7 @@ class _SelectAllButtonState extends State<SelectAllButton> {
                 listenable: selectionState!.selectedFiles,
                 builder: (context, _) {
                   if (selectionState.selectedFiles.files.length ==
-                      selectionState.allGalleryFiles?.length) {
+                      allGalleryFiles.length) {
                     _allSelected = true;
                   } else {
                     _allSelected = false;

--- a/mobile/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/lib/ui/viewer/file/detail_page.dart
@@ -355,7 +355,7 @@ class _DetailPageState extends State<DetailPage> {
       return;
     }
     setState(() {
-      _files!.remove(file);
+      _files!.removeAt(_selectedIndexNotifier.value);
       _selectedIndexNotifier.value = min(
         _selectedIndexNotifier.value,
         totalFiles - 2,

--- a/mobile/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/lib/ui/viewer/file/detail_page.dart
@@ -40,14 +40,12 @@ class DetailPageConfiguration {
   final int selectedIndex;
   final String tagPrefix;
   final DetailPageMode mode;
-  final bool sortOrderAsc;
 
   DetailPageConfiguration(
     this.files,
     this.selectedIndex,
     this.tagPrefix, {
     this.mode = DetailPageMode.full,
-    this.sortOrderAsc = false,
   });
 
   DetailPageConfiguration copyWith({
@@ -55,13 +53,11 @@ class DetailPageConfiguration {
     GalleryLoader? asyncLoader,
     int? selectedIndex,
     String? tagPrefix,
-    bool? sortOrderAsc,
   }) {
     return DetailPageConfiguration(
       files ?? this.files,
       selectedIndex ?? this.selectedIndex,
       tagPrefix ?? this.tagPrefix,
-      sortOrderAsc: sortOrderAsc ?? this.sortOrderAsc,
     );
   }
 }
@@ -91,6 +87,7 @@ class _DetailPageState extends State<DetailPage> {
   void initState() {
     super.initState();
     _files = widget.config.files;
+
     _selectedIndexNotifier.value = widget.config.selectedIndex;
     _pageController = PageController(initialPage: _selectedIndexNotifier.value);
     _guestViewEventSubscription =

--- a/mobile/lib/ui/viewer/gallery/archive_page.dart
+++ b/mobile/lib/ui/viewer/gallery/archive_page.dart
@@ -15,6 +15,7 @@ import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import "package:photos/ui/viewer/gallery/empty_state.dart";
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class ArchivePage extends StatelessWidget {
@@ -27,8 +28,8 @@ class ArchivePage extends StatelessWidget {
     this.tagPrefix = "archived_page",
     this.appBarType = GalleryType.archive,
     this.overlayType = GalleryType.archive,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -78,26 +79,28 @@ class ArchivePage extends StatelessWidget {
         CollectionsService.instance.getArchivedCollection,
       ),
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          appBarType,
-          S.of(context).archive,
-          _selectedFiles,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            appBarType,
+            S.of(context).archive,
+            _selectedFiles,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/collection_page.dart
+++ b/mobile/lib/ui/viewer/gallery/collection_page.dart
@@ -17,6 +17,7 @@ import "package:photos/ui/viewer/gallery/empty_album_state.dart";
 import 'package:photos/ui/viewer/gallery/empty_state.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class CollectionPage extends StatelessWidget {
@@ -30,8 +31,8 @@ class CollectionPage extends StatelessWidget {
     this.tagPrefix = "collection",
     this.hasVerifiedLock = false,
     this.isFromCollectPhotos = false,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final _selectedFiles = SelectedFiles();
 
@@ -98,35 +99,37 @@ class CollectionPage extends StatelessWidget {
           ? const SizedBox(height: 20)
           : const SizedBox(height: 212),
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          galleryType,
-          c.collection.displayName,
-          _selectedFiles,
-          collection: c.collection,
-          isFromCollectPhotos: isFromCollectPhotos,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            galleryType,
+            c.collection.displayName,
+            _selectedFiles,
+            collection: c.collection,
+            isFromCollectPhotos: isFromCollectPhotos,
+          ),
         ),
-      ),
-      bottomNavigationBar: isFromCollectPhotos
-          ? CollectPhotosBottomButtons(
-              c.collection,
-              selectedFiles: _selectedFiles,
-            )
-          : const SizedBox.shrink(),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              galleryType,
-              _selectedFiles,
-              collection: c.collection,
-            ),
-          ],
+        bottomNavigationBar: isFromCollectPhotos
+            ? CollectPhotosBottomButtons(
+                c.collection,
+                selectedFiles: _selectedFiles,
+              )
+            : const SizedBox.shrink(),
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                galleryType,
+                _selectedFiles,
+                collection: c.collection,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -22,7 +22,6 @@ class GalleryFileWidget extends StatelessWidget {
   final String tag;
   final int photoGridSize;
   final int? currentUserID;
-  final List<EnteFile> filesInGroup;
   final GalleryLoader asyncLoader;
   const GalleryFileWidget({
     required this.file,
@@ -31,7 +30,6 @@ class GalleryFileWidget extends StatelessWidget {
     required this.tag,
     required this.photoGridSize,
     required this.currentUserID,
-    required this.filesInGroup,
     required this.asyncLoader,
     super.key,
   });

--- a/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -11,6 +11,7 @@ import "package:photos/ui/viewer/file/detail_page.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_context_state.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/utils/file_util.dart";
 import "package:photos/utils/navigation_util.dart";
 
@@ -165,11 +166,11 @@ class GalleryFileWidget extends StatelessWidget {
   }
 
   void _routeToDetailPage(EnteFile file, BuildContext context) {
+    final galleryFiles = GalleryFilesState.of(context).galleryFiles;
     final page = DetailPage(
       DetailPageConfiguration(
-        List.unmodifiable(filesInGroup),
-        asyncLoader,
-        filesInGroup.indexOf(file),
+        galleryFiles,
+        galleryFiles.indexOf(file),
         tag,
         sortOrderAsc: GalleryContextState.of(context)!.sortOrderAsc,
       ),

--- a/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -172,7 +172,6 @@ class GalleryFileWidget extends StatelessWidget {
         galleryFiles,
         galleryFiles.indexOf(file),
         tag,
-        sortOrderAsc: GalleryContextState.of(context)!.sortOrderAsc,
       ),
     );
     routeToPage(context, page, forceCustomPageRoute: true);

--- a/mobile/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/component/grid/gallery_grid_view_widget.dart
@@ -38,7 +38,6 @@ class GalleryGridViewWidget extends StatelessWidget {
           tag: tag,
           photoGridSize: photoGridSize,
           currentUserID: currentUserID,
-          filesInGroup: filesInGroup,
           asyncLoader: asyncLoader,
         );
       },

--- a/mobile/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/mobile/lib/ui/viewer/gallery/device_folder_page.dart
@@ -22,13 +22,14 @@ import 'package:photos/ui/components/toggle_switch_widget.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class DeviceFolderPage extends StatelessWidget {
   final DeviceCollection deviceCollection;
   final _selectedFiles = SelectedFiles();
 
-  DeviceFolderPage(this.deviceCollection, {Key? key}) : super(key: key);
+  DeviceFolderPage(this.deviceCollection, {super.key});
 
   @override
   Widget build(Object context) {
@@ -57,27 +58,29 @@ class DeviceFolderPage extends StatelessWidget {
           : const SizedBox.shrink(),
       initialFiles: [deviceCollection.thumbnail!],
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          GalleryType.localFolder,
-          deviceCollection.name,
-          _selectedFiles,
-          deviceCollection: deviceCollection,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            GalleryType.localFolder,
+            deviceCollection.name,
+            _selectedFiles,
+            deviceCollection: deviceCollection,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              GalleryType.localFolder,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                GalleryType.localFolder,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/gallery.dart
+++ b/mobile/lib/ui/viewer/gallery/gallery.dart
@@ -16,7 +16,7 @@ import "package:photos/ui/viewer/gallery/component/group/type.dart";
 import "package:photos/ui/viewer/gallery/component/multiple_groups_gallery_view.dart";
 import 'package:photos/ui/viewer/gallery/empty_state.dart';
 import "package:photos/ui/viewer/gallery/state/gallery_context_state.dart";
-import "package:photos/ui/viewer/gallery/state/selection_state.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/utils/debouncer.dart";
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
@@ -88,8 +88,8 @@ class Gallery extends StatefulWidget {
     this.isScrollablePositionedList = true,
     this.reloadDebounceTime = const Duration(milliseconds: 500),
     this.reloadDebounceExecutionInterval = const Duration(seconds: 2),
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<Gallery> createState() {
@@ -252,7 +252,7 @@ class GalleryState extends State<Gallery> {
   @override
   Widget build(BuildContext context) {
     _logger.finest("Building Gallery  ${widget.tagPrefix}");
-    SelectionState.of(context)?.allGalleryFiles = _allFiles;
+    GalleryFilesState.of(context).setGalleryFiles = _allFiles;
     if (!_hasLoadedFiles) {
       return widget.loadingWidget;
     }

--- a/mobile/lib/ui/viewer/gallery/gallery.dart
+++ b/mobile/lib/ui/viewer/gallery/gallery.dart
@@ -53,7 +53,9 @@ class Gallery extends StatefulWidget {
   final bool limitSelectionToOne;
 
   /// When true, the gallery will be in selection mode. Tapping on any item
-  /// will select even when no other item is selected.
+  /// will select it even when no other item is selected. This is only used to
+  /// make selection possible without long pressing. If a gallery has selected
+  /// files, it's not necessary that this will be true.
   final bool inSelectionMode;
   final bool showSelectAllByDefault;
   final bool isScrollablePositionedList;

--- a/mobile/lib/ui/viewer/gallery/hidden_page.dart
+++ b/mobile/lib/ui/viewer/gallery/hidden_page.dart
@@ -19,6 +19,7 @@ import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/empty_hidden_widget.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class HiddenPage extends StatefulWidget {
@@ -30,8 +31,8 @@ class HiddenPage extends StatefulWidget {
     this.tagPrefix = "hidden_page",
     this.appBarType = GalleryType.hiddenSection,
     this.overlayType = GalleryType.hiddenSection,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<HiddenPage> createState() => _HiddenPageState();
@@ -131,26 +132,28 @@ class _HiddenPageState extends State<HiddenPage> {
         hasVerifiedLock: true,
       ),
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          widget.appBarType,
-          S.of(context).hidden,
-          _selectedFiles,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            widget.appBarType,
+            S.of(context).hidden,
+            _selectedFiles,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              widget.overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                widget.overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
+++ b/mobile/lib/ui/viewer/gallery/hooks/add_photos_sheet.dart
@@ -23,6 +23,7 @@ import "package:photos/ui/components/buttons/button_widget.dart";
 import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/photo_manager_util.dart";
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
@@ -279,36 +280,38 @@ class _DelayedGalleryState extends State<DelayedGallery> {
   @override
   Widget build(BuildContext context) {
     if (_showGallery) {
-      return Gallery(
-        inSelectionMode: true,
-        asyncLoader: (
-          creationStartTime,
-          creationEndTime, {
-          limit,
-          asc,
-        }) {
-          return FilesDB.instance.getAllPendingOrUploadedFiles(
+      return GalleryFilesState(
+        child: Gallery(
+          inSelectionMode: true,
+          asyncLoader: (
             creationStartTime,
-            creationEndTime,
-            Configuration.instance.getUserID()!,
-            limit: limit,
-            asc: asc,
-            filterOptions: DBFilterOptions(
-              hideIgnoredForUpload: true,
-              dedupeUploadID: true,
-              ignoredCollectionIDs: widget.hiddenCollectionIDs,
+            creationEndTime, {
+            limit,
+            asc,
+          }) {
+            return FilesDB.instance.getAllPendingOrUploadedFiles(
+              creationStartTime,
+              creationEndTime,
+              Configuration.instance.getUserID()!,
+              limit: limit,
+              asc: asc,
+              filterOptions: DBFilterOptions(
+                hideIgnoredForUpload: true,
+                dedupeUploadID: true,
+                ignoredCollectionIDs: widget.hiddenCollectionIDs,
+              ),
+              applyOwnerCheck: true,
+            );
+          },
+          tagPrefix: "pick_add_photos_gallery",
+          selectedFiles: widget.selectedFiles,
+          showSelectAllByDefault: true,
+          sortAsyncFn: () => false,
+        ).animate().fadeIn(
+              duration: const Duration(milliseconds: 175),
+              curve: Curves.easeOutCirc,
             ),
-            applyOwnerCheck: true,
-          );
-        },
-        tagPrefix: "pick_add_photos_gallery",
-        selectedFiles: widget.selectedFiles,
-        showSelectAllByDefault: true,
-        sortAsyncFn: () => false,
-      ).animate().fadeIn(
-            duration: const Duration(milliseconds: 175),
-            curve: Curves.easeOutCirc,
-          );
+      );
     } else {
       return const EnteLoadingWidget();
     }

--- a/mobile/lib/ui/viewer/gallery/hooks/pick_cover_photo.dart
+++ b/mobile/lib/ui/viewer/gallery/hooks/pick_cover_photo.dart
@@ -17,6 +17,7 @@ import "package:photos/ui/components/buttons/button_widget.dart";
 import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 
 Future<int?> showPickCoverPhotoSheet(
   BuildContext context,
@@ -81,43 +82,46 @@ class PickCoverPhotoWidget extends StatelessWidget {
                           showCloseButton: true,
                         ),
                         Expanded(
-                          child: Gallery(
-                            asyncLoader: (
-                              creationStartTime,
-                              creationEndTime, {
-                              limit,
-                              asc,
-                            }) async {
-                              final FileLoadResult result =
-                                  await FilesDB.instance.getFilesInCollection(
-                                collection.id,
+                          child: GalleryFilesState(
+                            child: Gallery(
+                              asyncLoader: (
                                 creationStartTime,
-                                creationEndTime,
-                                limit: limit,
-                                asc: asc,
-                              );
-                              // hide ignored files from home page UI
-                              final ignoredIDs = await IgnoredFilesService
-                                  .instance.idToIgnoreReasonMap;
-                              result.files.removeWhere(
-                                (f) =>
-                                    f.uploadedFileID == null &&
-                                    IgnoredFilesService.instance
-                                        .shouldSkipUpload(ignoredIDs, f),
-                              );
-                              return result;
-                            },
-                            reloadEvent:
-                                Bus.instance.on<CollectionUpdatedEvent>().where(
-                                      (event) =>
-                                          event.collectionID == collection.id,
-                                    ),
-                            tagPrefix: "pick_center_point_gallery",
-                            selectedFiles: selectedFiles,
-                            limitSelectionToOne: true,
-                            showSelectAllByDefault: false,
-                            sortAsyncFn: () =>
-                                collection.pubMagicMetadata.asc ?? false,
+                                creationEndTime, {
+                                limit,
+                                asc,
+                              }) async {
+                                final FileLoadResult result =
+                                    await FilesDB.instance.getFilesInCollection(
+                                  collection.id,
+                                  creationStartTime,
+                                  creationEndTime,
+                                  limit: limit,
+                                  asc: asc,
+                                );
+                                // hide ignored files from home page UI
+                                final ignoredIDs = await IgnoredFilesService
+                                    .instance.idToIgnoreReasonMap;
+                                result.files.removeWhere(
+                                  (f) =>
+                                      f.uploadedFileID == null &&
+                                      IgnoredFilesService.instance
+                                          .shouldSkipUpload(ignoredIDs, f),
+                                );
+                                return result;
+                              },
+                              reloadEvent: Bus.instance
+                                  .on<CollectionUpdatedEvent>()
+                                  .where(
+                                    (event) =>
+                                        event.collectionID == collection.id,
+                                  ),
+                              tagPrefix: "pick_center_point_gallery",
+                              selectedFiles: selectedFiles,
+                              limitSelectionToOne: true,
+                              showSelectAllByDefault: false,
+                              sortAsyncFn: () =>
+                                  collection.pubMagicMetadata.asc ?? false,
+                            ),
                           ),
                         ),
                       ],

--- a/mobile/lib/ui/viewer/gallery/large_files_page.dart
+++ b/mobile/lib/ui/viewer/gallery/large_files_page.dart
@@ -13,6 +13,7 @@ import "package:photos/services/search_service.dart";
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
 import 'package:photos/ui/viewer/gallery/gallery.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class LargeFilesPagePage extends StatelessWidget {
@@ -26,8 +27,8 @@ class LargeFilesPagePage extends StatelessWidget {
     this.tagPrefix = "Uncategorized_page",
     this.appBarType = GalleryType.homepage,
     this.overlayType = GalleryType.homepage,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -68,34 +69,36 @@ class LargeFilesPagePage extends StatelessWidget {
       initialFiles: null,
       albumName: S.of(context).viewLargeFiles,
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: AppBar(
-          elevation: 0,
-          centerTitle: false,
-          title: Text(
-            S.of(context).viewLargeFiles,
-            style: Theme.of(context)
-                .textTheme
-                .headlineSmall!
-                .copyWith(fontSize: 16),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: AppBar(
+            elevation: 0,
+            centerTitle: false,
+            title: Text(
+              S.of(context).viewLargeFiles,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall!
+                  .copyWith(fontSize: 16),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/state/gallery_files_inherited_widget.dart
+++ b/mobile/lib/ui/viewer/gallery/state/gallery_files_inherited_widget.dart
@@ -1,0 +1,45 @@
+import "package:flutter/material.dart";
+import "package:photos/models/file/file.dart";
+
+// ignore: must_be_immutable
+class GalleryFilesState extends InheritedWidget {
+  GalleryFilesState({
+    super.key,
+    required super.child,
+  });
+
+  ///Should be assigned later in gallery when files are loaded.
+  ///Note: EnteFiles in this list should be references of the same EnteFiles
+  ///that are grouped in gallery, so that when files are added/deleted,
+  ///both lists are in sync.
+  List<EnteFile>? _galleryFiles;
+
+  set setGalleryFiles(List<EnteFile> galleryFiles) {
+    _galleryFiles = galleryFiles;
+  }
+
+  List<EnteFile> get galleryFiles {
+    if (_galleryFiles == null) {
+      throw Exception(
+        "Gallery files not set yet. Should be set in the gallery widget",
+      );
+    }
+    return _galleryFiles!;
+  }
+
+  static GalleryFilesState? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<GalleryFilesState>();
+  }
+
+  static GalleryFilesState of(BuildContext context) {
+    final GalleryFilesState? result = maybeOf(context);
+    assert(
+      result != null,
+      'No GalleryFiles found in context. GalleryFilesState should be an ancestor of the GalleryWidget, preferably over the Scaffold of Gallery.',
+    );
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(GalleryFilesState oldWidget) => false;
+}

--- a/mobile/lib/ui/viewer/gallery/state/selection_state.dart
+++ b/mobile/lib/ui/viewer/gallery/state/selection_state.dart
@@ -1,6 +1,5 @@
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
-import "package:photos/models/file/file.dart";
 import "package:photos/models/selected_files.dart";
 
 ///This is an inherited widget that needs to be wrapped around Gallery and
@@ -9,17 +8,11 @@ import "package:photos/models/selected_files.dart";
 class SelectionState extends InheritedWidget {
   final SelectedFiles selectedFiles;
 
-  ///Should be assigned later in gallery when files are loaded.
-  ///Note: EnteFiles in this list should be references of the same EnteFiles
-  ///that are grouped in gallery, so that when files are added/deleted,
-  ///both lists are in sync.
-  List<EnteFile>? allGalleryFiles;
-
-  SelectionState({
-    Key? key,
+  const SelectionState({
+    super.key,
     required this.selectedFiles,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   static SelectionState? maybeOf(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<SelectionState>();

--- a/mobile/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/lib/ui/viewer/gallery/trash_page.dart
@@ -13,6 +13,7 @@ import 'package:photos/ui/common/bottom_shadow.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 import 'package:photos/utils/delete_file_util.dart';
 
@@ -25,8 +26,8 @@ class TrashPage extends StatelessWidget {
     this.tagPrefix = "trash_page",
     this.appBarType = GalleryType.trash,
     this.overlayType = GalleryType.trash,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -57,43 +58,45 @@ class TrashPage extends StatelessWidget {
       initialFiles: null,
     );
 
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          appBarType,
-          S.of(context).trash,
-          _selectedFiles,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            appBarType,
+            S.of(context).trash,
+            _selectedFiles,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            const BottomShadowWidget(
-              offsetDy: 20,
-            ),
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeInOut,
-              height: filesAreSelected ? 0 : 80,
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 100),
-                opacity: filesAreSelected ? 0.0 : 1.0,
-                curve: Curves.easeIn,
-                child: IgnorePointer(
-                  ignoring: filesAreSelected,
-                  child: const SafeArea(
-                    minimum: EdgeInsets.only(bottom: 6),
-                    child: BottomButtonsWidget(),
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              const BottomShadowWidget(
+                offsetDy: 20,
+              ),
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+                height: filesAreSelected ? 0 : 80,
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 100),
+                  opacity: filesAreSelected ? 0.0 : 1.0,
+                  curve: Curves.easeIn,
+                  child: IgnorePointer(
+                    ignoring: filesAreSelected,
+                    child: const SafeArea(
+                      minimum: EdgeInsets.only(bottom: 6),
+                      child: BottomButtonsWidget(),
+                    ),
                   ),
                 ),
               ),
-            ),
-            FileSelectionOverlayBar(GalleryType.trash, _selectedFiles),
-          ],
+              FileSelectionOverlayBar(GalleryType.trash, _selectedFiles),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/gallery/uncategorized_page.dart
+++ b/mobile/lib/ui/viewer/gallery/uncategorized_page.dart
@@ -13,6 +13,7 @@ import 'package:photos/services/ignored_files_service.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class UnCategorizedPage extends StatelessWidget {
@@ -27,8 +28,8 @@ class UnCategorizedPage extends StatelessWidget {
     this.tagPrefix = "Uncategorized_page",
     this.appBarType = GalleryType.uncategorized,
     this.overlayType = GalleryType.uncategorized,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -73,27 +74,29 @@ class UnCategorizedPage extends StatelessWidget {
       initialFiles: null,
       albumName: S.of(context).uncategorized,
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          appBarType,
-          S.of(context).uncategorized,
-          _selectedFiles,
-          collection: collection,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            appBarType,
+            S.of(context).uncategorized,
+            _selectedFiles,
+            collection: collection,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
+++ b/mobile/lib/ui/viewer/location/dynamic_location_gallery_widget.dart
@@ -12,6 +12,7 @@ import "package:photos/services/filter/db_filters.dart";
 import "package:photos/services/location_service.dart";
 import 'package:photos/states/location_state.dart';
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 
 ///This gallery will get rebuilt with the updated radius when
 ///InheritedLocationTagData notifies a change in radius.
@@ -100,20 +101,22 @@ class _DynamicLocationGalleryWidgetState
                   ),
                   constrains.maxWidth,
                 ),
-                child: Gallery(
-                  loadingWidget: const SizedBox.shrink(),
-                  disableScroll: true,
-                  asyncLoader: (
-                    creationStartTime,
-                    creationEndTime, {
-                    limit,
-                    asc,
-                  }) async {
-                    return snapshot.data as FileLoadResult;
-                  },
-                  tagPrefix: widget.tagPrefix,
-                  enableFileGrouping: false,
-                  showSelectAllByDefault: false,
+                child: GalleryFilesState(
+                  child: Gallery(
+                    loadingWidget: const SizedBox.shrink(),
+                    disableScroll: true,
+                    asyncLoader: (
+                      creationStartTime,
+                      creationEndTime, {
+                      limit,
+                      asc,
+                    }) async {
+                      return snapshot.data as FileLoadResult;
+                    },
+                    tagPrefix: widget.tagPrefix,
+                    enableFileGrouping: false,
+                    showSelectAllByDefault: false,
+                  ),
                 ),
               );
             },

--- a/mobile/lib/ui/viewer/location/location_screen.dart
+++ b/mobile/lib/ui/viewer/location/location_screen.dart
@@ -25,6 +25,7 @@ import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/components/title_bar_widget.dart";
 import "package:photos/ui/viewer/actions/file_selection_overlay_bar.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 import "package:photos/ui/viewer/location/edit_location_sheet.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -37,26 +38,28 @@ class LocationScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final heightOfStatusBar = MediaQuery.of(context).viewPadding.top;
     const heightOfAppBar = 48.0;
-    return Scaffold(
-      appBar: const PreferredSize(
-        preferredSize: Size(double.infinity, heightOfAppBar),
-        child: TitleBarWidget(
-          isSliver: false,
-          isFlexibleSpaceDisabled: true,
-          actionIcons: [LocationScreenPopUpMenu()],
-        ),
-      ),
-      body: Column(
-        children: <Widget>[
-          SizedBox(
-            height: MediaQuery.of(context).size.height -
-                (heightOfAppBar + heightOfStatusBar),
-            width: double.infinity,
-            child: LocationGalleryWidget(
-              tagPrefix: tagPrefix,
-            ),
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: const PreferredSize(
+          preferredSize: Size(double.infinity, heightOfAppBar),
+          child: TitleBarWidget(
+            isSliver: false,
+            isFlexibleSpaceDisabled: true,
+            actionIcons: [LocationScreenPopUpMenu()],
           ),
-        ],
+        ),
+        body: Column(
+          children: <Widget>[
+            SizedBox(
+              height: MediaQuery.of(context).size.height -
+                  (heightOfAppBar + heightOfStatusBar),
+              width: double.infinity,
+              child: LocationGalleryWidget(
+                tagPrefix: tagPrefix,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/ui/viewer/location/pick_center_point_widget.dart
+++ b/mobile/lib/ui/viewer/location/pick_center_point_widget.dart
@@ -20,6 +20,7 @@ import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/components/notification_widget.dart";
 import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 
 Future<Location?> showPickCenterPointSheet(
   BuildContext context, {
@@ -83,40 +84,42 @@ class PickCenterPointWidget extends StatelessWidget {
                           caption: locationTagName ?? "New location",
                         ),
                         Expanded(
-                          child: Gallery(
-                            asyncLoader: (
-                              creationStartTime,
-                              creationEndTime, {
-                              limit,
-                              asc,
-                            }) async {
-                              final collectionsToHide = CollectionsService
-                                  .instance
-                                  .archivedOrHiddenCollectionIds();
-                              FileLoadResult result;
-                              result = await FilesDB.instance
-                                  .fetchAllUploadedAndSharedFilesWithLocation(
-                                galleryLoadStartTime,
-                                galleryLoadEndTime,
-                                limit: null,
-                                asc: false,
-                                filterOptions: DBFilterOptions(
-                                  ignoredCollectionIDs: collectionsToHide,
-                                  hideIgnoredForUpload: true,
+                          child: GalleryFilesState(
+                            child: Gallery(
+                              asyncLoader: (
+                                creationStartTime,
+                                creationEndTime, {
+                                limit,
+                                asc,
+                              }) async {
+                                final collectionsToHide = CollectionsService
+                                    .instance
+                                    .archivedOrHiddenCollectionIds();
+                                FileLoadResult result;
+                                result = await FilesDB.instance
+                                    .fetchAllUploadedAndSharedFilesWithLocation(
+                                  galleryLoadStartTime,
+                                  galleryLoadEndTime,
+                                  limit: null,
+                                  asc: false,
+                                  filterOptions: DBFilterOptions(
+                                    ignoredCollectionIDs: collectionsToHide,
+                                    hideIgnoredForUpload: true,
+                                  ),
+                                );
+                                return result;
+                              },
+                              reloadEvent:
+                                  Bus.instance.on<LocalPhotosUpdatedEvent>(),
+                              tagPrefix: "pick_center_point_gallery",
+                              selectedFiles: selectedFiles,
+                              limitSelectionToOne: true,
+                              showSelectAllByDefault: false,
+                              header: const Padding(
+                                padding: EdgeInsets.all(10),
+                                child: NotificationTipWidget(
+                                  "You can also add a location centered on a photo from the photo's info screen",
                                 ),
-                              );
-                              return result;
-                            },
-                            reloadEvent:
-                                Bus.instance.on<LocalPhotosUpdatedEvent>(),
-                            tagPrefix: "pick_center_point_gallery",
-                            selectedFiles: selectedFiles,
-                            limitSelectionToOne: true,
-                            showSelectAllByDefault: false,
-                            header: const Padding(
-                              padding: EdgeInsets.all(10),
-                              child: NotificationTipWidget(
-                                "You can also add a location centered on a photo from the photo's info screen",
                               ),
                             ),
                           ),

--- a/mobile/lib/ui/viewer/people/cluster_page.dart
+++ b/mobile/lib/ui/viewer/people/cluster_page.dart
@@ -15,6 +15,7 @@ import 'package:photos/models/selected_files.dart';
 import "package:photos/services/machine_learning/face_ml/feedback/cluster_feedback.dart";
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 import "package:photos/ui/viewer/people/add_person_action_sheet.dart";
 import "package:photos/ui/viewer/people/cluster_app_bar.dart";
@@ -45,8 +46,8 @@ class ClusterPage extends StatefulWidget {
     this.personID,
     this.appendTitle = "",
     this.showNamingBanner = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<ClusterPage> createState() => _ClusterPageState();
@@ -138,79 +139,85 @@ class _ClusterPageState extends State<ClusterPage> {
       enableFileGrouping: widget.enableGrouping,
       initialFiles: [widget.searchResult.first],
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: ClusterAppBar(
-          SearchResultPage.appBarType,
-          "${files.length} memories${widget.appendTitle}",
-          _selectedFiles,
-          widget.clusterID,
-          key: ValueKey(files.length),
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: ClusterAppBar(
+            SearchResultPage.appBarType,
+            "${files.length} memories${widget.appendTitle}",
+            _selectedFiles,
+            widget.clusterID,
+            key: ValueKey(files.length),
+          ),
         ),
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: SelectionState(
-              selectedFiles: _selectedFiles,
-              child: Stack(
-                alignment: Alignment.bottomCenter,
-                children: [
-                  gallery,
-                  FileSelectionOverlayBar(
-                    ClusterPage.overlayType,
-                    _selectedFiles,
-                    clusterID: widget.clusterID,
-                  ),
-                ],
+        body: Column(
+          children: [
+            Expanded(
+              child: SelectionState(
+                selectedFiles: _selectedFiles,
+                child: Stack(
+                  alignment: Alignment.bottomCenter,
+                  children: [
+                    gallery,
+                    FileSelectionOverlayBar(
+                      ClusterPage.overlayType,
+                      _selectedFiles,
+                      clusterID: widget.clusterID,
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-          showNamingBanner
-              ? SafeArea(
-                  child: Dismissible(
-                    key: const Key("namingBanner"),
-                    direction: DismissDirection.horizontal,
-                    onDismissed: (direction) {
-                      setState(() {
-                        userDismissedNamingBanner = true;
-                      });
-                    },
-                    child: PeopleBanner(
-                      type: PeopleBannerType.addName,
-                      faceWidget: PersonFaceWidget(
-                        files.first,
-                        clusterID: widget.clusterID,
-                      ),
-                      actionIcon: Icons.add_outlined,
-                      text: S.of(context).addAName,
-                      subText: S.of(context).findPeopleByName,
-                      onTap: () async {
-                        if (widget.personID == null) {
-                          final result = await showAssignPersonAction(
-                            context,
-                            clusterID: widget.clusterID,
-                          );
-                          if (result != null &&
-                              result is (PersonEntity, EnteFile)) {
-                            Navigator.pop(context);
-                            // ignore: unawaited_futures
-                            routeToPage(context, PeoplePage(person: result.$1));
-                          } else if (result != null && result is PersonEntity) {
-                            Navigator.pop(context);
-                            // ignore: unawaited_futures
-                            routeToPage(context, PeoplePage(person: result));
-                          }
-                        } else {
-                          showShortToast(context, "No personID or clusterID");
-                        }
+            showNamingBanner
+                ? SafeArea(
+                    child: Dismissible(
+                      key: const Key("namingBanner"),
+                      direction: DismissDirection.horizontal,
+                      onDismissed: (direction) {
+                        setState(() {
+                          userDismissedNamingBanner = true;
+                        });
                       },
+                      child: PeopleBanner(
+                        type: PeopleBannerType.addName,
+                        faceWidget: PersonFaceWidget(
+                          files.first,
+                          clusterID: widget.clusterID,
+                        ),
+                        actionIcon: Icons.add_outlined,
+                        text: S.of(context).addAName,
+                        subText: S.of(context).findPeopleByName,
+                        onTap: () async {
+                          if (widget.personID == null) {
+                            final result = await showAssignPersonAction(
+                              context,
+                              clusterID: widget.clusterID,
+                            );
+                            if (result != null &&
+                                result is (PersonEntity, EnteFile)) {
+                              Navigator.pop(context);
+                              // ignore: unawaited_futures
+                              routeToPage(
+                                context,
+                                PeoplePage(person: result.$1),
+                              );
+                            } else if (result != null &&
+                                result is PersonEntity) {
+                              Navigator.pop(context);
+                              // ignore: unawaited_futures
+                              routeToPage(context, PeoplePage(person: result));
+                            }
+                          } else {
+                            showShortToast(context, "No personID or clusterID");
+                          }
+                        },
+                      ),
                     ),
-                  ),
-                )
-              : const SizedBox.shrink(),
-        ],
+                  )
+                : const SizedBox.shrink(),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/ui/viewer/search/result/file_result_widget.dart
+++ b/mobile/lib/ui/viewer/search/result/file_result_widget.dart
@@ -68,7 +68,6 @@ class FileSearchResultWidget extends StatelessWidget {
     final page = DetailPage(
       DetailPageConfiguration(
         List.unmodifiable([file]),
-        null,
         0,
         "file_details",
       ),

--- a/mobile/lib/ui/viewer/search/result/magic_result_screen.dart
+++ b/mobile/lib/ui/viewer/search/result/magic_result_screen.dart
@@ -13,6 +13,7 @@ import 'package:photos/models/selected_files.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class MagicResultScreen extends StatefulWidget {
@@ -155,31 +156,33 @@ class _MagicResultScreenState extends State<MagicResultScreen> {
       enableFileGrouping: _enableGrouping,
       initialFiles: [files.first],
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          MagicResultScreen.appBarType,
-          widget.name,
-          _selectedFiles,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            MagicResultScreen.appBarType,
+            widget.name,
+            _selectedFiles,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 250),
-              switchInCurve: Curves.easeInOutQuad,
-              switchOutCurve: Curves.easeInOutQuad,
-              child: gallery,
-            ),
-            FileSelectionOverlayBar(
-              MagicResultScreen.overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 250),
+                switchInCurve: Curves.easeInOutQuad,
+                switchOutCurve: Curves.easeInOutQuad,
+                child: gallery,
+              ),
+              FileSelectionOverlayBar(
+                MagicResultScreen.overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/ui/viewer/search/result/search_result_page.dart
+++ b/mobile/lib/ui/viewer/search/result/search_result_page.dart
@@ -12,6 +12,7 @@ import 'package:photos/models/selected_files.dart';
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import 'package:photos/ui/viewer/gallery/gallery.dart';
 import 'package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart';
+import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class SearchResultPage extends StatefulWidget {
@@ -26,8 +27,8 @@ class SearchResultPage extends StatefulWidget {
     this.searchResult, {
     this.enableGrouping = true,
     this.tagPrefix = "",
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<SearchResultPage> createState() => _SearchResultPageState();
@@ -91,26 +92,28 @@ class _SearchResultPageState extends State<SearchResultPage> {
       enableFileGrouping: widget.enableGrouping,
       initialFiles: [widget.searchResult.resultFiles().first],
     );
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(50.0),
-        child: GalleryAppBarWidget(
-          SearchResultPage.appBarType,
-          widget.searchResult.name(),
-          _selectedFiles,
+    return GalleryFilesState(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: GalleryAppBarWidget(
+            SearchResultPage.appBarType,
+            widget.searchResult.name(),
+            _selectedFiles,
+          ),
         ),
-      ),
-      body: SelectionState(
-        selectedFiles: _selectedFiles,
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            gallery,
-            FileSelectionOverlayBar(
-              SearchResultPage.overlayType,
-              _selectedFiles,
-            ),
-          ],
+        body: SelectionState(
+          selectedFiles: _selectedFiles,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              gallery,
+              FileSelectionOverlayBar(
+                SearchResultPage.overlayType,
+                _selectedFiles,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Description

Removed use of `asyncLoader` in `DetailPage` and instead, all files in gallery is now stored in an inherited widget (`GalleryFilesState`) and `DetailPage` uses that list of files instead of fetching from DB using `asyncLoader`. This 'all files' list reflects all changes in gallery (as observed when testing) so there is no issue of the list being out of sync with gallery. 

Where ever possible, `GalleryFilesState` has been wrapped around the `Scaffold` of galleries, so that all files are accessible to all ancestors of a gallery's `Scaffold`, which could come useful in the future.  
