### PR TITLE
[mob] Fix market URI on mobile

### DIFF
--- a/auth/lib/services/update_service.dart
+++ b/auth/lib/services/update_service.dart
@@ -99,7 +99,7 @@ class UpdateService {
       if (flavor == "playstore") {
         return const Tuple2(
           "Play Store",
-          "market://details??id=io.ente.auth",
+          "market://details?id=io.ente.auth",
         );
       }
       return const Tuple2(


### PR DESCRIPTION
## Description
This PR fix typos in the market URI that resulted in 404 page on android market.
![image](https://github.com/user-attachments/assets/f91669f0-cace-4f93-8a55-202adda4c164)