### PR TITLE
[server] Relax criteria for closing families

### DIFF
--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -57,19 +57,10 @@ func (repo *FamilyRepository) CloseFamily(ctx context.Context, adminID int64) er
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	affectResult, err := tx.ExecContext(ctx, `DELETE FROM families WHERE admin_id = $1`, adminID)
+	_, err = tx.ExecContext(ctx, `DELETE FROM families WHERE admin_id = $1`, adminID)
 	if err != nil {
 		tx.Rollback()
 		return stacktrace.Propagate(err, "")
-	}
-	affected, err := affectResult.RowsAffected()
-	if err != nil {
-		tx.Rollback()
-		return stacktrace.Propagate(err, "")
-	}
-	if affected != 1 {
-		tx.Rollback()
-		return stacktrace.Propagate(errors.New("exactly one row should be deleted"), "")
 	}
 	affectedRows, err := tx.ExecContext(ctx, `UPDATE users SET family_admin_id = null WHERE family_admin_id = $1`, adminID)
 
@@ -77,7 +68,7 @@ func (repo *FamilyRepository) CloseFamily(ctx context.Context, adminID int64) er
 		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
-	affected, err = affectedRows.RowsAffected()
+	affected, err := affectedRows.RowsAffected()
 	if err != nil {
 		tx.Rollback()
 		return stacktrace.Propagate(err, "")


### PR DESCRIPTION
## Description

Users can create a family, leave it and then join another.

In the `families` table, there will be one entry for each such family they have been a part of (against their `admin_id`).

This PR removes this constraint for only a single row to be affected, so users who have historically been associated with more than one family can have a fresh start.