### PR TITLE
[desktop] Improve first CLIP query behaviour

### DIFF
--- a/desktop/src/main/services/ml-worker.ts
+++ b/desktop/src/main/services/ml-worker.ts
@@ -184,14 +184,13 @@ const downloadModel = async (saveLocation: string, name: string) => {
 /**
  * Create an ONNX {@link InferenceSession} with some defaults.
  */
-const createInferenceSession = async (modelPath: string) => {
-    return await ort.InferenceSession.create(modelPath, {
+const createInferenceSession = async (modelPath: string) =>
+    ort.InferenceSession.create(modelPath, {
         // Restrict the number of threads to 1.
         intraOpNumThreads: 1,
         // Be more conservative with RAM usage.
         enableCpuMemArena: false,
     });
-};
 
 const cachedCLIPImageSession = makeCachedInferenceSession(
     "mobileclip_s2_image_opset18_rgba_opt.onnx",
@@ -233,9 +232,11 @@ const getTokenizer = () => (_tokenizer ??= new Tokenizer());
 export const computeCLIPTextEmbeddingIfAvailable = async (text: string) => {
     const sessionOrSkip = await Promise.race([
         cachedCLIPTextSession(),
-        // Wait for a tick to get the session promise to resolved the first time
-        // this code runs on each app start (and the model has been downloaded).
-        wait(0).then(() => 1),
+        // Wait a bit to get the session promise to resolved the first time this
+        // code runs on each app start (in these cases the model will already be
+        // downloaded, so session creation should take only a 1 or 2 ticks: file
+        // system stat, and ort.InferenceSession.create).
+        wait(50).then(() => 1),
     ]);
 
     // Don't wait for the download to complete.

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -123,6 +123,10 @@ export interface FileListProps {
      */
     modePlus?: GalleryBarMode | "search";
     showAppDownloadBanner?: boolean;
+    /**
+     * If `true`, then the current listing is showing magic search results.
+     */
+    isMagicSearchResult?: boolean;
     selectable?: boolean;
     setSelected: (
         selected: SelectedState | ((selected: SelectedState) => SelectedState),
@@ -167,6 +171,7 @@ export const FileList: React.FC<FileListProps> = ({
     modePlus,
     annotatedFiles,
     showAppDownloadBanner,
+    isMagicSearchResult,
     selectable,
     selected,
     setSelected,
@@ -235,7 +240,7 @@ export const FileList: React.FC<FileListProps> = ({
                     ),
                 );
             }
-            if (galleryContext.isClipSearchResult) {
+            if (isMagicSearchResult) {
                 noGrouping(timeStampList);
             } else {
                 groupByTime(timeStampList);
@@ -277,7 +282,7 @@ export const FileList: React.FC<FileListProps> = ({
         annotatedFiles,
         galleryContext.photoListHeader,
         publicCollectionGalleryContext.photoListHeader,
-        galleryContext.isClipSearchResult,
+        isMagicSearchResult,
     ]);
 
     useEffect(() => {

--- a/web/apps/photos/src/components/FileListWithViewer.tsx
+++ b/web/apps/photos/src/components/FileListWithViewer.tsx
@@ -53,6 +53,7 @@ export type FileListWithViewerProps = {
     | "mode"
     | "modePlus"
     | "showAppDownloadBanner"
+    | "isMagicSearchResult"
     | "selectable"
     | "selected"
     | "setSelected"
@@ -89,6 +90,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
     files,
     enableDownload,
     showAppDownloadBanner,
+    isMagicSearchResult,
     selectable,
     selected,
     setSelected,
@@ -175,6 +177,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
                             mode,
                             modePlus,
                             showAppDownloadBanner,
+                            isMagicSearchResult,
                             selectable,
                             selected,
                             setSelected,

--- a/web/apps/photos/src/components/Sidebar.tsx
+++ b/web/apps/photos/src/components/Sidebar.tsx
@@ -102,8 +102,8 @@ import {
     isSubscriptionPastDue,
     isSubscriptionStripe,
     leaveFamily,
+    pullUserDetails,
     redirectToCustomerPortal,
-    syncUserDetails,
     userDetailsAddOnBonuses,
     type UserDetails,
 } from "ente-new/photos/services/user-details";
@@ -230,7 +230,7 @@ const UserDetailsSection: React.FC<UserDetailsSectionProps> = ({
     } = useModalVisibility();
 
     useEffect(() => {
-        if (sidebarOpen) void syncUserDetails();
+        if (sidebarOpen) void pullUserDetails();
     }, [sidebarOpen]);
 
     const isNonAdminFamilyMember = useMemo(

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -91,7 +91,7 @@ import {
 import type { SearchOption } from "ente-new/photos/services/search/types";
 import { initSettings } from "ente-new/photos/services/settings";
 import {
-    initUserDetailsOrTriggerSync,
+    initUserDetailsOrTriggerPull,
     redirectToCustomerPortal,
     userDetailsSnapshot,
     verifyStripeSubscription,
@@ -296,7 +296,7 @@ const Page: React.FC = () => {
                 return;
             }
             initSettings();
-            await initUserDetailsOrTriggerSync();
+            await initUserDetailsOrTriggerPull();
             setupSelectAllKeyBoardShortcutHandler();
             dispatch({ type: "showAll" });
             setIsFirstLoad(isFirstLogin());

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -821,7 +821,7 @@ const Page: React.FC = () => {
                 // 2. Construct a fake a metadata object with the updates
                 //    reflected in it.
                 //
-                // 3. The caller (eventually) triggers a remote sync in the
+                // 3. The caller (eventually) triggers a remote pull in the
                 //    background, but meanwhile uses this updated metadata.
                 //
                 // TODO(RE): Replace with file fetch?

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -137,7 +137,6 @@ const defaultGalleryContext: GalleryContextType = {
     userIDToEmailMap: null,
     emailList: null,
     openHiddenSection: () => null,
-    isClipSearchResult: null,
     selectedFile: null,
     setSelectedFiles: () => null,
 };
@@ -201,9 +200,6 @@ const Page: React.FC = () => {
     >([]);
 
     const peopleState = usePeopleStateSnapshot();
-
-    const [isClipSearchResult, setIsClipSearchResult] =
-        useState<boolean>(false);
 
     // The (non-sticky) header shown at the top of the gallery items.
     const [photoListHeader, setPhotoListHeader] =
@@ -758,7 +754,6 @@ const Page: React.FC = () => {
         } else {
             dispatch({ type: "exitSearch" });
         }
-        setIsClipSearchResult(type == "clip");
     };
 
     const openUploader = (intent?: UploadTypeSelectorIntent) => {
@@ -895,7 +890,6 @@ const Page: React.FC = () => {
                 userIDToEmailMap: state.emailByUserID,
                 emailList: state.shareSuggestionEmails,
                 openHiddenSection,
-                isClipSearchResult,
                 selectedFile: selected,
                 setSelectedFiles: setSelected,
             }}
@@ -1093,6 +1087,9 @@ const Page: React.FC = () => {
                         enableDownload={true}
                         showAppDownloadBanner={
                             state.collectionFiles.length < 30 && !isInSearchMode
+                        }
+                        isMagicSearchResult={
+                            state.searchSuggestion?.type == "clip"
                         }
                         selectable={true}
                         selected={selected}

--- a/web/apps/photos/src/pages/shared-albums.tsx
+++ b/web/apps/photos/src/pages/shared-albums.tsx
@@ -362,7 +362,7 @@ export default function PublicCollectionGallery() {
                 setPublicCollection(null);
                 setPublicFiles(null);
             } else {
-                log.error("failed to sync public album with remote", e);
+                log.error("Public album remote pull failed", e);
             }
         } finally {
             hideLoadingBar();

--- a/web/apps/photos/src/types/gallery/index.ts
+++ b/web/apps/photos/src/types/gallery/index.ts
@@ -46,7 +46,6 @@ export interface GalleryContextType {
     userIDToEmailMap: Map<number, string>;
     emailList: string[];
     openHiddenSection: (callback?: () => void) => void;
-    isClipSearchResult: boolean;
     setSelectedFiles: (value) => void;
     selectedFile: SelectedState;
 }

--- a/web/apps/photos/tests/upload.test.ts
+++ b/web/apps/photos/tests/upload.test.ts
@@ -18,7 +18,7 @@ import {
     savedCollectionFiles,
     savedCollections,
 } from "ente-new/photos/services/photos-fdb";
-import { getUserDetailsV2 } from "ente-new/photos/services/user-details";
+import { userDetailsSnapshot } from "ente-new/photos/services/user-details";
 
 const DATE_TIME_PARSING_TEST_FILE_NAMES = [
     {
@@ -170,7 +170,7 @@ export async function testUpload() {
 }
 
 async function totalFileCountCheck(expectedState) {
-    const userDetails = await getUserDetailsV2();
+    const userDetails = userDetailsSnapshot();
     if (expectedState.total_file_count === userDetails.fileCount) {
         console.log("file count check passed ✅");
     } else {

--- a/web/packages/gallery/services/file-data.ts
+++ b/web/packages/gallery/services/file-data.ts
@@ -196,8 +196,8 @@ export interface UpdatedFileDataFileIDsPage {
     fileIDs: Set<number>;
     /**
      * The latest updatedAt (epoch microseconds) time obtained from remote in
-     * this batch of sync (from amongst all of the files in the batch, not just
-     * those that were filtered to be part of {@link fileIDs}).
+     * this batch being fetched (from amongst all of the files in the batch, not
+     * just those that were filtered to be part of {@link fileIDs}).
      */
     lastUpdatedAt: number;
 }

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -163,7 +163,7 @@ export interface GalleryState {
      * Unsynced modifications are those whose effects have already been made on
      * remote (so thus they have been "saved", so to say), but we still haven't
      * yet refreshed our local state to incorporate them. The refresh will
-     * happen on the next "file sync", until then they remain as in-memory state
+     * happen on the next files pull, until then they remain as in-memory state
      * in the reducer.
      */
     collectionFiles: EnteFile[];
@@ -318,9 +318,9 @@ export interface GalleryState {
      * the user's favorites, false otherwise) which should be used for that file
      * instead of what we get from our local DB.
      *
-     * The next time a sync with remote completes, we clear this map since
-     * thereafter just deriving {@link favoriteFileIDs} from our local files
-     * would reflect the correct state on remote too.
+     * The next time a remote pull completes, we clear this map since thereafter
+     * just deriving {@link favoriteFileIDs} from our local files would reflect
+     * the correct state on remote too.
      */
     unsyncedFavoriteUpdates: Map<number, boolean>;
     /**
@@ -338,9 +338,9 @@ export interface GalleryState {
      * Each entry from a file ID to the magic metadata that should be used for
      * that file instead of what we get from our local DB.
      *
-     * The next time a sync with remote completes, we clear this map since
-     * thereafter the synced files themselves will reflect the latest private
-     * magic metadata.
+     * The next time a remote pull completes, we clear this map since thereafter
+     * the synced files themselves will reflect the latest private magic
+     * metadata.
      */
     unsyncedPrivateMagicMetadataUpdates: Map<
         number,

--- a/web/packages/new/photos/services/ml/index.ts
+++ b/web/packages/new/photos/services/ml/index.ts
@@ -56,7 +56,7 @@ class MLState {
      *
      * - On app start, this is read from local storage during {@link initML}.
      *
-     * - It gets updated when we sync with remote (so if the user
+     * - It gets updated when we pull from remote (so if the user
      *   enables/disables ML on a different device, this local value will also
      *   become true/false).
      *

--- a/web/packages/new/photos/services/pull.ts
+++ b/web/packages/new/photos/services/pull.ts
@@ -79,7 +79,7 @@ interface PullFilesOpts {
  * This is a subset of a full remote pull, independently exposed for use at
  * times when we only want to pull the file related information (e.g. we just
  * made some API request that modified collections or files, and so now want to
- * sync our local changes to match remote).
+ * update our local changes to match remote).
  *
  * See also: [Note: Remote pull]
  *


### PR DESCRIPTION
Keep some leeway so that the first CLIP query in a session also gets resolved (on app starts after the model has been downloaded).