### PR TITLE
[desktop] Fix export when selecting root folder

### DIFF
--- a/web/apps/photos/src/services/export/index.ts
+++ b/web/apps/photos/src/services/export/index.ts
@@ -1264,31 +1264,17 @@ const readOnDiskFileExportRecordIDs = async (
 
     const fileExportNames = exportRecord.fileExportNames ?? {};
 
-    const ls2 = new Array([...ls].slice(0, 100));
-    log.info(JSON.stringify({ exportDir, ls: ls2, fileExportNames }));
-
     for (const file of files) {
         if (isCanceled.status) throw Error(CustomError.EXPORT_STOPPED);
 
         const collectionExportName = collectionIDFolderNameMap.get(
             file.collectionID,
         );
-        log.info(
-            JSON.stringify({ cid: file.collectionID, collectionExportName }),
-        );
         if (!collectionExportName) continue;
 
         const collectionExportPath = `${exportDir}/${collectionExportName}`;
         const recordID = getExportRecordFileUID(file);
         const exportName = fileExportNames[recordID];
-        log.info(
-            JSON.stringify({
-                exportName,
-                constructed: `${collectionExportPath}/${exportName}`,
-                has: ls.has(`${collectionExportPath}/${exportName}`),
-            }),
-        );
-
         if (!exportName) continue;
 
         if (ls.has(`${collectionExportPath}/${exportName}`)) {

--- a/web/apps/photos/src/services/export/migration.ts
+++ b/web/apps/photos/src/services/export/migration.ts
@@ -1,5 +1,5 @@
 import { ensureElectron } from "@/base/electron";
-import { nameAndExtension } from "@/base/file-name";
+import { joinPath, nameAndExtension } from "@/base/file-name";
 import log from "@/base/log";
 import { downloadManager } from "@/gallery/services/download";
 import type { Collection } from "@/media/collection";
@@ -225,7 +225,10 @@ const migrateCollectionFolders = async (
 ) => {
     const fs = ensureElectron().fs;
     for (const collection of collections) {
-        const oldPath = `${exportDir}/${collection.id}_${oldSanitizeName(collection.name)}`;
+        const oldPath = joinPath(
+            exportDir,
+            `${collection.id}_${oldSanitizeName(collection.name)}`,
+        );
         const newPath = await safeDirectoryName(
             exportDir,
             collection.name,
@@ -249,19 +252,28 @@ async function migrateFiles(
     const fs = ensureElectron().fs;
     for (const file of files) {
         const collectionPath = collectionIDPathMap.get(file.collectionID);
-        const metadataPath = `${collectionPath}/${exportMetadataDirectoryName}`;
+        const metadataPath = joinPath(
+            collectionPath,
+            exportMetadataDirectoryName,
+        );
 
         const oldFileName = `${file.id}_${oldSanitizeName(file.metadata.title)}`;
-        const oldFilePath = `${collectionPath}/${oldFileName}`;
-        const oldFileMetadataPath = `${metadataPath}/${oldFileName}.json`;
+        const oldFilePath = joinPath(collectionPath, oldFileName);
+        const oldFileMetadataPath = joinPath(
+            metadataPath,
+            `${oldFileName}.json`,
+        );
 
         const newFileName = await safeFileName(
             collectionPath,
             file.metadata.title,
             fs.exists,
         );
-        const newFilePath = `${collectionPath}/${newFileName}`;
-        const newFileMetadataPath = `${metadataPath}/${newFileName}.json`;
+        const newFilePath = joinPath(collectionPath, newFileName);
+        const newFileMetadataPath = joinPath(
+            metadataPath,
+            `${newFileName}.json`,
+        );
 
         if (!(await fs.exists(oldFilePath))) continue;
 
@@ -444,7 +456,7 @@ async function removeCollectionExportMissingMetadataFolder(
         if (
             await fs.exists(
                 getMetadataFolderExportPath(
-                    `${exportDir}/${collectionExportName}`,
+                    joinPath(exportDir, collectionExportName),
                 ),
             )
         ) {
@@ -511,7 +523,7 @@ const oldSanitizeName = (name: string) =>
     name.replaceAll("/", "_").replaceAll(" ", "_");
 
 const getFileSavePath = (collectionFolderPath: string, fileSaveName: string) =>
-    `${collectionFolderPath}/${fileSaveName}`;
+    joinPath(collectionFolderPath, fileSaveName);
 
 const getUniqueFileExportNameForMigration = (
     collectionPath: string,

--- a/web/apps/photos/src/utils/collection.ts
+++ b/web/apps/photos/src/utils/collection.ts
@@ -1,4 +1,5 @@
 import { ensureElectron } from "@/base/electron";
+import { joinPath } from "@/base/file-name";
 import log from "@/base/log";
 import {
     COLLECTION_ROLE,
@@ -168,7 +169,10 @@ async function createCollectionDownloadFolder(
         collectionName,
         fs.exists,
     );
-    const collectionDownloadPath = `${downloadDirPath}/${collectionDownloadName}`;
+    const collectionDownloadPath = joinPath(
+        downloadDirPath,
+        collectionDownloadName,
+    );
     await fs.mkdirIfNeeded(collectionDownloadPath);
     return collectionDownloadPath;
 }

--- a/web/apps/photos/src/utils/file/index.ts
+++ b/web/apps/photos/src/utils/file/index.ts
@@ -1,4 +1,5 @@
 import { sharedCryptoWorker } from "@/base/crypto";
+import { joinPath } from "@/base/file-name";
 import log from "@/base/log";
 import { type Electron } from "@/base/types/ipc";
 import { downloadAndRevokeObjectURL } from "@/base/utils/web";
@@ -404,7 +405,7 @@ async function downloadFileDesktop(
         const imageStream = new Response(imageData).body;
         await writeStream(
             electron,
-            `${downloadDir}/${imageExportName}`,
+            joinPath(downloadDir, imageExportName),
             imageStream,
         );
         try {
@@ -416,11 +417,11 @@ async function downloadFileDesktop(
             const videoStream = new Response(videoData).body;
             await writeStream(
                 electron,
-                `${downloadDir}/${videoExportName}`,
+                joinPath(downloadDir, videoExportName),
                 videoStream,
             );
         } catch (e) {
-            await fs.rm(`${downloadDir}/${imageExportName}`);
+            await fs.rm(joinPath(downloadDir, imageExportName));
             throw e;
         }
     } else {
@@ -429,7 +430,11 @@ async function downloadFileDesktop(
             file.metadata.title,
             fs.exists,
         );
-        await writeStream(electron, `${downloadDir}/${fileExportName}`, stream);
+        await writeStream(
+            electron,
+            joinPath(downloadDir, fileExportName),
+            stream,
+        );
     }
 }
 

--- a/web/packages/base/file-name.ts
+++ b/web/packages/base/file-name.ts
@@ -82,3 +82,24 @@ export const dirname = (path: string) => {
     }
     return pathComponents.join("/");
 };
+
+/**
+ * Return a new path by joining two path components using the POSIX path
+ * separator ("/").
+ *
+ * This is usually a trivial `p1/p2`, however it also handles the case where p1
+ * already ends with a trailing slash. This can happen even if p1 is obtained
+ * from a place which guarantees that only directory paths will be returned,
+ * because p1 can be the path to a root folder (e.g. "/" on Linux, or "C:/" on
+ * Windows), and the trivial join would then result in double slashes.
+ *
+ * @param p1 A path component that is expected to be using POSIX path
+ * separators.
+ *
+ * @param p2 A path component that is expected to be using POSIX path
+ * separators.
+ *
+ * @returns A path by joining p1 and p2 with a POSIX path separator if needed.
+ */
+export const joinPath = (p1: string, p2: string) =>
+    p1.endsWith("/") ? p1 + p2 : `${p1}/${p2}`;

--- a/web/packages/new/photos/utils/native-fs.ts
+++ b/web/packages/new/photos/utils/native-fs.ts
@@ -5,7 +5,7 @@
  * written for use by the code that runs in our desktop app.
  */
 
-import { nameAndExtension } from "@/base/file-name";
+import { joinPath, nameAndExtension } from "@/base/file-name";
 import {
     exportMetadataDirectoryName,
     exportTrashDirectoryName,
@@ -47,7 +47,7 @@ export const safeDirectoryName = async (
     let result = sanitizeFilename(name);
     let count = 1;
     while (
-        (await exists(`${directoryPath}/${result}`)) ||
+        (await exists(joinPath(directoryPath, result))) ||
         specialDirectoryNames.includes(result)
     ) {
         result = `${sanitizeFilename(name)}(${count})`;
@@ -69,7 +69,7 @@ export const safeFileName = async (
 ) => {
     let result = sanitizeFilename(name);
     let count = 1;
-    while (await exists(`${directoryPath}/${result}`)) {
+    while (await exists(joinPath(directoryPath, result))) {
         const [fn, ext] = nameAndExtension(sanitizeFilename(name));
         if (ext) result = `${fn}(${count}).${ext}`;
         else result = `${fn}(${count})`;


### PR DESCRIPTION
This fixes the issue where files would be exported twice on pressing resync if the user selected "C://" (or some other root drive) as the export destination.