### PR TITLE
[desktop] Update build for latest electron builder

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
         "build:quick": "yarn build-renderer && yarn build-main:quick",
         "build-main": "tsc && electron-builder",
         "build-main:quick": "tsc && electron-builder --dir --config.compression=store --config.mac.identity=null",
-        "build-renderer": "cross-env-shell _ENTE_IS_DESKTOP=1 \"cd ../web && yarn install && yarn build:photos && cd ../desktop && shx rm -f out && shx ln -sf ../web/apps/photos/out out\"",
+        "build-renderer": "cross-env-shell _ENTE_IS_DESKTOP=1 \"cd ../web && yarn install && yarn build:photos && cd ../desktop && shx rm -rf out && shx cp -r ../web/apps/photos/out out\"",
         "dev": "concurrently --kill-others --success first --names 'main,rndr' \"yarn dev-main\" \"yarn dev-renderer\"",
         "dev-main": "tsc && electron .",
         "dev-renderer": "cross-env-shell _ENTE_IS_DESKTOP=1 \"cd ../web && yarn install && yarn workspace photos next dev -p 3008\"",


### PR DESCRIPTION
Since the eb update, the CI job fails with errors like

    unable to copy, file is symlinked outside the package  source=out/404.html realPathFile=/Users/runner/work/photos-desktop/photos-desktop/web/apps/photos/out/404.html

    Error: Cannot copy file (xxx.js) symlinked to file (xxx.js) outside the package as that violates asar security integrity
      at writeFileOrProcessSymlink (/Users/runner/work/photos-desktop/photos-desktop/desktop/node_modules/app-builder-lib/src/asar/asarUtil.ts:126:15)
