### PR TITLE
[auth] Fix ente auth crash on close

### DIFF
--- a/auth/lib/app/view/app.dart
+++ b/auth/lib/app/view/app.dart
@@ -169,6 +169,11 @@ class _AppState extends State<App>
   }
 
   @override
+  void onWindowClose() {
+    windowManager.destroy();
+  }
+
+  @override
   void onWindowResize() {
     WindowListenerService.instance.onWindowResize().ignore();
   }

--- a/auth/lib/main.dart
+++ b/auth/lib/main.dart
@@ -86,13 +86,6 @@ void main() async {
   }
 }
 
-class WindowManagerListener with WindowListener {
-  @override
-  void onWindowClose() async {
-    windowManager.destroy();
-  }
-}
-
 Future<void> _runInForeground() async {
   final savedThemeMode = _themeMode(await AdaptiveTheme.getThemeMode());
   return await _runWithLogs(() async {

--- a/auth/lib/main.dart
+++ b/auth/lib/main.dart
@@ -86,6 +86,13 @@ void main() async {
   }
 }
 
+class WindowManagerListener with WindowListener {
+  @override
+  void onWindowClose() async {
+    windowManager.destroy();
+  }
+}
+
 Future<void> _runInForeground() async {
   final savedThemeMode = _themeMode(await AdaptiveTheme.getThemeMode());
   return await _runWithLogs(() async {


### PR DESCRIPTION
Flutter Windows applications must explicitly call OnDestroy.
may be a Flutter bug, causing crashes if cleanup isn't handled.