### PR TITLE
[photos][mob] Trim whitespace from search query

### DIFF
--- a/mobile/lib/ui/collections/collection_action_sheet.dart
+++ b/mobile/lib/ui/collections/collection_action_sheet.dart
@@ -170,7 +170,7 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
                             prefixIcon: Icons.search_rounded,
                             onChange: (value) {
                               setState(() {
-                                _searchQuery = value;
+                                _searchQuery = value.trim();
                               });
                             },
                             isClearable: true,

--- a/mobile/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/lib/ui/viewer/search/search_widget.dart
@@ -114,7 +114,7 @@ class SearchWidgetState extends State<SearchWidget> {
     isLoading.value = true;
     _debouncer.run(() async {
       if (mounted) {
-        query = textController.text;
+        query = textController.text.trim();
         IndexOfStackNotifier().isSearchQueryEmpty = query.isEmpty;
         searchResultsStreamNotifier.value =
             _getSearchResultsStream(context, query);


### PR DESCRIPTION
## Description

Previously, when searching for e.g. `test ` would not find an album called `test`. That's because the trailing whitespace is not ignored. On mobile this can be especially annoying because sometimes auto-completion automatically inserts whitespace after a word.

This patch trims whitespace of the search query in two places:
* When searching for an album name when moving photos to an album.
* When using the global search.

## Tests
