### PR TITLE
Dashes in ENV var names not supported by docker compose

### DIFF
--- a/docs/docs/self-hosting/guides/external-s3.md
+++ b/docs/docs/self-hosting/guides/external-s3.md
@@ -72,6 +72,7 @@ services:
             - ./.credentials.env
         volumes:
             - custom-logs:/var/logs
+            - museum.yaml:/museum.yaml:ro
         networks:
             - internal
 
@@ -199,22 +200,33 @@ ENTE_KEY_ENCRYPTION=
 ENTE_KEY_HASH=
 ENTE_JWT_SECRET=
 
-ENTE_S3_B2-EU-CEN_KEY=YOUR_S3_KEY
-ENTE_S3_B2-EU-CEN_SECRET=YOUR_S3_SECRET
-ENTE_S3_B2-EU-CEN_ENDPOINT=YOUR_S3_ENDPOINT
-ENTE_S3_B2-EU-CEN_REGION=YOUR_S3_REGION
-ENTE_S3_B2-EU-CEN_BUCKET=YOUR_S3_BUCKET
-ENTE_S3_ARE_LOCAL_BUCKETS=false
-
-ENTE_INTERNAL_HARDCODED-OTT_LOCAL-DOMAIN-SUFFIX="@example.com"
-ENTE_INTERNAL_HARDCODED-OTT_LOCAL-DOMAIN-VALUE=123456
-
 # if you deploy it on a server under a domain, you need to set the correct value of the following variables
 # it can be changed later
+
+# The backend server URL (Museum) to be used by the webapp
 ENDPOINT=http://localhost:8080
+# The URL of the public albums webapp (also need to be updated in museum.yml so the correct links are generated)
 ALBUMS_ENDPOINT=http://localhost:8082
-# This is used to generate sharable URLs
-ENTE_APPS_PUBLIC-ALBUMS=http://localhost:8082
+```
+
+Create the `museum.yml` with additional configuration, this will be mounted
+(read-only) into the container:
+
+```yaml
+s3:
+    are_local_buckets: false
+    # For some self-hosted S3 deployments you (e.g. Minio) you might need to disable bucket subdomains
+    use_path_style_urls: true
+    # The key must be named like so
+    b2-eu-cen:
+        key:      $YOUR_S3_KEY
+        secret:   $YOUR_S3_SECRET
+        endpoint: $YOUR_S3_ENDPOINT
+        region:   $YOUR_S3_REGION
+        bucket:   $YOUR_S3_BUCKET_NAME
+# The same value as the one specified in ALBUMS_ENDPOINT
+apps:
+    public-albums: http://localhost:8082
 ```
 
 ## 3. Run `docker-compose up`

--- a/docs/docs/self-hosting/guides/external-s3.md
+++ b/docs/docs/self-hosting/guides/external-s3.md
@@ -209,7 +209,7 @@ ENDPOINT=http://localhost:8080
 ALBUMS_ENDPOINT=http://localhost:8082
 ```
 
-Create the `museum.yml` with additional configuration, this will be mounted
+Create the `museum.yaml` with additional configuration, this will be mounted
 (read-only) into the container:
 
 ```yaml


### PR DESCRIPTION
When I was trying to set this up, I was getting errors from `docker compose`:

```
failed to read /var/hosts/ente/.credentials.env: line 11: unexpected character "-" in variable name "ENTE_APPS_PUBLIC-ALBUMS=https://<redacted>"
```

There was, apparently, a brief period in time when `docker compose` supported dashes in ENV var names, [but this is no longer the case](https://github.com/docker/compose/issues/12302), hence some vars need to be defined in a `museum.yml` and mounted into the instance. Maybe there is some rewriting in place that allows to redefine `museum.yml` entries with dashes in ENV vars, however I couldn't find it (and if there isn't, there probably should be, but this change should make the guide usable again at least).