### PR TITLE
[server] Fix canDowngrade storage check

### DIFF
--- a/server/ente/storagebonus/storge_bonus.go
+++ b/server/ente/storagebonus/storge_bonus.go
@@ -133,6 +133,8 @@ func (a *ActiveStorageBonus) GetAddonStorage() int64 {
 	return addonStorage
 }
 
+// GetUsableBonus Returns the add_on_bonus + referral_bonus for a given user. The referral bonus is restricted
+// to max of addonStorage + subStorage
 func (a *ActiveStorageBonus) GetUsableBonus(subStorage int64) int64 {
 	refBonus := a.GetReferralBonus()
 	totalSubAndAddOnStorage := a.GetAddonStorage() + subStorage


### PR DESCRIPTION
## Description
Previously, we were only checking if the usage is less than newStorage + Paid Add Ons.
If the user also have referral bonus, we also need to calculate the new usable bonus based on the newStorage.

## Tests
