### PR TITLE
[web] add favorite button to SelectedFileBar to bulk favorite selection

### DIFF
--- a/web/apps/photos/src/components/pages/gallery/PreviewCard.tsx
+++ b/web/apps/photos/src/components/pages/gallery/PreviewCard.tsx
@@ -14,6 +14,7 @@ import { Overlay } from "@ente/shared/components/Container";
 import { CustomError } from "@ente/shared/error";
 import useLongPress from "@ente/shared/hooks/useLongPress";
 import AlbumOutlined from "@mui/icons-material/AlbumOutlined";
+import Favorite from "@mui/icons-material/FavoriteRounded";
 import PlayCircleOutlineOutlinedIcon from "@mui/icons-material/PlayCircleOutlineOutlined";
 import { Tooltip, styled } from "@mui/material";
 import i18n from "i18next";
@@ -23,7 +24,6 @@ import React, { useContext, useEffect, useRef, useState } from "react";
 import { TRASH_SECTION } from "utils/collection";
 import { shouldShowAvatar } from "utils/file";
 import Avatar from "./Avatar";
-import Favorite from "@mui/icons-material/FavoriteRounded";
 
 interface IProps {
     file: EnteFile;
@@ -363,7 +363,7 @@ export default function PreviewCard(props: IProps) {
             )}
             {props.isFav && (
                 <FavOverlay>
-                    <Favorite/>
+                    <Favorite />
                 </FavOverlay>
             )}
 

--- a/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -29,7 +29,6 @@ import {
 import { FILE_OPS_TYPE } from "utils/file";
 import { formatNumber } from "utils/number/format";
 import { getTrashFilesMessage } from "utils/ui";
-import Favorite from "@mui/icons-material/FavoriteRounded";
 
 interface Props {
     handleCollectionOps: (

--- a/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -15,6 +15,7 @@ import RestoreIcon from "@mui/icons-material/Restore";
 import UnArchiveIcon from "@mui/icons-material/Unarchive";
 import VisibilityOffOutlined from "@mui/icons-material/VisibilityOffOutlined";
 import VisibilityOutlined from "@mui/icons-material/VisibilityOutlined";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorderRounded";
 import { Box, IconButton, Stack, Tooltip } from "@mui/material";
 import { t } from "i18next";
 import { AppContext } from "pages/_app";
@@ -28,6 +29,7 @@ import {
 import { FILE_OPS_TYPE } from "utils/file";
 import { formatNumber } from "utils/number/format";
 import { getTrashFilesMessage } from "utils/ui";
+import Favorite from "@mui/icons-material/FavoriteRounded";
 
 interface Props {
     handleCollectionOps: (
@@ -332,6 +334,15 @@ const SelectedFileOptions = ({
                                 <ClockIcon />
                             </IconButton>
                         </Tooltip>
+                        {!isFavoriteCollection && (
+                            <Tooltip title={t("favorites")}>
+                                <IconButton
+                                    onClick={handleFileOps(FILE_OPS_TYPE.SET_FAVORITE)}
+                                >
+                                    <FavoriteBorderIcon />
+                                </IconButton>
+                            </Tooltip>
+                        )}
                         <Tooltip title={t("download")}>
                             <IconButton
                                 onClick={handleFileOps(FILE_OPS_TYPE.DOWNLOAD)}

--- a/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
+++ b/web/apps/photos/src/components/pages/gallery/SelectedFileOptions.tsx
@@ -10,12 +10,12 @@ import MoveIcon from "@mui/icons-material/ArrowForward";
 import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorderRounded";
 import RemoveIcon from "@mui/icons-material/RemoveCircleOutline";
 import RestoreIcon from "@mui/icons-material/Restore";
 import UnArchiveIcon from "@mui/icons-material/Unarchive";
 import VisibilityOffOutlined from "@mui/icons-material/VisibilityOffOutlined";
 import VisibilityOutlined from "@mui/icons-material/VisibilityOutlined";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorderRounded";
 import { Box, IconButton, Stack, Tooltip } from "@mui/material";
 import { t } from "i18next";
 import { AppContext } from "pages/_app";
@@ -336,7 +336,9 @@ const SelectedFileOptions = ({
                         {!isFavoriteCollection && (
                             <Tooltip title={t("favorites")}>
                                 <IconButton
-                                    onClick={handleFileOps(FILE_OPS_TYPE.SET_FAVORITE)}
+                                    onClick={handleFileOps(
+                                        FILE_OPS_TYPE.SET_FAVORITE,
+                                    )}
                                 >
                                     <FavoriteBorderIcon />
                                 </IconButton>

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -1120,7 +1120,7 @@ export default function Gallery() {
         [],
     );
 
-    const updateFavItemIds = async (ids: Set<Number>) => {
+    const updateFavItemIds = async () => {
         const favItemIds = await getFavItemIds(files);
         setFavItemIds(favItemIds);
     };

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -992,6 +992,7 @@ export default function Gallery() {
                     setTempHiddenFileIds,
                     setFixCreationTimeAttributes,
                     setFilesDownloadProgressAttributesCreator,
+                    updateFavItemIds,
                 );
             }
             clearSelection();
@@ -1118,6 +1119,11 @@ export default function Gallery() {
         () => setOpenCollectionSelector(false),
         [],
     );
+
+    const updateFavItemIds = async (ids: Set<Number>) => {
+        const favItemIds = await getFavItemIds(files);
+        setFavItemIds(favItemIds);
+    };
 
     if (!collectionSummaries || !filteredData) {
         return <div></div>;

--- a/web/apps/photos/src/services/collectionService.ts
+++ b/web/apps/photos/src/services/collectionService.ts
@@ -487,7 +487,7 @@ export const createFavoritesCollection = () => {
 
 export const addToFavorites = async (file: EnteFile) => {
     await addMultipleToFavorites([file]);
-}
+};
 
 export const addMultipleToFavorites = async (files: EnteFile[]) => {
     try {

--- a/web/apps/photos/src/services/collectionService.ts
+++ b/web/apps/photos/src/services/collectionService.ts
@@ -486,12 +486,16 @@ export const createFavoritesCollection = () => {
 };
 
 export const addToFavorites = async (file: EnteFile) => {
+    await addMultipleToFavorites([file]);
+}
+
+export const addMultipleToFavorites = async (files: EnteFile[]) => {
     try {
         let favCollection = await getFavCollection();
         if (!favCollection) {
             favCollection = await createFavoritesCollection();
         }
-        await addToCollection(favCollection, [file]);
+        await addToCollection(favCollection, files);
     } catch (e) {
         log.error("failed to add to favorite", e);
     }

--- a/web/apps/photos/src/utils/file/index.ts
+++ b/web/apps/photos/src/utils/file/index.ts
@@ -24,7 +24,7 @@ import { LS_KEYS, getData } from "@ente/shared/storage/localStorage";
 import type { User } from "@ente/shared/user/types";
 import { downloadUsingAnchor } from "@ente/shared/utils";
 import { t } from "i18next";
-import { addMultipleToFavorites, addToFavorites, moveToHiddenCollection } from "services/collectionService";
+import { addMultipleToFavorites, moveToHiddenCollection } from "services/collectionService";
 import {
     deleteFromTrash,
     trashFiles,

--- a/web/apps/photos/src/utils/file/index.ts
+++ b/web/apps/photos/src/utils/file/index.ts
@@ -24,7 +24,10 @@ import { LS_KEYS, getData } from "@ente/shared/storage/localStorage";
 import type { User } from "@ente/shared/user/types";
 import { downloadUsingAnchor } from "@ente/shared/utils";
 import { t } from "i18next";
-import { addMultipleToFavorites, moveToHiddenCollection } from "services/collectionService";
+import {
+    addMultipleToFavorites,
+    moveToHiddenCollection,
+} from "services/collectionService";
 import {
     deleteFromTrash,
     trashFiles,
@@ -46,7 +49,7 @@ export enum FILE_OPS_TYPE {
     HIDE,
     TRASH,
     DELETE_PERMANENTLY,
-    SET_FAVORITE
+    SET_FAVORITE,
 }
 
 export async function downloadFile(file: EnteFile) {
@@ -633,7 +636,7 @@ export const handleFileOps = async (
             break;
         case FILE_OPS_TYPE.SET_FAVORITE:
             await setBulkFavorite(files);
-            updateFavItemIds(new Set(files.map(f=>f.id)))
+            updateFavItemIds(new Set(files.map((f) => f.id)));
             break;
     }
 };
@@ -688,10 +691,10 @@ const fixTimeHelper = async (
     setFixCreationTimeAttributes({ files: selectedFiles });
 };
 
-const setBulkFavorite = async (files: EnteFile []) => {
+const setBulkFavorite = async (files: EnteFile[]) => {
     try {
         await addMultipleToFavorites(files);
     } catch (e) {
         log.error("Could not add to favorites", e);
     }
-}
+};


### PR DESCRIPTION
## Description
This allows on the web app to bulk favorite multiple photos in one go, by adding a favorite button to the SelectedFileOptions.tsx component. Just like for the Android App.
This could be enhanced by having the button plain or empty depending the selection and by setting/unsetting favarite depending previous status. For now it just set as favorite whatever the status (like the Android app).

## Tests
- Select at least 2 pictures in another album than hidden, favorited, trash, ...
- Click at top right of the screen the favorite icon
- the favorite icon on the previously selected thumbnails should appear