### PR TITLE
[server] Update service definition for recent env var lookup changes

### DIFF
--- a/server/pkg/utils/config/config.go
+++ b/server/pkg/utils/config/config.go
@@ -39,11 +39,9 @@ func ConfigureViper(environment string) error {
 	// Set the prefix for the environment variables that Viper will look for.
 	viper.SetEnvPrefix("ENTE")
 	// Ask Viper to look for underscores (instead of dots) for nested configs.
-	viper.SetEnvKeyReplacer(strings.NewReplacer(`.`, `_`))
-
-	// Also replace "-" with underscores since "-" cannot be used in
-	// environment variable names.
-	viper.SetEnvKeyReplacer(strings.NewReplacer(`-`, `_`))
+	// Also replace "-" with underscores since "-" cannot be used in environment
+	// variable names.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
 	viper.SetConfigFile("configurations/" + environment + ".yaml")
 	err := viper.ReadInConfig()

--- a/server/pkg/utils/config/config.go
+++ b/server/pkg/utils/config/config.go
@@ -8,9 +8,11 @@
 //
 // The names of the OS environment variables should be
 //
-//   - prefixed with 'ENTE_'
+//   - prefixed with 'ENTE_',
 //
-//   - uppercased versions of the config file variable names
+//   - uppercased versions of the config file variable names,
+//
+//   - dashes are replaced with '_',
 //
 //   - for nested config variables, dots should be replaced with '_'.
 //
@@ -19,7 +21,7 @@
 //	foo:
 //	    bar-baz: quux
 //
-// would be `ENTE_FOO_BAR-BAZ`.
+// would be `ENTE_FOO_BAR_BAZ`.
 package config
 
 import (

--- a/server/scripts/deploy/museum.nginx.service
+++ b/server/scripts/deploy/museum.nginx.service
@@ -12,7 +12,7 @@ ExecStartPre=-docker stop museum
 ExecStartPre=-docker rm museum
 ExecStart=docker run --name museum \
      -e ENVIRONMENT=production \
-     -e ENTE_HTTP_USE-TLS=0 \
+     -e ENTE_HTTP_USE_TLS=0 \
      --hostname "%H" \
      -p 8080:8080 \
      -p 2112:2112 \


### PR DESCRIPTION
**Tested by**

Modifying the compose.yaml to provide an environment variable:
```diff
      environment:
        ENTE_CREDENTIALS_FILE: /credentials.yaml
+       ENTE_HTTP_USE_TLS: 1
```
then observing that museum is honoring it 
```
...
[GIN-debug] Listening and serving HTTPS on :443
```