### PR TITLE
[web] Update docs after verifying the behaviour

### DIFF
--- a/web/packages/new/photos/components/mui-custom.tsx
+++ b/web/packages/new/photos/components/mui-custom.tsx
@@ -38,7 +38,7 @@ export const UnstyledButton = styled("button")`
        inherit that customization also. */
     letter-spacing: inherit;
 
-    /* The button default is to show an flipped arrow. Show a hand instead. */
+    /* Default cursor on mouse over of a button is not a hand pointer */
     cursor: pointer;
 `;
 


### PR DESCRIPTION
Indeed, it seems like the default is not a hand pointer, and MUI has customized its button, so we need to replicate that behaviour if we directly use HTML buttons.

Ref:
- https://ux.stackexchange.com/questions/3788/default-cursor-on-mouse-over-of-a-button-is-not-a-hand-pointer
