### PR TITLE
[mob][photos] Fix state issue when reloading avatar (#4311)

### DIFF
--- a/mobile/lib/ui/viewer/people/save_or_edit_person.dart
+++ b/mobile/lib/ui/viewer/people/save_or_edit_person.dart
@@ -362,6 +362,7 @@ class _SaveOrEditPersonState extends State<SaveOrEditPerson> {
                       itemBuilder: (context, index) {
                         final person = searchResults[index];
                         return PersonGridItem(
+                          key: ValueKey(person.$1.remoteID),
                           person: person.$1,
                           personFile: person.$2,
                           onTap: () async {


### PR DESCRIPTION
## Description

- Fixed by adding a key to the PersonGridItem, that way it gets refreshed when the person is changed

(related issue : #4311)

## Tests
