### PR TITLE
[desktop] [macOS] Hide dock icon on Window close

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -35,6 +35,7 @@ import log, { initLogging } from "./main/log";
 import { createApplicationMenu, createTrayContextMenu } from "./main/menu";
 import { setupAutoUpdater } from "./main/services/app-update";
 import autoLauncher from "./main/services/auto-launcher";
+import { shouldHideDockIcon } from "./main/services/store";
 import { createWatcher } from "./main/services/watch";
 import { userPreferences } from "./main/stores/user-preferences";
 import { migrateLegacyWatchStoreIfNeeded } from "./main/stores/watch";
@@ -421,9 +422,8 @@ const createMainWindow = () => {
 
     window.on("hide", () => {
         // On macOS, when hiding the window also hide the app's icon in the dock
-        // if the user has selected the Settings > Hide dock icon checkbox.
-        if (process.platform == "darwin" && userPreferences.get("hideDockIcon"))
-            app.dock.hide();
+        // unless the user has unchecked the Settings > Hide dock icon checkbox.
+        if (shouldHideDockIcon()) app.dock.hide();
     });
 
     window.on("show", () => {

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -7,7 +7,7 @@ import {
 } from "electron";
 import { allowWindowClose } from "../main";
 import { forceCheckForAppUpdates } from "./services/app-update";
-import { userPreferences } from "./stores/user-preferences";
+import { setShouldHideDockIcon, shouldHideDockIcon } from "./services/store";
 
 /** Create and return the entries in the app's main menu bar */
 export const createApplicationMenu = (mainWindow: BrowserWindow) => {
@@ -15,18 +15,7 @@ export const createApplicationMenu = (mainWindow: BrowserWindow) => {
     //
     // Whenever the menu is redrawn the current value of these variables is used
     // to set the checked state for the various settings checkboxes.
-    //
-    // Note that if the user has not set a value for this preference (i.e., the
-    // value is `undefined`), we use the default `true`. This is confusing, but
-    // this way we retain the older preference key instead of doing a migration.
-    //
-    //    Value     | Behaviour
-    //    ----------|--------------
-    //    undefined |  default (hide)
-    //    false     |  show
-    //    true      |  hide
-    //
-    let shouldHideDockIcon = userPreferences.get("hideDockIcon") !== false;
+    let hideDockIcon = shouldHideDockIcon();
 
     const macOSOnly = (options: MenuItemConstructorOptions[]) =>
         process.platform == "darwin" ? options : [];
@@ -35,9 +24,9 @@ export const createApplicationMenu = (mainWindow: BrowserWindow) => {
 
     const toggleHideDockIcon = () => {
         // Persist
-        userPreferences.set("hideDockIcon", !shouldHideDockIcon);
+        setShouldHideDockIcon(!hideDockIcon);
         // And update the in-memory state
-        shouldHideDockIcon = !shouldHideDockIcon;
+        hideDockIcon = !hideDockIcon;
     };
 
     const handleHelp = () =>
@@ -59,7 +48,7 @@ export const createApplicationMenu = (mainWindow: BrowserWindow) => {
                             {
                                 label: "Hide Dock Icon",
                                 type: "checkbox",
-                                checked: shouldHideDockIcon,
+                                checked: hideDockIcon,
                                 click: toggleHideDockIcon,
                             },
                         ],

--- a/desktop/src/main/menu.ts
+++ b/desktop/src/main/menu.ts
@@ -15,7 +15,18 @@ export const createApplicationMenu = (mainWindow: BrowserWindow) => {
     //
     // Whenever the menu is redrawn the current value of these variables is used
     // to set the checked state for the various settings checkboxes.
-    let shouldHideDockIcon = !!userPreferences.get("hideDockIcon");
+    //
+    // Note that if the user has not set a value for this preference (i.e., the
+    // value is `undefined`), we use the default `true`. This is confusing, but
+    // this way we retain the older preference key instead of doing a migration.
+    //
+    //    Value     | Behaviour
+    //    ----------|--------------
+    //    undefined |  default (hide)
+    //    false     |  show
+    //    true      |  hide
+    //
+    let shouldHideDockIcon = userPreferences.get("hideDockIcon") !== false;
 
     const macOSOnly = (options: MenuItemConstructorOptions[]) =>
         process.platform == "darwin" ? options : [];

--- a/desktop/src/main/services/store.ts
+++ b/desktop/src/main/services/store.ts
@@ -42,3 +42,31 @@ export const lastShownChangelogVersion = (): number | undefined =>
 
 export const setLastShownChangelogVersion = (version: number) =>
     userPreferences.set("lastShownChangelogVersion", version);
+
+/**
+ * Return true if the dock icon should be hidden when the window is closed
+ * [macOS only].
+ *
+ * On macOS, if this function returns true then when hiding ("closing" it with
+ * the x traffic light) the window we also hide the app's icon in the dock. The
+ * user can modify their preference using the Menu bar > ente > Settings > Hide
+ * dock icon checkbox.
+ *
+ * If the user has not set a value for this preference (i.e., the value is
+ * `undefined`), we use the default `true`. This is confusing, but this way we
+ * can retain the preexisting preference key instead of doing a migration.
+ *
+ *     Value     | Behaviour
+ *     ----------|--------------
+ *     undefined |  default (hide)
+ *     false     |  show
+ *     true      |  hide
+ *
+ * On non-macOS platforms, it always returns false.
+ */
+export const shouldHideDockIcon = (): boolean =>
+    process.platform == "darwin" &&
+    userPreferences.get("hideDockIcon") !== false;
+
+export const setShouldHideDockIcon = (hide: boolean) =>
+    userPreferences.set("hideDockIcon", hide);


### PR DESCRIPTION
Based on customer feedback. The dock icon will hide when the window is closed by using the "x" without quitting the app. 

The menu bar icon remains as it is, and so does the existing preferences (whose value is also retained if it were set explicitly).