### PR TITLE
[server] Fix expiry time for free users

### DIFF
--- a/server/migrations/101_fix_free_storage_expiry.down.sql
+++ b/server/migrations/101_fix_free_storage_expiry.down.sql
@@ -1,0 +1,1 @@
+UPDATE subscriptions SET expiry_time = 1749355117000000 where storage = 10737418240 and product_id = 'free';

--- a/server/migrations/101_fix_free_storage_expiry.up.sql
+++ b/server/migrations/101_fix_free_storage_expiry.up.sql
@@ -1,0 +1,1 @@
+UPDATE subscriptions SET expiry_time = 4749355117000000 where storage = 10737418240 and product_id = 'free';


### PR DESCRIPTION
## Description
Fix the bug introduced by https://github.com/ente-io/ente/commit/69c71d23c35355842de80158afc7fdf0856fd274 where we reset the expiry-time for free users.