### PR TITLE
[auth][macos] show hidden window when user clicks on the dock

### DIFF
--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -338,8 +338,8 @@ class _HomePageState extends State<HomePage> {
                       _searchText = _textController.text;
 
                       // Request focus on the search box
-                      // For Windows only for now. "Platform.isWindows" can be removed if other platforms has been tested.
-                      if (Platform.isWindows) {
+                      // For Windows and macOS only for now. This if statement can be removed if other platforms has been tested.
+                      if (Platform.isWindows || Platform.isMacOS) {
                         searchBoxFocusNode.requestFocus();
                       }
                     }

--- a/auth/macos/Runner/AppDelegate.swift
+++ b/auth/macos/Runner/AppDelegate.swift
@@ -3,6 +3,13 @@ import FlutterMacOS
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  override func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+      sender.windows.first?.makeKeyAndOrderFront(self)
+    }
+    return true
+  }
+    
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return false
   }


### PR DESCRIPTION
## Description

In the current version of Ente Auth, nothing happens when the user closes the Ente Auth window on macOS and then clicks on the Ente Auth icon in the dock.

This PR changes this behaviour and brings it in-line with other macOS applications by showing the main application window when the user clicks on the dock icon.

## Tests
