### PR TITLE
[server] Create totpSession when both passkey and totp are enabled

### DIFF
--- a/server/ente/user.go
+++ b/server/ente/user.go
@@ -55,6 +55,10 @@ type EmailAuthorizationResponse struct {
 	Token              string         `json:"token,omitempty"`
 	PasskeySessionID   string         `json:"passkeySessionID"`
 	TwoFactorSessionID string         `json:"twoFactorSessionID"`
+	// TwoFactorSessionIDV2 is set only if user has both passkey and two factor enabled.
+	// This is to ensure older clients keep using passkey flow when both are set. We can remove
+	// This field once the clients starts surface both options for performing 2fa
+	TwoFactorSessionIDV2 string `json:"twoFactorSessionIDV2"`
 	// SrpM2 is sent only if the user is logging via SRP
 	// SrpM2 is the SRP M2 value aka the proof that the server has the verifier
 	SrpM2 *string `json:"srpM2,omitempty"`


### PR DESCRIPTION
## Description

- When both `passkeySessionID` and `twoFactorSessionID` are set in the response, the web will surface passkey based login while mobile will only surface totp based login.

- For now, I have added a new field in the response (`twoFactorSessionIDV2) for totpBased twoFactor, that will be only set when both passkey and totp based MFA are enabled.
- Once both mobile and desktop changes are out, we can remove this new field `twoFactorSessionIDV2` from the response

Corresponding mobile diff: https://github.com/ente-io/ente/pull/4210
## Tests
