### PR TITLE
[auth] Fix logo for Enom

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -316,7 +316,7 @@
     },
     {
       "title": "enom",
-      "slug": "enom_v1"
+      "slug": "enom"
     },
     {
       "title": "Epic Games",


### PR DESCRIPTION
Fix enom logo "slug"

## Description
Enom logo wasn't working

## Tests
tested this edit on the desktop version and worked.