### PR TITLE
[mob][photos] Ensure that the shared data received through the intent is a photo or video before showing a dialog specific to shared photo/video.

### DIFF
--- a/mobile/lib/ui/tabs/home_widget.dart
+++ b/mobile/lib/ui/tabs/home_widget.dart
@@ -446,53 +446,57 @@ class _HomeWidgetState extends State<HomeWidget> {
           return;
         }
 
-        showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return AlertDialog(
-              actions: [
-                const SizedBox(height: 24),
-                ButtonWidget(
-                  labelText: S.of(context).openFile,
-                  buttonType: ButtonType.primary,
-                  onTap: () async {
-                    Navigator.of(context).pop(true);
+        if (value.isNotEmpty &&
+            (value[0].mimeType == "image/*" ||
+                value[0].mimeType == "video/*")) {
+          showDialog(
+            context: context,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                actions: [
+                  const SizedBox(height: 24),
+                  ButtonWidget(
+                    labelText: S.of(context).openFile,
+                    buttonType: ButtonType.primary,
+                    onTap: () async {
+                      Navigator.of(context).pop(true);
+                    },
+                  ),
+                  const SizedBox(
+                    height: 12,
+                  ),
+                  ButtonWidget(
+                    buttonType: ButtonType.secondary,
+                    labelText: S.of(context).backupFile,
+                    onTap: () async {
+                      Navigator.of(context).pop(false);
+                    },
+                  ),
+                ],
+              );
+            },
+          ).then((shouldOpenFile) {
+            if (shouldOpenFile) {
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) {
+                    return FileViewer(
+                      sharedMediaFile: value[0],
+                    );
                   },
                 ),
-                const SizedBox(
-                  height: 12,
-                ),
-                ButtonWidget(
-                  buttonType: ButtonType.secondary,
-                  labelText: S.of(context).backupFile,
-                  onTap: () async {
-                    Navigator.of(context).pop(false);
-                  },
-                ),
-              ],
-            );
-          },
-        ).then((shouldOpenFile) {
-          if (shouldOpenFile) {
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(
-                builder: (_) {
-                  return FileViewer(
-                    sharedMediaFile: value[0],
-                  );
-                },
-              ),
-            );
-          } else {
-            if (mounted) {
-              setState(() {
-                _shouldRenderCreateCollectionSheet = true;
-                _sharedFiles = value;
-              });
+              );
+            } else {
+              if (mounted) {
+                setState(() {
+                  _shouldRenderCreateCollectionSheet = true;
+                  _sharedFiles = value;
+                });
+              }
             }
-          }
-        });
+          });
+        }
       },
       onError: (err) {
         _logger.severe("getIntentDataStream error: $err");


### PR DESCRIPTION
This dialog. It was coming up when redirecting back to the app after passkey verification. 

![dialog](https://github.com/user-attachments/assets/d585b33f-bc5a-4557-bd52-b46eb0ced61b)
