### PR TITLE
[web] Add workaround for Safari live photo download

### DIFF
--- a/web/apps/photos/src/utils/file/index.ts
+++ b/web/apps/photos/src/utils/file/index.ts
@@ -22,6 +22,7 @@ import {
 import { safeFileName } from "ente-new/photos/utils/native-fs";
 import { getData } from "ente-shared/storage/localStorage";
 import type { User } from "ente-shared/user/types";
+import { wait } from "ente-utils/promise";
 import { t } from "i18next";
 import {
     addMultipleToFavorites,
@@ -60,6 +61,9 @@ export async function downloadFile(file: EnteFile) {
                 new Blob([videoData], { type: videoType.mimeType }),
             );
             downloadAndRevokeObjectURL(tempImageURL, imageFileName);
+            // Downloading multiple works everywhere except, you guessed it,
+            // Safari. Make up for their incompetence by adding a setTimeout.
+            await wait(300) /* arbitrary constant, 300ms */;
             downloadAndRevokeObjectURL(tempVideoURL, videoFileName);
         } else {
             const fileType = await detectFileTypeInfo(


### PR DESCRIPTION
Tested on Safari (obv) and Chrome.