### PR TITLE
[mob] Fix: Add missing check for widget mount

### DIFF
--- a/mobile/lib/ui/home/loading_photos_widget.dart
+++ b/mobile/lib/ui/home/loading_photos_widget.dart
@@ -39,7 +39,9 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
   void initState() {
     super.initState();
     Future.delayed(const Duration(seconds: 60), () {
-      oneMinuteOnScreen.value = true;
+      if (mounted) {
+        oneMinuteOnScreen.value = true;
+      }
     });
     _firstImportEvent =
         Bus.instance.on<SyncStatusUpdate>().listen((event) async {


### PR DESCRIPTION
## Description
```
FlutterError (A ValueNotifier<bool> was used after being disposed.
                       Once you have called dispose() on a ValueNotifier<bool>, it can no longer be used.)
[sentry.platformError] #0      ChangeNotifier.debugAssertNotDisposed.<anonymous closure> (package:flutter/src/foundation/change_notifier.dart:183:9)
                          1  ChangeNotifier.debugAssertNotDisposed (package:flutter/src/foundation/change_notifier.dart:190:6)
change_notifier.dart:190
                         2    ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:416:27)
change_notifier.dart:416
                       3      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:559:5)
change_notifier.dart:559
                       4      _LoadingPhotosWidgetState.initState.<anonymous closure> (package:photos/ui/home/loading_photos_widget.dart:42:25)
```
## Tests
