### PR TITLE
[web] Update ffmpeg dep

### DIFF
--- a/web/packages/gallery/package.json
+++ b/web/packages/gallery/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "dependencies": {
-        "@ffmpeg/ffmpeg": "^0.12.10",
+        "@ffmpeg/ffmpeg": "^0.12.15",
         "bs58": "^6.0.0",
         "ente-base": "*",
         "ente-utils": "*",

--- a/web/packages/gallery/services/ffmpeg/web.ts
+++ b/web/packages/gallery/services/ffmpeg/web.ts
@@ -23,8 +23,8 @@ const ffmpegLazy = (): Promise<FFmpeg> => (_ffmpeg ??= createFFmpeg());
 const createFFmpeg = async () => {
     const ffmpeg = new FFmpeg();
     await ffmpeg.load({
-        coreURL: "https://assets.ente.io/ffmpeg-core-0.12.6/ffmpeg-core.js",
-        wasmURL: "https://assets.ente.io/ffmpeg-core-0.12.6/ffmpeg-core.wasm",
+        coreURL: "https://assets.ente.io/ffmpeg-core-0.12.10/ffmpeg-core.js",
+        wasmURL: "https://assets.ente.io/ffmpeg-core-0.12.10/ffmpeg-core.wasm",
     });
     return ffmpeg;
 };

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -475,17 +475,17 @@
     "@eslint/core" "^0.12.0"
     levn "^0.4.1"
 
-"@ffmpeg/ffmpeg@^0.12.10":
-  version "0.12.13"
-  resolved "https://registry.yarnpkg.com/@ffmpeg/ffmpeg/-/ffmpeg-0.12.13.tgz#654bb24d74638469e768c04e72ebd0988f65284a"
-  integrity sha512-DX5xvpxkV0QaHIJRMRiz8zfh4mJO01rPKrpXgIzHWSB0A58YMUvbBJxHs4cSJPcX1Lar7HK6RAi28ObsUe7V8A==
+"@ffmpeg/ffmpeg@^0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz#e5b05c2b5c946f3464b3aa85461e4654a4649d80"
+  integrity sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==
   dependencies:
-    "@ffmpeg/types" "^0.12.3"
+    "@ffmpeg/types" "^0.12.4"
 
-"@ffmpeg/types@^0.12.3":
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/@ffmpeg/types/-/types-0.12.3.tgz#9065bbfaee45daf41b7a0163d5a1cd05a96e9f49"
-  integrity sha512-WK01NqTfFfdXxxVD2+OQnd6LQp4ahWq2kjIh/eVoTo43Lo9ICI5nLOItg/1rcIvOuM7J1ANWTBazWGBKk1kACA==
+"@ffmpeg/types@^0.12.4":
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/@ffmpeg/types/-/types-0.12.4.tgz#aecd9b1a035882ee0bdf8853af37271a3b447473"
+  integrity sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==
 
 "@floating-ui/core@^1.6.0":
   version "1.6.8"


### PR DESCRIPTION
Assets via:

    mkdir ffmpeg-core-0.12.10
    curl -fsSLO https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.js
    curl -fsSLO https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.wasm

Note that the latest core version is (0.12.10) is different from the (latest, 0.12.15) @ffmpeg/ffmpeg version we're updating to.
