### PR TITLE
[server] Report a client error instead of 5xx on invalid pk signature

### DIFF
--- a/server/pkg/repo/passkey/passkey.go
+++ b/server/pkg/repo/passkey/passkey.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ente-io/museum/ente"
 	"github.com/ente-io/museum/pkg/utils/byteMarshaller"
@@ -392,7 +393,8 @@ func (r *Repository) FinishAuthentication(user *ente.User, req *http.Request, se
 
 	_, err = r.webAuthnInstance.FinishLogin(passkeyUser, *sessionData, req)
 	if err != nil {
-		err = stacktrace.Propagate(err, "")
+		logrus.Warnf("Could not finish passkey authentication: %s", err)
+		err = &ente.ApiError{Code: ente.BadRequest, Message: "Invalid signature", HttpStatusCode: http.StatusUnauthorized}
 		return
 	}
 


### PR DESCRIPTION
e.g.

    --- at /etc/ente/pkg/api/user.go:352 (UserHandler.FinishPasskeyAuthenticationCeremony) ---
    --- at /etc/ente/pkg/repo/passkey/passkey.go:395 (Repository.FinishAuthentication) ---
    Caused by: Error validating the assertion signature: \u003cnil\u003e

## Tested by

Modifying the pk app to pass null as the signature, and observing that client gets back a 401 (previously 500).
