### PR TITLE
Workaround for Admins list in Environment Variables by specifying singular admin

### DIFF
--- a/server/pkg/middleware/auth.go
+++ b/server/pkg/middleware/auth.go
@@ -93,6 +93,12 @@ func (m *AuthMiddleware) AdminAuthMiddleware() gin.HandlerFunc {
 		}
 		// if no admins are set, then check if the user is first user in the system
 		if len(admins) == 0 {
+			// Fallback for specifying a singular admin ID when encountering https://github.com/spf13/viper/issues/1611
+			if viper.GetInt("internal.admin") == userId {
+				c.Next()
+				return
+			}
+
 			id, err := m.UserAuthRepo.GetMinUserID()
 			if err != nil && id == userID {
 				c.Next()


### PR DESCRIPTION
## Description

This allows working around an issue with Viper where it doesn't properly unmarshal GetIntSlice from environment variables. Seems like this is a known issue and is quite old. I'm assuming there isn't plans to fix it on the Viper side.

https://github.com/spf13/viper/issues/339

## Tests

I'll be brutally honest, I don't know how to run Go, but this seemed like a pretty quick low hanging fix.