### PR TITLE
[auth] fix(linux): generic icon on Wayland sessions

### DIFF
--- a/auth/linux/my_application.cc
+++ b/auth/linux/my_application.cc
@@ -160,6 +160,12 @@ static void my_application_init(MyApplication *self) {}
 
 MyApplication *my_application_new()
 {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_HANDLES_COMMAND_LINE | G_APPLICATION_HANDLES_OPEN,


### PR DESCRIPTION
This change sets the program name to the application ID, which helps various
systems like GTK and desktop environments map this running application to its
corresponding .desktop file. This ensures better integration by allowing the
application to be recognized beyond its binary name.

Notably, this is necessary on Wayland to map the running application window to
the desktop file, and therefore apply the correct icon.

This is the [same fix that is applied to new Flutter projects](https://github.com/flutter/flutter/pull/154522).

|  | Before | After |
|--------|--------|--------|
| Window | ![before-window](https://github.com/user-attachments/assets/71f3c5bb-f5e0-4d33-a9f6-344480761f53) | ![after-window](https://github.com/user-attachments/assets/b208bfd2-25c0-4583-9bce-46f5761f0886) |
| Taskbar | ![before-taskbar](https://github.com/user-attachments/assets/77b05efb-890e-4ef8-bd3f-2236c0284d19) | ![after-taskbar](https://github.com/user-attachments/assets/ff9aa8e1-5372-4888-8f54-7e96f85610c8) |


## How to test

- Run `main` on a Wayland session
- Note the generic Wayland logo for the icon in the window decorations, taskbar, task switcher (alt+tab), and overview effects
- Run this branch, note the correct ente auth icon is now used