### PR TITLE
[auth] fix: don't use GNOME header bar outside of GNOME

### DIFF
--- a/auth/linux/my_application.cc
+++ b/auth/linux/my_application.cc
@@ -5,6 +5,10 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
 #include "flutter/generated_plugin_registrant.h"
 
 struct _MyApplication
@@ -38,6 +42,7 @@ static void my_application_activate(GApplication *application)
   // If running on Wayland assume the header bar will work (may need changing
   // if future cases occur).
   gboolean use_header_bar = TRUE;
+
 #ifdef GDK_WINDOWING_X11
   GdkScreen *screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen))
@@ -49,6 +54,21 @@ static void my_application_activate(GApplication *application)
     }
   }
 #endif
+
+#ifdef GDK_WINDOWING_WAYLAND
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+  if (GDK_IS_WAYLAND_DISPLAY(display)) {
+    // Check the XDG_CURRENT_DESKTOP environment variable to determine the
+    // desktop environment.
+    const gchar* current_desktop = g_getenv("XDG_CURRENT_DESKTOP");
+    if (current_desktop != NULL && g_str_has_prefix(current_desktop, "GNOME")) {
+      use_header_bar = TRUE;
+    } else {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+
   if (use_header_bar)
   {
     GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());


### PR DESCRIPTION
Currently, Flutter defaults to always using GTK
window decorations regardless of the window
manager, when running Wayland. This makes the app
look out of place on KDE Plasma and other Qt-based desktop environments.

This change checks the XDG_CURRENT_DESKTOP
environment variable to determine the running
desktop environment, and if it is GNOME continues
to use the GTK header, otherwise it uses the Qt
header.

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/db7161fa-3d87-4c62-bc38-e74763cb2304) | ![after](https://github.com/user-attachments/assets/f6ece7d6-f2cc-4ee7-b3d2-3eda722aee67) | 