### PR TITLE
Correct typo in cli

### DIFF
--- a/cli/pkg/admin_actions.go
+++ b/cli/pkg/admin_actions.go
@@ -135,7 +135,7 @@ func (c *ClICtrl) UpdateFreeStorage(ctx context.Context, params model.AdminActio
 		return err
 	}
 
-	fmt.Printf("Updating storage for user %s to %s (old %s) with new expirty %s (old %s) \n",
+	fmt.Printf("Updating storage for user %s to %s (old %s) with new expiry %s (old %s) \n",
 		params.UserEmail,
 		utils.ByteCountDecimalGIB(storageSize), utils.ByteCountDecimalGIB(userDetails.Subscription.Storage),
 		date.Format("2006-01-02"),


### PR DESCRIPTION
Corrected "expirty" typo in ente admin update-subscription --no-limit False success workflow.

## Description
Fixed typo "expirty" to "expiry" in file limit success flow.


## Tests
