### PR TITLE
[auth] fix bingx icon

### DIFF
--- a/auth/assets/custom-icons/icons/bingx.svg
+++ b/auth/assets/custom-icons/icons/bingx.svg
@@ -1,1 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?><svg id="a" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 150 150"><defs><style>.e{fill:#2a54ff;}.f{fill:url(#d);}.g{fill:none;}</style><linearGradient id="d" x1="17.68" y1="116.45" x2="132.14" y2="32.11" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#2a54ff"/><stop offset=".52" stop-color="#2143cb"/><stop offset="1" stop-color="#2a54ff"/></linearGradient></defs><g id="b"><path id="c" class="g" d="M0,0H150V150H0V0Z"/></g><path class="f" d="M140.2,22.33c-25.18-.09-49.79,10.83-66.63,29.47-6.06,6.27-10.1,13.95-14.96,21.06-11.64,15.93-29.81,25.14-49.5,25.13h0v28.65h0c25.17,.1,49.78-10.86,66.63-29.5,6.03-6.27,10.13-13.94,14.96-21.06,11.64-15.91,29.81-25.12,49.5-25.11V22.33h0Z"/><path class="e" d="M140.2,97.99c-19.68,0-37.86-9.2-49.5-25.11-4.81-7.12-8.92-14.78-14.94-21.06C58.95,33.18,34.3,22.24,9.13,22.35h0v28.65h0c21.8-.11,42.05,11.62,53.01,30.46,3.22,5.62,7.06,10.9,11.45,15.74,16.83,18.63,41.46,29.59,66.63,29.5l-.02-28.7h0Z"/></svg>
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" id="a" viewBox="0 0 150 150">
+    <defs>
+        <linearGradient id="d" x1="17.68" y1="116.45" x2="132.14" y2="32.11"
+            gradientTransform="matrix(1, 0, 0, 1, 0, 0)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#2a54ff" />
+            <stop offset=".52" stop-color="#2143cb" />
+            <stop offset="1" stop-color="#2a54ff" />
+        </linearGradient>
+    </defs>
+    <g id="b">
+        <path id="c" d="M0,0H150V150H0V0Z" fill="none" />
+    </g>
+    <path
+        d="M140.2,22.33c-25.18-.09-49.79,10.83-66.63,29.47-6.06,6.27-10.1,13.95-14.96,21.06-11.64,15.93-29.81,25.14-49.5,25.13h0v28.65h0c25.17,.1,49.78-10.86,66.63-29.5,6.03-6.27,10.13-13.94,14.96-21.06,11.64-15.91,29.81-25.12,49.5-25.11V22.33h0Z"
+        fill="url(#d)" />
+    <path
+        d="M140.2,97.99c-19.68,0-37.86-9.2-49.5-25.11-4.81-7.12-8.92-14.78-14.94-21.06C58.95,33.18,34.3,22.24,9.13,22.35h0v28.65h0c21.8-.11,42.05,11.62,53.01,30.46,3.22,5.62,7.06,10.9,11.45,15.74,16.83,18.63,41.46,29.59,66.63,29.5l-.02-28.7h0Z"
+        fill="#2a54ff" />
+</svg>


### PR DESCRIPTION
## Description
the bingx icon added in #5186 was displayed as black.
i fixed the source using [this code](https://github.com/Bl4ckspell7/svg-css-to-inline-styling)

|  | old | fixed |
|-------|-------|------|
| light |![Screenshot From 2025-04-16 14-14-13](https://github.com/user-attachments/assets/ce0d1226-c82a-4e1b-a0d0-4a34839e8dce)|![Screenshot From 2025-04-16 14-19-36](https://github.com/user-attachments/assets/c8955cbd-7917-49dc-9c1f-24764da37765)|
| dark |![Screenshot From 2025-04-16 14-07-42](https://github.com/user-attachments/assets/dfeec407-6a32-40c4-a57f-fbf728406238)|![Screenshot From 2025-04-16 14-09-55](https://github.com/user-attachments/assets/3742dd50-deb2-474d-920f-f34d707983d6)|