### PR TITLE
[cli] sync deleted files before syncing new/updates files

### DIFF
--- a/cli/pkg/model/remote.go
+++ b/cli/pkg/model/remote.go
@@ -65,7 +65,7 @@ type AlbumFileEntry struct {
 func SortAlbumFileEntry(entries []*AlbumFileEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].IsDeleted != entries[j].IsDeleted {
-			return !entries[i].IsDeleted && entries[j].IsDeleted
+			return entries[i].IsDeleted && !entries[j].IsDeleted
 		}
 		return entries[i].AlbumID < entries[j].AlbumID
 	})


### PR DESCRIPTION
## Description
The CLI sorts deleted photos to the bottom of the sync queue. 
When an album is synced, a photo is removed from the album and later re-added to the album (same name) and doing another sync the new file is added first and a new name is generated since the original filename is (still) taken. Afterwards the initial photo is deleted and the filename would be available.
This leads to having a file, e.g. IMG_0001_1.JPG instead of the original filename IMG_0001.JPG despite the initial filename is no longer on disk and could have been used.

This PR changes the sort order so that deleted files are first removed and afterwards new files are created. In this case all files where the filename is now available, but were taken, are named like they were uploaded.