### PR TITLE
[mob] Fix discovery section reload condition

### DIFF
--- a/mobile/lib/services/location_service.dart
+++ b/mobile/lib/services/location_service.dart
@@ -68,7 +68,8 @@ class LocationService {
     List<EnteFile> allFiles,
     String query,
   ) async {
-    if (allFiles.isEmpty && query.isEmpty) {
+    // check if the cities where not loaded when discovery section was loaded
+    if (allFiles.isNotEmpty && _cities.isEmpty && query.isEmpty) {
       reloadLocationDiscoverySection = true;
     }
     final EnteWatch w = EnteWatch("cities_search")..start();


### PR DESCRIPTION
## Description
Previous condition didn't handle the case when the cities were not loaded when discovery section was getting computed.
## Tests
