### PR TITLE
[server] Improvements to Dockerfile and compose.yaml

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   go build -o museum cmd/museum/main.go
 
 FROM alpine:3.17
-RUN apk add libsodium-dev
+COPY --from=builder /usr/lib/libsodium.so* /usr/lib/
 COPY --from=builder /etc/ente/museum .
 COPY configurations configurations
 COPY migrations migrations

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -30,7 +30,7 @@ services:
     command: "TCP-LISTEN:3200,fork,reuseaddr TCP:minio:3200"
 
   postgres:
-    image: postgres:15
+    image: postgres:15-alpine
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
## Description
Gets rid of `libsodium-dev` installation on the final image build, instead copy the runtime libs over. shaves around 10 seconds on a clean `docker compose up -build` and around 3 MB on the server image. Not much, but hey..

This commit also switches the postgres container image from default `bookworm-slim` to `alpine`
## Tests
