### PR TITLE
[mob][photos] Fix #2894 - Edited image resolution

### DIFF
--- a/mobile/lib/ui/tools/editor/image_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/image_editor_page.dart
@@ -2,9 +2,11 @@ import "dart:async";
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
+import 'dart:ui' as ui show Image;
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart' show decodeImageFromList;
 import "package:flutter_image_compress/flutter_image_compress.dart";
 import 'package:image_editor/image_editor.dart';
 import 'package:logging/logging.dart';
@@ -336,8 +338,10 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       showToast(context, S.of(context).somethingWentWrong);
       return;
     }
-    _logger.info('Size before compression = ${result.length}');
-    result = await FlutterImageCompress.compressWithList(result);
+    _logger.info('Size before compression = ${result.length}');    
+    
+    final ui.Image decodedResult = await decodeImageFromList(result);
+    result = await FlutterImageCompress.compressWithList(result, minWidth: decodedResult.width, minHeight: decodedResult.height);
     _logger.info('Size after compression = ${result.length}');
     final Duration diff = DateTime.now().difference(start);
     _logger.info('image_editor time : $diff');


### PR DESCRIPTION
## Description

Proposal to fix #2894 so that edited image keep same dimensions/resolution as original image

The issue was that `FlutterImageCompress.compressWithList` was forcing the result to be resized using the method's default values {minWidth = 1920, minHeight = 1080}.

It is now forcing the size to be the one right before the compression, after the potential alterations (flip, rotate, ..).

## Tests

Tested on my Pixel 6a

Built with :

Flutter 3.24.3
JDK 17.0.2
Gradle 7.2