### PR TITLE
[mob][photos] Contacts section performance improvements

### DIFF
--- a/mobile/lib/states/all_sections_examples_state.dart
+++ b/mobile/lib/states/all_sections_examples_state.dart
@@ -96,9 +96,16 @@ class _AllSectionsExamplesProviderState
         _logger.info("'_debounceTimer: reloading all sections in search tab");
         final allSectionsExamples = <Future<List<SearchResult>>>[];
         for (SectionType sectionType in SectionType.values) {
-          allSectionsExamples.add(
-            sectionType.getData(context, limit: kSearchSectionLimit),
-          );
+          // Contacts section have been moved to shared collections tab
+          // temporarily from search tab. So we can skip computing data here
+          // since 'allSectionsExamples' is for search tab sections only.
+          if (sectionType == SectionType.contacts) {
+            allSectionsExamples.add(Future.value([]));
+          } else {
+            allSectionsExamples.add(
+              sectionType.getData(context, limit: kSearchSectionLimit),
+            );
+          }
         }
         try {
           allSectionsExamplesFuture = Future.wait<List<SearchResult>>(


### PR DESCRIPTION
## Description

- Defer the initial load until the Shared Collection tab is in view to avoid unnecessary work at app startup.
- Remove the computation previously done for the Search tab sections that was intended for the Contacts section, as it is no longer present.
