### PR TITLE
[auth] Make "Ente Auth" at the top of app similar to marketing images/Photos app

### DIFF
--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -354,7 +354,7 @@ class _HomePageState extends State<HomePage> {
         resizeToAvoidBottomInset: false,
         appBar: AppBar(
           title: !_showSearchBox
-              ? const Text('Ente Auth')
+              ? const Text('Ente Auth', style: brandStyleMedium)
               : TextField(
                   autocorrect: false,
                   enableSuggestions: false,

--- a/auth/lib/ui/home_page.dart
+++ b/auth/lib/ui/home_page.dart
@@ -18,6 +18,7 @@ import 'package:ente_auth/services/preference_service.dart';
 import 'package:ente_auth/services/user_service.dart';
 import 'package:ente_auth/store/code_display_store.dart';
 import 'package:ente_auth/store/code_store.dart';
+import 'package:ente_auth/theme/text_style.dart';
 import 'package:ente_auth/ui/account/logout_dialog.dart';
 import 'package:ente_auth/ui/code_error_widget.dart';
 import 'package:ente_auth/ui/code_widget.dart';


### PR DESCRIPTION
## Description

Currently the "Ente Auth" text at the top of the mobile/desktop app is different in style to the one in the marketing images and the equivalent in the Photos app. So I just copied the style from the Photos app.

Marketing image:

![auth-home-screen-dark](https://github.com/user-attachments/assets/0e90b524-391c-4de5-b5d4-da4688149aea)

Currently: (not the latest version of the app but the text part is the same except for the capitalization)

![screenshots](https://github.com/user-attachments/assets/cd39fdf1-d518-4b24-8f60-e0960f2c9985)

## Tests

I haven't tested this.
