### PR TITLE
[auth] Use issuerName as default sort key

### DIFF
--- a/auth/lib/services/preference_service.dart
+++ b/auth/lib/services/preference_service.dart
@@ -38,7 +38,7 @@ class PreferenceService {
 
   CodeSortKey codeSortKey() {
     return CodeSortKey
-        .values[_prefs.getInt("codeSortKey") ?? CodeSortKey.manual.index];
+        .values[_prefs.getInt("codeSortKey") ?? CodeSortKey.issuerName.index];
   }
 
   Future<void> setCodeSortKey(CodeSortKey key) async {

--- a/auth/pubspec.yaml
+++ b/auth/pubspec.yaml
@@ -1,7 +1,7 @@
 
 name: ente_auth
 description: ente two-factor authenticator
-version: 4.2.4+424
+version: 4.2.5+425
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Description

Resolves https://github.com/ente-io/ente/issues/4670 (confusion for users who upgrade or install the app on a new device)


## Tests
