### PR TITLE
[docs] Update Authy import docs to mention Authy-iOS-MiTM

### DIFF
--- a/docs/docs/auth/migration-guides/authy/index.md
+++ b/docs/docs/auth/migration-guides/authy/index.md
@@ -10,8 +10,8 @@ A guide written by Green, an ente.io lover
 > [!WARNING]
 >
 > Authy has dropped all support for its desktop apps. It is no longer possible
-> to export data from Authy using methods 1 and 2. You will either need a rooted
-> android phone or you will need to reconfigure 2FA for each of your accounts.
+> to export data from Authy using methods 1 and 2. You will need either an iOS device
+> and computer (method 4) or a rooted Android phone (method 3) to follow this guide.
 
 ---
 
@@ -202,7 +202,15 @@ This uses the tool [Aegis Authenticator](https://getaegis.app/) from
 6. Then export the codes from Aegis Authenticator to `json` or `txt` using the
    "Export to file" option in the "Import & Export" menu.
 
-## Importing to Ente Authenticator (Method 1, method 2.1)
+## Method 4: Authy-iOS-MiTM
+
+**Who should use this?** Technical iOS users of Authy that cannot export their tokens with methods 1 or 2 (due to those methods being patched) or method 3 (due to that method requiring a rooted Android device).
+
+This method works by intercepting the data the Authy app receives while logging in for the first time, which contains your encrypted authenticator tokens. After the encrypted authenticator tokens are dumped, you can decrypt them using your backup password and convert them to an Ente token file.
+
+For an up-to-date guide of how to retrieve the encrypted authenticator tokens and decrypt them, please see [Authy-iOS-MiTM](https://github.com/AlexTech01/Authy-iOS-MiTM). To convert the `decrypted_tokens.json` file from that guide into a format Ente Authenticator can recognize, use [this](https://gist.github.com/gboudreau/94bb0c11a6209c82418d01a59d958c93?permalink_comment_id=5317087#gistcomment-5317087) Python script. Once you have the `ente_auth_import.plain` file from that script, transfer it to your device and follow the instructions below to import it into Ente Authenticator.
+
+## Importing to Ente Authenticator (Method 1, method 2.1, method 4)
 
 1. Copy the TXT file to one of your devices with Ente Authenticator.
 2. Log in to your account (if you haven't already), or press "Use without


### PR DESCRIPTION
## Description
This pull request adds mention of the Authy-iOS-MiTM method to Ente's documentation on migrating from Authy. Currently, the only working method to import Authy tokens into Ente is to use a rooted Android device, which is not ideal due to most people not having rooted Android devices. The Authy-iOS-MiTM method (that I made) only requires an iOS device with Authy and a computer with Python and mitmproxy, making it significantly more accessible to people looking to migrate their Authy tokens. By mentioning my method in Ente's Authy import docs, it would help more people discover it and would hopefully make some people's lives easier since they wouldn't have to manually re-register 2FA on every website. Let me know if you have any questions.

## Tests
N/A, this pull request does not modify any code