### PR TITLE
Copy --link

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.23-alpine3.21 AS builder
 RUN apk add --no-cache gcc musl-dev git build-base pkgconfig libsodium-dev
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -5,18 +5,18 @@ ENV GOOS=linux
 
 WORKDIR /etc/ente/
 
-COPY go.mod .
-COPY go.sum .
+COPY --link go.mod .
+COPY --link go.sum .
 RUN go mod download
 
-COPY . .
+COPY --link . .
 # the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
 RUN --mount=type=cache,target=/root/.cache/go-build \
   go build -o ente-cli main.go
 
 FROM alpine:3.21
 RUN apk add libsodium-dev
-COPY --from=builder /etc/ente/ente-cli .
+COPY --link --from=builder /etc/ente/ente-cli .
 
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT

--- a/cli/Dockerfile-x86
+++ b/cli/Dockerfile-x86
@@ -10,11 +10,11 @@ ENV GOOS=linux
 
 WORKDIR /etc/ente/
 RUN uname -a
-COPY go.mod .
-COPY go.sum .
+COPY --link go.mod .
+COPY --link go.sum .
 RUN go mod download
 
 
-COPY . .
+COPY --link . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
      go build -o ente-cli main.go

--- a/cli/Dockerfile-x86
+++ b/cli/Dockerfile-x86
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.23-alpine3.21@sha256:6c5c9590f169f77c8046e45c611d3b28fe477789acd8d3762d23d4744de69812 AS builder386
 RUN apt-get  update
 RUN apt-get  install -y gcc

--- a/infra/copycat-db/Dockerfile
+++ b/infra/copycat-db/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get install -y curl gnupg

--- a/infra/copycat-db/Dockerfile
+++ b/infra/copycat-db/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y jq
 RUN apt-get install -y unzip
 RUN curl https://rclone.org/install.sh | bash
 
-COPY src /
+COPY --link src /
 
 ENTRYPOINT ["tini", "--"]
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,20 +5,20 @@ ENV GOOS=linux
 
 WORKDIR /etc/ente/
 
-COPY go.mod .
-COPY go.sum .
+COPY --link go.mod .
+COPY --link go.sum .
 RUN go mod download
 
-COPY . .
+COPY --link . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
   go build -o museum cmd/museum/main.go
 
 FROM alpine:3.21
-COPY --from=builder /usr/lib/libsodium.so* /usr/lib
-COPY --from=builder /etc/ente/museum .
-COPY configurations configurations
-COPY migrations migrations
-COPY mail-templates mail-templates
+COPY --link --from=builder /usr/lib/libsodium.so* /usr/lib
+COPY --link --from=builder /etc/ente/museum .
+COPY --link configurations configurations
+COPY --link migrations migrations
+COPY --link mail-templates mail-templates
 
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.23.4-alpine3.21 AS builder
 RUN apk add --no-cache gcc musl-dev git build-base pkgconfig libsodium-dev
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Docs - https://github.com/ente-io/ente/blob/main/web/docs/docker.md
 
 FROM node:22-alpine AS builder

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:22-alpine AS builder
 
 WORKDIR /build
-COPY . .
+COPY --link . .
 
 ENV NEXT_PUBLIC_ENTE_ENDPOINT=ENTE_API_ORIGIN_PLACEHOLDER
 ENV NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT=ENTE_ALBUMS_ORIGIN_PLACEHOLDER
@@ -21,12 +21,12 @@ FROM nginx
 
 WORKDIR /out
 
-COPY --from=builder /build/apps/photos/out /out/photos
-COPY --from=builder /build/apps/accounts/out /out/accounts
-COPY --from=builder /build/apps/auth/out /out/auth
-COPY --from=builder /build/apps/cast/out /out/cast
+COPY --link --from=builder /build/apps/photos/out /out/photos
+COPY --link --from=builder /build/apps/accounts/out /out/accounts
+COPY --link --from=builder /build/apps/auth/out /out/auth
+COPY --link --from=builder /build/apps/cast/out /out/cast
 
-COPY <<EOF /etc/nginx/conf.d/default.conf
+COPY --link <<EOF /etc/nginx/conf.d/default.conf
 server {
     listen 3000; root /out/photos;
     location / { try_files \$uri \$uri.html /index.html; }
@@ -58,7 +58,7 @@ EXPOSE 3004
 ENV ENTE_API_ORIGIN=http://localhost:8080
 ENV ENTE_ALBUMS_ORIGIN=https://localhost:3002
 
-COPY <<EOF /docker-entrypoint.d/90-replace-ente-env.sh
+COPY --link <<EOF /docker-entrypoint.d/90-replace-ente-env.sh
 find /out -name '*.js' |
     xargs sed -i'' "s#ENTE_API_ORIGIN_PLACEHOLDER#\$ENTE_API_ORIGIN#g"
 find /out/photos -name '*.js' |


### PR DESCRIPTION
## Description
`--link` is desirable in almost all situations where `COPY` is used due to caching improvements. See https://docs.docker.com/reference/dockerfile/#benefits-of-using---link and https://docs.docker.com/reference/dockerfile/#incompatibilities-with---linkfalse. The syntax parser directive is used to pin the Dockerfile syntax for BuildKit. See https://docs.docker.com/reference/dockerfile/#syntax.

## Tests
Have confirmed all of the images build successfully, with the exception of cli/Dockerfile-x86, which is broken for unrelated reasons. I assume there are some tests defined in the Actions workflows, but will run tests locally if needed.