### PR TITLE
[cli][setup] add: public-albums-url subcommand to configure albums url

### DIFF
--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -7,6 +7,7 @@ import (
   "github.com/spf13/cobra"
   "os"
   "net/url"
+  "strings"
 )
 
 var setupCmd = &cobra.Command {
@@ -30,6 +31,7 @@ var addPublicAlbumsUrl = &cobra.Command {
 
     dir := pkg.ConfigureServerDir()
 
+    // Adding path to the museum config file
     viper.AddConfigPath(dir)
     viper.SetConfigName(environment)
     viper.SetConfigType("yaml")
@@ -39,7 +41,7 @@ var addPublicAlbumsUrl = &cobra.Command {
       fmt.Errorf("%v", err)
       return
     }
-    albumsUrl := args[0]
+    albumsUrl := strings.TrimSuffix(args[0], "/")
     _, err = url.ParseRequestURI(albumsUrl)
     if err != nil {
       // Report Error and exit
@@ -60,6 +62,7 @@ var addPublicAlbumsUrl = &cobra.Command {
 }
 
 func init() {
+  // `ente setup` will be the initial root command
   rootCmd.AddCommand(setupCmd)
   rootCmd.Flags().String("public-albums-url", "", "Sets the public-albums url in your environments configuration file")
 

--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -1,0 +1,67 @@
+package cmd 
+
+import (
+  "fmt"
+  "github.com/ente-io/cli/pkg"
+  "github.com/spf13/viper"
+  "github.com/spf13/cobra"
+  "os"
+  "net/url"
+)
+
+var setupCmd = &cobra.Command {
+  Use: "setup",
+  Short: "Manage setup/configuration settings",
+}
+
+// Command to set the public albums url in configurations/<environment>.yaml file
+// Reads value from environment variable "ENTE_MUSEUM_DIR"
+var addPublicAlbumsUrl = &cobra.Command {
+  Use: "public-albums-url account add-public-url [url]",
+  Short: "Set the public-albums URL in Museum YAML configuraiton file",
+  Args: cobra.ExactArgs(1),
+  Run: func(cmd *cobra.Command, args []string) {
+    // Get environment to make changes to valid file  
+    environment := os.Getenv("ENVIRONMENT")
+
+    if environment == "" {
+      environment = "local"
+    } 
+
+    dir := pkg.ConfigureServerDir()
+
+    viper.AddConfigPath(dir)
+    viper.SetConfigName(environment)
+    viper.SetConfigType("yaml")
+
+    err := viper.ReadInConfig()
+    if err != nil {
+      fmt.Errorf("%v", err)
+      return
+    }
+    albumsUrl := args[0]
+    _, err = url.ParseRequestURI(albumsUrl)
+    if err != nil {
+      // Report Error and exit
+      fmt.Printf("Invalid URL: %s\nPlease enter a valid endpoint for public albums", err) 
+      os.Exit(1)
+    } else {
+      viper.Set("apps.public-albums", albumsUrl)
+    }
+
+    // Overwrite the public album url in Configuration File
+    err = viper.WriteConfig()
+    if err != nil {
+      fmt.Println("Error saving config: %v\n", err)
+    } else {
+      fmt.Println("Public Albums URL set to", albumsUrl)
+    }
+  },
+}
+
+func init() {
+  rootCmd.AddCommand(setupCmd)
+  rootCmd.Flags().String("public-albums-url", "", "Sets the public-albums url in your environments configuration file")
+
+  setupCmd.AddCommand(addPublicAlbumsUrl)
+}

--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
   "fmt"
-  "github.com/ente-io/cli/pkg"
-  "github.com/spf13/viper"
-  "github.com/spf13/cobra"
   "os"
   "net/url"
   "strings"
+  
+  "github.com/spf13/viper"
+  "github.com/spf13/cobra"
+
+  "github.com/ente-io/cli/pkg"
 )
 
 var setupCmd = &cobra.Command {

--- a/cli/pkg/cli.go
+++ b/cli/pkg/cli.go
@@ -41,3 +41,17 @@ func GetCLITempPath() (string) {
 	}
 	return os.TempDir()
 }
+
+// Configure Museum Server Directory to find proper <environment.yaml> file.
+// Made for and used in command `ente account public-albums-url [url]`
+func ConfigureServerDir() (string) {
+  serverEnv := os.Getenv("ENTE_SERVER_DIR")
+  if serverEnv != "" {
+    fmt.Errorf(`ENTE_SERVER_DIR environment is not set, please setup it with\n 
+      export ENTE_SERVER_DIR=/path/to/ente/
+      `)
+  }
+
+  configDir := filepath.Join(serverEnv, "server", "configurations")
+  return configDir
+}


### PR DESCRIPTION
Adds a command `ente setup public-albums-url`. 

![Capture-Nov-28-17-12-36](https://github.com/user-attachments/assets/1884332f-635e-4173-a48e-69d762725590)
