### PR TITLE
[workflow] revert to ubuntu 22.04 runner for auth-release

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
     build-linux-latest:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         defaults:
             run:


### PR DESCRIPTION
## Description

- [x] Auth is dependent on GLIB 2.38 due to ubuntu latest runner, this downgrades the ubuntu runner to fix this and support atleast GLIB 2.35

## Tests
