### PR TITLE
[mob][photos] Fix clipping of TextInputWidget

### DIFF
--- a/mobile/lib/ui/components/text_input_widget.dart
+++ b/mobile/lib/ui/components/text_input_widget.dart
@@ -189,25 +189,17 @@ class _TextInputWidgetState extends State<TextInputWidget> {
                 ),
                 borderRadius: BorderRadius.circular(8),
               ),
-              suffixIcon: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 175),
-                  switchInCurve: Curves.easeInExpo,
-                  switchOutCurve: Curves.easeOutExpo,
-                  child: SuffixIconWidget(
-                    key: ValueKey(executionState),
-                    executionState: executionState,
-                    shouldSurfaceExecutionStates:
-                        widget.shouldSurfaceExecutionStates,
-                    obscureTextNotifier: _obscureTextNotifier,
-                    isPasswordInput: widget.isPasswordInput,
-                    textController: _textController,
-                    isClearable: widget.isClearable,
-                    shouldUnfocusOnClearOrSubmit:
-                        widget.shouldUnfocusOnClearOrSubmit,
-                  ),
-                ),
+              suffixIcon: SuffixIconWidget(
+                key: ValueKey(executionState),
+                executionState: executionState,
+                shouldSurfaceExecutionStates:
+                    widget.shouldSurfaceExecutionStates,
+                obscureTextNotifier: _obscureTextNotifier,
+                isPasswordInput: widget.isPasswordInput,
+                textController: _textController,
+                isClearable: widget.isClearable,
+                shouldUnfocusOnClearOrSubmit:
+                    widget.shouldUnfocusOnClearOrSubmit,
               ),
               prefixIconConstraints: const BoxConstraints(
                 maxHeight: 44,
@@ -218,8 +210,8 @@ class _TextInputWidgetState extends State<TextInputWidget> {
               suffixIconConstraints: const BoxConstraints(
                 maxHeight: 24,
                 maxWidth: 48,
-                minHeight: 24,
-                minWidth: 48,
+                minHeight: 0,
+                minWidth: 0,
               ),
               prefixIcon: widget.prefixIcon != null
                   ? Icon(
@@ -442,7 +434,7 @@ class SuffixIconWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Widget trailingWidget;
+    final Widget? trailingWidget;
     final colorScheme = getEnteColorScheme(context);
     if (executionState == ExecutionState.idle ||
         !shouldSurfaceExecutionStates) {
@@ -473,7 +465,7 @@ class SuffixIconWidget extends StatelessWidget {
           ),
         );
       } else {
-        trailingWidget = const SizedBox.shrink();
+        trailingWidget = null;
       }
     } else if (executionState == ExecutionState.inProgress) {
       trailingWidget = EnteLoadingWidget(
@@ -486,8 +478,21 @@ class SuffixIconWidget extends StatelessWidget {
         color: colorScheme.primary500,
       );
     } else {
-      trailingWidget = const SizedBox.shrink();
+      trailingWidget = null;
     }
-    return trailingWidget;
+    if (trailingWidget != null) {
+      return AnimatedSwitcher(
+        duration: const Duration(milliseconds: 175),
+        switchInCurve: Curves.easeInExpo,
+        switchOutCurve: Curves.easeOutExpo,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: trailingWidget,
+        ),
+      );
+    } else {
+      // return trailingWidget;
+      return const SizedBox.shrink();
+    }
   }
 }

--- a/mobile/lib/ui/components/text_input_widget.dart
+++ b/mobile/lib/ui/components/text_input_widget.dart
@@ -480,19 +480,17 @@ class SuffixIconWidget extends StatelessWidget {
     } else {
       trailingWidget = null;
     }
-    if (trailingWidget != null) {
-      return AnimatedSwitcher(
-        duration: const Duration(milliseconds: 175),
-        switchInCurve: Curves.easeInExpo,
-        switchOutCurve: Curves.easeOutExpo,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: trailingWidget,
-        ),
-      );
-    } else {
-      // return trailingWidget;
-      return const SizedBox.shrink();
-    }
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 175),
+      switchInCurve: Curves.easeInExpo,
+      switchOutCurve: Curves.easeOutExpo,
+      child: trailingWidget != null
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: trailingWidget,
+            )
+          : const SizedBox.shrink(),
+    );
   }
 }


### PR DESCRIPTION
## Description

#### Before
Text is clipped more towards the right end
<img width="312" alt="Screenshot 2024-12-05 at 4 18 49 PM" src="https://github.com/user-attachments/assets/56577526-defb-4c03-a31c-03a34283c886">


#### After

<img width="312" alt="Screenshot 2024-12-05 at 4 17 36 PM" src="https://github.com/user-attachments/assets/add18d28-6d75-4cf0-9c6d-1924f70b699d">


