### PR TITLE
Fix Belo icon displaying as a violet square instead of the correct icon

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -73,8 +73,7 @@
       ]
     },
     {
-      "title": "Belo",
-      "hex": "5717d4"
+      "title": "Belo"
     },
     {
       "title": "Bethesda",


### PR DESCRIPTION
Fixing the icon introduced in https://github.com/ente-io/ente/pull/4548