### PR TITLE
[server] Copy only libsodium lib to Docker image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   go build -o museum cmd/museum/main.go
 
 FROM alpine:3.21
-RUN apk add libsodium-dev
+COPY --from=builder /usr/lib/libsodium.so* /usr/lib
 COPY --from=builder /etc/ente/museum .
 COPY configurations configurations
 COPY migrations migrations


### PR DESCRIPTION
Suggested twice:
- https://github.com/ente-io/ente/pull/3952
- https://github.com/ente-io/ente/issues/5631

Fixes: https://github.com/ente-io/ente/issues/5631

**Tested by**

Theory: On a clean alpine container, ran `apk add libsodium` then visually glanced using
`docker container diff` that the .so is the only relevant file.

Practice: Recreated the local Docker compose using this updated file and
verified that server runs and can upload files etc.
