### PR TITLE
[workflow](auth-release) separate checksum as *-linux & *-apk

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -117,7 +117,9 @@ jobs:
                   mv dist/**/*-*-linux.deb artifacts/ente-${{ github.ref_name }}-x86_64.deb
 
             - name: Generate checksums
-              run: sha256sum artifacts/ente-* >> artifacts/sha256sum-rpm-appimage
+              run: |
+                sha256sum artifacts/ente-auth-*.apk >> artifacts/sha256sum-apk
+                sha256sum artifacts/ente-auth-*.deb artifacts/ente-auth-*.rpm artifacts/ente-auth-*.AppImage >> artifacts/sha256sum-linux
 
             - name: Create a draft GitHub release
               uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Description

After last change the checksum name also need to changed to suffice the new files and the unified ubuntu workflow. Here I am modifying the checksum so that there are two different versions, one for linux related binaries and another for the solo apk file.

## Tests
