### PR TITLE
[quickstart] Gracefully handle case when docker compose is not present

### DIFF
--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -10,7 +10,7 @@ set -e
 dcv=""
 if command -v docker >/dev/null
 then
-    dcv=`docker compose version --short 2>/dev/null`
+    dcv=`docker compose version --short 2>/dev/null || echo`
 fi
 
 if test -z "$dcv"


### PR DESCRIPTION
When docker is present but docker compose is not present, the `docker compose` invocation would fail. We want the early exit (`set -e`), so instead do a fallback to set dcv to an empty string so that it later fails in the `test -z dcv` case below and prints the intended error message.
