### PR TITLE
[photos][mob] Allow renaming uploader

### DIFF
--- a/mobile/lib/generated/l10n.dart
+++ b/mobile/lib/generated/l10n.dart
@@ -6026,6 +6026,16 @@ class S {
     );
   }
 
+  /// `Rename uploader`
+  String get renameUploader {
+    return Intl.message(
+      'Rename uploader',
+      name: 'renameUploader',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Leave shared album?`
   String get leaveSharedAlbum {
     return Intl.message(

--- a/mobile/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/added_by_widget.dart
@@ -1,27 +1,37 @@
 import "package:flutter/material.dart";
+import "package:logging/logging.dart";
 import "package:photos/extensions/user_extension.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
 import "package:photos/services/collections_service.dart";
 import "package:photos/theme/ente_theme.dart";
+import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/magic_util.dart";
 
-class AddedByWidget extends StatelessWidget {
+final _logger = Logger('AddedBy');
+
+class AddedByWidget extends StatefulWidget {
   final EnteFile file;
 
   const AddedByWidget(this.file, {super.key});
 
   @override
+  State<AddedByWidget> createState() => _AddedByWidgetState();
+}
+
+class _AddedByWidgetState extends State<AddedByWidget> {
+  @override
   Widget build(BuildContext context) {
-    if (!file.isUploaded) {
+    if (!widget.file.isUploaded) {
       return const SizedBox.shrink();
     }
     String? addedBy;
-    if (file.isOwner && file.isCollect) {
-      addedBy = file.uploaderName;
+    if (widget.file.isOwner && widget.file.isCollect) {
+      addedBy = widget.file.uploaderName;
     } else {
       final fileOwner = CollectionsService.instance
-          .getFileOwner(file.ownerID!, file.collectionID);
+          .getFileOwner(widget.file.ownerID!, widget.file.collectionID);
       addedBy = fileOwner.displayName ?? fileOwner.email;
     }
     if (addedBy == null || addedBy.isEmpty) {
@@ -29,10 +39,52 @@ class AddedByWidget extends StatelessWidget {
     }
     return Padding(
       padding: const EdgeInsets.only(top: 4.0, bottom: 4.0, left: 16),
-      child: Text(
-        S.of(context).addedBy(addedBy),
-        style: getEnteTextTheme(context).miniMuted,
+      child: GestureDetector(
+        onTap: () async {
+          if (!widget.file.isOwner) {
+            return;
+          }
+          if (!widget.file.isCollect) {
+            return;
+          }
+          final result = await showTextInputDialog(
+            context,
+            title: "Rename Uploader",
+            submitButtonLabel: S.of(context).rename,
+            initialValue: widget.file.uploaderName,
+            maxLength: 50,
+            onSubmit: (String text) async {
+              text = text.trim();
+              if (text.isEmpty) {
+                return;
+              }
+              if (text == widget.file.uploaderName) {
+                return;
+              }
+              Navigator.pop(context);
+              await onRenameUploader(context, text);
+              setState(() {});
+            },
+          );
+          if (result is Exception) {
+            _logger.severe("Failed to rename uploader");
+            await showGenericErrorDialog(context: context, error: result);
+          }
+        },
+        child: Text(
+          S.of(context).addedBy(addedBy),
+          style: getEnteTextTheme(context).miniMuted,
+        ),
       ),
     );
+  }
+
+  Future<bool> onRenameUploader(
+    BuildContext context,
+    String newUploaderName,
+  ) async {
+    final filesToNewUploaderName = <EnteFile, String>{};
+    filesToNewUploaderName[widget.file] = newUploaderName;
+    return await editUploaderName(context, filesToNewUploaderName);
   }
 }

--- a/mobile/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/added_by_widget.dart
@@ -50,7 +50,7 @@ class _AddedByWidgetState extends State<AddedByWidget> {
           }
           final result = await showTextInputDialog(
             context,
-            title: "Rename Uploader",
+            title: S.of(context).renameUploader,
             submitButtonLabel: S.of(context).rename,
             initialValue: widget.file.uploaderName,
             maxLength: 50,

--- a/mobile/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/lib/ui/viewer/file_details/added_by_widget.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
+import "package:photos/db/files_db.dart";
 import "package:photos/extensions/user_extension.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
@@ -85,6 +86,16 @@ class _AddedByWidgetState extends State<AddedByWidget> {
   ) async {
     final filesToNewUploaderName = <EnteFile, String>{};
     filesToNewUploaderName[widget.file] = newUploaderName;
+    if (widget.file.collectionID != null) {
+      // Also rename all other uploader names in the same collection.
+      final files = await FilesDB.instance
+          .getAllFilesCollection(widget.file.collectionID!);
+      for (final file in files) {
+        if (file.uploaderName == widget.file.uploaderName) {
+          filesToNewUploaderName[file] = newUploaderName;
+        }
+      }
+    }
     return await editUploaderName(context, filesToNewUploaderName);
   }
 }


### PR DESCRIPTION
## Description

When collecting photos from friends, they sometimes enter a wrong name. Currently, there does not seem to be a way to correct this after the upload which is unfortunate. This patch adds a way to rename an uploader.

The main tricky aspect is the UI because currently the name is mainly displayed when looking at the info of a single file but when renaming one generally wants to rename the uploader of all files with the same name.

Right now, this patch just makes it possible to tap on the `Added by X` label to rename the uploader (this is where I attempted to change the name first). It's not ideal because (1) there is no indication that it is editable and (2) it's in the file info of a single file while changing the uploader name of potentially many files.

It still seems to be good enough for the most common use-cases when collecting photos and someone types a wrong name. 

## Tests

https://github.com/user-attachments/assets/0a9f2e0c-669e-4f63-ba6f-b5c4776d918d

----

There is an older discussion thread for this topic already which didn't have a response yet: https://github.com/ente-io/ente/discussions/585

I also agree with the second part of the mentioned problem that the dialog where people should enter their name is not very clear. At a quick glance it was not obvious to me what name should be written there (file name, collection name, author name, ...). Maybe I could look into improving that separately if desired.
