### PR TITLE
Add `internal.disable-registration` to config

### DIFF
--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -321,6 +321,9 @@ internal:
     # the "admin" instead of "admins". This can be useful e.g. when wishing to
     # pass the admin as an environment variable.
     admin:
+    # If set to true, users will not be able to register a new account.
+    # Account creation will fail when entering the email ott
+    disable-registration: false
 
 # Replication config
 #

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -362,13 +362,13 @@ func (c *UserController) onVerificationSuccess(context *gin.Context, email strin
 	userID, err := c.UserRepo.GetUserIDWithEmail(email)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			if !viper.GetBool("internal.disable-registration") {
+			if viper.GetBool("internal.disable-registration") {
+				return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(ente.ErrPermissionDenied, "")
+			} else {
 				userID, _, err = c.createUser(email, source)
 				if err != nil {
 					return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")
 				}
-			} else {
-				return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(ente.ErrPermissionDenied, "")
 			}
 		} else {
 			return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -362,9 +362,13 @@ func (c *UserController) onVerificationSuccess(context *gin.Context, email strin
 	userID, err := c.UserRepo.GetUserIDWithEmail(email)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			userID, _, err = c.createUser(email, source)
-			if err != nil {
-				return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")
+			if !viper.GetBool("internal.disable-registration") {
+				userID, _, err = c.createUser(email, source)
+				if err != nil {
+					return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")
+				}
+			} else {
+				return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(ente.ErrPermissionDenied, "")
 			}
 		} else {
 			return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")


### PR DESCRIPTION
## Description
As discussed in #2476, I added an option `internal.disable-registration` to allow disabling the registration of new users on selfhosted instances.
Users can still go through the registration flow, but when entering the ott they received via mail, they get an unauthorized error.

Should this be documented in any of the self-hosting documentation?