### PR TITLE
[desktop] Attempt to fix macOS universal build after electron builder update

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -34,3 +34,4 @@ mac:
         arch: [universal]
     category: public.app-category.photography
     hardenedRuntime: true
+    mergeASARs: false


### PR DESCRIPTION
CI failures since updating Electron building (and Electron):

 • packaging       platform=darwin arch=arm64 electron=34.0.0 appOutDir=dist/mac-universal-arm64-temp
  • packaging       platform=darwin arch=universal electron=34.0.0 appOutDir=dist/mac-universal
  ⨯ pattern is too long  failedTask=build stackTrace=TypeError: pattern is too long
