### PR TITLE
[mob] Notify internal Discord when internal release is available on PlayStore

### DIFF
--- a/.github/workflows/auth-internal-release.yml
+++ b/.github/workflows/auth-internal-release.yml
@@ -54,3 +54,11 @@ jobs:
                   packageName: io.ente.auth
                   releaseFiles: auth/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab
                   track: internal
+
+            - name: Notify Discord
+              uses: sarisia/actions-status-discord@v1
+              with:
+                  nodetail: true
+                  title: "🏆 Internal release available for Auth"
+                  description: "[Download](https://play.google.com/store/apps/details?id=io.ente.auth)"
+                  color: 0x800080

--- a/.github/workflows/auth-internal-release.yml
+++ b/.github/workflows/auth-internal-release.yml
@@ -58,6 +58,7 @@ jobs:
             - name: Notify Discord
               uses: sarisia/actions-status-discord@v1
               with:
+                  webhook: ${{ secrets.DISCORD_INTERNAL_RELEASE_WEBHOOK }}
                   nodetail: true
                   title: "🏆 Internal release available for Auth"
                   description: "[Download](https://play.google.com/store/apps/details?id=io.ente.auth)"

--- a/.github/workflows/mobile-internal-release.yml
+++ b/.github/workflows/mobile-internal-release.yml
@@ -58,6 +58,7 @@ jobs:
             - name: Notify Discord
               uses: sarisia/actions-status-discord@v1
               with:
+                  webhook: ${{ secrets.DISCORD_INTERNAL_RELEASE_WEBHOOK }}
                   nodetail: true
                   title: "🏆 Internal release available for Photos"
                   description: "[Download](https://play.google.com/store/apps/details?id=io.ente.photos)"

--- a/.github/workflows/mobile-internal-release.yml
+++ b/.github/workflows/mobile-internal-release.yml
@@ -54,3 +54,11 @@ jobs:
                   packageName: io.ente.photos
                   releaseFiles: mobile/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab
                   track: internal
+            
+            - name: Notify Discord
+              uses: sarisia/actions-status-discord@v1
+              with:
+                  nodetail: true
+                  title: "🏆 Internal release available for Photos"
+                  description: "[Download](https://play.google.com/store/apps/details?id=io.ente.photos)"
+                  color: 0x00ff00


### PR DESCRIPTION
# Description
Pings in `#testing`.
<img width="384" alt="Screenshot 2025-02-13 at 10 06 21 AM" src="https://github.com/user-attachments/assets/35d6c58e-5af3-4ac8-ba64-d78bfdebe3c6" />

# Test plan
- [x] Tested manually