### PR TITLE
 Fixes to make the source 32bit compatible

### DIFF
--- a/server/ente/billing.go
+++ b/server/ente/billing.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// FreePlanStorage is the amount of storage in free plan
-	FreePlanStorage = 5 * 1024 * 1024 * 1024
+	FreePlanStorage int64 = 5 * 1024 * 1024 * 1024
 	// FreePlanProductID is the product ID of free plan
 	FreePlanProductID = "free"
 	// FreePlanTransactionID is the dummy transaction ID for the free plan
@@ -112,7 +112,7 @@ type BillingPlan struct {
 }
 
 type FreePlan struct {
-	Storage  int    `json:"storage"`
+	Storage  int64  `json:"storage"`
 	Duration int    `json:"duration"`
 	Period   string `json:"period"`
 }

--- a/server/pkg/middleware/rate_limit.go
+++ b/server/pkg/middleware/rate_limit.go
@@ -19,13 +19,13 @@ import (
 )
 
 type RateLimitMiddleware struct {
-	limit10ReqPerMin  *limiter.Limiter
-	limit200ReqPerSec *limiter.Limiter
-	discordCtrl       *discord.DiscordController
 	count             int64 // Use int64 for atomic operations
 	limit             int64
 	reset             time.Duration
 	ticker            *time.Ticker
+	limit10ReqPerMin  *limiter.Limiter
+	limit200ReqPerSec *limiter.Limiter
+	discordCtrl       *discord.DiscordController
 }
 
 func NewRateLimitMiddleware(discordCtrl *discord.DiscordController, limit int64, reset time.Duration) *RateLimitMiddleware {


### PR DESCRIPTION
## Description
I have tried to build ente server using the source and have found various bugs that in a 64bit system would not pose an issue but when ran on 32bit architecture would result in errors. After the fixes, Ente works beautifully.

## Why bother merging?
I understand that Ente does not support 32bit architectures by nature and hence there would be no point in merging this PR and solving these issues but I have put this PR out there in hopes that it helps others run Ente on their own desired architecture. 

## Changes Description
1. `billing.go` - `storage` variables are not properly typed as int64 despite them being able to hold more than the 32bit integer limit. On a 32bit system, this will lead to an integer overflow (especially with the default 5GB value). Typing them appropriately as an int64 will resolve this bug and have no impacts on a 64bit execution.
2. `rate_limit.go` - The code as is will result in an unaligned 64bit atomic operation ([read more](https://blog.openziti.io/my-pi-day-journey-with-go-64-bit-alignment)). In short, the fields were ordered in a way that `count` would start at the middle of an 8-byte block which is not permitted. Aligning it by reordering it does not affect the functional aspect but in terms of golang's memory management, the int64 fields are now properly at an 8-byte boundary, fixing the issue.

## Other 32bit changes
To other open source tinkerers out there, if you wish to use Ente on a 32bit architecture, the dependencies will also need to be recompiled and rebuilt as they do not have openly available docker images for arm32. Feel free to use [my built images](https://github.com/fourjr/ente-megarepo-arm32v7).