### PR TITLE
[mob] Fix: Treat sandbox file as unique file during upload

### DIFF
--- a/mobile/lib/utils/file_uploader.dart
+++ b/mobile/lib/utils/file_uploader.dart
@@ -907,12 +907,15 @@ class FileUploader {
   files. if the link is successful, it returns true otherwise false.
   When false, we should go ahead and re-upload or update the file.
   It performs following checks:
-    a) Uploaded file with same localID and destination collection. Delete the
-     fileToUpload entry
+    a) Target file with same localID and destination collection exists. Delete the
+     fileToUpload entry. If target file is sandbox file, then we skip localID match
+     check.
     b) Uploaded file in any collection but with missing localID.
      Update the localID for uploadedFile and delete the fileToUpload entry
     c) A uploaded file exist with same localID but in a different collection.
-    Add a symlink in the destination collection and update the fileToUpload
+    Add a symlink in the destination collection and update the fileToUpload.
+    If target file is sandbox file, then we skip localID match
+     check.
     d) File already exists but different localID. Re-upload
     In case the existing files already have local identifier, which is
     different from the {fileToUpload}, then most probably device has
@@ -931,6 +934,7 @@ class FileUploader {
       );
       return Tuple2(false, fileToUpload);
     }
+    final bool isSandBoxFile = fileToUpload.isSharedMediaToAppSandbox;
 
     final List<EnteFile> existingUploadedFiles =
         await FilesDB.instance.getUploadedFilesWithHashes(
@@ -947,12 +951,13 @@ class FileUploader {
     final EnteFile? sameLocalSameCollection =
         existingUploadedFiles.firstWhereOrNull(
       (e) =>
-          e.collectionID == toCollectionID && e.localID == fileToUpload.localID,
+          e.collectionID == toCollectionID &&
+          (e.localID == fileToUpload.localID || isSandBoxFile),
     );
     if (sameLocalSameCollection != null) {
       _logger.fine(
-        "sameLocalSameCollection: \n toUpload  ${fileToUpload.tag} "
-        "\n existing: ${sameLocalSameCollection.tag}",
+        "sameLocalSameCollection: toUpload  ${fileToUpload.tag} "
+        "existing: ${sameLocalSameCollection.tag} $isSandBoxFile",
       );
       // should delete the fileToUploadEntry
       if (fileToUpload.generatedID != null) {
@@ -1005,12 +1010,13 @@ class FileUploader {
     final EnteFile? fileExistsButDifferentCollection =
         existingUploadedFiles.firstWhereOrNull(
       (e) =>
-          e.collectionID != toCollectionID && e.localID == fileToUpload.localID,
+          e.collectionID != toCollectionID &&
+          (e.localID == fileToUpload.localID || isSandBoxFile),
     );
     if (fileExistsButDifferentCollection != null) {
       _logger.fine(
-        "fileExistsButDifferentCollection: \n toUpload  ${fileToUpload.tag} "
-        "\n existing: ${fileExistsButDifferentCollection.tag}",
+        "fileExistsButDifferentCollection: toUpload  ${fileToUpload.tag} "
+        "existing: ${fileExistsButDifferentCollection.tag} $isSandBoxFile",
       );
       final linkedFile = await CollectionsService.instance
           .linkLocalFileToExistingUploadedFileInAnotherCollection(


### PR DESCRIPTION
## Description
- If user has two different local files which are exact duplicate, we upload them two different files. This to ensure any modification in the local asset via third party gallery only update one of the asset on Ente.
- As we use special localID for shared files (filePath-randomUUID), if the user shares same file to ente multiple times, we treat them as two different local asset. This result in duplicate uploads.

**Change**
- For files that are shared to Ente, avoid re-uploading if there's any file that belongs to the user with same hash, even if they have different local identifier.

**Unhandled edge case**
- If the shared files are not uploaded, and picked up parallely for upload, we will end up uploading duplicates. I don't see the need to handle this case.

