### PR TITLE
[web] Dockerfile accounts fix

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -29,23 +29,23 @@ COPY --from=builder /build/apps/cast/out /out/cast
 COPY <<EOF /etc/nginx/conf.d/default.conf
 server {
     listen 3000; root /out/photos;
-    location / { try_files \$uri \$uri/ \$uri.html /index.html; }
+    location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
     listen 3001; root /out/accounts;
-    location / { try_files \$uri \$uri/ \$uri.html /index.html; }
+    location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
     listen 3002; root /out/photos;
-    location / { try_files \$uri \$uri/ \$uri.html /index.html; }
+    location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
     listen 3003; root /out/auth;
-    location / { try_files \$uri \$uri/ \$uri.html /index.html; }
+    location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
     listen 3004; root /out/cast;
-    location / { try_files \$uri \$uri/ \$uri.html /index.html; }
+    location / { try_files \$uri \$uri.html /index.html; }
 }
 EOF
 


### PR DESCRIPTION
try_files $uri/ matches the passkeys/ folder in accounts app, causing nginx to
try loading (e.g.)  http://localhost:3001/passkeys/?xxx instead of
http://localhost:3001/passkeys?xxx

The way Next is currently generating the static renders, we anyways don't need
the slug/index.html lookup, the only index.html we have is at the root, rest of
them are of the form slug.html.
