### PR TITLE
[server][quickstart] migrate to mc alias set for creating bucket

### DIFF
--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -131,7 +131,7 @@ services:
           sh -c '
           #!/bin/sh
 
-          while ! mc config host add h0 http://minio:3200 $minio_user $minio_pass 2>/dev/null
+          while ! mc alias set h0 http://minio:3200 $minio_user $minio_pass 2>/dev/null
           do
             echo "Waiting for minio..."
             sleep 0.5


### PR DESCRIPTION
## Description
This PR fixes the infinite looping due to mc config not being found in latest server images, which is replaced in favor of mc alias set, responsible for creating buckets in post_start hook. This should fix the issue that users run into while using our quickstart script 

## Tests
- [x] I have tested with the latest MinIO server image