### PR TITLE
[mob] Schedule sync after runApp

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -81,6 +81,7 @@ void main() async {
 
   final savedThemeMode = await AdaptiveTheme.getThemeMode();
   await _runInForeground(savedThemeMode);
+
   unawaited(BackgroundFetch.registerHeadlessTask(_headlessTaskHandler));
   if (Platform.isAndroid) FlutterDisplayMode.setHighRefreshRate().ignore();
   SystemChrome.setSystemUIOverlayStyle(
@@ -101,11 +102,6 @@ Future<void> _runInForeground(AdaptiveThemeMode? savedThemeMode) async {
     _logger.info("Starting app in foreground");
     await _init(false, via: 'mainMethod');
     final Locale locale = await getLocale();
-    if (Platform.isAndroid) {
-      unawaited(_scheduleFGHomeWidgetSync());
-    }
-    unawaited(_scheduleFGSync('appStart in FG'));
-
     runApp(
       AppLock(
         builder: (args) =>
@@ -119,6 +115,10 @@ Future<void> _runInForeground(AdaptiveThemeMode? savedThemeMode) async {
         savedThemeMode: _themeMode(savedThemeMode),
       ),
     );
+    if (Platform.isAndroid) {
+      unawaited(_scheduleFGHomeWidgetSync());
+    }
+    unawaited(_scheduleFGSync('appStart in FG'));
   });
 }
 


### PR DESCRIPTION
## Description
Although we don't await on the result, running these method can affect app start up time because the OS may take some CPU away till it execute the next step.

## Tests
