### PR TITLE
[mob][photos] Fix misaligned hint text in search bar

### DIFF
--- a/mobile/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/lib/ui/viewer/search/search_widget.dart
@@ -143,6 +143,7 @@ class SearchWidgetState extends State<SearchWidget> {
                     controller: textController,
                     focusNode: focusNode,
                     style: Theme.of(context).textTheme.titleMedium,
+                    textAlignVertical: const TextAlignVertical(y: 0),
                     // Below parameters are to disable auto-suggestion
                     // Above parameters are to disable auto-suggestion
                     decoration: InputDecoration(
@@ -154,21 +155,6 @@ class SearchWidgetState extends State<SearchWidget> {
                       ),
                       focusedBorder: const UnderlineInputBorder(
                         borderSide: BorderSide.none,
-                      ),
-                      prefixIconConstraints: const BoxConstraints(
-                        maxHeight: 44,
-                        maxWidth: 44,
-                        minHeight: 44,
-                        minWidth: 44,
-                      ),
-                      suffixIconConstraints: const BoxConstraints(
-                        maxHeight: 44,
-                        maxWidth: 44,
-                        minHeight: 44,
-                        minWidth: 44,
-                      ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        vertical: 8,
                       ),
                       prefixIcon: Hero(
                         tag: "search_icon",

--- a/mobile/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/lib/ui/viewer/search/search_widget.dart
@@ -17,7 +17,7 @@ import "package:photos/utils/date_time_util.dart";
 import "package:photos/utils/debouncer.dart";
 
 class SearchWidget extends StatefulWidget {
-  const SearchWidget({Key? key}) : super(key: key);
+  const SearchWidget({super.key});
 
   @override
   State<SearchWidget> createState() => SearchWidgetState();

--- a/mobile/lib/ui/viewer/search_tab/search_tab.dart
+++ b/mobile/lib/ui/viewer/search_tab/search_tab.dart
@@ -26,7 +26,7 @@ import "package:photos/ui/viewer/search_tab/moments_section.dart";
 import "package:photos/ui/viewer/search_tab/people_section.dart";
 
 class SearchTab extends StatefulWidget {
-  const SearchTab({Key? key}) : super(key: key);
+  const SearchTab({super.key});
 
   @override
   State<SearchTab> createState() => _SearchTabState();
@@ -105,7 +105,10 @@ class _AllSearchSectionsState extends State<AllSearchSections> {
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 72),
                     child: Text(
-                      S.of(context).searchSectionsLengthMismatch(snapshot.data!.length, searchTypes.length),
+                      S.of(context).searchSectionsLengthMismatch(
+                            snapshot.data!.length,
+                            searchTypes.length,
+                          ),
                     ),
                   );
                 }


### PR DESCRIPTION
## Description

Fix for the hint text ("Search") in the search bar getting misaligned more towards the top for smaller font sizes (normal for a big enough majority of people). 
 
