### PR TITLE
[desktop] HLS gen - WIP - Part x/x

### DIFF
--- a/desktop/src/main/services/ffmpeg.ts
+++ b/desktop/src/main/services/ffmpeg.ts
@@ -442,6 +442,10 @@ export const ffmpegGenerateHLSPlaylistAndSegments = async (
  *     Stream #0:0: Video: h264 (High 10) ([27][0][0][0] / 0x001B), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 1920x1080, 30 fps, 30 tbr, 90k tbn
  *
  * The part after Video: is the first capture group.
+ *
+ * Another example:
+ *
+ *     Stream #0:1[0x2](und): Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p(progressive), 480x270 [SAR 1:1 DAR 16:9], 539 kb/s, 29.97 fps, 29.97 tbr, 30k tbn (default)
  */
 const videoStreamLineRegex = /Stream #.+: Video:(.+)\n/;
 
@@ -449,18 +453,20 @@ const videoStreamLineRegex = /Stream #.+: Video:(.+)\n/;
 const videoStreamLinesRegex = /Stream #.+: Video:(.+)\n/g;
 
 /**
- * A regex that matches "<digits> kb/s" preceded by a space and followed by a
- * trailing comma. See {@link videoStreamLineRegex} for the context in which it
- * is used.
+ * A regex that matches "<digits> kb/s" preceded by a space. See
+ * {@link videoStreamLineRegex} for the context in which it is used.
  */
-const videoBitrateRegex = / (\d+) kb\/s,/;
+const videoBitrateRegex = / ([1-9]\d*) kb\/s/;
 
 /**
- * A regex that matches <digits>x<digits> pair preceded by a space and followed
- * by a trailing comma. See {@link videoStreamLineRegex} for the context in
- * which it is used.
+ * A regex that matches <digits>x<digits> pair preceded by a space. See
+ * {@link videoStreamLineRegex} for the context in which it is used.
+ *
+ * We constrain the digit sequence not to begin with 0 to exclude hexadecimal
+ * representations of various constants that ffmpeg prints on this line (e.g.
+ * "avc1 / 0x31637661").
  */
-const videoDimensionsRegex = / (\d+)x(\d+),/;
+const videoDimensionsRegex = / ([1-9]\d*)x([1-9]\d*)/;
 
 interface VideoCharacteristics {
     isH264: boolean;

--- a/desktop/src/main/services/ffmpeg.ts
+++ b/desktop/src/main/services/ffmpeg.ts
@@ -143,8 +143,19 @@ export interface FFmpegGenerateHLSPlaylistAndSegmentsResult {
  * A bespoke variant of {@link ffmpegExec} for generation of HLS playlists for
  * videos.
  *
+ * Overview of the cases:
+ *
+ *     H.264, <= 10 MB             - Skip
+ *     H.264, <= 4000 kb/s bitrate - Don't re-encode video stream
+ *     <= 2000 kb/s bitrate        - Don't apply the scale+fps filter
+ *     !BT.709                     - Apply tonemap (zscale+tonemap+zscale)
+ *
+ * Example invocation:
+ *
+ *     ffmpeg -i in.mov -vf 'scale=-2:720,fps=30,zscale=transfer=linear,tonemap=tonemap=hable:desat=0,zscale=primaries=709:transfer=709:matrix=709,format=yuv420p' -c:v libx264 -c:a aac -f hls -hls_key_info_file out.m3u8.info -hls_list_size 0 -hls_flags single_file out.m3u8
+ *
  * See: [Note: Preview variant of videos]
-
+ *
  * @param inputFilePath The path to a file on the user's local file system. This
  * is the video we want to generate an streamable HLS playlist for.
  *

--- a/desktop/src/main/stream.ts
+++ b/desktop/src/main/stream.ts
@@ -328,7 +328,7 @@ const handleGenerateHLSWrite = async (
 
         if (!result) {
             // This video doesn't require stream generation.
-            return new Response("", { status: 204 });
+            return new Response(null, { status: 204 });
         }
 
         const { playlistPath, videoPath } = result;

--- a/web/packages/gallery/services/video.ts
+++ b/web/packages/gallery/services/video.ts
@@ -420,12 +420,18 @@ const processQueueItem = async (
 
     log.info(`Generate HLS for ${fileLogID(file)} | start`);
 
-    const { playlistToken, dimensions, videoSize } = await initiateGenerateHLS(
+    const res = await initiateGenerateHLS(
         electron,
         sourceVideo!,
         objectUploadURL,
     );
 
+    if (!res) {
+        log.info(`Generate HLS for ${fileLogID(file)} | not-required`);
+        return;
+    }
+
+    const { playlistToken, dimensions, videoSize } = res;
     try {
         const playlist = await readVideoStream(electron, playlistToken).then(
             (res) => res.text(),

--- a/web/packages/gallery/utils/native-stream.ts
+++ b/web/packages/gallery/utils/native-stream.ts
@@ -190,13 +190,17 @@ export type GenerateHLSResult = z.infer<typeof GenerateHLSResult>;
  * metadata about the generated video (its byte size and dimensions). See {@link
  * GenerateHLSResult.
  *
+ * In case the video is such that it doesn't require a separate stream to be
+ * generated (e.g. it is a small video using an already compatible codec), then
+ * this function will return `undefined`.
+ *
  * See: [Note: Preview variant of videos].
  */
 export const initiateGenerateHLS = async (
     _: Electron,
     video: UploadItem | ReadableStream,
     objectUploadURL: string,
-): Promise<GenerateHLSResult> => {
+): Promise<GenerateHLSResult | undefined> => {
     const params = new URLSearchParams({ op: "generate-hls", objectUploadURL });
 
     let body: ReadableStream | null;
@@ -237,6 +241,8 @@ export const initiateGenerateHLS = async (
     });
     if (!res.ok)
         throw new Error(`Failed to write stream to ${url}: HTTP ${res.status}`);
+
+    if (res.status == 204) return undefined;
 
     return GenerateHLSResult.parse(await res.json());
 };


### PR DESCRIPTION
Four cases:

    H.264, <= 10 MB             - Skip
    H.264, <= 4000 kb/s bitrate - Don't re-encode video stream
    <= 2000 kb/s bitrate        - Don't apply the scale+fps filter
    !BT.709                     - Apply tonemap (zscale+tonemap+zscale)

Example invocation:

    ffmpeg -i in.mov -vf 'scale=-2:720,fps=30,zscale=transfer=linear,tonemap=tonemap=hable:desat=0,zscale=primaries=709:transfer=709:matrix=709,format=yuv420p' -c:v libx264 -c:a aac -f hls -hls_key_info_file out.m3u8.info -hls_list_size 0 -hls_flags single_file out.m3u8