### PR TITLE
Add support for Takeout's new .supplemental-metadata.json files

### DIFF
--- a/web/apps/photos/tests/upload.test.ts
+++ b/web/apps/photos/tests/upload.test.ts
@@ -7,10 +7,11 @@ import {
 } from "@/new/photos/services/files";
 import { parseDateFromDigitGroups } from "services/upload/date";
 import {
-    MAX_FILE_NAME_LENGTH_GOOGLE_EXPORT,
     getClippedMetadataJSONMapKeyForFile,
     getMetadataJSONMapKeyForFile,
     getMetadataJSONMapKeyForJSON,
+    getSupplementaryMetadataJSONMapKeyForFile,
+    getFileNameComponents,
 } from "services/upload/takeout";
 import { getUserDetailsV2 } from "services/userService";
 
@@ -99,6 +100,30 @@ const FILE_NAME_TO_JSON_NAME = [
     {
         filename: "IMG2021021(1)74722(1).jpg",
         jsonFilename: "IMG2021021(1)74722.jpg(1).json",
+    },
+    {
+        filename: "IMG_1159.HEIC",
+        jsonFilename: "IMG_1159.HEIC.supplemental-metadata.json",
+    },
+    {
+        filename: "PXL_20241231_151646544.MP.jpg",
+        jsonFilename: "PXL_20241231_151646544.MP.jpg.supplemental-met.json",
+    },
+    {
+        filename: "PXL_20240827_094331806.PORTRAIT(1).jpg",
+        jsonFilename: "PXL_20240827_094331806.PORTRAIT.jpg.supplement(1).json",
+    },
+    {
+        filename: "PXL_20240506_142610305.LONG_EXPOSURE-01.COVER.jpg",
+        jsonFilename: "PXL_20240506_142610305.LONG_EXPOSURE-01.COVER..json",
+    },
+    {
+        filename: "PXL_20211120_223243932.MOTION-02.ORIGINAL.jpg",
+        jsonFilename: "PXL_20211120_223243932.MOTION-02.ORIGINAL.jpg..json",
+    },
+    {
+        filename: "20220322_205147-edited(1).jpg",
+        jsonFilename: "20220322_205147.jpg.supplemental-metadata(1).json",
     },
 ];
 
@@ -401,14 +426,20 @@ function mappingFileAndJSONFileCheck() {
             0,
             jsonFilename,
         );
-        let fileNameGeneratedKey = getMetadataJSONMapKeyForFile(0, filename);
-        if (
-            fileNameGeneratedKey !== jsonFileNameGeneratedKey &&
-            filename.length > MAX_FILE_NAME_LENGTH_GOOGLE_EXPORT
-        ) {
+
+        // this duplicates somewhat the logic in takeout.ts:matchTakeoutMetadata()
+        const components = getFileNameComponents(filename);
+        let fileNameGeneratedKey = getMetadataJSONMapKeyForFile(0, components);
+        if (fileNameGeneratedKey !== jsonFileNameGeneratedKey) {
             fileNameGeneratedKey = getClippedMetadataJSONMapKeyForFile(
                 0,
-                filename,
+                components,
+            );
+        }
+        if (fileNameGeneratedKey !== jsonFileNameGeneratedKey) {
+            fileNameGeneratedKey = getSupplementaryMetadataJSONMapKeyForFile(
+                0,
+                components,
             );
         }
 


### PR DESCRIPTION
In recent Google Takeout archives, the metadata JSON files are named
"${original_filename}.supplemental-metadata.json" instead of
"${original_filename}.json", as before.

I refactored the previous code so that `getMetadataJSONMapKeyForJSON()`
only removes the ".json" suffix from the metadata filename and does not
make any other changes. All of the filename munging is now done to the
name of the media file. That was the only way I could make the process
deterministic. As far as I can figure out, there's no deterministic way
of deriving the media filename from the metadata filename -- it's only
deterministic going from the media filename to the metadata filename.

These new names are still subject to the 46-character clipping limit,
with some specific rules about how the filename is clipped:

- The ".json" suffix is never clipped, only the ".supplemental-metadata"
  portion is.
- If the original filename is longer than 46 characters, then the
  ".supplemental-metadata" suffix gets completely removed during the
  clipping, along with a portion of the original filename (as before).
- The numbered suffix (if present) is also never clipped. It is however
  added at the end of the clipped ".supplemental-metadata" portion,
  instead of after the original filename. E.g. "IMG_1234(1).jpg" would
  previously use a metadata filename of "IMG_1234.jpg(1).json". Now it
  uses a metadata filename of
  "IMG_1234.jpg.supplemental-metadata(1).json". But if the filename is
  too long, it gets turned into something like
  "IMG_1234.jpg.suppl(1).json".
- Worth noting is that if the original filename is 45 characters long,
  then everything except for the "." from ".supplemental-metadata" will
  get clipped. So the metadata file ends up with a filename like
  "filename_that_is_45_chars_long.jpg..json".

I added a bunch of additional test cases in `upload.test.ts` based on
actual filenames I have in my Google Photos Takeout archives. The new
code passes all of the new test cases, as well as the original ones.

Fixes #4953 