### PR TITLE
[mob] Reduce home gallery refresh during iOS upload/indexing

### DIFF
--- a/mobile/lib/utils/file_uploader_util.dart
+++ b/mobile/lib/utils/file_uploader_util.dart
@@ -24,6 +24,7 @@ import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import "package:photos/models/location/location.dart";
 import "package:photos/models/metadata/file_magic.dart";
+import "package:photos/services/sync/local_sync_service.dart";
 import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
 import "package:uuid/uuid.dart";
@@ -109,6 +110,9 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     throw InvalidFileError("", InvalidReason.assetDeleted);
   }
   _assertFileType(asset, file);
+  if (Platform.isIOS) {
+    trackOriginFetchForUploadOrML.put(file.localID!, true);
+  }
   sourceFile = await asset.originFile
       .timeout(const Duration(seconds: 15))
       .catchError((e) async {

--- a/mobile/lib/utils/ml_util.dart
+++ b/mobile/lib/utils/ml_util.dart
@@ -1,4 +1,4 @@
-import "dart:io" show File;
+import "dart:io" show File, Platform;
 import "dart:math" as math show sqrt, min, max;
 
 import "package:flutter/services.dart" show PlatformException;
@@ -21,6 +21,7 @@ import "package:photos/services/machine_learning/ml_exceptions.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/machine_learning/semantic_search/semantic_search_service.dart";
 import "package:photos/services/search_service.dart";
+import "package:photos/services/sync/local_sync_service.dart";
 import "package:photos/utils/file_util.dart";
 import "package:photos/utils/image_ml_util.dart";
 import "package:photos/utils/network_util.dart";
@@ -348,6 +349,9 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
       );
     }
     try {
+      if (Platform.isIOS && enteFile.localID != null) {
+        trackOriginFetchForUploadOrML.put(enteFile.localID!, true);
+      }
       file = await getFile(enteFile, isOrigin: true);
     } catch (e, s) {
       _logger.severe(


### PR DESCRIPTION
## Description

During upload, when we request the original asset, iOS modifies the modification time, that resulting in a redundant reload of entire assets form the DB for home gallery. 

Based on logs, it seems like this frequent reading from DB for large number of assets is causing crashes for folks with large libraries.

## Tests
