### PR TITLE
[mob][perf] Improve computation for discover sections by batching lookup

### DIFF
--- a/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
+++ b/mobile/lib/services/machine_learning/semantic_search/semantic_search_service.dart
@@ -147,11 +147,13 @@ class SemanticSearchService {
     }
     final textEmbedding = await _getTextEmbedding(query);
 
-    final queryResults = await _getSimilarities(
-      textEmbedding,
-      minimumSimilarity: similarityThreshold,
+    final similarityResults = await _getSimilarities(
+      {query: textEmbedding},
+      minimumSimilarityMap: {
+        query: similarityThreshold ?? kMinimumSimilarityThreshold,
+      },
     );
-
+    final queryResults = similarityResults[query]!;
     // print query for top ten scores
     for (int i = 0; i < min(10, queryResults.length); i++) {
       final result = queryResults[i];
@@ -202,11 +204,11 @@ class SemanticSearchService {
   ) async {
     final textEmbedding = await _getTextEmbedding(query);
     final queryResults = await _getSimilarities(
-      textEmbedding,
-      minimumSimilarity: minimumSimilarity,
+      {query: textEmbedding},
+      minimumSimilarityMap: {query: minimumSimilarity},
     );
     final result = <int>[];
-    for (final r in queryResults) {
+    for (final r in queryResults.values.first) {
       result.add(r.id);
     }
     return result;
@@ -249,24 +251,25 @@ class SemanticSearchService {
     return textEmbedding;
   }
 
-  Future<List<QueryResult>> _getSimilarities(
-    List<double> textEmbedding, {
-    double? minimumSimilarity,
+  Future<Map<String, List<QueryResult>>> _getSimilarities(
+    Map<String, List<double>> textQueryToEmbeddingMap, {
+    required Map<String, double> minimumSimilarityMap,
   }) async {
     final startTime = DateTime.now();
     final imageEmbeddings = await _getClipVectors();
-    final List<QueryResult> queryResults = await _computer.compute(
+    final Map<String, List<QueryResult>> queryResults = await _computer
+        .compute<Map<String, dynamic>, Map<String, List<QueryResult>>>(
       computeBulkSimilarities,
       param: {
         "imageEmbeddings": imageEmbeddings,
-        "textEmbedding": textEmbedding,
-        "minimumSimilarity": minimumSimilarity,
+        "textQueryToEmbeddingMap": textQueryToEmbeddingMap,
+        "minimumSimilarityMap": minimumSimilarityMap,
       },
       taskName: "computeBulkSimilarities",
     );
     final endTime = DateTime.now();
     _logger.info(
-      "computingSimilarities took: " +
+      "computingSimilarities took for ${textQueryToEmbeddingMap.length} queries " +
           (endTime.millisecondsSinceEpoch - startTime.millisecondsSinceEpoch)
               .toString() +
           "ms",
@@ -293,39 +296,44 @@ class SemanticSearchService {
   }
 }
 
-List<QueryResult> computeBulkSimilarities(Map args) {
-  final queryResults = <QueryResult>[];
+Map<String, List<QueryResult>> computeBulkSimilarities(Map args) {
   final imageEmbeddings = args["imageEmbeddings"] as List<EmbeddingVector>;
-  final textEmbedding = args["textEmbedding"] as List<double>;
-  final minimumSimilarity = args["minimumSimilarity"] ??
-      SemanticSearchService.kMinimumSimilarityThreshold;
-
-  final Vector textVector = Vector.fromList(textEmbedding);
-  if (!kDebugMode) {
-    for (final imageEmbedding in imageEmbeddings) {
-      final similarity = imageEmbedding.vector.dot(textVector);
-      if (similarity >= minimumSimilarity) {
-        queryResults.add(QueryResult(imageEmbedding.fileID, similarity));
+  final textEmbedding =
+      args["textQueryToEmbeddingMap"] as Map<String, List<double>>;
+  final minimumSimilarityMap =
+      args["minimumSimilarityMap"] as Map<String, double>;
+  final result = <String, List<QueryResult>>{};
+  for (final MapEntry<String, List<double>> entry in textEmbedding.entries) {
+    final query = entry.key;
+    final textVector = Vector.fromList(entry.value);
+    final minimumSimilarity = minimumSimilarityMap[query]!;
+    final queryResults = <QueryResult>[];
+    if (!kDebugMode) {
+      for (final imageEmbedding in imageEmbeddings) {
+        final similarity = imageEmbedding.vector.dot(textVector);
+        if (similarity >= minimumSimilarity) {
+          queryResults.add(QueryResult(imageEmbedding.fileID, similarity));
+        }
+      }
+    } else {
+      double bestScore = 0.0;
+      for (final imageEmbedding in imageEmbeddings) {
+        final similarity = imageEmbedding.vector.dot(textVector);
+        if (similarity >= minimumSimilarity) {
+          queryResults.add(QueryResult(imageEmbedding.fileID, similarity));
+        }
+        if (similarity > bestScore) {
+          bestScore = similarity;
+        }
+      }
+      if (kDebugMode && queryResults.isEmpty) {
+        dev.log("No results found for query with best score: $bestScore");
       }
     }
-  } else {
-    double bestScore = 0.0;
-    for (final imageEmbedding in imageEmbeddings) {
-      final similarity = imageEmbedding.vector.dot(textVector);
-      if (similarity >= minimumSimilarity) {
-        queryResults.add(QueryResult(imageEmbedding.fileID, similarity));
-      }
-      if (similarity > bestScore) {
-        bestScore = similarity;
-      }
-    }
-    if (kDebugMode && queryResults.isEmpty) {
-      dev.log("No results found for query with best score: $bestScore");
-    }
+    queryResults.sort((first, second) => second.score.compareTo(first.score));
+    result[query] = queryResults;
   }
-
-  queryResults.sort((first, second) => second.score.compareTo(first.score));
-  return queryResults;
+  return result;
 }
 
 class QueryResult {

--- a/mobile/lib/services/magic_cache_service.dart
+++ b/mobile/lib/services/magic_cache_service.dart
@@ -393,14 +393,17 @@ class MagicCacheService {
   Future<List<MagicCache>> _nonEmptyMagicResults(
     List<Prompt> magicPromptsData,
   ) async {
+    final TimeLogger t = TimeLogger();
     final results = <MagicCache>[];
     final List<int> matchCount = [];
+    final Map<String, double> queryToScore = {};
     for (Prompt prompt in magicPromptsData) {
-      final fileUploadedIDs =
-          await SemanticSearchService.instance.getMatchingFileIDs(
-        prompt.query,
-        prompt.minScore,
-      );
+      queryToScore[prompt.query] = prompt.minScore;
+    }
+    final clipResults =
+        await SemanticSearchService.instance.getMatchingFileIDs(queryToScore);
+    for (Prompt prompt in magicPromptsData) {
+      final List<int> fileUploadedIDs = clipResults[prompt.query] ?? [];
       if (fileUploadedIDs.isNotEmpty) {
         results.add(
           MagicCache(prompt.title, fileUploadedIDs),
@@ -408,7 +411,7 @@ class MagicCacheService {
       }
       matchCount.add(fileUploadedIDs.length);
     }
-    _logger.info('magic result count $matchCount');
+    _logger.info('magic result count $matchCount $t');
     return results;
   }
 }


### PR DESCRIPTION
## Description
- For 14k files, this reduced the overall time to calculate discovery section from **1600ms** to **250ms**
- This should also reduce the memory overhead as we have reduce the number of times we are passing vector to different isolate.

## Tests
