### PR TITLE
[Auth] Fix title typo

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -218,7 +218,7 @@
       "title": "CloudAMQP"
     },
     {
-      "title": "CloudDNS"
+      "title": "ClouDNS"
     },
     {
       "title": "Cloudflare"


### PR DESCRIPTION
ClouDNS title typo

icon not showing in app because of typo