### PR TITLE
[web] Node 20 => 22

### DIFF
--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "desktop/yarn.lock"
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "docs/yarn.lock"
 

--- a/.github/workflows/docs-verify-build.yml
+++ b/.github/workflows/docs-verify-build.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "docs/yarn.lock"
 

--- a/.github/workflows/infra-deploy-staff.yml
+++ b/.github/workflows/infra-deploy-staff.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "infra/staff/yarn.lock"
 

--- a/.github/workflows/infra-lint-staff.yml
+++ b/.github/workflows/infra-lint-staff.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "infra/staff/yarn.lock"
 

--- a/.github/workflows/web-deploy-one.yml
+++ b/.github/workflows/web-deploy-one.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "web/yarn.lock"
 

--- a/.github/workflows/web-deploy-preview.yml
+++ b/.github/workflows/web-deploy-preview.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "web/yarn.lock"
 

--- a/.github/workflows/web-deploy-staging.yml
+++ b/.github/workflows/web-deploy-staging.yml
@@ -41,7 +41,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "web/yarn.lock"
 

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "web/yarn.lock"
 

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup node and enable yarn caching
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
                   cache: "yarn"
                   cache-dependency-path: "web/yarn.lock"
 

--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -52,7 +52,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Increase yarn timeout
               # `yarn install` times out sometimes on the Windows runner,

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 # Docs - https://github.com/ente-io/ente/blob/main/web/docs/docker.md
 
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /build
 COPY . .

--- a/web/apps/photos/package.json
+++ b/web/apps/photos/package.json
@@ -26,7 +26,7 @@
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^22.14.0",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.1",
         "@types/react-window": "^1.8.8",

--- a/web/docs/new.md
+++ b/web/docs/new.md
@@ -13,9 +13,9 @@ development, here is a recommended workflow:
    some examples:
 
     - OS agnostic: Install [NVM](https://github.com/nvm-sh/nvm), then
-      `nvm install 20 && corepack enable`.
+      `nvm install 22 && corepack enable`.
 
-    - macOS: `brew install node@20`
+    - macOS: `brew install node@22`
 
     - Ubuntu: `sudo apt install nodejs npm && sudo npm i -g corepack`
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1097,12 +1097,12 @@
   resolved "https://registry.yarnpkg.com/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz#f688f8d44e46ed61c401f82ff757581655fbcc42"
   integrity sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==
 
-"@types/node@^20":
-  version "20.17.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.11.tgz#2c05215fc37316b1596df7fbdba52151eaf83c50"
-  integrity sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==
+"@types/node@^22.14.0":
+  version "22.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.0.tgz#d3bfa3936fef0dbacd79ea3eb17d521c628bb47e"
+  integrity sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -4089,10 +4089,10 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Contributors do not necessarily need to update to node 22, I tested that the dev server works with node 20 also.

That said, if someone wishes to update - here is the dance I needed to do on macOS. Garnish to taste and OS.
```sh
brew uninstall node@20
brew install node@22
brew link node@22
corepack disable
corepack enable
```

