### PR TITLE
[desktop] Support rejected faces in clusters synced with remote 

### DIFF
--- a/web/packages/new/photos/services/ml/cluster.ts
+++ b/web/packages/new/photos/services/ml/cluster.ts
@@ -4,7 +4,11 @@ import log from "@/base/log";
 import type { EnteFile } from "@/media/file";
 import { ensure } from "@/utils/ensure";
 import { wait } from "@/utils/promise";
-import { savedCGroups, updateOrCreateUserEntities } from "../user-entity";
+import {
+    pullUserEntities,
+    savedCGroups,
+    updateOrCreateUserEntities,
+} from "../user-entity";
 import { savedFaceClusters, saveFaceClusters } from "./db";
 import {
     faceDirection,
@@ -409,4 +413,7 @@ export const reconcileClusters = async (
     await saveFaceClusters(
         clusters.filter(({ id }) => !isRemoteClusterID.has(id)),
     );
+
+    // Refresh our local state if we'd updated remote.
+    if (changedCGroups.length) await pullUserEntities("cgroup", masterKey);
 };

--- a/web/packages/new/photos/services/ml/cluster.ts
+++ b/web/packages/new/photos/services/ml/cluster.ts
@@ -310,7 +310,7 @@ const clusterBatchLinear = async (
             // Don't add the face back to a cluster it has been rejected from.
             if (rejectedClusters) {
                 const cjx = state.faceIDToClusterIndex.get(fj.faceID);
-                if (cjx) {
+                if (cjx !== undefined) {
                     const cj = ensure(state.clusters[cjx]);
                     if (rejectedClusters.has(cj.id)) {
                         continue;

--- a/web/packages/new/photos/services/ml/people.ts
+++ b/web/packages/new/photos/services/ml/people.ts
@@ -58,12 +58,17 @@ export interface CGroupUserEntityData {
      */
     name?: string | undefined;
     /**
-     * An unordered set ofe clusters that have been assigned to this group.
+     * An unordered set of clusters that have been assigned to this group.
      *
      * For ease of transportation and persistence this is an array, but it
      * should conceptually be thought of as a set.
      */
     assigned: FaceCluster[];
+    /**
+     * An unordered set of faces (IDs) that the user has manually marked as not
+     * belonging to this group.
+     */
+    rejectedFaceIDs: string[];
     /**
      * True if this cluster group should be hidden.
      *

--- a/web/packages/new/photos/services/ml/people.ts
+++ b/web/packages/new/photos/services/ml/people.ts
@@ -656,7 +656,6 @@ export const _applyPersonSuggestionUpdates = async (
     const localClusters = await savedFaceClusters();
 
     let assignedClusters = [...cgroup.data.assigned];
-    const newlyAssignedFaceIDs = new Set();
     let rejectedClusterIDs = await savedRejectedClustersForCGroup(cgroup.id);
     let newlyRejectedFaceIDs: string[] = [];
 
@@ -670,7 +669,6 @@ export const _applyPersonSuggestionUpdates = async (
     const assign = (clusterID: string) => {
         const cluster = clusterWithID(clusterID);
         assignedClusters.push(cluster);
-        cluster.faces.forEach((id) => newlyAssignedFaceIDs.add(id));
         assignUpdateCount += 1;
     };
 
@@ -748,9 +746,8 @@ export const _applyPersonSuggestionUpdates = async (
 
     if (assignUpdateCount > 0 || newlyRejectedFaceIDs.length > 0) {
         const assigned = assignedClusters;
-        const rejectedFaceIDs = cgroup.data.rejectedFaceIDs
-            .concat(newlyRejectedFaceIDs)
-            .filter((id) => !newlyAssignedFaceIDs.has(id));
+        const rejectedFaceIDs =
+            cgroup.data.rejectedFaceIDs.concat(newlyRejectedFaceIDs);
         await updateOrCreateUserEntities(
             "cgroup",
             [

--- a/web/packages/new/photos/services/ml/people.ts
+++ b/web/packages/new/photos/services/ml/people.ts
@@ -446,7 +446,12 @@ export const _suggestionsAndChoicesForPerson = async (
 ): Promise<PersonSuggestionsAndChoices> => {
     const startTime = Date.now();
 
-    const personClusters = person.cgroup.data.assigned;
+    const rejectedFaceIDs = new Set(person.cgroup.data.rejectedFaceIDs);
+    const personClusters = person.cgroup.data.assigned.map((cluster) => ({
+        ...cluster,
+        faces: cluster.faces.filter((id) => !rejectedFaceIDs.has(id)),
+    }));
+
     const rejectedClusterIDs = new Set(
         await savedRejectedClustersForCGroup(person.cgroup.id),
     );

--- a/web/packages/new/photos/services/ml/worker.ts
+++ b/web/packages/new/photos/services/ml/worker.ts
@@ -326,12 +326,12 @@ export class MLWorker {
      * cgroups if needed.
      */
     async clusterFaces(masterKey: Uint8Array) {
-        const clusters = await _clusterFaces(
+        const { clusters, modifiedClusterIDs } = await _clusterFaces(
             await savedFaceIndexes(),
             await getAllLocalFiles(),
             (progress) => this.updateClusteringProgress(progress),
         );
-        await reconcileClusters(clusters, masterKey);
+        await reconcileClusters(clusters, modifiedClusterIDs, masterKey);
         this.updateClusteringProgress(undefined);
     }
 

--- a/web/packages/new/photos/services/user-details.ts
+++ b/web/packages/new/photos/services/user-details.ts
@@ -2,7 +2,11 @@ import { authenticatedRequestHeaders, ensureOk } from "@/base/http";
 import { getKV, setKV } from "@/base/kv";
 import { apiURL, familyAppOrigin, paymentsAppOrigin } from "@/base/origins";
 import { ensure } from "@/utils/ensure";
-import { nullishToZero, nullToUndefined } from "@/utils/transform";
+import {
+    nullishToEmpty,
+    nullishToZero,
+    nullToUndefined,
+} from "@/utils/transform";
 import { getData, LS_KEYS, setLSUser } from "@ente/shared/storage/localStorage";
 import isElectron from "is-electron";
 import { z } from "zod";
@@ -112,9 +116,7 @@ const BonusData = z.object({
     /**
      * List of bonuses applied for the user.
      */
-    storageBonuses: Bonus.array()
-        .nullish()
-        .transform((v) => v ?? []),
+    storageBonuses: Bonus.array().nullish().transform(nullishToEmpty),
 });
 
 /**

--- a/web/packages/new/photos/services/user-entity/index.ts
+++ b/web/packages/new/photos/services/user-entity/index.ts
@@ -4,7 +4,7 @@ import {
     encryptBoxB64,
     generateNewBlobOrStreamKey,
 } from "@/base/crypto";
-import { nullToUndefined } from "@/utils/transform";
+import { nullishToEmpty, nullToUndefined } from "@/utils/transform";
 import { z } from "zod";
 import { gunzip, gzip } from "../../utils/gzip";
 import type { CGroupUserEntityData } from "../ml/people";
@@ -85,7 +85,7 @@ const RemoteFaceCluster = z.object({
 const RemoteCGroupData = z.object({
     name: z.string().nullish().transform(nullToUndefined),
     assigned: z.array(RemoteFaceCluster),
-    rejectedFaceIDs: z.array(z.string()).nullish().transform(nullToUndefined),
+    rejectedFaceIDs: z.array(z.string()).nullish().transform(nullishToEmpty),
     isHidden: z.boolean(),
     avatarFaceID: z.string().nullish().transform(nullToUndefined),
 });

--- a/web/packages/new/photos/services/user-entity/index.ts
+++ b/web/packages/new/photos/services/user-entity/index.ts
@@ -85,8 +85,7 @@ const RemoteFaceCluster = z.object({
 const RemoteCGroupData = z.object({
     name: z.string().nullish().transform(nullToUndefined),
     assigned: z.array(RemoteFaceCluster),
-    // The remote cgroup also has a "rejected" property, but that is not
-    // currently used by any of the clients.
+    rejectedFaceIDs: z.array(z.string()).nullish().transform(nullToUndefined),
     isHidden: z.boolean(),
     avatarFaceID: z.string().nullish().transform(nullToUndefined),
 });

--- a/web/packages/utils/transform.ts
+++ b/web/packages/utils/transform.ts
@@ -8,3 +8,8 @@ export const nullToUndefined = <T>(v: T | null | undefined): T | undefined =>
  * Convert `null` and `undefined` to `0`, passthrough everything else unchanged.
  */
 export const nullishToZero = (v: number | null | undefined) => v ?? 0;
+
+/**
+ * Convert `null` and `undefined` to `[]`, passthrough everything else unchanged.
+ */
+export const nullishToEmpty = <T>(v: T[] | null | undefined) => v ?? [];


### PR DESCRIPTION
Sibling of https://github.com/ente-io/ente/pull/4027