### PR TITLE
[server] Soft error msgs when billing/payment data(config) is not found

### DIFF
--- a/server/pkg/controller/offer/offer.go
+++ b/server/pkg/controller/offer/offer.go
@@ -42,7 +42,7 @@ func NewOfferController(
 	blackFridayOffers := make(ente.BlackFridayOfferPerCountry)
 	path, err := config.BillingConfigFilePath("black-friday.json")
 	if err != nil {
-		log.Fatalf("Error getting offer config file: %v", err)
+		log.Fatalf("Skipping BF configuration, config file not found: %v", err)
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/server/pkg/utils/billing/billing.go
+++ b/server/pkg/utils/billing/billing.go
@@ -88,7 +88,7 @@ func parsePricingFile(fileName string) ente.BillingPlansPerCountry {
 	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		logrus.Errorf("Skipping payment configuration, (config file not found): %v\n", err)
+		logrus.Errorf("Skipping payment configuration, pricing data unavailable in config: %v\n", err)
 		return nil
 	}
 

--- a/server/pkg/utils/billing/billing.go
+++ b/server/pkg/utils/billing/billing.go
@@ -88,7 +88,7 @@ func parsePricingFile(fileName string) ente.BillingPlansPerCountry {
 	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		logrus.Errorf("Error reading file %s: %v\n", filePath, err)
+		logrus.Errorf("Skipping payment configuration, (config file not found): %v\n", err)
 		return nil
 	}
 


### PR DESCRIPTION
From discord discussion

the pr makes changes to the error strings which are thrown when configuration reltaed to payment and billing isn't found. The error messages are changed so to not scare self hosters while we are aware of it on the production instance. 

