### PR TITLE
[mob][photos] Video editor improvements

### DIFF
--- a/mobile/lib/models/ffmpeg/ffprobe_props.dart
+++ b/mobile/lib/models/ffmpeg/ffprobe_props.dart
@@ -82,6 +82,8 @@ class FFProbeProps {
     return width! / height!;
   }
 
+  int? get rotation => _rotation;
+
   // toString() method
   @override
   String toString() {

--- a/mobile/lib/ui/common/linear_progress_dialog.dart
+++ b/mobile/lib/ui/common/linear_progress_dialog.dart
@@ -11,19 +11,44 @@ class LinearProgressDialog extends StatefulWidget {
   LinearProgressDialogState createState() => LinearProgressDialogState();
 }
 
-class LinearProgressDialogState extends State<LinearProgressDialog> {
-  double? _progress;
+class LinearProgressDialogState extends State<LinearProgressDialog>
+    with TickerProviderStateMixin {
+  late AnimationController controller;
+  late Tween<double> _tween;
+  late Animation<double> _animation;
+
+  double _target = 0.0;
 
   @override
   void initState() {
-    _progress = 0;
     super.initState();
+    controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+
+    _tween = Tween<double>(begin: _target, end: _target);
+
+    _animation = _tween.animate(
+      CurvedAnimation(
+        curve: Curves.easeInOut,
+        parent: controller,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
   }
 
   void setProgress(double progress) {
-    setState(() {
-      _progress = progress;
-    });
+    _target = progress;
+    _tween.begin = _tween.end;
+    controller.reset();
+    _tween.end = progress;
+    controller.forward();
   }
 
   @override
@@ -36,11 +61,16 @@ class LinearProgressDialogState extends State<LinearProgressDialog> {
           style: getEnteTextTheme(context).smallMuted,
           textAlign: TextAlign.center,
         ),
-        content: LinearProgressIndicator(
-          value: _progress,
-          valueColor: AlwaysStoppedAnimation<Color>(
-            Theme.of(context).colorScheme.greenAlternative,
-          ),
+        content: AnimatedBuilder(
+          animation: _animation,
+          builder: (context, child) {
+            return LinearProgressIndicator(
+              value: _animation.value,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                Theme.of(context).colorScheme.greenAlternative,
+              ),
+            );
+          },
         ),
       ),
     );

--- a/mobile/lib/ui/common/linear_progress_dialog.dart
+++ b/mobile/lib/ui/common/linear_progress_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:photos/ente_theme_data.dart';
+import "package:photos/theme/ente_theme.dart";
 
 class LinearProgressDialog extends StatefulWidget {
   final String message;
@@ -32,9 +33,7 @@ class LinearProgressDialogState extends State<LinearProgressDialog> {
       child: AlertDialog(
         title: Text(
           widget.message,
-          style: const TextStyle(
-            fontSize: 16,
-          ),
+          style: getEnteTextTheme(context).smallMuted,
           textAlign: TextAlign.center,
         ),
         content: LinearProgressIndicator(

--- a/mobile/lib/ui/tools/editor/video_crop_page.dart
+++ b/mobile/lib/ui/tools/editor/video_crop_page.dart
@@ -9,7 +9,12 @@ import "package:photos/ui/tools/editor/video_editor/video_editor_player_control.
 import 'package:video_editor/video_editor.dart';
 
 class VideoCropPage extends StatefulWidget {
-  const VideoCropPage({super.key, required this.controller});
+  final int quarterTurnsForRotationCorrection;
+  const VideoCropPage({
+    super.key,
+    required this.controller,
+    required this.quarterTurnsForRotationCorrection,
+  });
 
   final VideoEditorController controller;
 
@@ -31,10 +36,13 @@ class _VideoCropPageState extends State<VideoCropPage> {
             Expanded(
               child: Hero(
                 tag: "video-editor-preview",
-                child: CropGridViewer.edit(
-                  controller: widget.controller,
-                  rotateCropArea: false,
-                  margin: const EdgeInsets.symmetric(horizontal: 20),
+                child: RotatedBox(
+                  quarterTurns: widget.quarterTurnsForRotationCorrection,
+                  child: CropGridViewer.edit(
+                    controller: widget.controller,
+                    rotateCropArea: false,
+                    margin: const EdgeInsets.symmetric(horizontal: 20),
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -50,7 +50,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
   final _logger = Logger("VideoEditor");
 
   /// Some videos have a 'rotation' property in exif that is not 0 which
-  /// causes the video to appear rotated in the video editor preview.
+  /// causes the video to appear rotated in the video editor preview on Andoird.
   /// This variable is used as a workaround to rotate the video back to its
   /// expected orientation.
   int? _quarterTurnsForRotationCorrection;
@@ -93,14 +93,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
       );
     });
 
-    getVideoPropsAsync(widget.ioFile).then((props) async {
-      if (props?.rotation != null) {
-        _quarterTurnsForRotationCorrection = -(props!.rotation! / 90).round();
-      } else {
-        _quarterTurnsForRotationCorrection = 0;
-      }
-      setState(() {});
-    });
+    _doRotationCorrectionIfAndroid();
   }
 
   @override
@@ -344,6 +337,21 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
       Navigator.of(dialogKey.currentContext!).pop('dialog');
     } finally {
       await PhotoManager.startChangeNotify();
+    }
+  }
+
+  void _doRotationCorrectionIfAndroid() {
+    if (Platform.isAndroid) {
+      getVideoPropsAsync(widget.ioFile).then((props) async {
+        if (props?.rotation != null) {
+          _quarterTurnsForRotationCorrection = -(props!.rotation! / 90).round();
+        } else {
+          _quarterTurnsForRotationCorrection = 0;
+        }
+        setState(() {});
+      });
+    } else {
+      _quarterTurnsForRotationCorrection = 0;
     }
   }
 }

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -49,10 +49,10 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
   final _isExporting = ValueNotifier<bool>(false);
   final _logger = Logger("VideoEditor");
 
-  /// Some videos have a 'rotation' property in exif that is not 0 which
-  /// causes the video to appear rotated in the video editor preview on Andoird.
+  /// Some videos have a non-zero 'rotation' property in exif which causes the
+  /// video to appear rotated in the video editor preview on Andoird.
   /// This variable is used as a workaround to rotate the video back to its
-  /// expected orientation.
+  /// expected orientation in the viewer.
   int? _quarterTurnsForRotationCorrection;
 
   VideoEditorController? _controller;

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -48,6 +48,11 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
   final _exportingProgress = ValueNotifier<double>(0.0);
   final _isExporting = ValueNotifier<bool>(false);
   final _logger = Logger("VideoEditor");
+
+  /// Some videos have a 'rotation' property in exif that is not 0 which
+  /// causes the video to appear rotated in the video editor preview.
+  /// This variable is used as a workaround to rotate the video back to its
+  /// expected orientation.
   int? _quarterTurnsForRotationCorrection;
 
   VideoEditorController? _controller;

--- a/mobile/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/lib/ui/tools/editor/video_editor_page.dart
@@ -52,6 +52,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
 
   @override
   void initState() {
+    _logger.info("Initializing video editor page");
     super.initState();
 
     Future.microtask(() {
@@ -97,6 +98,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
 
   @override
   Widget build(BuildContext context) {
+    _logger.info("Bulding video editor page");
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {

--- a/mobile/lib/ui/tools/editor/video_rotate_page.dart
+++ b/mobile/lib/ui/tools/editor/video_rotate_page.dart
@@ -8,7 +8,12 @@ import "package:photos/ui/tools/editor/video_editor/video_editor_player_control.
 import 'package:video_editor/video_editor.dart';
 
 class VideoRotatePage extends StatelessWidget {
-  const VideoRotatePage({super.key, required this.controller});
+  final int quarterTurnsForRotationCorrection;
+  const VideoRotatePage({
+    super.key,
+    required this.controller,
+    required this.quarterTurnsForRotationCorrection,
+  });
 
   final VideoEditorController controller;
 
@@ -26,8 +31,11 @@ class VideoRotatePage extends StatelessWidget {
             Expanded(
               child: Hero(
                 tag: "video-editor-preview",
-                child: CropGridViewer.preview(
-                  controller: controller,
+                child: RotatedBox(
+                  quarterTurns: quarterTurnsForRotationCorrection,
+                  child: CropGridViewer.preview(
+                    controller: controller,
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/ui/tools/editor/video_trim_page.dart
+++ b/mobile/lib/ui/tools/editor/video_trim_page.dart
@@ -6,7 +6,12 @@ import "package:photos/ui/tools/editor/video_editor/video_editor_player_control.
 import 'package:video_editor/video_editor.dart';
 
 class VideoTrimPage extends StatefulWidget {
-  const VideoTrimPage({super.key, required this.controller});
+  final int quarterTurnsForRotationCorrection;
+  const VideoTrimPage({
+    super.key,
+    required this.controller,
+    required this.quarterTurnsForRotationCorrection,
+  });
 
   final VideoEditorController controller;
 
@@ -30,16 +35,19 @@ class _VideoTrimPageState extends State<VideoTrimPage> {
       body: SafeArea(
         child: Column(
           children: [
+            VideoEditorPlayerControl(
+              controller: widget.controller,
+            ),
             Expanded(
               child: Hero(
                 tag: "video-editor-preview",
-                child: CropGridViewer.preview(
-                  controller: widget.controller,
+                child: RotatedBox(
+                  quarterTurns: widget.quarterTurnsForRotationCorrection,
+                  child: CropGridViewer.preview(
+                    controller: widget.controller,
+                  ),
                 ),
               ),
-            ),
-            VideoEditorPlayerControl(
-              controller: widget.controller,
             ),
             ..._trimSlider(),
             const SizedBox(height: 40),


### PR DESCRIPTION
## Description

- #### Better UX on exporting an edited video
    If a video is large enough (even an 8s 4k video), the export process can take a while. Previously, we were only showing a 'Saving edits...' message in a dialog, which gave users no indication of how much time it would take and some even thought the app was stuck. I’ve resolved this by adding a linear progress indicator to show the progress.
    
    https://github.com/user-attachments/assets/b078337f-0e29-4738-a8b6-f8f94474a4c8

- #### Fix video previewing in a flipped state upon opening video editor (Bug exists only android).

