### PR TITLE
[quickstart] add guidelines on HTTPS museum usage

### DIFF
--- a/server/docs/quickstart.md
+++ b/server/docs/quickstart.md
@@ -48,7 +48,7 @@ open ports:
 
 | Service     | Port     | Notes                   |
 | ----------- | -------- | ----------------------- |
-| museum      | `:8080`  | Ente's API server       |
+| museum      | `:8080`  | Ente's HTTP API server. You can [enable](#configuring-the-museum-for-https) HTTPS on `:443` manually. |
 | web         | `:3000`  | Ente Photos web app     |
 | postgres    |          | DB                      |
 | minio       | `:3200`  | S3                      |
@@ -119,6 +119,25 @@ persistent data is saved in volumes managed by Docker.
 > starting museum, one possibility is that you're recreating the `my-ente`
 > folder but still have leftover volumes (`my-ente_postgres-data` and
 > `my-ente_minio-data` from a previous attempt).
+
+### Configuring the museum for HTTPS
+
+The `compose.yaml` and `museum.yaml` require small changes to enable secure HTTPS for communication with museum API:
+- `compose.yaml`:
+   - change the port that the museum API listens on to `443`
+   - add the certificate files, i.e. `tls.cert` and `tls.key`, to `./credentials` folder
+- `museum.yaml`:
+   - set the `use-tls` to `true`
+
+> [!IMPORTANT]
+> Use copies or hardlinks for certificate files, not symlinks.
+
+> [!IMPORTANT]
+> You need to use the fullchain certificate file (`fullchain.cer`) if using Let's Encrypt.
+
+You then need to stop the cluster and start it up again, as instructed above. If you already
+connected any of the client apps to your instance, you will need to log out and [configure your your
+app(s)](#next-steps) to point to your ente instance using the fully-qualified URL over the 443 port.
 
 ### Caveat
 

--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -72,13 +72,21 @@ services:
   museum:
     image: ghcr.io/ente-io/server
     ports:
-      - 8080:8080 # API
+      - 8080:8080 # Museum API without HTTPS
+      # - 443:443 # Museum API with HTTPS. Also add certificates below and enable TLS in museum.yaml.
     depends_on:
       postgres:
         condition: service_healthy
     volumes:
       - ./museum.yaml:/museum.yaml:ro
       - ./data:/data:ro
+      # For certificates, if using HTTPS.
+      # Use copies or hardlinks, not symlinks. Needs fullchain certificate if using Let's Encrypt.  
+      # Also see https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml
+      # - ./credentials:/credentials:ro
+      # You can also map the certificates directly from another folder, e.g.:
+      # - /root/.acme.sh/ente.your.host.com_ecc/ente.your.host.com.key:/credentials/tls.key:ro
+      # - /root/.acme.sh/ente.your.host.com_ecc/fullchain.cer:/credentials/tls.cert:ro
 
   # Resolve "localhost:3200" in the museum container to the minio container.
   socat:
@@ -157,6 +165,10 @@ key:
 jwt:
       secret: $museum_jwt_secret
 
+http:
+      # Change to true if using HTTPS for museum API.
+      # Requires providing certificates and changing the exposed API port in compose.yaml
+      use-tls: false 
 db:
       host: postgres
       port: 5432

--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -84,7 +84,7 @@ services:
       # Use copies or hardlinks, not symlinks. Needs fullchain certificate if using Let's Encrypt.  
       # Also see https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml
       # - ./credentials:/credentials:ro
-      # You can also map the certificates directly from another folder, e.g.:
+      # Alternatively, you can mount the certificates directly from another folder, e.g.:
       # - /root/.acme.sh/ente.your.host.com_ecc/ente.your.host.com.key:/credentials/tls.key:ro
       # - /root/.acme.sh/ente.your.host.com_ecc/fullchain.cer:/credentials/tls.cert:ro
 
@@ -158,6 +158,8 @@ printf " \033[1;32mN\033[0m   Created \033[1mcompose.yaml\033[0m\n"
 sleep 1
 
 cat <<EOF >museum.yaml
+# See https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml for reference
+
 key:
       encryption: $museum_key
       hash: $museum_hash


### PR DESCRIPTION
## Description
Setting up Museum over the HTTPS for self-hosting is actually very easy, but requires 3 extra steps. This adds necessary but commented out parameters, with extra instructions, as well some extra docs content to the `quickstart.md` document — although I do not see it linked anywhere on https://help.ente.io ?
