### PR TITLE
[auth] fix missing [ ] in altNames in custom-icons.json

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -533,7 +533,9 @@
     },
     {
       "title": "matlab",
-      "altNames": ["mathworks"]
+      "altNames": [
+        "mathworks"
+      ]
     },
     {
       "title": "Mercado Livre",
@@ -636,7 +638,9 @@
       "title": "nordvpn",
       "slug": "nordaccount",
       "hex": "#4687FF",
-      "altNames": "Nord Account"
+      "altNames": [
+        "Nord Account"
+      ]
     },
     {
       "title": "Notesnook"


### PR DESCRIPTION
## Description
Debug build failing due missing [ ] in altNames in the custom-icon.json from PR  [https://github.com/ente-io/ente/pull/4348/files]()
Code Ref: https://github.com/ente-io/ente/blob/main/auth/assets/custom-icons/_data/custom-icons.json#L639