### PR TITLE
[mob] Store remote ml data before scheduling processing

### DIFF
--- a/mobile/lib/services/filedata/model/file_data.dart
+++ b/mobile/lib/services/filedata/model/file_data.dart
@@ -85,6 +85,17 @@ class FileDataEntity {
           remoteRawData[_clipKey] as Map<String, dynamic>,
         )
       : null;
+
+  RemoteClipEmbedding? getClipEmbeddingIfCompatible(
+    int minClipMlVersion,
+  ) {
+    final clipData = remoteRawData[_clipKey];
+    if (clipData == null) return null;
+
+    final clipEmbedding =
+        RemoteClipEmbedding.fromJson(clipData as Map<String, dynamic>);
+    return clipEmbedding.version >= minClipMlVersion ? clipEmbedding : null;
+  }
 }
 
 class RemoteFaceEmbedding {

--- a/mobile/lib/services/filedata/model/file_data.dart
+++ b/mobile/lib/services/filedata/model/file_data.dart
@@ -80,12 +80,6 @@ class FileDataEntity {
         )
       : null;
 
-  RemoteClipEmbedding? get clipEmbedding => remoteRawData[_clipKey] != null
-      ? RemoteClipEmbedding.fromJson(
-          remoteRawData[_clipKey] as Map<String, dynamic>,
-        )
-      : null;
-
   RemoteClipEmbedding? getClipEmbeddingIfCompatible(
     int minClipMlVersion,
   ) {

--- a/mobile/lib/utils/ml_util.dart
+++ b/mobile/lib/utils/ml_util.dart
@@ -235,6 +235,9 @@ Stream<List<FileMLInstruction>> fetchEmbeddingsAndInstructions(
         pendingIndex[fileMl.fileID] = existingInstruction;
       }
     }
+
+    await mlDataDB.bulkInsertFaces(faces);
+    await mlDataDB.putClip(clipEmbeddings);
     for (final fileID in pendingIndex.keys) {
       final instruction = pendingIndex[fileID]!;
       if (instruction.pendingML) {
@@ -246,8 +249,6 @@ Stream<List<FileMLInstruction>> fetchEmbeddingsAndInstructions(
         }
       }
     }
-    await mlDataDB.bulkInsertFaces(faces);
-    await mlDataDB.putClip(clipEmbeddings);
   }
   // Yield any remaining instructions
   if (batchToYield.isNotEmpty) {

--- a/mobile/lib/utils/ml_util.dart
+++ b/mobile/lib/utils/ml_util.dart
@@ -217,13 +217,14 @@ Stream<List<FileMLInstruction>> fetchEmbeddingsAndInstructions(
         faces.addAll(facesFromRemoteEmbedding);
         existingInstruction.shouldRunFaces = false;
       }
-      if (fileMl.clipEmbedding != null &&
-          fileMl.clipEmbedding!.version >= clipMlVersion) {
+      final remoteClipEmbedding =
+          fileMl.getClipEmbeddingIfCompatible(clipMlVersion);
+      if (remoteClipEmbedding != null) {
         clipEmbeddings.add(
           ClipEmbedding(
             fileID: fileMl.fileID,
-            embedding: fileMl.clipEmbedding!.embedding,
-            version: fileMl.clipEmbedding!.version,
+            embedding: remoteClipEmbedding.embedding,
+            version: remoteClipEmbedding.version,
           ),
         );
         existingInstruction.shouldRunClip = false;


### PR DESCRIPTION
## Description
This will ensure that MLData that was already fetched is saved in the DB before running the ML pipeline on files that requires indexing. 

## Tests
