### PR TITLE
[auth] fix generic icon not updating when issuer name is changed

### DIFF
--- a/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
+++ b/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
@@ -362,7 +362,13 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
               CodeDisplay(tags: selectedTags);
       display.note = notes;
 
-      display.iconID = _customIconID.toLowerCase();
+      if (widget.code!.issuer != issuer) {
+        display.iconID = issuer.toLowerCase();
+      }
+      if (widget.code!.display.iconID != _customIconID.toLowerCase()) {
+        display.iconID = _customIconID.toLowerCase();
+      }
+
       display.iconSrc =
           _iconSrc == IconType.simpleIcon ? 'simpleIcon' : 'customIcon';
 


### PR DESCRIPTION
## Description
Fix #4683 
1. If the name of `issuer` is change the icon is updated accordingly
2. If the `issuer` name and the `custom icon` (from the icon picker) both are changed than the final icon is selected from the custom icon. 

## Tests
