### PR TITLE
[auth] Update custom-icons.json

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -1106,13 +1106,6 @@
       "slug": "wargamingnet"
     },
     {
-      "title": "World Cube Association",
-      "altNames": [
-        "WCA",
-        "worldcubeassociation"
-      ]
-    },
-    {
       "title": "Wealthfront"
     },
     {
@@ -1138,6 +1131,14 @@
       "title": "WorkOS",
       "altNames": [
         "Work OS"
+      ]
+    },
+    {
+      "title": "World Cube Association",
+      "slug": "wca",
+      "altNames": [
+        "WCA",
+        "worldcubeassociation"
       ]
     },
     {


### PR DESCRIPTION
I moved World Cube Association entry to the proper alphabetical place and added the "slug" line because icon is showing blank and I think that could be the reason.

If there's other common issues with blank SVG icons I would love to check it, because I've not touch the icon code and is showing in red for closing `</g>` but is showing fine in the viewer.

Sorry about this.
Regards