### PR TITLE
fix(android): allow cleartext traffic for domains other ente

### DIFF
--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />


### PR DESCRIPTION
Fixes #6186

## Description

It seems that while trying to show user certificates we broke cleartext connections. Since having an SSL certificate for self hosted ente deployments is not mandatory, we shouldn't restrict users from making cleartext connections
