### PR TITLE
[mob][photos] Use better batching when freeing up space in batches on iOS

### DIFF
--- a/mobile/lib/utils/delete_file_util.dart
+++ b/mobile/lib/utils/delete_file_util.dart
@@ -659,7 +659,7 @@ Future<List<String>> _iosDeleteLocalFilesInBatchesFallback(
     "Trying to delete local files in batches",
   );
   deletedIDs.addAll(
-    await _deleteLocalFilesInBatchesRecursively(localAssetIDs),
+    await _deleteLocalFilesInBatchesRecursively(localAssetIDs, context),
   );
   if (deletedIDs.isEmpty) {
     _logger.warning(
@@ -676,10 +676,11 @@ Future<List<String>> _iosDeleteLocalFilesInBatchesFallback(
 
 Future<List<String>> _deleteLocalFilesInBatchesRecursively(
   List<String> localAssetIDs,
+  BuildContext context,
 ) async {
   if (localAssetIDs.isEmpty) return [];
 
-  final deletedIDs = await _deleteLocalFiles(localAssetIDs);
+  final deletedIDs = await _deleteLocalFiles(localAssetIDs, context);
   if (deletedIDs.isNotEmpty) {
     return deletedIDs;
   }
@@ -693,13 +694,18 @@ Future<List<String>> _deleteLocalFilesInBatchesRecursively(
   final left = localAssetIDs.sublist(0, midIndex);
   final right = localAssetIDs.sublist(midIndex);
 
-  final leftDeleted = await _deleteLocalFilesInBatchesRecursively(left);
-  final rightDeleted = await _deleteLocalFilesInBatchesRecursively(right);
+  final leftDeleted =
+      await _deleteLocalFilesInBatchesRecursively(left, context);
+  final rightDeleted =
+      await _deleteLocalFilesInBatchesRecursively(right, context);
 
   return [...leftDeleted, ...rightDeleted];
 }
 
-Future<List<String>> _deleteLocalFiles(List<String> localIDs) async {
+Future<List<String>> _deleteLocalFiles(
+  List<String> localIDs,
+  BuildContext context,
+) async {
   _logger.info(
     "Trying to delete batch of size " +
         localIDs.length.toString() +
@@ -707,13 +713,22 @@ Future<List<String>> _deleteLocalFiles(List<String> localIDs) async {
         localIDs.toString(),
   );
 
+  final dialog = createProgressDialog(
+    context,
+    "Deleting " + localIDs.length.toString() + " backed up files...",
+  );
+  await dialog.show();
+
   final List<String> deletedIDs = [];
   try {
     deletedIDs.addAll(await PhotoManager.editor.deleteWithIds(localIDs));
     _logger.info("Deleted " + localIDs.toString());
   } catch (e, s) {
     _logger.severe("Could not delete batch " + localIDs.toString(), e, s);
+    await showGenericErrorDialog(context: context, error: e);
   }
+
+  await dialog.hide();
 
   return deletedIDs;
 }

--- a/mobile/lib/utils/delete_file_util.dart
+++ b/mobile/lib/utils/delete_file_util.dart
@@ -673,7 +673,7 @@ Future<List<String>> _iosDeleteLocalFilesInBatchesFallback(
       );
     }
     maximumBatchSize = max((maximumBatchSize ~/ 2), 10);
-  } while (deletedIDs.isEmpty && maximumBatchSize >= 10);
+  } while (deletedIDs.isEmpty && maximumBatchSize > 10);
 
   _logger.severe("iOS free-space fallback, deleted ${deletedIDs.length} files "
       "in batches}");

--- a/mobile/lib/utils/delete_file_util.dart
+++ b/mobile/lib/utils/delete_file_util.dart
@@ -675,7 +675,8 @@ Future<List<String>> _iosDeleteLocalFilesInBatchesFallback(
     maximumBatchSize = max((maximumBatchSize ~/ 2), 10);
   } while (deletedIDs.isEmpty && maximumBatchSize > 10);
 
-  _logger.severe("iOS free-space fallback, deleted ${deletedIDs.length} files "
+  _logger.severe(
+      "iOS free-space fallback, deleted ${deletedIDs.length} files with distinct localIDs"
       "in batches}");
 
   return deletedIDs;

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,7 +12,7 @@ description: ente photos application
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 0.9.75+975
+version: 0.9.76+976
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Description

On iOS, deletion fails without any error if a batch has at least one shared file. The only indicator that deletion failed is `List<String>` returned by `PhotoManager.editor.deleteWithIds` will be empty.

So if shared files are distributed pretty evenly across list of `localIDs` to be deleted, almost all batches would fail even with a batch size of 10 (which was the minimum batch size before this change). 

Recursively trying with a smaller batch size if the bigger batch size fails makes it possible to delete all non-shared local files with more system delete conformation dialogs though, but gets the work done for users blocked on this. 


```plaintext
[A, B, C, D, E]
 └─ Attempt to delete; if failure:
    ├─ [A, B]
    │  └─ Attempt to delete; if failure:
    │     ├─ [A]
    │     └─ [B]
    └─ [C, D, E]
       └─ Attempt to delete; if failure:
          ├─ [C]
          └─ [D, E]
             └─ Attempt to delete; if failure:
                ├─ [D]
                └─ [E]