### PR TITLE
Revert "[desktop] Show/hide the window on tray icon double click on Linux/Win"

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -675,14 +675,6 @@ const setupTrayItem = (mainWindow: BrowserWindow) => {
     const tray = new Tray(trayIcon);
     tray.setToolTip("Ente Photos");
     tray.setContextMenu(createTrayContextMenu(mainWindow));
-
-    // On Windows and Linux, toggle the window on double-click (Double clicks
-    // are captured by the context menu on macOS).
-    if (process.platform != "darwin") {
-        tray.on("double-click", () =>
-            mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show(),
-        );
-    }
 };
 
 /**


### PR DESCRIPTION
Reverts ente-io/ente#5526. Like macOS, the double click interferes with the click event that shows the context menu on Linux too.