### PR TITLE
[cli] Don't perform CLI secret initialisation unless needed

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -49,14 +49,28 @@ func main() {
 			panic(err)
 		}
 	}
+
+	// Define a set of commands that do not require KeyHolder initialisation.
+	skipKeyHolderCommands := map[string]struct{}{"version": {}, "docs": {}, "help": {}}
+
+	var keyHolder *secrets.KeyHolder
+
+	// Only initialise KeyHolder if the command isn't in the skip list.
+	if len(os.Args) > 1 {
+		if _, skip := skipKeyHolderCommands[os.Args[1]]; !skip {
+			keyHolder = secrets.NewKeyHolder(secrets.GetOrCreateClISecret())
+		}
+	}
+
 	ctrl := pkg.ClICtrl{
 		Client: api.NewClient(api.Params{
 			Debug: viper.GetBool("log.http"),
 			Host:  viper.GetString("endpoint.api"),
 		}),
 		DB:        db,
-		KeyHolder: secrets.NewKeyHolder(secrets.GetOrCreateClISecret()),
+		KeyHolder: keyHolder,
 	}
+
 	err = ctrl.Init()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Description

Calling `GetOrCreateClISecret()` can cause issues in some unattended scenarios.

I'm creating a Brew formula for ente CLI with the following test:

```
  test do
    assert_match "Version #{version}", shell_output("#{bin}/ente version")
  end
```

When running `brew test` for the formula, ente would fail with the following error: `2024/11/13 11:49:56 error setting password in keyring: exit status 154`

And I would see this pop-up:

![image](https://github.com/user-attachments/assets/ccd64b0d-1cb8-469c-9c16-be1b944d3b72)
