### PR TITLE
[photos][mob] Fix: Close input dialog after album creation

### DIFF
--- a/mobile/lib/ui/collections/album/new_row_item.dart
+++ b/mobile/lib/ui/collections/album/new_row_item.dart
@@ -42,6 +42,10 @@ class NewAlbumRowItemWidget extends StatelessWidget {
             try {
               final Collection c =
                   await CollectionsService.instance.createAlbum(text);
+
+              // Close the dialog now so that it does not flash when leaving the album again.
+              Navigator.of(context).pop();
+
               // ignore: unawaited_futures
               await routeToPage(
                 context,


### PR DESCRIPTION
## Description

There is an annoyingly flashing dialog when creating exiting a newly created album. The solution is to close the new-album-dialog before entering the album so that it is not visible anymore when leaving the album again.

The dialog is closed after the album is created and before routing to the album. An alternative is to close it directly when tapping on the Create button, but then the dialog disappears and it might take a while until the album is opened which feels worse.

Old (note how the dialog is still open when leaving the album):

https://github.com/user-attachments/assets/e57d27af-2339-4ba7-a5d8-be052aede99c

New (note how there is no dialog when leaving the album):

https://github.com/user-attachments/assets/874164a3-9550-4fc3-9144-342b5888dbb7

## Tests

I don't know how to add tests for this.