### PR TITLE
[server] API for modifying family member storage limit

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -293,6 +293,7 @@ func main() {
 		BillingCtrl:   billingController,
 		UserRepo:      userRepo,
 		UserCacheCtrl: userCacheCtrl,
+		UsageRepo:     usageRepo,
 	}
 
 	publicCollectionCtrl := &controller.PublicCollectionController{

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -621,6 +621,7 @@ func main() {
 	familiesJwtAuthAPI.GET("/family/members", familyHandler.FetchMembers)
 	familiesJwtAuthAPI.DELETE("/family/remove-member/:id", familyHandler.RemoveMember)
 	familiesJwtAuthAPI.DELETE("/family/revoke-invite/:id", familyHandler.RevokeInvite)
+	familiesJwtAuthAPI.POST("/family/modify-storage", familyHandler.ModifyStorageLimit)
 
 	emergencyHandler := &api.EmergencyHandler{
 		Controller: emergencyCtrl,

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -94,6 +94,13 @@ var ErrLockUnavailable = errors.New("could not acquire lock")
 // ErrActiveLinkAlreadyExists is thrown when the collection already has active public link
 var ErrActiveLinkAlreadyExists = errors.New("Collection already has active public link")
 
+// ErrCannotModifyAdminStoragLimit is thrown when the admin is modifying their own storage limit
+var ErrCannotModifyAdminStoragLimit = errors.New("Cannot modify admin storage limit")
+
+// ErrFailedReducingStorageLimit is thrown when the admin is setting storage limit lesser than
+// members pre-consumed storage
+var ErrFailedReducingStorageLimit = errors.New("Members Usage is more than potential storage limit")
+
 // ErrNotImplemented indicates that the action that we tried to perform is not
 // available at this museum instance. e.g. this could be something that is not
 // enabled on this particular instance of museum.

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -95,11 +95,11 @@ var ErrLockUnavailable = errors.New("could not acquire lock")
 var ErrActiveLinkAlreadyExists = errors.New("Collection already has active public link")
 
 // ErrCannotModifyAdminStoragLimit is thrown when the admin is modifying their own storage limit
-var ErrCannotModifyAdminStoragLimit = errors.New("Cannot modify admin storage limit")
+var ErrCannotModifyAdminStoragLimit = errors.New("cannot modify admin storage limit")
 
 // ErrFailedReducingStorageLimit is thrown when the admin is setting storage limit lesser than
 // members pre-consumed storage
-var ErrFailedReducingStorageLimit = errors.New("Members Usage is more than potential storage limit")
+var ErrFailedReducingStorageLimit = errors.New("members usage is more than potential storage limit")
 
 // ErrNotImplemented indicates that the action that we tried to perform is not
 // available at this museum instance. e.g. this could be something that is not

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -94,13 +94,6 @@ var ErrLockUnavailable = errors.New("could not acquire lock")
 // ErrActiveLinkAlreadyExists is thrown when the collection already has active public link
 var ErrActiveLinkAlreadyExists = errors.New("Collection already has active public link")
 
-// ErrCannotModifyAdminStoragLimit is thrown when the admin is modifying their own storage limit
-var ErrCannotModifyAdminStoragLimit = errors.New("cannot modify admin storage limit")
-
-// ErrFailedReducingStorageLimit is thrown when the admin is setting storage limit lesser than
-// members pre-consumed storage
-var ErrFailedReducingStorageLimit = errors.New("members usage is more than potential storage limit")
-
 // ErrNotImplemented indicates that the action that we tried to perform is not
 // available at this museum instance. e.g. this could be something that is not
 // enabled on this particular instance of museum.

--- a/server/ente/family.go
+++ b/server/ente/family.go
@@ -49,6 +49,11 @@ type FamilyMember struct {
 	AdminUserID  int64 `json:"-"` // for internal use only, ignore from json response
 }
 
+type ModifyMemberStorage struct {
+	ID           uuid.UUID `json:"id" binding:"required"`
+	StorageLimit *int64    `json:"storageLimit" binding:"required"`
+}
+
 type FamilyMemberResponse struct {
 	Members []FamilyMember `json:"members" binding:"required"`
 	// Family admin subscription storage capacity. This excludes add-on and any other bonus storage

--- a/server/ente/family.go
+++ b/server/ente/family.go
@@ -51,7 +51,7 @@ type FamilyMember struct {
 
 type ModifyMemberStorage struct {
 	ID           uuid.UUID `json:"id" binding:"required"`
-	StorageLimit *int64    `json:"storageLimit" binding:"required"`
+	StorageLimit *int64    `json:"storageLimit"`
 }
 
 type FamilyMemberResponse struct {

--- a/server/pkg/api/family.go
+++ b/server/pkg/api/family.go
@@ -120,6 +120,21 @@ func (h *FamilyHandler) AcceptInvite(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// ModifyStorageLimit allows adminUser to Modify the storage for a member in the Family.
+func (h *FamilyHandler) ModifyStorageLimit(c *gin.Context) {
+	var request ente.FamilyMember
+	if err := c.ShouldBindJSON(&request); err != nil {
+		handler.Error(c, stacktrace.Propagate(err, "Could not bind request params"))
+		return
+	}
+
+	err := h.Controller.ModifyMemberStorage(c, auth.GetUserID(c.Request.Header), request.ID, request.StorageLimit)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+	}
+	c.JSON(http.StatusOK, nil)
+}
+
 // GetInviteInfo returns basic information about invitor/admin as long as the invite is valid
 func (h *FamilyHandler) GetInviteInfo(c *gin.Context) {
 	inviteToken := c.Param("token")

--- a/server/pkg/api/family.go
+++ b/server/pkg/api/family.go
@@ -122,7 +122,7 @@ func (h *FamilyHandler) AcceptInvite(c *gin.Context) {
 
 // ModifyStorageLimit allows adminUser to Modify the storage for a member in the Family.
 func (h *FamilyHandler) ModifyStorageLimit(c *gin.Context) {
-	var request ente.FamilyMember
+	var request ente.ModifyMemberStorage
 	if err := c.ShouldBindJSON(&request); err != nil {
 		handler.Error(c, stacktrace.Propagate(err, "Could not bind request params"))
 		return

--- a/server/pkg/controller/family/admin.go
+++ b/server/pkg/controller/family/admin.go
@@ -230,11 +230,11 @@ func (c *Controller) ModifyMemberStorage(ctx context.Context, actorUserID int64,
 		if memberUsage > *storageLimit {
 			return stacktrace.Propagate(ente.NewBadRequestWithMessage("Failed to reduce storage"), "User's current usage is more")
 		}
+	}
 
-		modifyStorageErr := c.FamilyRepo.ModifyMemberStorage(ctx, actorUserID, member.ID, storageLimit)
-		if modifyStorageErr != nil {
-			return stacktrace.Propagate(modifyStorageErr, "Failed to modify members storage")
-		}
+	modifyStorageErr := c.FamilyRepo.ModifyMemberStorage(ctx, actorUserID, member.ID, storageLimit)
+	if modifyStorageErr != nil {
+		return stacktrace.Propagate(modifyStorageErr, "Failed to modify members storage")
 	}
 
 	return nil

--- a/server/pkg/controller/family/family.go
+++ b/server/pkg/controller/family/family.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ente-io/museum/pkg/controller/usercache"
 	"github.com/ente-io/museum/pkg/utils/time"
 
@@ -26,6 +27,7 @@ type Controller struct {
 	UserRepo      *repo.UserRepository
 	FamilyRepo    *repo.FamilyRepository
 	UserCacheCtrl *usercache.Controller
+	UsageRepo     *repo.UsageRepository
 }
 
 // FetchMembers return list of members who are part of a family plan

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -198,7 +198,7 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 
 // UpdateStorage is used to set Pre-existing Members Storage Limit.
 func (repo *FamilyRepository) ModifyMemberStorage(ctx context.Context, adminID int64, id uuid.UUID, storageLimit *int64) error {
-	_, err := repo.DB.Exec(`UPDATE families SET storage_limi=$1 where id=$2`, *storageLimit, id)
+	_, err := repo.DB.Exec(`UPDATE families SET storage_limit=$1 where id=$2`, *storageLimit, id)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not update Members Storage Limit")
 	}

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -196,6 +196,16 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 	return stacktrace.Propagate(tx.Commit(), "failed to commit")
 }
 
+// UpdateStorage is used to set Pre-existing Members Storage Limit.
+func (repo *FamilyRepository) ModifyMemberStorage(ctx context.Context, adminID int64, id uuid.UUID, storageLimit *int64) error {
+	_, err := repo.DB.Exec(`UPDATE families SET storage=$1 where token=$2`, *storageLimit, id)
+	if err != nil {
+		return stacktrace.Propagate(err, "Could not update Members Storage Limit")
+	}
+
+	return stacktrace.Propagate(err, "Failed to Modify Members Storage Limit")
+}
+
 // RevokeInvite revokes the invitation invite
 func (repo *FamilyRepository) RevokeInvite(ctx context.Context, adminID int64, memberID int64) error {
 	tx, err := repo.DB.BeginTx(ctx, nil)

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -198,7 +198,7 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 
 // UpdateStorage is used to set Pre-existing Members Storage Limit.
 func (repo *FamilyRepository) ModifyMemberStorage(ctx context.Context, adminID int64, id uuid.UUID, storageLimit *int64) error {
-	_, err := repo.DB.Exec(`UPDATE families SET storage=$1 where token=$2`, *storageLimit, id)
+	_, err := repo.DB.Exec(`UPDATE families SET storage_limit=$1 where token=$2`, *storageLimit, id)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not update Members Storage Limit")
 	}

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -198,7 +198,7 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 
 // UpdateStorage is used to set Pre-existing Members Storage Limit.
 func (repo *FamilyRepository) ModifyMemberStorage(ctx context.Context, adminID int64, id uuid.UUID, storageLimit *int64) error {
-	_, err := repo.DB.Exec(`UPDATE families SET storage_limit=$1 where id=$2`, *storageLimit, id)
+	_, err := repo.DB.Exec(`UPDATE families SET storage_limit=$1 where id=$2`, storageLimit, id)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not update Members Storage Limit")
 	}

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -198,7 +198,7 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 
 // UpdateStorage is used to set Pre-existing Members Storage Limit.
 func (repo *FamilyRepository) ModifyMemberStorage(ctx context.Context, adminID int64, id uuid.UUID, storageLimit *int64) error {
-	_, err := repo.DB.Exec(`UPDATE families SET storage_limit=$1 where token=$2`, *storageLimit, id)
+	_, err := repo.DB.Exec(`UPDATE families SET storage_limi=$1 where id=$2`, *storageLimit, id)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not update Members Storage Limit")
 	}


### PR DESCRIPTION
## Tests 

Tested in followin cases 
1. various statuses "REJECTED", "REVOKED" and "SELF" etc
2. user not part of any family & admin user
3. storage limit check on bulk upload
4. reduce storage check 
5. set storage bigger than anything available in the world
6. admin shouldn't be able to set his own storage.

- [x] check for potential refactoring