### PR TITLE
[desktop] Flush file writes

### DIFF
--- a/desktop/src/main/services/fs.ts
+++ b/desktop/src/main/services/fs.ts
@@ -22,7 +22,7 @@ export const fsReadTextFile = async (filePath: string) =>
     fs.readFile(filePath, "utf-8");
 
 export const fsWriteFile = (path: string, contents: string) =>
-    fs.writeFile(path, contents);
+    fs.writeFile(path, contents, { flush: true });
 
 export const fsIsDir = async (dirPath: string) => {
     if (!existsSync(dirPath)) return false;


### PR DESCRIPTION
A customer reported a partial export_status.json being written to an external drive. Forcing a flush to attempt to reduce chances of this happening. Since this particular code path is only used for writing JSON files (export status and metadata), we unconditionally enable this for all writes.
