### PR TITLE
[photos][mob] Deselect albums with back navigation in second tab

### DIFF
--- a/mobile/lib/ui/tabs/home_widget.dart
+++ b/mobile/lib/ui/tabs/home_widget.dart
@@ -611,6 +611,11 @@ class _HomeWidgetState extends State<HomeWidget> {
             } else {
               Navigator.pop(context);
             }
+          } else if (_selectedTabIndex == 1) {
+            if (_selectedAlbums.albums.isNotEmpty) {
+              _selectedAlbums.clearAll();
+              return;
+            }
           } else {
             Bus.instance
                 .fire(TabChangedEvent(0, TabChangedEventSource.backButton));

--- a/mobile/lib/ui/tabs/home_widget.dart
+++ b/mobile/lib/ui/tabs/home_widget.dart
@@ -611,15 +611,16 @@ class _HomeWidgetState extends State<HomeWidget> {
             } else {
               Navigator.pop(context);
             }
-          } else if (_selectedTabIndex == 1) {
+            return;
+          }
+          if (_selectedTabIndex == 1) {
             if (_selectedAlbums.albums.isNotEmpty) {
               _selectedAlbums.clearAll();
               return;
             }
-          } else {
-            Bus.instance
-                .fire(TabChangedEvent(0, TabChangedEventSource.backButton));
           }
+          Bus.instance
+              .fire(TabChangedEvent(0, TabChangedEventSource.backButton));
         },
         child: Scaffold(
           drawerScrimColor: getEnteColorScheme(context).strokeFainter,


### PR DESCRIPTION
## Description

Previously, back navigation would always go to the home screen, even when albums are currently selected. This is unexpected because typically back navigation first deselect everything if anything is selected.

This patch implements this expected behavior for albums on the second tab. If at least one album is selected, all will be deselected when going-back. Only when everything is deselect, the app transitions to the first tab like before.

## Tests
