### PR TITLE
[desktop] Add IndexedDB circuit breaker

### DIFF
--- a/web/apps/auth/src/pages/_app.tsx
+++ b/web/apps/auth/src/pages/_app.tsx
@@ -15,11 +15,7 @@ import {
 import { authTheme } from "@/base/components/utils/theme";
 import { logStartupBanner } from "@/base/log-web";
 import HTTPService from "@ente/shared/network/HTTPService";
-import {
-    LS_KEYS,
-    getData,
-    migrateKVToken,
-} from "@ente/shared/storage/localStorage";
+import { LS_KEYS, getData } from "@ente/shared/storage/localStorage";
 import type { User } from "@ente/shared/user/types";
 import "@fontsource-variable/inter";
 import { CssBaseline } from "@mui/material";

--- a/web/apps/auth/src/pages/_app.tsx
+++ b/web/apps/auth/src/pages/_app.tsx
@@ -38,7 +38,6 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
 
     useEffect(() => {
         const user = getData(LS_KEYS.USER) as User | undefined | null;
-        void migrateKVToken(user);
         logStartupBanner(user?.id);
         HTTPService.setHeaders({ "X-Client-Package": clientPackageName });
     }, []);

--- a/web/packages/shared/storage/localStorage/index.ts
+++ b/web/packages/shared/storage/localStorage/index.ts
@@ -95,3 +95,20 @@ export const migrateKVToken = async (user: unknown) => {
             "The user's token was present in local storage but not in IndexedDB",
         );
 };
+
+/**
+ * Return true if the user's data is in local storage but not in IndexedDB.
+ *
+ * This acts a sanity check on IndexedDB by ensuring that if the user has a
+ * token in local storage, then it should also be present in IndexedDB.
+ */
+export const isLocalStorageAndIndexedDBMismatch = async () => {
+    const oldLSUser = getData(LS_KEYS.USER);
+    return (
+        oldLSUser &&
+        typeof oldLSUser == "object" &&
+        "token" in oldLSUser &&
+        typeof oldLSUser.token == "string" &&
+        !(await getKVS("token"))
+    );
+};


### PR DESCRIPTION
From one customer's logs (Windows):

[rndr] [error] Unhandled promise rejection: Error: The user's token was present in local storage but not in IndexedDB

And thereafter the app started behaving erratically. Restarting fixed it. This
sequence happened during an app update.

This sequence is not reproducible, but adding as a extra precaution adding a
circuit breaker to prevent execution if IndexedDB is not readable.
