### PR TITLE
[auth] Fix logout button not showing on lockscreen

### DIFF
--- a/auth/lib/ui/tools/lock_screen.dart
+++ b/auth/lib/ui/tools/lock_screen.dart
@@ -33,8 +33,7 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
   int remainingTimeInSeconds = 0;
   final _lockscreenSetting = LockScreenSettings.instance;
   late Brightness _platformBrightness;
-  final bool hasOptedForOfflineMode =
-      Configuration.instance.hasOptedForOfflineMode();
+  final bool isLoggedIn = Configuration.instance.isLoggedIn();
 
   @override
   void initState() {
@@ -56,15 +55,15 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        leading: hasOptedForOfflineMode
-            ? const SizedBox.shrink()
-            : IconButton(
+        leading: isLoggedIn
+            ? IconButton(
                 icon: const Icon(Icons.logout_outlined),
                 color: Theme.of(context).iconTheme.color,
                 onPressed: () {
                   _onLogoutTapped(context);
                 },
-              ),
+              )
+            : const SizedBox.shrink(),
       ),
       body: GestureDetector(
         onTap: () {


### PR DESCRIPTION
## Description
1. Logout button was hidden when user first opt for **Use without backup** and then **Log in** due the `hasOptedForOfflineMode` been set to true if we follow the above way , fixed by checking `isLoggedIn`
## Tests
