### PR TITLE
[mob] Fix: Handle already linked email err

### DIFF
--- a/mobile/lib/generated/intl/messages_sr.dart
+++ b/mobile/lib/generated/intl/messages_sr.dart
@@ -1,0 +1,25 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a sr locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
+// ignore_for_file:unnecessary_string_interpolations, unnecessary_string_escapes
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'sr';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
+}

--- a/mobile/lib/module/upload/service/multipart.dart
+++ b/mobile/lib/module/upload/service/multipart.dart
@@ -54,7 +54,7 @@ class MultiPartUploader {
     return multipartPartSize;
   }
 
-  Future<int> calculatePartCount(int fileSize) async {
+  int calculatePartCount(int fileSize) {
     // If the feature flag is disabled, return 1
     if (!_featureFlagService.enableMobMultiPart) return 1;
     if (!localSettings.userEnabledMultiplePart) return 1;

--- a/mobile/lib/ui/viewer/people/link_email_screen.dart
+++ b/mobile/lib/ui/viewer/people/link_email_screen.dart
@@ -318,7 +318,8 @@ class _LinkEmailScreen extends State<LinkEmailScreen> {
     BuildContext context,
   ) async {
     if (await checkIfEmailAlreadyAssignedToAPerson(email)) {
-      throw Exception("Email already linked to a person");
+      await showAlreadyLinkedEmailDialog(context, email);
+      return false;
     }
 
     String? publicKey;

--- a/mobile/lib/ui/viewer/people/person_selection_action_widgets.dart
+++ b/mobile/lib/ui/viewer/people/person_selection_action_widgets.dart
@@ -143,7 +143,8 @@ class _LinkContactToPersonSelectionPageState
     required PersonEntity personEntity,
   }) async {
     if (await checkIfEmailAlreadyAssignedToAPerson(emailToLink)) {
-      throw Exception("Email already linked to a person");
+      await showAlreadyLinkedEmailDialog(context, emailToLink);
+      return null;
     }
 
     final personName = personEntity.data.name;


### PR DESCRIPTION
## Description
While linking contact to a person, we were not gracefully handling the error where email id is already mapped to another person. And when such person doesn't have any face attached, they don't have any way to unlink the email from that person entity.
## Tests
