### PR TITLE
[auth] Fix ~/.cache being deleted on linux

### DIFF
--- a/auth/lib/utils/directory_utils.dart
+++ b/auth/lib/utils/directory_utils.dart
@@ -27,9 +27,9 @@ class DirectoryUtils {
     Directory? directory;
     if (Platform.isLinux) {
       try {
-        return cacheHome;
+        return await getApplicationCacheDirectory();
       } catch (e) {
-        logger.warning("Failed to get cacheHome: $e");
+        logger.warning("Failed to get application cache directory: $e");
       }
     }
 

--- a/auth/lib/utils/directory_utils.dart
+++ b/auth/lib/utils/directory_utils.dart
@@ -24,16 +24,7 @@ class DirectoryUtils {
   }
 
   static Future<Directory> getDirectoryForInit() async {
-    Directory? directory;
-    if (Platform.isLinux) {
-      try {
-        return await getApplicationCacheDirectory();
-      } catch (e) {
-        logger.warning("Failed to get application cache directory: $e");
-      }
-    }
-
-    directory ??= await getApplicationDocumentsDirectory();
+    Directory directory = await getApplicationCacheDirectory();
 
     return Directory(p.join(directory.path, "enteauthinit"));
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/ente-io/ente/issues/4536 and https://github.com/ente-io/ente/issues/4464.

## Tests

After opening the app on linux, my 1.3G cache folder remained intact.

## Technical details

Now the path resolves to `~/.cache/io.ente.auth` instead of `~/.cache`. [Under the hood](https://github.com/flutter/packages/blob/ca4671cc0f2d0a347db662144978f06ae9c017e8/packages/path_provider/path_provider_linux/lib/src/path_provider_linux.dart#L75-L82) it uses the app's ID and the `xdg_directories` package, so it will work when the user has `XDG_CACHE_HOME` set to something else.