### PR TITLE
[server] Limit unverifeid sessions

### DIFF
--- a/server/pkg/middleware/rate_limit.go
+++ b/server/pkg/middleware/rate_limit.go
@@ -152,6 +152,7 @@ func (r *RateLimitMiddleware) getLimiter(reqPath string, reqMethod string) *limi
 		reqPath == "/users/srp/attributes" ||
 		(reqPath == "/cast/device-info" && reqMethod == "POST") ||
 		(reqPath == "/cast/device-info/" && reqMethod == "POST") ||
+		reqPath == "/users/srp/create-session" ||
 		reqPath == "/users/srp/verify-session" ||
 		reqPath == "/family/invite-info/:token" ||
 		reqPath == "/family/add-member" ||

--- a/server/pkg/repo/srp.go
+++ b/server/pkg/repo/srp.go
@@ -19,6 +19,12 @@ func (repo *UserAuthRepository) AddSRPSession(srpUserID uuid.UUID, serverKey str
 	return id, stacktrace.Propagate(err, "")
 }
 
+func (repo *UserAuthRepository) GetUnverifiedSessionsInLastHour(srpUserID uuid.UUID) (int64, error) {
+	var count int64
+	err := repo.DB.QueryRow(`SELECT COUNT(*) FROM srp_sessions WHERE srp_user_id = $1 AND has_verified = false AND created_at > (now_utc_micro_seconds() - (60::BIGINT * 60 * 1000 * 1000))`, srpUserID).Scan(&count)
+	return count, stacktrace.Propagate(err, "")
+}
+
 func (repo *UserAuthRepository) GetSRPAuthEntity(ctx context.Context, userID int64) (*ente.SRPAuthEntity, error) {
 	result := ente.SRPAuthEntity{}
 	row := repo.DB.QueryRowContext(ctx, `SELECT user_id, srp_user_id, salt, verifier FROM srp_auth WHERE user_id = $1`, userID)


### PR DESCRIPTION
## Description

This (cosmetic?) change is to reduce the brute-force attempt on password cracking.

It feels cosmetic because each create-session call requires an expensive KDF steps for different password. It's also not prone to dictionary attack because of the nonce.

Still, this change felt harmless to make, and it's hardens the security further.

## Tests
Tested locally