### PR TITLE
[meta] Allow running CodeQL manually

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@
 name: "CodeQL"
 
 on:
+    workflow_dispatch: # Allow running manually
     schedule:
         - cron: "22 1 * * 1"
 


### PR DESCRIPTION
Necessary to get GitHub to resync the status until the next time it runs
