### PR TITLE
[desktop] Fix HLS regex for Windows

### DIFF
--- a/desktop/src/main/services/ffmpeg-worker.ts
+++ b/desktop/src/main/services/ffmpeg-worker.ts
@@ -544,10 +544,10 @@ const deletePathIgnoringErrors = async (tempFilePath: string) => {
  *
  *     Stream #0:1[0x2](und): Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p(progressive), 480x270 [SAR 1:1 DAR 16:9], 539 kb/s, 29.97 fps, 29.97 tbr, 30k tbn (default)
  */
-const videoStreamLineRegex = /Stream #.+: Video:(.+)\n/;
+const videoStreamLineRegex = /Stream #.+: Video:(.+)$/;
 
 /** {@link videoStreamLineRegex}, but global. */
-const videoStreamLinesRegex = /Stream #.+: Video:(.+)\n/g;
+const videoStreamLinesRegex = /Stream #.+: Video:(.+)$/g;
 
 /**
  * A regex that matches "<digits> kb/s" preceded by a space. See


### PR DESCRIPTION
`$` eol should match both `\r\n` (windows) and `\n` (rest)