### PR TITLE
remove hex for LinkedIn icon.

### DIFF
--- a/auth/assets/custom-icons/_data/custom-icons.json
+++ b/auth/assets/custom-icons/_data/custom-icons.json
@@ -625,8 +625,7 @@
     },
     {
       "title": "LinkedIn",
-      "slug": "linkedin",
-      "hex": "2596be"
+      "slug": "linkedin"
     },
     {
       "title": "Linux.Do",


### PR DESCRIPTION
Fix LinkedIn icon rendering by removing unwanted hex code.

Before:

![image](https://github.com/user-attachments/assets/32bd8b2b-e92b-47fb-918e-c7a8fc0ae735)
