### PR TITLE
[fix] Database Authentication Error in Quickstart

### DIFF
--- a/server/docs/quickstart.md
+++ b/server/docs/quickstart.md
@@ -46,12 +46,12 @@ Then it creates a Docker compose file (`compose.yaml`) from a template, and a
 Finally, it start the Docker compose cluster running the following services on 3
 open ports:
 
-| Service     | Port     | Notes                   |
-| ----------- | -------- | ----------------------- |
-| museum      | `:8080`  | Ente's API server       |
-| web         | `:3000`  | Ente Photos web app     |
-| postgres    |          | DB                      |
-| minio       | `:3200`  | S3                      |
+| Service  | Port    | Notes               |
+| -------- | ------- | ------------------- |
+| museum   | `:8080` | Ente's API server   |
+| web      | `:3000` | Ente Photos web app |
+| postgres |         | DB                  |
+| minio    | `:3200` | S3                  |
 
 For each of these, it'll use the latest published Docker image.
 
@@ -119,6 +119,15 @@ persistent data is saved in volumes managed by Docker.
 > starting museum, one possibility is that you're recreating the `my-ente`
 > folder but still have leftover volumes (`my-ente_postgres-data` and
 > `my-ente_minio-data` from a previous attempt).
+
+> [!TIP]
+>
+> If you're getting errors like `pq: password authentication failed` when
+> starting museum, another possibility is that the password is not being sent
+> in `scram-sha-256` if there are mentions of using `scram-sha-256` in the
+> logs. Set `password_encryption = scram-sha-256` in `postgresql.conf` 
+> (present in `/var/lib/postgresql/data/`) and restart the cluster after
+> removing it along with volumes.
 
 ### Caveat
 

--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -196,4 +196,10 @@ printf "(Verification code will be in the logs here)\n\n"
 
 sleep 1
 
-docker compose up
+docker compose up -d
+
+docker exec -it my-ente-postgres-1 sh -c "echo \"password_encryption = scram-sha-256\" >> /var/lib/postgresql/data/postgresql.conf"
+
+docker exec -it my-ente-postgres-1 psql -U pguser -d postgres -c "SELECT 'CREATE DATABASE ente_db' WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'ente_db') LIMIT 1;"
+
+docker compose down && docker compose up


### PR DESCRIPTION
# Description

This PR fixes an error in `quickstart.sh` script used for deploying Ente on self-hosted instances where authentication to the database by museum was failing due to failure in sending password in SCRAM-SHA-256 format, which need to be configured in the container's configuration file (`postgresql.conf`)

It fixes a dirty migration caused upon enabling the configuration and the documentation is updated to reflect the changes, allowing users to troubleshoot issues related to password-based authentication failure.

# Notes:
- This error has been replicated on Artix Linux using OpenRC 0.61 and Linux 6.13.8
- The error has not been present on Ubuntu and Debian based distributions