### PR TITLE
[desktop] Start next release train

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,9 +1,15 @@
 # CHANGELOG
 
+## v1.7.7 (Unreleased)
+
+-   .
+
 ## v1.7.6
 
+-   Face merging and suggestions (beta).
 -   Parse description from metadata JSON.
 -   Support Italian, Ukrainian and Lithuanian translations.
+-   Fix an out of memory crash on uploading large libraries.
 
 ## v1.7.5
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ente",
-    "version": "1.7.6",
+    "version": "1.7.7-beta",
     "private": true,
     "description": "Desktop client for Ente Photos",
     "repository": "github:ente-io/photos-desktop",


### PR DESCRIPTION
Also updated 1.7.6 changelog with two entries I'd forgotten to add earlier.
