### PR TITLE
[server] Add workaround for intermittent Safari CORS errors

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1007,7 +1007,9 @@ func cors() gin.HandlerFunc {
 		c.Writer.Header().Set("Access-Control-Max-Age", "1728000")
 
 		if c.Request.Method == http.MethodOptions {
-			c.AbortWithStatus(http.StatusNoContent)
+			// While 204 No Content is more appropriate, Safari intermittently
+			// (intermittently!) fails CORS if we return 204 instead of 200 OK.
+			c.Status(http.StatusOK)
 			return
 		}
 		c.Next()


### PR DESCRIPTION
At times, Safari will fail our API responses because its CORS preflight fails. The errors are reproducible, but intermittently, and not on localhost.  We seem not to be the first ones to hit [this](https://github.com/processing/p5.js-web-editor/issues/3156).

Based on a hint from:

https://github.com/supabase/supabase/issues/20982#issuecomment-2548329565

Modify our CORS responses to use 200 instead of 204 to try and fix Safari.
