### PR TITLE
[staff] populate attributes from userDataResponse when UpdateStorage returns data

### DIFF
--- a/infra/staff/src/components/UpdateSubscription.tsx
+++ b/infra/staff/src/components/UpdateSubscription.tsx
@@ -22,6 +22,10 @@ interface Subscription {
     originalTransactionID: string;
     expiryTime: number;
     userID: string;
+    attributes: {
+        customerID: string;
+        stripeAccountCountry: string;
+    };
 }
 
 interface UserDataResponse {
@@ -40,6 +44,10 @@ interface FormValues {
     transactionId: string;
     expiryTime: string | Date | null;
     userId: string;
+    attributes: {
+        customerID: string;
+        stripeAccountCountry: string;
+    };
 }
 
 const UpdateSubscription: React.FC<UpdateSubscriptionProps> = ({
@@ -53,6 +61,10 @@ const UpdateSubscription: React.FC<UpdateSubscriptionProps> = ({
         transactionId: "",
         expiryTime: "",
         userId: "",
+        attributes: {
+            "customerID": "",
+            "stripeAccountCountry": ""
+        },
     });
 
     const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
@@ -95,7 +107,12 @@ const UpdateSubscription: React.FC<UpdateSubscriptionProps> = ({
                         "",
                     expiryTime: expiryTime,
                     userId: userDataResponse.subscription.userID || "",
+                    attributes: {
+                        customerID: userDataResponse.subscription.attributes.customerID || "",
+                        stripeAccountCountry: userDataResponse.subscription.attributes.stripeAccountCountry || ""
+                    }
                 });
+                console.log(userDataResponse)
             } catch (error) {
                 console.error("Error fetching data:", error);
             }
@@ -156,6 +173,10 @@ const UpdateSubscription: React.FC<UpdateSubscriptionProps> = ({
                 productId: values.productId,
                 paymentProvider: values.provider,
                 transactionId: values.transactionId,
+                attributes: {
+                    customerID: values.attributes.customerID,
+                    stripeAccountCountry: values.attributes.stripeAccountCountry
+                }
             };
 
             try {

--- a/infra/staff/src/components/UpdateSubscription.tsx
+++ b/infra/staff/src/components/UpdateSubscription.tsx
@@ -112,7 +112,6 @@ const UpdateSubscription: React.FC<UpdateSubscriptionProps> = ({
                         stripeAccountCountry: userDataResponse.subscription.attributes.stripeAccountCountry || ""
                     }
                 });
-                console.log(userDataResponse)
             } catch (error) {
                 console.error("Error fetching data:", error);
             }


### PR DESCRIPTION
/cc @vishnukvmd mentioned that the json Response does not include attributes data (like customerID, StripeAccountCountry) and it is skipped in the jsonResponse while updating the storage.