### PR TITLE
[cli] Implement multithreaded downloading of files in export

### DIFF
--- a/cli/cmd/export.go
+++ b/cli/cmd/export.go
@@ -16,12 +16,14 @@ var exportCmd = &cobra.Command{
 		hidden, _ := cmd.Flags().GetBool("hidden")
 		albums, _ := cmd.Flags().GetStringSlice("albums")
 		emails, _ := cmd.Flags().GetStringSlice("emails")
+		jobs, _ := cmd.Flags().GetInt64("jobs")
 		// Create Filters struct with flag values
 		filters := model.Filter{
 			ExcludeShared: !shared,
 			ExcludeHidden: !hidden,
 			Albums:        albums,
 			Emails:        emails,
+			Jobs:          jobs,
 		}
 		// Call the Export function with the filters
 		ctrl.Export(filters)
@@ -36,4 +38,5 @@ func init() {
 	exportCmd.Flags().Bool("hidden", true, "to exclude hidden albums, pass --hidden=false")
 	exportCmd.Flags().StringSlice("albums", []string{}, "Comma-separated list of album names to export")
 	exportCmd.Flags().StringSlice("emails", []string{}, "Comma-separated list of emails to export files shared with")
+	exportCmd.Flags().Int64("jobs", 12, "amount of jobs to run for downloading files simultaneously")
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/zalando/go-keyring v0.2.3
 	golang.org/x/crypto v0.14.0
+	golang.org/x/sync v0.1.0
 )
 
 require (

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -312,6 +312,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/cli/pkg/model/filter.go
+++ b/cli/pkg/model/filter.go
@@ -16,6 +16,8 @@ type Filter struct {
 	Albums []string
 	// when email is provided, only files shared with that email are exported
 	Emails []string
+	// when jobs is provided, amount of jobs to use for downloading in exports
+	Jobs int64
 }
 
 func (f Filter) SkipAccount(email string) bool {


### PR DESCRIPTION
## Description

Using [Golang Semaphores](golang.org/x/sync/semaphore), i was able to implement multithreaded downloading of files during the export process of files.

## Functional changes

1. A cache is in place for the retrieval of an `albumDiskInfo`, rather than using a pointer. This is made due to the nature of goroutines.
2. `log.Fatal` is called upon failure of a download, where the previous behavior was to simply return the error. This is intentional, since otherwise, there would be two ways to forward the error, such as errgroups or cancelling the context.
3. A new log is printed when a download finishes.

This speeds up the download process **significantly!** The jobs count out of the box is 12, but i feel like it should be increased too.

## Tests

None to be implemented, since this is on the user's side