### PR TITLE
[auth] Fixing taskbar overlapping window panel

### DIFF
--- a/auth/windows/runner/main.cpp
+++ b/auth/windows/runner/main.cpp
@@ -72,7 +72,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
   FlutterWindow window(project);
-  Win32Window::Point origin(50, 50);
+  Win32Window::Point origin(70, 70);
   Win32Window::Size size(1280, 720);
   if (!window.Create(L"Ente Auth", origin, size))
   {

--- a/auth/windows/runner/main.cpp
+++ b/auth/windows/runner/main.cpp
@@ -72,7 +72,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
   FlutterWindow window(project);
-  Win32Window::Point origin(10, 10);
+  Win32Window::Point origin(50, 50);
   Win32Window::Size size(1280, 720);
   if (!window.Create(L"Ente Auth", origin, size))
   {


### PR DESCRIPTION
## Description

Pull request was made because of some user percentage has taskbar connected on top, so it overlaps auth window for WinApp at start.
After some measuring, I found that taskbar occupies:

- 50px on FHD with 125% scaling (standard values on some notebooks)
- 40px on FHD with 100% scaling
- 30px on FHD with 100% scaling and small taskbar icons
