### PR TITLE
[docs][ente-cli]: add docs to troubleshoot keyring errors

### DIFF
--- a/docs/docs/.vitepress/sidebar.ts
+++ b/docs/docs/.vitepress/sidebar.ts
@@ -295,6 +295,10 @@ export const sidebar = [
                         text: "Yarn",
                         link: "/self-hosting/troubleshooting/yarn",
                     },
+                    {
+                        text: "Ente CLI Secrets",
+                        link: "/self-hosting/troubleshooting/keyring",
+                    },
                 ],
             },
         ],

--- a/docs/docs/self-hosting/troubleshooting/keyring.md
+++ b/docs/docs/self-hosting/troubleshooting/keyring.md
@@ -1,0 +1,32 @@
+---
+title: Ente CLI Secrets 
+description: A quick hotfix for keyring errors while running Ente CLI. 
+---
+
+# Ente CLI Secrets 
+
+Ente CLI makes use of keyring for storing sensitive information 
+like your passwords. And running the cli straight out of the 
+box might give you some errors related to keyrings in some case. 
+
+Follow the below steps to run Ente CLI and also avoid keyrings errors. 
+
+- Create a secrets.txt file and save your user password inside it.
+
+```sh 
+# export the secrets path
+
+export ENTE_CLI_SECRETS_PATH=./<path-to-secrets.txt>
+
+./ente-cli
+```
+
+And you are good to go.
+
+- You can also add the above line to your shell's rc file, to not 
+having to export it manually every time. 
+
+## Ref 
+
+- [Ente CLI Secrets Path](https://www.reddit.com/r/selfhosted/comments/1gc09il/comment/lu2hox2/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)
+- [Keyrings](https://man7.org/linux/man-pages/man7/keyrings.7.html)


### PR DESCRIPTION
## Description

Adding docs for setting up the ENTE_CLI_SECRET_PATH variable. This fix is for errors related to keyrings with ente-cli. 

## Tests
