### PR TITLE
[server] Check in with paid customers

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -989,6 +989,10 @@ func setupAndStartCrons(userAuthRepo *repo.UserAuthRepository, publicCollectionR
 		emailNotificationCtrl.SendStorageLimitExceededMails()
 	})
 
+	scheduleAndRun(c, "@every 24h", func() {
+		emailNotificationCtrl.SayHelloToCustomers()
+	})
+
 	schedule(c, "@every 1m", func() {
 		pushController.SendPushes()
 	})

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/ente-io/museum/pkg/controller/collections"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/ente-io/museum/pkg/controller/collections"
 
 	"github.com/ente-io/museum/ente/base"
 	"github.com/ente-io/museum/pkg/controller/emergency"
@@ -920,8 +921,8 @@ func setupAndStartCrons(userAuthRepo *repo.UserAuthRepository, publicCollectionR
 	})
 
 	schedule(c, "@every 24h", func() {
-		_ = userAuthRepo.RemoveDeletedTokens(timeUtil.MicrosecondBeforeDays(30))
-		_ = castDb.DeleteOldSessions(context.Background(), timeUtil.MicrosecondBeforeDays(7))
+		_ = userAuthRepo.RemoveDeletedTokens(timeUtil.MicrosecondsBeforeDays(30))
+		_ = castDb.DeleteOldSessions(context.Background(), timeUtil.MicrosecondsBeforeDays(7))
 		_ = publicCollectionRepo.CleanupAccessHistory(context.Background())
 	})
 

--- a/server/ente/billing.go
+++ b/server/ente/billing.go
@@ -30,7 +30,7 @@ const (
 	Period3Years = "3"
 
 	Period5Years = "5"
-	
+
 	Period10Years = "10"
 
 	// FamilyPlanProductID is the product ID of family (internal employees & their friends & family) plan
@@ -127,6 +127,7 @@ type Subscription struct {
 	// LinkedPurchaseToken on PlayStore , OriginalTransactionID on AppStore and SubscriptionID on Stripe
 	OriginalTransactionID string                 `json:"originalTransactionID"`
 	ExpiryTime            int64                  `json:"expiryTime"`
+	UpgradedAt            int64                  `json:"upgradedAt,omitempty"`
 	PaymentProvider       PaymentProvider        `json:"paymentProvider"`
 	Attributes            SubscriptionAttributes `json:"attributes"`
 	Price                 string                 `json:"price"`

--- a/server/mail-templates/customer_hello.html
+++ b/server/mail-templates/customer_hello.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+  <meta content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1,
+  minimum-scale=1" />
+  <style>
+    body {
+      background-color: #f0f1f3;
+      font-family: "Helvetica Neue", "Segoe UI", Helvetica, sans-serif;
+      font-size: 16px;
+      line-height: 27px;
+      margin: 0;
+      color: #444;
+    }
+
+    pre {
+      background: #f4f4f4f4;
+      padding: 2px;
+    }
+
+    table {
+      width: 100%;
+      border: 1px solid #ddd;
+    }
+
+    table td {
+      border-color: #ddd;
+      padding: 5px;
+    }
+
+    .wrap {
+      background-color: #fff;
+      padding: 30px;
+      max-width: 525px;
+      margin: 0 auto;
+      border-radius: 5px;
+    }
+
+    .button {
+      background: #0055d4;
+      border-radius: 3px;
+      text-decoration: none !important;
+      color: #fff !important;
+      font-weight: bold;
+      padding: 10px 30px;
+      display: inline-block;
+    }
+
+    .button:hover {
+      background: #111;
+    }
+
+    .footer {
+      text-align: center;
+      font-size: 12px;
+      color: #888;
+    }
+
+    .footer a {
+      color: #888;
+      margin-right: 5px;
+    }
+
+    .gutter {
+      padding: 30px;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    a {
+      color: #0055d4;
+    }
+
+    a:hover {
+      color: #111;
+    }
+
+    @media screen and (max-width: 600px) {
+      .wrap {
+        max-width: auto;
+      }
+
+      .gutter {
+        padding: 10px;
+      }
+    }
+
+    .footer-icons {
+      padding: 4px !important;
+      width: 24px !important;
+    }
+  </style>
+
+  <body>
+    <div class="gutter" style="padding: 4px">&nbsp;</div>
+    <div class="wrap" style=" background-color: rgb(255, 255, 255); padding: 2px
+    30px 30px 30px; max-width: 525px; margin: 0 auto; border-radius: 5px;
+    font-size: 16px; " >
+      <p>Hi there,</p>
+
+      <p>Vishnu here, CEO of Ente.</p>
+
+      <p>Thank you for checking out Ente Photos, and upgrading to a paid plan.</p>
+
+      <p>This is my personal email address. If you need help with anything or
+      have feedback to share, please write back - we want this to be a great
+      experience for you!</p>
+
+      <p>Best,
+        <br/>
+        Vishnu
+        <br/>
+        Founder & CEO at <a href="https://ente.io">Ente</a>
+      </p>
+    </div>
+    <br />
+    <div class="footer" style="text-align: center; font-size: 12px; color:
+    rgb(136, 136, 136)" >
+      <div>
+        <a href="https://ente.io" target="_blank" ><img
+        src="https://email-assets.ente.io/ente-green.png" style="width: 100px;
+        padding: 24px" title="Ente" alt="Ente" /></a>
+      </div>
+      <div>
+        <a href="https://fosstodon.org/@ente" target="_blank" ><img
+        src="https://email-assets.ente.io/mastodon-icon.png"
+        class="footer-icons" style="width: 24px; padding: 4px" title="Mastodon"
+        alt="Mastodon" /></a>
+        <a href="https://twitter.com/enteio" target="_blank" ><img
+        src="https://email-assets.ente.io/twitter-icon.png" class="footer-icons"
+        style="width: 24px; padding: 4px" title="Twitter" alt="Twitter" /></a>
+        <a href="https://discord.ente.io" target="_blank" ><img
+        src="https://email-assets.ente.io/discord-icon.png" class="footer-icons"
+        style="width: 24px; padding: 4px" title="Discord" alt="Discord" /></a>
+        <a href="https://github.com/ente-io" target="_blank" ><img
+        src="https://email-assets.ente.io/github-icon.png" class="footer-icons"
+        style="width: 24px; padding: 4px" title="GitHub" alt="GitHub" /></a>
+      </div>
+      <p>
+        Ente Technologies, Inc.
+        <br /> 1111B S Governors Ave 6032 Dover, DE 19904
+      </p>
+      <br />
+    </div>
+  </body>
+</html>

--- a/server/migrations/99_add_upgraded_at.down.sql
+++ b/server/migrations/99_add_upgraded_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions DROP COLUMN upgraded_at;

--- a/server/migrations/99_add_upgraded_at.up.sql
+++ b/server/migrations/99_add_upgraded_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions ADD COLUMN upgraded_at BIGINT DEFAULT 0;

--- a/server/pkg/controller/billing.go
+++ b/server/pkg/controller/billing.go
@@ -285,6 +285,9 @@ func (c *BillingController) VerifySubscription(
 			}
 		}
 	}
+	if isUpgradingFromFreePlan {
+		newSubscription.UpgradedAt = time.Microseconds()
+	}
 	err = c.BillingRepo.ReplaceSubscription(
 		currentSubscription.ID,
 		newSubscription,

--- a/server/pkg/controller/email/email_notification.go
+++ b/server/pkg/controller/email/email_notification.go
@@ -18,6 +18,11 @@ const (
 	MobileAppFirstUploadTemplate = "mobile_app_first_upload.html"
 	FirstUploadEmailSubject      = "Congratulations! 🎉"
 
+	CustomerHelloMailLock   = "customer_hello_mail_lock"
+	CustomerHelloSubject    = "Hello from Ente"
+	CustomerHelloTemplate   = "customer_hello.html"
+	CustomerHelloTemplateID = "customer_hello"
+
 	StorageLimitExceededMailLock   = "storage_limit_exceeded_mail_lock"
 	StorageLimitExceededTemplateID = "storage_limit_exceeded"
 	StorageLimitExceededTemplate   = "storage_limit_exceeded.html"
@@ -155,6 +160,45 @@ func (c *EmailNotificationController) OnSubscriptionCancelled(userID int64) {
 	err = email.SendTemplatedEmail([]string{user.Email}, "vishnu@ente.io", "vishnu@ente.io", SubscriptionCancelledSubject, SubscriptionCancelledTemplate, nil, nil)
 	if err != nil {
 		log.Error("Error sending email", err)
+	}
+}
+
+// SayHelloToCustomers sends an email to check in with customers who upgraded 7
+// days ago.
+func (c *EmailNotificationController) SayHelloToCustomers() {
+	log.Info("Running SayHelloToCustomers")
+	lockStatus := c.LockController.TryLock(CustomerHelloMailLock, time.MicrosecondsAfterHours(24))
+	if !lockStatus {
+		log.Error("Could not acquire lock to send customer hellos")
+		return
+	}
+	defer c.LockController.ReleaseLock(CustomerHelloMailLock)
+
+	users, err := c.UserRepo.GetUsersWhoUpgradedNDaysAgo(7)
+	if err != nil {
+		log.Error("Error while fetching users", err)
+		return
+	}
+	for _, u := range users {
+		lastNotificationTime, err := c.NotificationHistoryRepo.GetLastNotificationTime(u.ID, CustomerHelloTemplateID)
+		logger := log.WithFields(log.Fields{
+			"user_id": u.ID,
+			"email":   u.Email,
+		})
+		if err != nil {
+			logger.Error("Could not fetch last notification time", err)
+			continue
+		}
+		if lastNotificationTime > 0 {
+			continue
+		}
+		logger.Info("Sending hello email to customer")
+		err = email.SendTemplatedEmail([]string{u.Email}, "vishnu@ente.io", "vishnu@ente.io", CustomerHelloSubject, CustomerHelloTemplate, nil, nil)
+		if err != nil {
+			logger.Info("Error notifying", err)
+			continue
+		}
+		c.NotificationHistoryRepo.SetLastNotificationTimeToNow(u.ID, CustomerHelloTemplateID)
 	}
 }
 

--- a/server/pkg/repo/billing.go
+++ b/server/pkg/repo/billing.go
@@ -69,9 +69,9 @@ func (repo *BillingRepository) UpdateTransactionIDOnDeletion(userID int64) error
 // ReplaceSubscription replaces a subscription with a new one
 func (repo *BillingRepository) ReplaceSubscription(subscriptionID int64, s ente.Subscription) error {
 	_, err := repo.DB.Exec(`UPDATE subscriptions
-		SET storage = $2, original_transaction_id = $3, expiry_time = $4, product_id = $5, payment_provider = $6, attributes = $7
+		SET storage = $2, original_transaction_id = $3, expiry_time = $4, product_id = $5, payment_provider = $6, attributes = $7, upgraded_at = $8
 		WHERE subscription_id = $1`,
-		subscriptionID, s.Storage, s.OriginalTransactionID, s.ExpiryTime, s.ProductID, s.PaymentProvider, s.Attributes)
+		subscriptionID, s.Storage, s.OriginalTransactionID, s.ExpiryTime, s.ProductID, s.PaymentProvider, s.Attributes, s.UpgradedAt)
 	return stacktrace.Propagate(err, "")
 }
 
@@ -155,7 +155,7 @@ func (repo *BillingRepository) LogStripePush(eventLog ente.StripeEventLog) error
 	return stacktrace.Propagate(err, "")
 }
 
-// LogStripePush logs a subscription modification by an admin
+// LogAdminTriggeredSubscriptionUpdate logs a subscription modification by an admin
 func (repo *BillingRepository) LogAdminTriggeredSubscriptionUpdate(r ente.UpdateSubscriptionRequest) error {
 	requestJSON, _ := json.Marshal(r)
 	_, err := repo.DB.Exec(`INSERT INTO subscription_logs(user_id, payment_provider, notification, verification_response) VALUES($1, $2, $3, '{}'::json)`,

--- a/server/pkg/utils/time/time.go
+++ b/server/pkg/utils/time/time.go
@@ -38,8 +38,8 @@ func MicrosecondsAfterDays(noOfDays int) int64 {
 	return Microseconds() + int64(noOfDays*24)*MicroSecondsInOneHour
 }
 
-// MicrosecondBeforeDays returns the time in micro seconds before noOfDays
-func MicrosecondBeforeDays(noOfDays int) int64 {
+// MicrosecondsBeforeDays returns the time in micro seconds before noOfDays
+func MicrosecondsBeforeDays(noOfDays int) int64 {
 	return Microseconds() - int64(noOfDays*24)*MicroSecondsInOneHour
 }
 


### PR DESCRIPTION
## Description
Update the `subscriptions` table to store the time at which subscriptions were upgraded (`upgraded_at`).

Reach out to customers who upgraded 7 days ago to make sure all is well.
<img width="628" alt="Screenshot 2025-05-31 at 1 41 09 PM" src="https://github.com/user-attachments/assets/7d1e970a-c7fa-4666-8d4f-db13ba7c105d" />

Store this information within `notification_history` so they are not contacted again (in case of admin interventions).

> Note: We will not be back-filling data for existing subscriptions.

## Tests
- [x] Tested locally to make sure only customers who upgraded 7 days ago were pinged.