### PR TITLE
[docs] update with minio troubleshooting for deprecated command

### DIFF
--- a/docs/docs/self-hosting/index.md
+++ b/docs/docs/self-hosting/index.md
@@ -40,12 +40,16 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ente-io/ente/main/server/q
 ```
 
 The above `curl` command pulls the Docker image, creates a directory `my-ente`
-in the current working directory and prompts to start the cluster, which upon
-entering `y`, starts all the containers required to run Ente.
+in the current working directory, prompts to start the cluster and starts all the containers required to run Ente.
 
 ![quickstart](/quickstart.png)
 
 ![self-hosted-ente](/web-app.webp)
+
+> [!TIP] Important:
+> If you have used quickstart for self-hosting Ente and are facing issues while > trying to run the cluster due to MinIO buckets not being created, please check [troubleshooting MinIO](/self-hosting/troubleshooting/docker#minio-provisioning-error)
+> 
+> 
 
 ## Queries?
 


### PR DESCRIPTION
## Description
This PR updates documentation for users who are self-hosting Ente to update post_start hook for MinIO provisioning and bucket creation to work properly with the latest version of MinIO
