### PR TITLE
[web] Restore translations for search

### DIFF
--- a/web/packages/base/locales/ar-SA/translation.json
+++ b/web/packages/base/locales/ar-SA/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "",
     "SHARING_BAD_REQUEST_ERROR": "لا يسمح بمشاركة الألبوم",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "المشاركة معطلة للحسابات المجانية",
-    "search": "",
+    "search": "بحث",
     "search_results": "نتائج البحث",
     "no_results": "لا توجد نتائج",
     "search_hint": "البحث عن الألبومات، التواريخ، والأوصاف...",

--- a/web/packages/base/locales/de-DE/translation.json
+++ b/web/packages/base/locales/de-DE/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Hoppla, Sie teilen dies bereits mit {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Albumfreigabe nicht erlaubt",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Freigabe ist für kostenlose Konten deaktiviert",
-    "search": "",
+    "search": "Suchen",
     "search_results": "Ergebnisse durchsuchen",
     "no_results": "Keine Ergebnisse gefunden",
     "search_hint": "Suche nach Alben, Datum, Beschreibungen, ...",

--- a/web/packages/base/locales/el-GR/translation.json
+++ b/web/packages/base/locales/el-GR/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "",
     "SHARING_BAD_REQUEST_ERROR": "Δεν επιτρέπεται η κοινοποίηση άλμπουμ",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Η κοινοποίηση είναι απενεργοποιημένη στους δωρεάν λογαριασμούς",
-    "search": "",
+    "search": "Αναζήτηση",
     "search_results": "Αποτελέσματα αναζήτησης",
     "no_results": "Δε βρέθηκαν αποτελέσματα",
     "search_hint": "",

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Oops, you're already sharing this with {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Sharing album not allowed",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Sharing is disabled for free accounts",
-    "search": "search",
+    "search": "Search",
     "search_results": "Search results",
     "no_results": "No results found",
     "search_hint": "Search for albums, dates, descriptions, ...",

--- a/web/packages/base/locales/es-ES/translation.json
+++ b/web/packages/base/locales/es-ES/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Uy, ya estás compartiendo esto con {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Compartir álbum no permitido",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Compartir está desactivado para cuentas gratis",
-    "search": "",
+    "search": "Buscar",
     "search_results": "Buscar resultados",
     "no_results": "No se han encontrado resultados",
     "search_hint": "Buscar álbumes, fechas...",

--- a/web/packages/base/locales/fr-FR/translation.json
+++ b/web/packages/base/locales/fr-FR/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Oups, vous partager déjà cela avec {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Partage d'album non autorisé",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Le partage est désactivé pour les comptes gratuits",
-    "search": "",
+    "search": "Recherche",
     "search_results": "Résultats de la recherche",
     "no_results": "Aucun résultat trouvé",
     "search_hint": "Recherche d'albums, dates, descriptions, ...",

--- a/web/packages/base/locales/it-IT/translation.json
+++ b/web/packages/base/locales/it-IT/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Ops, lo stai già condividendo con {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Condividere gli album non è consentito",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "La condivisione è disabilitata per gli account free",
-    "search": "",
+    "search": "Ricerca",
     "search_results": "Risultati della ricerca",
     "no_results": "Nessun risultato trovato",
     "search_hint": "Cerca per album, date, descrizioni, ...",

--- a/web/packages/base/locales/lt-LT/translation.json
+++ b/web/packages/base/locales/lt-LT/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Ups, jūs jau bendrinate tai su {{email}}.",
     "SHARING_BAD_REQUEST_ERROR": "Neleidžiama bendrinti albumo.",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Bendrinimas išjungtas nemokamoms paskyroms.",
-    "search": "",
+    "search": "Ieškoti",
     "search_results": "Paieškos rezultatai",
     "no_results": "Rezultatų nerasta.",
     "search_hint": "Ieškokite albumų, datų ir aprašymų...",

--- a/web/packages/base/locales/nl-NL/translation.json
+++ b/web/packages/base/locales/nl-NL/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Oeps, je deelt dit al met {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Album delen niet toegestaan",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Delen is uitgeschakeld voor gratis accounts",
-    "search": "",
+    "search": "Zoeken",
     "search_results": "Zoekresultaten",
     "no_results": "Geen resultaten gevonden",
     "search_hint": "Zoeken naar albums, datums ...",

--- a/web/packages/base/locales/pl-PL/translation.json
+++ b/web/packages/base/locales/pl-PL/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Ups, już to udostępniasz z {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Udostępnianie albumu nie jest dozwolone",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Udostępnianie jest wyłączone dla darmowych kont",
-    "search": "",
+    "search": "Szukaj",
     "search_results": "Wyniki wyszukiwania",
     "no_results": "Nie znaleziono wyników",
     "search_hint": "Szukaj albumów, dat, opisów, ...",

--- a/web/packages/base/locales/pt-BR/translation.json
+++ b/web/packages/base/locales/pt-BR/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Opa! Você já está compartilhando isso com {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Não permitido compartilhar álbum",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "A compartilhação está desativada para contas grátis",
-    "search": "",
+    "search": "Buscar",
     "search_results": "Resultados da busca",
     "no_results": "Nenhum resultado encontrado",
     "search_hint": "Buscar álbuns, datas, descrições, ...",

--- a/web/packages/base/locales/pt-PT/translation.json
+++ b/web/packages/base/locales/pt-PT/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Já está a partilhar isto com o {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Álbum compartilhado não permitido",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "A partilha está desactivada para contas gratuitas",
-    "search": "",
+    "search": "Pesquisar",
     "search_results": "Resultados de pesquisa",
     "no_results": "Nenhum resultado encontrado",
     "search_hint": "Procurar por álbuns, datas, descrições, ...",

--- a/web/packages/base/locales/ru-RU/translation.json
+++ b/web/packages/base/locales/ru-RU/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Упс, Вы уже делились этим с {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Делиться альбомом запрещено",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Совместное использование отключено для бесплатных аккаунтов",
-    "search": "",
+    "search": "Поиск",
     "search_results": "Результаты поиска",
     "no_results": "Ничего не найдено",
     "search_hint": "Поиск альбомов, дат, описаний, ...",

--- a/web/packages/base/locales/sv-SE/translation.json
+++ b/web/packages/base/locales/sv-SE/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "",
     "SHARING_BAD_REQUEST_ERROR": "",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "",
-    "search": "",
+    "search": "Sök",
     "search_results": "Sökresultat",
     "no_results": "Inga resultat hittades",
     "search_hint": "Sök efter album, datum, beskrivningar, ...",

--- a/web/packages/base/locales/uk-UA/translation.json
+++ b/web/packages/base/locales/uk-UA/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Упс, ви вже ділитеся цим з {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Заборонено ділитися альбомом",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Спільний доступ вимкнено для безплатних облікових записів",
-    "search": "",
+    "search": "Пошук",
     "search_results": "Результати пошуку",
     "no_results": "Нічого не знайдено",
     "search_hint": "Пошук альбомів, дат, описів, ...",

--- a/web/packages/base/locales/vi-VN/translation.json
+++ b/web/packages/base/locales/vi-VN/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "Ôi, bạn đã chia sẻ điều này với {{email}}",
     "SHARING_BAD_REQUEST_ERROR": "Chia sẻ album không được phép",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "Chia sẻ bị vô hiệu hóa cho các tài khoản miễn phí",
-    "search": "",
+    "search": "Tìm kiếm",
     "search_results": "Kết quả tìm kiếm",
     "no_results": "Không tìm thấy kết quả",
     "search_hint": "Tìm kiếm album, ngày tháng, mô tả, ...",

--- a/web/packages/base/locales/zh-CN/translation.json
+++ b/web/packages/base/locales/zh-CN/translation.json
@@ -206,7 +206,7 @@
     "ALREADY_SHARED": "哎呀，您已经和 {{email}} 分享了",
     "SHARING_BAD_REQUEST_ERROR": "不允许分享相册",
     "SHARING_DISABLED_FOR_FREE_ACCOUNTS": "免费账户禁用共享",
-    "search": "",
+    "search": "搜索",
     "search_results": "搜索结果",
     "no_results": "未找到任何结果",
     "search_hint": "搜索相册、日期、描述，...",


### PR DESCRIPTION
Crowdin apparently overrode them even when we selected the option to retain translations when changing the case and then manually fixing the case in their web UI.
