### PR TITLE
[server] Retain published image commit as branch instead of tag

### DIFF
--- a/.github/workflows/server-publish.yml
+++ b/.github/workflows/server-publish.yml
@@ -1,4 +1,4 @@
-name: "Publish (server)"
+name: "Publish ghcr (server)"
 
 on:
     # Run manually, providing it the commit.
@@ -39,7 +39,6 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Tag as server/ghcr
+            - name: Update branch server/ghcr to point to source commit
               run: |
-                  git tag -f server/ghcr
-                  git push -f origin server/ghcr
+                  git push -f origin HEAD:server/ghcr

--- a/server/docs/publish.md
+++ b/server/docs/publish.md
@@ -40,6 +40,7 @@ Once the workflow completes, the resultant image will be available at
 `ghcr.io/ente-io/server`. The image will be tagged by the commit SHA. The latest
 image will also be tagged, well, "latest".
 
-The workflow will also tag the commit it used to build the image with
-`server/ghcr`. This tag will be overwritten on each publish, and it'll point to
-the code that was used in the most recent publish.
+The workflow will also update the branch `server/ghcr` to point to the commit it
+used to build the image. This branch will be overwritten on each publish, and
+thus it `server/ghcr` points to the code from which the most recent ghcr docker
+image for museum has been built.


### PR DESCRIPTION
Overwriting tags is clunky (besides being generally discouraged). e.g. pulling the overwritten tags locally requires `git fetch --force --tags`. So instead use the branch `server/ghcr` to point to the commit from which the latest published ghcr docker image has been built.
