### PR TITLE
[mob] fix: only cache at max 50 files for memory widget

### DIFF
--- a/mobile/lib/services/memory_home_widget_service.dart
+++ b/mobile/lib/services/memory_home_widget_service.dart
@@ -145,7 +145,7 @@ class MemoryHomeWidgetService {
     final files = Map.fromEntries(
       memories.map((m) {
         return MapEntry(m.title, m.memories.map((e) => e.file).toList());
-      }).take(50),
+      }),
     );
 
     return files;

--- a/mobile/lib/services/memory_home_widget_service.dart
+++ b/mobile/lib/services/memory_home_widget_service.dart
@@ -230,7 +230,16 @@ class MemoryHomeWidgetService {
             );
           }
           index++;
+
+          if (index >= 50) {
+            _logger.warning(">>> Max memory limit reached");
+            break;
+          }
         }
+      }
+
+      if (index >= 50) {
+        break;
       }
     }
 


### PR DESCRIPTION
## Description

Previously we were caching all the memories without a working limit, this PR fixes that.

## Tests
