### PR TITLE
[web] Make the endpoints configurable without rebuilding the image

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:20-alpine AS builder
 
-ARG ENTE_API_ORIGIN=http://localhost:8080
-ARG ENTE_ALBUMS_APP_ORIGIN=https://localhost:3002
-
-ENV NEXT_PUBLIC_ENTE_ENDPOINT="$ENTE_API_ORIGIN"
-ENV NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT="$ENTE_ALBUMS_APP_ORIGIN"
-
 WORKDIR /build
 COPY . .
 
@@ -20,7 +14,6 @@ FROM nginx
 WORKDIR /out
 
 COPY --from=builder /build/apps/photos/out /out/photos
-COPY --from=builder /build/apps/photos/out /out/albums
 COPY --from=builder /build/apps/accounts/out /out/accounts
 COPY --from=builder /build/apps/auth/out /out/auth
 COPY --from=builder /build/apps/cast/out /out/cast
@@ -35,7 +28,7 @@ server {
     location / { try_files \$uri \$uri/ \$uri.html /index.html; }
 }
 server {
-    listen 3002; root /out/albums;
+    listen 3002; root /out/photos;
     location / { try_files \$uri \$uri/ \$uri.html /index.html; }
 }
 server {
@@ -53,3 +46,13 @@ EXPOSE 3001
 EXPOSE 3002
 EXPOSE 3003
 EXPOSE 3004
+
+ENV ENTE_API_ORIGIN=http://localhost:8080
+ENV ENTE_ALBUMS_ORIGIN=https://localhost:3002
+
+COPY <<EOF /docker-entrypoint.d/replace-ente-env.sh
+find /out -name '*.js' | xargs sed -i'' "s#https://api.ente.io#\$ENTE_API_ORIGIN#"
+find /out/photos -name '*.js' | xargs sed -i'' "s#https://albums.ente.io#\$ENTE_ALBUMS_ORIGIN#"
+EOF
+
+RUN chmod +x /docker-entrypoint.d/replace-ente-env.sh

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,6 +3,9 @@ FROM node:20-alpine AS builder
 WORKDIR /build
 COPY . .
 
+ENV NEXT_PUBLIC_ENTE_ENDPOINT=ENTE_API_ORIGIN_PLACEHOLDER
+ENV NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=ENTE_ALBUMS_ORIGIN_PLACEHOLDER
+
 RUN yarn install
 RUN yarn build:photos
 RUN yarn build:accounts
@@ -50,9 +53,11 @@ EXPOSE 3004
 ENV ENTE_API_ORIGIN=http://localhost:8080
 ENV ENTE_ALBUMS_ORIGIN=https://localhost:3002
 
-COPY <<EOF /docker-entrypoint.d/replace-ente-env.sh
-find /out -name '*.js' | xargs sed -i'' "s#https://api.ente.io#\$ENTE_API_ORIGIN#"
-find /out/photos -name '*.js' | xargs sed -i'' "s#https://albums.ente.io#\$ENTE_ALBUMS_ORIGIN#"
+COPY <<EOF /docker-entrypoint.d/90-replace-ente-env.sh
+find /out -name '*.js' |
+    xargs sed -i'' "s#ENTE_API_ORIGIN_PLACEHOLDER#\$ENTE_API_ORIGIN#g"
+find /out/photos -name '*.js' |
+    xargs sed -i'' "s#ENTE_ALBUMS_ORIGIN_PLACEHOLDER#\$ENTE_ALBUMS_ORIGIN#g"
 EOF
 
-RUN chmod +x /docker-entrypoint.d/replace-ente-env.sh
+RUN chmod +x /docker-entrypoint.d/90-replace-ente-env.sh


### PR DESCRIPTION
Sibling of https://github.com/ente-io/ente/pull/5364.

**Tested by**
```sh
docker build -t web-test .

# Uses provided values
docker run -it --rm -p 3000:3000 -p 3090:3002 -e ENTE_API_ORIGIN=http://localhost:8090 -e ENTE_ALBUMS_ORIGIN=http://localhost:3090 web-test

# Uses defaults
docker run -it --rm -p 3000:3000 -p 3002:3002 web-test 
```
