### PR TITLE
[auth] fix x64 installer on arm64 Windows

### DIFF
--- a/auth/windows/packaging/exe/inno_setup.iss
+++ b/auth/windows/packaging/exe/inno_setup.iss
@@ -16,8 +16,8 @@ SetupIconFile={{SETUP_ICON_FILE}}
 WizardStyle=modern
 ;PrivilegesRequired={{PRIVILEGES_REQUIRED}}
 PrivilegesRequiredOverridesAllowed=dialog
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
 UninstallDisplayIcon={app}\auth.exe
 
 [Languages]


### PR DESCRIPTION
Portable x64 Ente Auth works on arm64 Windows, but the installer version fails due to not supporting arm64. As per Inno Setup's documentation the 'x64' option will only allow installing on x64 Windows, changing to 'x64compatible' allows the x64 installer to work on arm64 as well.