### PR TITLE
Add OTP ente_account_add.md

### DIFF
--- a/cli/docs/generated/ente_account_add.md
+++ b/cli/docs/generated/ente_account_add.md
@@ -15,6 +15,7 @@ ente account add [flags]
 ```
   -h, --help   help for add
 ```
+The process will ask for a role, email, a password, and an OTP.  OTP stands for "One Time Password" and is available in the output of the Museum logs.
 
 ### SEE ALSO
 


### PR DESCRIPTION
Clear up documentation for users who are trying to get set up.

## Description
I spent a lot of time digging through the documentation in order to discover what OTP was and where the password was.  This should help others.  Ideally the CLI would mention this as well.
## Tests
