### PR TITLE
[photos][mob] Trim whitespace from new album name

### DIFF
--- a/mobile/lib/ui/collections/album/new_row_item.dart
+++ b/mobile/lib/ui/collections/album/new_row_item.dart
@@ -35,7 +35,8 @@ class NewAlbumRowItemWidget extends StatelessWidget {
           textCapitalization: TextCapitalization.words,
           popnavAfterSubmission: true,
           onSubmit: (String text) async {
-            if (text.trim() == "") {
+            text = text.trim();
+            if (text == "") {
               return;
             }
 


### PR DESCRIPTION
## Description

Previously, newly created albums could easily end with trailing whitespace, especially when using auto-completion that automatically adds the next space character. It's not super bad obviously, but I found it slightly annoying. I can't think of any good reason for why an album name should ever start or end with whitespace.

## Tests
