### PR TITLE
Add support for the password flag to the decrypt command

### DIFF
--- a/cli/cmd/authenticator.go
+++ b/cli/cmd/authenticator.go
@@ -19,11 +19,16 @@ var decryptExportCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		inputPath := args[0]
 		outputPath := args[1]
-		return authenticator.DecryptExport(inputPath, outputPath)
+
+		password, _ := cmd.Flags().GetString("password")
+
+		return authenticator.DecryptExport(inputPath, outputPath, password)
 	},
 }
 
 func init() {
+	decryptExportCmd.Flags().StringP("password", "p", "", "Password for decryption")
+
 	rootCmd.AddCommand(authenticatorCmd)
 	authenticatorCmd.AddCommand(decryptExportCmd)
 }

--- a/cli/pkg/authenticator/decrypt.go
+++ b/cli/pkg/authenticator/decrypt.go
@@ -21,7 +21,7 @@ type _KDF struct {
 	Salt     string `json:"salt"`
 }
 
-func DecryptExport(inputPath string, outputPath string) error {
+func DecryptExport(inputPath string, outputPath string, password string) error {
 	exportFile, err := internal.ResolvePath(inputPath)
 	if err != nil {
 		return fmt.Errorf("error resolving exportFile path (in): %v", err)
@@ -45,10 +45,13 @@ func DecryptExport(inputPath string, outputPath string) error {
 		return fmt.Errorf("unsupported export version: %d", export.Version)
 	}
 
-	password, err := internal.GetSensitiveField("Enter password to decrypt export")
-	if err != nil {
-		return err
+	if password == "" {
+		password, err = internal.GetSensitiveField("Enter password to decrypt export")
+		if err != nil {
+			return err
+		}
 	}
+
 	fmt.Printf("\n....")
 	key, err := eCrypto.DeriveArgonKey(password, export.KDFParams.Salt, export.KDFParams.MemLimit, export.KDFParams.OpsLimit)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR adds a new flag `--password` (with `-p` for short format) to the `auth decrypt` command.
This will allow to run the decryption in just one command, without the need for interactive user input.

## Tests

Run the command with a `--password` or `-p` flag and check the encrypted file is correctly decrypted.
