### PR TITLE
[web] Ensure ellipsizing of caption

### DIFF
--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -155,19 +155,19 @@
     bottom: 0px;
     right: 0;
     margin: 20px 24px;
-    padding-inline: 16px;
     border-radius: 3px;
     /* Same opacity as the other controls. */
     color: rgb(255 255 255 / 0.85);
     background-color: rgb(0 0 0 / 0.2);
     backdrop-filter: blur(10px);
-    text-align: right;
     max-width: 375px;
     max-height: 200px;
     p {
+        margin: 12px 17px;
         /* 4 lines max, ellipsis on overflow. */
         word-break: break-word;
         overflow: hidden;
+        text-overflow: ellipsis;
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 4;


### PR DESCRIPTION
`text-align: right` causes the ellipsizing to sometimes work, sometimes not, depending on the exact contents of the line (tested in current Chrome). Tweak the design to work with the normal text align to try and ensure the elision is always ellipsized.
