### PR TITLE
Update AASA to be more specific on what links to open

### DIFF
--- a/web/apps/photos/public/.well-known/apple-app-site-association
+++ b/web/apps/photos/public/.well-known/apple-app-site-association
@@ -6,12 +6,12 @@
         "appIDs": [
           "6Z68YJY9Q2.io.ente.frame"
         ],
-        "paths": [
-          "*"
-        ],
         "components": [
           {
-            "/": "/*"
+            "/": "/",
+            "?": { "t": "*" },
+            "#": "*",
+            "comment": "Matches URLs with no path, any query item 't', and any or no fragment"
           }
         ]
       }


### PR DESCRIPTION
## Description

iOS sometimes falls back to opening Ente Photos app if Safari is disabled and AASA claims all paths even if a non-matching domain link is tapped. So making it more specific in AASA on what to open.
