### PR TITLE
[auth] Bugfix/auth icons with period

### DIFF
--- a/auth/lib/ui/utils/icon_utils.dart
+++ b/auth/lib/ui/utils/icon_utils.dart
@@ -17,6 +17,7 @@ class IconUtils {
   final Map<String, CustomIconData> _customIcons = {};
   // Map of icon-color to its luminance
   final Map<Color, double> _colorLuminance = {};
+  final List<String> _titleSplitCharacters = ['(', '.'];
 
   Future<void> init() async {
     await _loadJson();
@@ -28,23 +29,32 @@ class IconUtils {
     double width = 24,
   }) {
     final title = _getProviderTitle(provider);
-    if (_customIcons.containsKey(title)) {
-      return _getSVGIcon(
-        "assets/custom-icons/icons/${_customIcons[title]!.slug ?? title}.svg",
-        title,
-        _customIcons[title]!.color,
-        width,
-        context,
-      );
-    } else if (_simpleIcons.containsKey(title)) {
-      return _getSVGIcon(
-        "assets/simple-icons/icons/$title.svg",
-        title,
-        _simpleIcons[title],
-        width,
-        context,
-      );
-    } else if (title.isNotEmpty) {
+    final List<String> possibleTitles = [title];
+    for(final splitCharacter in _titleSplitCharacters){
+      if (title.contains(splitCharacter)){
+        possibleTitles.add(title.split(splitCharacter)[0]);
+      }
+    }
+    for(final possibleTitle in possibleTitles){
+      if (_customIcons.containsKey(possibleTitle)) {
+        return _getSVGIcon(
+          "assets/custom-icons/icons/${_customIcons[possibleTitle]!.slug ?? possibleTitle}.svg",
+          possibleTitle,
+          _customIcons[possibleTitle]!.color,
+          width,
+          context,
+        );
+      } else if (_simpleIcons.containsKey(possibleTitle)) {
+        return _getSVGIcon(
+          "assets/simple-icons/icons/$possibleTitle.svg",
+          possibleTitle,
+          _simpleIcons[possibleTitle],
+          width,
+          context,
+        );
+      }
+    }
+    if (title.isNotEmpty) {
       bool showLargeIcon = width > 24;
       return CircleAvatar(
         radius: width / 2,
@@ -144,7 +154,7 @@ class IconUtils {
   }
 
   String _getProviderTitle(String provider) {
-    return provider.split(RegExp(r'[.(]'))[0].replaceAll(' ', '').toLowerCase();
+    return provider.replaceAll(' ', '').toLowerCase();
   }
 }
 

--- a/auth/lib/ui/utils/icon_utils.dart
+++ b/auth/lib/ui/utils/icon_utils.dart
@@ -28,40 +28,40 @@ class IconUtils {
     String provider, {
     double width = 24,
   }) {
-    final title = _getProviderTitle(provider);
-    final List<String> possibleTitles = [title];
+    final providerTitle = _getProviderTitle(provider);
+    final List<String> titlesList = [providerTitle];
     for(final splitCharacter in _titleSplitCharacters){
-      if (title.contains(splitCharacter)){
-        possibleTitles.add(title.split(splitCharacter)[0]);
+      if (providerTitle.contains(splitCharacter)){
+        titlesList.add(providerTitle.split(splitCharacter)[0]);
       }
     }
-    for(final possibleTitle in possibleTitles){
-      if (_customIcons.containsKey(possibleTitle)) {
+    for(final title in titlesList){
+      if (_customIcons.containsKey(title)) {
         return _getSVGIcon(
-          "assets/custom-icons/icons/${_customIcons[possibleTitle]!.slug ?? possibleTitle}.svg",
-          possibleTitle,
-          _customIcons[possibleTitle]!.color,
+          "assets/custom-icons/icons/${_customIcons[title]!.slug ?? title}.svg",
+          title,
+          _customIcons[title]!.color,
           width,
           context,
         );
-      } else if (_simpleIcons.containsKey(possibleTitle)) {
+      } else if (_simpleIcons.containsKey(title)) {
         return _getSVGIcon(
-          "assets/simple-icons/icons/$possibleTitle.svg",
-          possibleTitle,
-          _simpleIcons[possibleTitle],
+          "assets/simple-icons/icons/$title.svg",
+          title,
+          _simpleIcons[title],
           width,
           context,
         );
       }
     }
-    if (title.isNotEmpty) {
+    if (providerTitle.isNotEmpty) {
       bool showLargeIcon = width > 24;
       return CircleAvatar(
         radius: width / 2,
         backgroundColor: getEnteColorScheme(context).avatarColors[
-            title.hashCode % getEnteColorScheme(context).avatarColors.length],
+            providerTitle.hashCode % getEnteColorScheme(context).avatarColors.length],
         child: Text(
-          title.toUpperCase()[0],
+          providerTitle.toUpperCase()[0],
           // fixed color
           style: showLargeIcon
               ? getEnteTextTheme(context).h3Bold.copyWith(color: Colors.white)


### PR DESCRIPTION
## Description

Previously it would check if the substring that precedes the first `.` or `(` of the lowercase spaceless provider title was a valid icon.

Now: 
1. Checks if lowercase spaceless provider title is valid icon
2. If the title contains a `(` it checks if the preceding part of the title is a valid icon
3. If the title contains a `.` it checks if the preceding part of the title is a valid icon

| Provider Title | Previous Check | Now Checks |
| -------- | ------- | ----------|
| Login.gov | `login` ❌| `login.gov` ✅ |
| GOV.UK (Brian) | `gov` ❌| `gov.uk(brian)`❌ then `gov.uk`✅ |

This PR resolves issue #3473 