### PR TITLE
Fix: Do not request compute lock if streaming is disabled

### DIFF
--- a/mobile/lib/services/video_preview_service.dart
+++ b/mobile/lib/services/video_preview_service.dart
@@ -856,6 +856,10 @@ class VideoPreviewService {
   }
 
   void queueFiles({Duration duration = const Duration(seconds: 5)}) {
+    if (!isVideoStreamingEnabled) {
+      _logger.fine("Video streaming is disabled, not queuing files");
+      return;
+    }
     Future.delayed(duration, () {
       if (!_hasQueuedFile && computeController.requestCompute(stream: true)) {
         _putFilesForPreviewCreation(true).catchError((_) {

--- a/mobile/lib/services/video_preview_service.dart
+++ b/mobile/lib/services/video_preview_service.dart
@@ -110,8 +110,7 @@ class VideoPreviewService {
     EnteFile enteFile, [
     bool forceUpload = false,
   ]) async {
-    if (!isVideoStreamingEnabled ||
-        !computeController.requestCompute(stream: true)) {
+    if (!_allowStream()) {
       _logger.info(
         "Pause preview due to disabledSteaming($isVideoStreamingEnabled) or computeController permission)",
       );
@@ -855,13 +854,14 @@ class VideoPreviewService {
     chunkAndUploadVideo(null, file).ignore();
   }
 
+  bool _allowStream() {
+    return isVideoStreamingEnabled &&
+        computeController.requestCompute(stream: true);
+  }
+
   void queueFiles({Duration duration = const Duration(seconds: 5)}) {
-    if (!isVideoStreamingEnabled) {
-      _logger.fine("Video streaming is disabled, not queuing files");
-      return;
-    }
     Future.delayed(duration, () {
-      if (!_hasQueuedFile && computeController.requestCompute(stream: true)) {
+      if (!_hasQueuedFile && _allowStream()) {
         _putFilesForPreviewCreation(true).catchError((_) {
           _hasQueuedFile = false;
         });

--- a/mobile/lib/ui/viewer/people/person_face_widget.dart
+++ b/mobile/lib/ui/viewer/people/person_face_widget.dart
@@ -163,7 +163,7 @@ class _PersonFaceWidgetState extends State<PersonFaceWidget> {
           }
         }
         if (fileForFaceCrop == null) {
-          _logger.severe(
+          _logger.warning(
             "No suitable file found for face crop for person: ${widget.personId} or cluster: ${widget.clusterID}",
           );
           return null;


### PR DESCRIPTION
## Description


## Tests
During testing, i noticed a log saying the ML lock is denied because stream is getting generated. I hadn't enabled video streaming on that device.
