### PR TITLE
fix: Updated the broken link in the README.md

### DIFF
--- a/mobile/apps/auth/README.md
+++ b/mobile/apps/auth/README.md
@@ -73,7 +73,7 @@ If the code you're working needs to modify user facing strings, see
 ## 🔩 Architecture
 
 The architecture that powers end-to-end encrypted storage and sync of your
-tokens has been documented [here](../architecture/README.md).
+tokens has been documented [here](architecture/README.md).
 
 ## 🌍 Translate
 


### PR DESCRIPTION
## Description
This PR fixes the broken link [issue](https://github.com/ente-io/ente/issues/6526) in the documentation related to [architecture](https://github.com/ente-io/ente/blob/main/mobile/apps/auth/README.md#-architecture) present in the README.md.

## Tests
