### PR TITLE
[Auth] Flakey fix for steam codes in web app

### DIFF
--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -262,6 +262,9 @@ const parseCodeDisplay = (url: URL): CodeDisplay | undefined => {
 export const generateOTPs = (code: Code): [otp: string, nextOTP: string] => {
     let otp: string;
     let nextOTP: string;
+    if (code.issuer.toLowerCase().includes("steam")) {
+        code.type = "steam";
+    }
     switch (code.type) {
         case "totp": {
             const totp = new TOTP({

--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -111,13 +111,16 @@ export const codeFromURIString = (id: string, uriString: string): Code => {
 const _codeFromURIString = (id: string, uriString: string): Code => {
     const url = new URL(uriString);
 
-    const [type, path] = parsePathname(url);
+    const [originalType, path] = parsePathname(url);
+    const issuer = parseIssuer(url, path);
+
+    const type = issuer.toLowerCase().includes("steam") ? "steam" : originalType
 
     return {
         id,
         type,
+        issuer,
         account: parseAccount(path),
-        issuer: parseIssuer(url, path),
         length: parseLength(url, type),
         period: parsePeriod(url),
         algorithm: parseAlgorithm(url),
@@ -262,9 +265,7 @@ const parseCodeDisplay = (url: URL): CodeDisplay | undefined => {
 export const generateOTPs = (code: Code): [otp: string, nextOTP: string] => {
     let otp: string;
     let nextOTP: string;
-    if (code.issuer.toLowerCase().includes("steam")) {
-        code.type = "steam";
-    }
+
     switch (code.type) {
         case "totp": {
             const totp = new TOTP({


### PR DESCRIPTION
## Description
There is difference in how steam otps are handled in flutter and in web app, in flutter we check both code.type and code.issuer to be steam while in Web app we only rely on code.type, which breaks code generation for steam.

Closes #5325 

I know this fix is not of best quality, if you are open to change this generate codes function to not use switch and instead we call based on conditions to include issuer condition as well, I think that can be a better solution.