### PR TITLE
[mob][photos] Compression settings & Face detection issue logging

### DIFF
--- a/mobile/apps/photos/lib/generated/intl/messages_ar.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ar.dart
@@ -54,7 +54,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "يرجى إلغاء اشتراكك الحالي من ${paymentProvider} أولاً.";
 
   static String m13(user) =>
-      "لن يتمكن ${user} من إضافة المزيد من الصور إلى هذا الألبوم.\n\nسيظل بإمكانه إزالة الصور الحالية التي أضافها.";
+      "لن يتمكن ${user} من إضافة المزيد من الصور إلى هذا الألبوم\n\nسيظل بإمكانه إزالة الصور الحالية التي أضافها";
 
   static String m14(isFamilyMember, storageAmountInGb) =>
       "${Intl.select(isFamilyMember, {
@@ -314,7 +314,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "لقد أرسلنا بريدًا إلكترونيًا إلى <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "أتمنى لـ${name} عيد ميلاد سعيد! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: 'قبل سنة', two: 'قبل سنتين', other: 'قبل ${count} سنة')}";
@@ -367,6 +367,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addOns": MessageLookupByLibrary.simpleMessage("الإضافات"),
         "addParticipants":
             MessageLookupByLibrary.simpleMessage("إضافة مشاركين"),
+        "addPeopleWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "أضف عنصر واجهة الأشخاص إلى شاشتك الرئيسية ثم عد إلى هنا لتخصيصه."),
         "addPhotos": MessageLookupByLibrary.simpleMessage("إضافة صور"),
         "addSelected": MessageLookupByLibrary.simpleMessage("إضافة المحدد"),
         "addToAlbum": MessageLookupByLibrary.simpleMessage("إضافة إلى الألبوم"),
@@ -399,11 +401,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "albumUpdated":
             MessageLookupByLibrary.simpleMessage("تم تحديث الألبوم"),
         "albums": MessageLookupByLibrary.simpleMessage("الألبومات"),
+        "albumsWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "حدد الألبومات التي تريد ظهورها على شاشتك الرئيسية."),
         "allClear": MessageLookupByLibrary.simpleMessage("✨ كل شيء واضح"),
         "allMemoriesPreserved":
             MessageLookupByLibrary.simpleMessage("تم حفظ جميع الذكريات"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "سيتم إعادة تعيين جميع تجمعات هذا الشخص، وستفقد جميع الاقتراحات المقدمة لهذا الشخص."),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "سيتم دمج جميع المجموعات غير المسماة مع الشخص المحدد. يمكن التراجع عن هذا الإجراء لاحقًا من خلال نظرة عامة على سجل الاقتراحات التابع لهذا الشخص."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "هذه هي الأولى في المجموعة. سيتم تغيير تواريخ الصور المحددة الأخرى تلقائيًا بناءً على هذا التاريخ الجديد."),
         "allow": MessageLookupByLibrary.simpleMessage("السماح"),
@@ -452,6 +459,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "archive": MessageLookupByLibrary.simpleMessage("الأرشيف"),
         "archiveAlbum": MessageLookupByLibrary.simpleMessage("أرشفة الألبوم"),
         "archiving": MessageLookupByLibrary.simpleMessage("جارٍ الأرشفة..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("هل هم "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "هل أنت متأكد من رغبتك في إزالة هذا الوجه من هذا الشخص؟"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "هل أنت متأكد من رغبتك في مغادرة الخطة العائلية؟"),
@@ -464,6 +475,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "هل أنت متأكد من رغبتك في الخروج؟"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "هل أنت متأكد من رغبتك في تسجيل الخروج؟"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "هل أنت متأكد من رغبتك في دمجهم؟"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "هل أنت متأكد من رغبتك في التجديد؟"),
         "areYouSureYouWantToResetThisPerson":
@@ -619,6 +632,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "click": MessageLookupByLibrary.simpleMessage("• انقر على"),
         "clickOnTheOverflowMenu": MessageLookupByLibrary.simpleMessage(
             "• انقر على قائمة الخيارات الإضافية"),
+        "clickToInstallOurBestVersionYet": MessageLookupByLibrary.simpleMessage(
+            "انقر لتثبيت أفضل إصدار لنا حتى الآن"),
         "close": MessageLookupByLibrary.simpleMessage("إغلاق"),
         "clubByCaptureTime":
             MessageLookupByLibrary.simpleMessage("التجميع حسب وقت الالتقاط"),
@@ -1077,6 +1092,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "تم تعطيل المصادقة البيومترية. يرجى قفل شاشتك وفتحها لتمكينها."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("موافق"),
+        "ignore": MessageLookupByLibrary.simpleMessage("تجاهل"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("تجاهل"),
         "ignored": MessageLookupByLibrary.simpleMessage("تم التجاهل"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1272,9 +1288,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
         "me": MessageLookupByLibrary.simpleMessage("أنا"),
         "memories": MessageLookupByLibrary.simpleMessage("ذكريات"),
+        "memoriesWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "اختر نوع الذكريات التي ترغب في رؤيتها على شاشتك الرئيسية."),
         "memoryCount": m50,
         "merchandise":
             MessageLookupByLibrary.simpleMessage("المنتجات الترويجية"),
+        "merge": MessageLookupByLibrary.simpleMessage("دمج"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("الدمج مع شخص موجود"),
         "mergedPhotos": MessageLookupByLibrary.simpleMessage("الصور المدمجة"),
@@ -1383,6 +1402,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "onTheRoad":
             MessageLookupByLibrary.simpleMessage("على الطريق مرة أخرى"),
         "onThisDay": MessageLookupByLibrary.simpleMessage("في هذا اليوم"),
+        "onThisDayNotificationExplanation":
+            MessageLookupByLibrary.simpleMessage(
+                "تلقي  تذكيرات حول ذكريات مثل اليوم في السنوات السابقة."),
         "onlyFamilyAdminCanChangeCode": m55,
         "onlyThem": MessageLookupByLibrary.simpleMessage("هم فقط"),
         "oops": MessageLookupByLibrary.simpleMessage("عفوًا"),
@@ -1407,6 +1429,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("أو اختر واحدًا موجودًا"),
         "orPickFromYourContacts":
             MessageLookupByLibrary.simpleMessage("أو اختر من جهات اتصالك"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("وجوه أخرى تم اكتشافها"),
         "pair": MessageLookupByLibrary.simpleMessage("إقران"),
         "pairWithPin":
             MessageLookupByLibrary.simpleMessage("الإقران بالرمز السري"),
@@ -1439,6 +1463,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "people": MessageLookupByLibrary.simpleMessage("الأشخاص"),
         "peopleUsingYourCode":
             MessageLookupByLibrary.simpleMessage("الأشخاص الذين يستخدمون رمزك"),
+        "peopleWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "حدد الأشخاص الذين ترغب في ظهورهم على شاشتك الرئيسية."),
         "permDeleteWarning": MessageLookupByLibrary.simpleMessage(
             "سيتم حذف جميع العناصر في سلة المهملات نهائيًا.\n\nلا يمكن التراجع عن هذا الإجراء."),
         "permanentlyDelete": MessageLookupByLibrary.simpleMessage("حذف نهائي"),
@@ -1527,6 +1553,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("تم إنشاء الرابط العام."),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("تمكين الرابط العام"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("؟"),
         "queued": MessageLookupByLibrary.simpleMessage("في قائمة الانتظار"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("روابط سريعة"),
         "radius": MessageLookupByLibrary.simpleMessage("نصف القطر"),
@@ -1539,6 +1566,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "reassignedToName": m69,
         "reassigningLoading":
             MessageLookupByLibrary.simpleMessage("جارٍ إعادة التعيين..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "استلم تذكيرات عندما يحين عيد ميلاد أحدهم. النقر على الإشعار سينقلك إلى صور الشخص المحتفل بعيد ميلاده."),
         "recover": MessageLookupByLibrary.simpleMessage("استعادة"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("استعادة الحساب"),
@@ -1637,6 +1666,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportBug": MessageLookupByLibrary.simpleMessage("الإبلاغ عن خطأ"),
         "resendEmail": MessageLookupByLibrary.simpleMessage(
             "إعادة إرسال البريد الإلكتروني"),
+        "reset": MessageLookupByLibrary.simpleMessage("إعادة تعيين"),
         "resetIgnoredFiles": MessageLookupByLibrary.simpleMessage(
             "إعادة تعيين الملفات المتجاهلة"),
         "resetPasswordTitle":
@@ -1664,6 +1694,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "rotateRight": MessageLookupByLibrary.simpleMessage("تدوير لليمين"),
         "safelyStored": MessageLookupByLibrary.simpleMessage("مخزنة بأمان"),
         "save": MessageLookupByLibrary.simpleMessage("حفظ"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("حفظ كشخص آخر"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage("حفظ التغييرات قبل المغادرة؟"),
         "saveCollage": MessageLookupByLibrary.simpleMessage("حفظ الكولاج"),
@@ -1821,7 +1853,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("جارٍ المشاركة..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("تغيير التواريخ والوقت"),
+        "showLessFaces": MessageLookupByLibrary.simpleMessage("إظهار وجوه أقل"),
         "showMemories": MessageLookupByLibrary.simpleMessage("عرض الذكريات"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("إظهار المزيد من الوجوه"),
         "showPerson": MessageLookupByLibrary.simpleMessage("إظهار الشخص"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
             "تسجيل الخروج من الأجهزة الأخرى"),
@@ -1936,6 +1971,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "انتهت صلاحية الرابط الذي تحاول الوصول إليه."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "لن تظهر مجموعات الأشخاص في قسم الأشخاص بعد الآن. ستظل الصور دون تغيير."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "لن يتم عرض هذا الشخص في قسم الأشخاص بعد الآن. الصور ستبقى كما هي دون تغيير."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "مفتاح الاسترداد الذي أدخلته غير صحيح."),
@@ -2115,6 +2154,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("ما الجديد"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "يمكن لجهة الاتصال الموثوقة المساعدة في استعادة بياناتك."),
+        "widgets": MessageLookupByLibrary.simpleMessage("عناصر واجهة"),
         "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("سنة"),
         "yearly": MessageLookupByLibrary.simpleMessage("سنويًا"),
@@ -2126,6 +2166,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("نعم، حذف"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("نعم، تجاهل التغييرات"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("نعم، تجاهل"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("نعم، تسجيل الخروج"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("نعم، إزالة"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("نعم، تجديد"),

--- a/mobile/apps/photos/lib/generated/intl/messages_be.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_be.dart
@@ -28,8 +28,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Ліст адпраўлены на электронную пошту <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "about": MessageLookupByLibrary.simpleMessage("Пра праграму"),
@@ -297,7 +295,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weHaveSendEmailTo": m114,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Ненадзейны"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("З вяртаннем!"),
-        "wishThemAHappyBirthday": m115,
         "yesDelete": MessageLookupByLibrary.simpleMessage("Так, выдаліць"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("Так, выйсці"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Так, выдаліць"),

--- a/mobile/apps/photos/lib/generated/intl/messages_bg.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_bg.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'bg';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_ca.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ca.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ca';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_cs.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_cs.dart
@@ -32,8 +32,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m111(email) => "Ověřit ${email}";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m117(name) => "Vy a ${name}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -80,10 +78,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "archiveAlbum":
             MessageLookupByLibrary.simpleMessage("Archivovat album"),
         "archiving": MessageLookupByLibrary.simpleMessage("Archivování..."),
-        "areThey": MessageLookupByLibrary.simpleMessage("Are they "),
-        "areYouSureRemoveThisFaceFromPerson":
-            MessageLookupByLibrary.simpleMessage(
-                "Are you sure you want to remove this face from this person?"),
         "areYouSureYouWantToLogout":
             MessageLookupByLibrary.simpleMessage("Opravdu se chcete odhlásit?"),
         "askDeleteReason": MessageLookupByLibrary.simpleMessage(
@@ -365,8 +359,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "openFile": MessageLookupByLibrary.simpleMessage("Otevřít soubor"),
         "openSettings":
             MessageLookupByLibrary.simpleMessage("Otevřít Nastavení"),
-        "otherDetectedFaces":
-            MessageLookupByLibrary.simpleMessage("Other detected faces"),
         "pair": MessageLookupByLibrary.simpleMessage("Spárovat"),
         "panorama": MessageLookupByLibrary.simpleMessage("Panorama"),
         "password": MessageLookupByLibrary.simpleMessage("Heslo"),
@@ -390,7 +382,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "processing": MessageLookupByLibrary.simpleMessage("Zpracovává se"),
         "publicLinkCreated":
             MessageLookupByLibrary.simpleMessage("Veřejný odkaz vytvořen"),
-        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("Ve frontě"),
         "radius": MessageLookupByLibrary.simpleMessage("Rádius"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Ohodnoť nás"),
@@ -442,8 +433,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Bezpečně uloženo"),
         "save": MessageLookupByLibrary.simpleMessage("Uložit"),
-        "saveAsAnotherPerson":
-            MessageLookupByLibrary.simpleMessage("Save as another person"),
         "saveCopy": MessageLookupByLibrary.simpleMessage("Uložit kopii"),
         "saveKey": MessageLookupByLibrary.simpleMessage("Uložit klíč"),
         "savePerson": MessageLookupByLibrary.simpleMessage("Uložit osobu"),
@@ -486,10 +475,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("Sdíleno se mnou"),
         "sharedWithYou": MessageLookupByLibrary.simpleMessage("Sdíleno s vámi"),
         "sharing": MessageLookupByLibrary.simpleMessage("Sdílení..."),
-        "showLessFaces":
-            MessageLookupByLibrary.simpleMessage("Show less faces"),
-        "showMoreFaces":
-            MessageLookupByLibrary.simpleMessage("Show more faces"),
         "skip": MessageLookupByLibrary.simpleMessage("Přeskočit"),
         "sorry": MessageLookupByLibrary.simpleMessage("Omlouváme se"),
         "sort": MessageLookupByLibrary.simpleMessage("Seřadit"),
@@ -553,7 +538,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("Slabé"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("Vítejte zpět!"),
         "whatsNew": MessageLookupByLibrary.simpleMessage("Co je nového"),
-        "wishThemAHappyBirthday": m115,
         "yearly": MessageLookupByLibrary.simpleMessage("Ročně"),
         "yes": MessageLookupByLibrary.simpleMessage("Ano"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Ano, zrušit"),

--- a/mobile/apps/photos/lib/generated/intl/messages_da.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_da.dart
@@ -49,8 +49,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Vi har sendt en email til <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -462,7 +460,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("Svagt"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Velkommen tilbage!"),
-        "wishThemAHappyBirthday": m115,
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage(
             "Ja, konverter til præsentation"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Ja, fjern"),

--- a/mobile/apps/photos/lib/generated/intl/messages_de.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_de.dart
@@ -321,7 +321,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Wir haben eine E-Mail an <green>${email}</green> gesendet";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Wünsche ${name} alles Gute zum Geburtstag! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: 'vor einem Jahr', other: 'vor ${count} Jahren')}";
@@ -425,6 +425,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Alle Erinnerungsstücke gesichert"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Alle Gruppierungen für diese Person werden zurückgesetzt und du wirst alle Vorschläge für diese Person verlieren"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Alle unbenannten Gruppen werden zur ausgewählten Person zusammengeführt. Dies kann im Verlauf der Vorschläge für diese Person rückgängig gemacht werden."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "Dies ist die erste in der Gruppe. Andere ausgewählte Fotos werden automatisch nach diesem neuen Datum verschoben"),
         "allow": MessageLookupByLibrary.simpleMessage("Erlauben"),
@@ -478,6 +481,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "archiveAlbum":
             MessageLookupByLibrary.simpleMessage("Album archivieren"),
         "archiving": MessageLookupByLibrary.simpleMessage("Archiviere …"),
+        "areThey": MessageLookupByLibrary.simpleMessage("Ist das "),
+        "areYouSureRemoveThisFaceFromPerson": MessageLookupByLibrary.simpleMessage(
+            "Bist du sicher, dass du dieses Gesicht von dieser Person entfernen möchtest?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Bist du sicher, dass du den Familien-Tarif verlassen möchtest?"),
@@ -488,8 +494,16 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Bist du sicher, dass du deinen Tarif ändern möchtest?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Möchtest du Vorgang wirklich abbrechen?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Bist du sicher, dass du diese Personen ignorieren willst?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Bist du sicher, dass du diese Person ignorieren willst?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Bist Du sicher, dass du dich abmelden möchtest?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Bist du sicher, dass du sie zusammenführen willst?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "Bist du sicher, dass du verlängern möchtest?"),
         "areYouSureYouWantToResetThisPerson":
@@ -578,28 +592,29 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Black-Friday-Aktion"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
         "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Nach der Video-Streaming-Beta und der Arbeit an fortsetzbaren Uploads und Downloads haben wir das Datei-Upload-Limit auf 10 GB erhöht. Dies ist jetzt sowohl in Desktop- als auch in mobilen Apps verfügbar."),
+            "Zusammen mit der Beta-Version des Video-Streamings und der Arbeit an wiederaufnehmbarem Hoch- und Herunterladen haben wir jetzt das Limit für das Hochladen von Dateien auf 10 GB erhöht. Dies ist ab sofort sowohl in den Desktop- als auch Mobil-Apps verfügbar."),
         "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Hintergrund-Uploads werden jetzt auch auf iOS unterstützt, zusätzlich zu Android-Geräten. Du musst die App nicht öffnen, um deine neuesten Fotos und Videos zu sichern."),
+            "Das Hochladen im Hintergrund wird jetzt auch unter iOS unterstützt, zusätzlich zu Android-Geräten. Es ist nicht mehr notwendig, die App zu öffnen, um die letzten Fotos und Videos zu sichern."),
         "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Wir haben erhebliche Verbesserungen an unserer Erinnerungserfahrung vorgenommen, einschließlich Autoplay, Wischen zur nächsten Erinnerung und vieles mehr."),
+            "Wir haben deutliche Verbesserungen an der Darstellung von Erinnerungen vorgenommen, u.a. automatische Wiedergabe, Wischen zur nächsten Erinnerung und vieles mehr."),
         "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Zusammen mit vielen internen Verbesserungen ist es jetzt viel einfacher, alle erkannten Gesichter zu sehen, Feedback zu ähnlichen Gesichtern zu geben und Gesichter zu einem einzelnen Foto hinzuzufügen/zu entfernen."),
+            "Zusammen mit einer Reihe von Verbesserungen unter der Haube ist es jetzt viel einfacher, alle erkannten Gesichter zu sehen, Feedback zu ähnlichen Gesichtern geben und Gesichter für ein einzelnes Foto hinzuzufügen oder zu entfernen."),
         "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Du erhältst jetzt eine optionale Benachrichtigung für alle Geburtstage, die du auf Ente gespeichert hast, zusammen mit einer Sammlung ihrer besten Fotos."),
+            "Du erhältst jetzt eine Opt-Out-Benachrichtigung für alle Geburtstage, die du bei Ente gespeichert hast, zusammen mit einer Sammlung der besten Fotos."),
         "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Kein Warten mehr darauf, dass Uploads/Downloads abgeschlossen werden, bevor du die App schließen kannst. Alle Uploads und Downloads können jetzt mitten im Vorgang pausiert und von dort fortgesetzt werden, wo du aufgehört hast."),
-        "cLTitle1":
-            MessageLookupByLibrary.simpleMessage("Upload großer Videodateien"),
-        "cLTitle2": MessageLookupByLibrary.simpleMessage("Hintergrund-Upload"),
-        "cLTitle3":
-            MessageLookupByLibrary.simpleMessage("Autoplay-Erinnerungen"),
+            "Kein Warten mehr auf das Hoch- oder Herunterladen, bevor du die App schließen kannst. Alle Übertragungen können jetzt mittendrin pausiert und fortgesetzt werden, wo du aufgehört hast."),
+        "cLTitle1": MessageLookupByLibrary.simpleMessage(
+            "Lade große Videodateien hoch"),
+        "cLTitle2":
+            MessageLookupByLibrary.simpleMessage("Hochladen im Hintergrund"),
+        "cLTitle3": MessageLookupByLibrary.simpleMessage(
+            "Automatische Wiedergabe von Erinnerungen"),
         "cLTitle4": MessageLookupByLibrary.simpleMessage(
             "Verbesserte Gesichtserkennung"),
         "cLTitle5": MessageLookupByLibrary.simpleMessage(
             "Geburtstags-Benachrichtigungen"),
         "cLTitle6": MessageLookupByLibrary.simpleMessage(
-            "Fortsetzbare Uploads und Downloads"),
+            "Wiederaufnehmbares Hoch- und Herunterladen"),
         "cachedData": MessageLookupByLibrary.simpleMessage("Daten im Cache"),
         "calculating":
             MessageLookupByLibrary.simpleMessage("Wird berechnet..."),
@@ -855,6 +870,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Gerät nicht gefunden"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Schon gewusst?"),
+        "different": MessageLookupByLibrary.simpleMessage("Verschieden"),
         "disableAutoLock": MessageLookupByLibrary.simpleMessage(
             "Automatische Sperre deaktivieren"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
@@ -1152,6 +1168,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "Die biometrische Authentifizierung ist deaktiviert. Bitte sperren und entsperren Sie Ihren Bildschirm, um sie zu aktivieren."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("OK"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Ignorieren"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Ignorieren"),
         "ignored": MessageLookupByLibrary.simpleMessage("ignoriert"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1171,6 +1188,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Falscher Wiederherstellungs-Schlüssel"),
         "indexedItems":
             MessageLookupByLibrary.simpleMessage("Indizierte Elemente"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "Die Indizierung ist pausiert. Sie wird automatisch fortgesetzt, wenn das Gerät bereit ist. Das Gerät wird als bereit angesehen, wenn sich der Akkustand, die Akkugesundheit und der thermische Zustand in einem gesunden Bereich befinden."),
         "ineligible": MessageLookupByLibrary.simpleMessage("Unzulässig"),
         "info": MessageLookupByLibrary.simpleMessage("Info"),
         "insecureDevice":
@@ -1354,6 +1373,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Wähle die Arten von Erinnerungen, die du auf der Startseite sehen möchtest."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
+        "merge": MessageLookupByLibrary.simpleMessage("Zusammenführen"),
         "mergeWithExisting": MessageLookupByLibrary.simpleMessage(
             "Mit vorhandenem zusammenführen"),
         "mergedPhotos":
@@ -1493,6 +1513,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Oder eine vorherige auswählen"),
         "orPickFromYourContacts": MessageLookupByLibrary.simpleMessage(
             "oder wähle aus deinen Kontakten"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("Andere erkannte Gesichter"),
         "pair": MessageLookupByLibrary.simpleMessage("Koppeln"),
         "pairWithPin":
             MessageLookupByLibrary.simpleMessage("Mit PIN verbinden"),
@@ -1624,6 +1646,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Öffentlicher Link erstellt"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Öffentlicher Link aktiviert"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("In der Warteschlange"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Quick Links"),
         "radius": MessageLookupByLibrary.simpleMessage("Umkreis"),
@@ -1740,6 +1763,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportBug": MessageLookupByLibrary.simpleMessage("Fehler melden"),
         "resendEmail":
             MessageLookupByLibrary.simpleMessage("E-Mail erneut senden"),
+        "reset": MessageLookupByLibrary.simpleMessage("Zurücksetzen"),
         "resetIgnoredFiles": MessageLookupByLibrary.simpleMessage(
             "Ignorierte Dateien zurücksetzen"),
         "resetPasswordTitle":
@@ -1767,7 +1791,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "rotateRight":
             MessageLookupByLibrary.simpleMessage("Nach rechts drehen"),
         "safelyStored": MessageLookupByLibrary.simpleMessage("Gesichert"),
+        "same": MessageLookupByLibrary.simpleMessage("Gleich"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("Dieselbe Person?"),
         "save": MessageLookupByLibrary.simpleMessage("Speichern"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("Als andere Person speichern"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Änderungen vor dem Verlassen speichern?"),
@@ -1928,8 +1956,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Teilt..."),
         "shiftDatesAndTime": MessageLookupByLibrary.simpleMessage(
             "Datum und Uhrzeit verschieben"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Weniger Gesichter zeigen"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Erinnerungen anschauen"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Mehr Gesichter zeigen"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Person anzeigen"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
             "Von anderen Geräten abmelden"),
@@ -2057,6 +2089,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "Der Link, den du aufrufen möchtest, ist abgelaufen."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Diese Personengruppen werden im Personen-Abschnitt nicht mehr angezeigt. Die Fotos bleiben unverändert."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Diese Person wird im Personen-Abschnitt nicht mehr angezeigt. Die Fotos bleiben unverändert."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "Der eingegebene Schlüssel ist ungültig"),
@@ -2256,6 +2292,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Ja, löschen"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Ja, Änderungen verwerfen"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Ja, ignorieren"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("Ja, ausloggen"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Ja, entfernen"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("Ja, erneuern"),

--- a/mobile/apps/photos/lib/generated/intl/messages_el.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_el.dart
@@ -20,12 +20,9 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'el';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "enterYourEmailAddress": MessageLookupByLibrary.simpleMessage(
-            "Εισάγετε την διεύθυνση ηλ. ταχυδρομείου σας"),
-        "wishThemAHappyBirthday": m115
+            "Εισάγετε την διεύθυνση ηλ. ταχυδρομείου σας")
       };
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_en.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_en.dart
@@ -1005,6 +1005,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Face not clustered yet, please come back later"),
         "faceRecognition":
             MessageLookupByLibrary.simpleMessage("Face recognition"),
+        "faceThumbnailGenerationFailed": MessageLookupByLibrary.simpleMessage(
+            "Unable to generate face thumbnails"),
         "faces": MessageLookupByLibrary.simpleMessage("Faces"),
         "failed": MessageLookupByLibrary.simpleMessage("Failed"),
         "failedToApplyCode":
@@ -1040,6 +1042,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "feastingWithThem": m34,
         "feedback": MessageLookupByLibrary.simpleMessage("Feedback"),
         "file": MessageLookupByLibrary.simpleMessage("File"),
+        "fileAnalysisFailed":
+            MessageLookupByLibrary.simpleMessage("Unable to analyze file"),
         "fileFailedToSaveToGallery": MessageLookupByLibrary.simpleMessage(
             "Failed to save file to gallery"),
         "fileInfoAddDescHint":

--- a/mobile/apps/photos/lib/generated/intl/messages_es.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_es.dart
@@ -313,8 +313,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Hemos enviado un correo a <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: 'Hace ${count} año', other: 'Hace ${count} años')}";
 
@@ -554,30 +552,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "blackFridaySale":
             MessageLookupByLibrary.simpleMessage("Oferta del Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
-        "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Tras el lanzamiento de la versión beta de transmisión de video y el trabajo en subidas y descargas reanudables, ahora hemos aumentado el límite de subida de archivos a 10GB. Esto ya está disponible tanto en aplicaciones de escritorio como móviles."),
-        "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Las subidas en segundo plano ahora también son compatibles con iOS, además de dispositivos Android. No necesitas abrir la aplicación para hacer una copia de seguridad de tus fotos y videos más recientes."),
-        "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Hemos hecho mejoras significativas en nuestra experiencia de recuerdos, incluyendo reproducción automática, deslizar al siguiente recuerdo y mucho más."),
-        "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Junto con un montón de mejoras internas, ahora es mucho más fácil ver todas las caras detectadas, proporcionar comentarios sobre caras similares y agregar/eliminar caras de una sola foto."),
-        "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Ahora recibirás una notificación opcional para todos los cumpleaños que hayas guardado en Ente, junto con una colección de sus mejores fotos."),
-        "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "No más esperas para que se completen las subidas/descargas antes de poder cerrar la aplicación. Todas las subidas y descargas ahora tienen la capacidad de pausarse a mitad de camino y reanudarse desde donde lo dejaste."),
-        "cLTitle1": MessageLookupByLibrary.simpleMessage(
-            "Subida de archivos de video grandes"),
-        "cLTitle2":
-            MessageLookupByLibrary.simpleMessage("Subida en segundo plano"),
-        "cLTitle3": MessageLookupByLibrary.simpleMessage(
-            "Reproducción automática de recuerdos"),
-        "cLTitle4": MessageLookupByLibrary.simpleMessage(
-            "Reconocimiento facial mejorado"),
-        "cLTitle5": MessageLookupByLibrary.simpleMessage(
-            "Notificaciones de cumpleaños"),
-        "cLTitle6": MessageLookupByLibrary.simpleMessage(
-            "Subidas y descargas reanudables"),
         "cachedData":
             MessageLookupByLibrary.simpleMessage("Datos almacenados en caché"),
         "calculating": MessageLookupByLibrary.simpleMessage("Calculando..."),
@@ -2199,7 +2173,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Qué hay de nuevo"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Un contacto de confianza puede ayudar a recuperar sus datos."),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("año"),
         "yearly": MessageLookupByLibrary.simpleMessage("Anualmente"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_et.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_et.dart
@@ -20,8 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'et';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "about": MessageLookupByLibrary.simpleMessage("Info"),
@@ -260,7 +258,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("Nõrk"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Tere tulemast tagasi!"),
-        "wishThemAHappyBirthday": m115,
         "yes": MessageLookupByLibrary.simpleMessage("Jah"),
         "yesConvertToViewer":
             MessageLookupByLibrary.simpleMessage("Jah, muuda vaatajaks"),

--- a/mobile/apps/photos/lib/generated/intl/messages_eu.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_eu.dart
@@ -99,8 +99,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Mezua bidali dugu <green>${email}</green> helbidera";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -631,7 +629,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("Ahula"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Ongi etorri berriro!"),
-        "wishThemAHappyBirthday": m115,
         "yesConvertToViewer":
             MessageLookupByLibrary.simpleMessage("Bai, egin ikusle"),
         "yesDelete": MessageLookupByLibrary.simpleMessage("Bai, ezabatu"),

--- a/mobile/apps/photos/lib/generated/intl/messages_fa.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_fa.dart
@@ -42,8 +42,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "ما یک ایمیل به <green>${email}</green> ارسال کرده‌ایم";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "aNewVersionOfEnteIsAvailable": MessageLookupByLibrary.simpleMessage(
@@ -426,7 +424,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("ضعیف"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("خوش آمدید!"),
         "whatsNew": MessageLookupByLibrary.simpleMessage("تغییرات جدید"),
-        "wishThemAHappyBirthday": m115,
         "yes": MessageLookupByLibrary.simpleMessage("بله"),
         "yesConvertToViewer":
             MessageLookupByLibrary.simpleMessage("بله، تبدیل به بیننده شود"),

--- a/mobile/apps/photos/lib/generated/intl/messages_fr.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_fr.dart
@@ -321,7 +321,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Nous avons envoyé un email à <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Souhaitez à ${name} un joyeux anniversaire ! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: 'il y a ${count} an', other: 'il y a ${count} ans')}";
@@ -427,6 +427,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Tous les souvenirs sont sauvegardés"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Tous les groupements pour cette personne seront réinitialisés, et vous perdrez toutes les suggestions faites pour cette personne"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Tous les groupes sans nom seront fusionnés dans la personne sélectionnée. Cela peut toujours être annulé à partir de l\'historique des suggestions de la personne."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "C\'est la première dans le groupe. Les autres photos sélectionnées se déplaceront automatiquement en fonction de cette nouvelle date"),
         "allow": MessageLookupByLibrary.simpleMessage("Autoriser"),
@@ -480,6 +483,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Archiver l\'album"),
         "archiving":
             MessageLookupByLibrary.simpleMessage("Archivage en cours..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Vraiment"),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Êtes-vous sûr de vouloir retirer ce visage de cette personne ?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Êtes-vous certains de vouloir quitter le plan familial?"),
@@ -490,8 +497,16 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Êtes-vous certains de vouloir changer d\'offre ?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Êtes-vous sûr de vouloir quitter ?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Êtes-vous sûr de vouloir ignorer ces personnes ?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Êtes-vous sûr de vouloir ignorer cette personne ?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Voulez-vous vraiment vous déconnecter ?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Êtes-vous sûr de vouloir les fusionner?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "Êtes-vous sûr de vouloir renouveler ?"),
         "areYouSureYouWantToResetThisPerson":
@@ -583,29 +598,29 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Offre Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
         "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Suite à la version bêta du streaming vidéo et au travail sur les téléchargements reprenables, nous avons maintenant augmenté la limite de téléchargement de fichiers à 10 Go. Ceci est maintenant disponible dans les applications desktop et mobiles."),
+            "Derrière la version beta du streaming vidéo, tout en travaillant sur la reprise des chargements et téléchargements, nous avons maintenant augmenté la limite de téléchargement de fichiers à 10 Go. Ceci est maintenant disponible dans les applications bureau et mobiles."),
         "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Les téléchargements en arrière-plan sont maintenant pris en charge sur iOS également, en plus des appareils Android. Pas besoin d\'ouvrir l\'application pour sauvegarder vos dernières photos et vidéos."),
+            "Les chargements en arrière-plan sont maintenant pris en charge sur iOS, en plus des appareils Android. Inutile d\'ouvrir l\'application pour sauvegarder vos dernières photos et vidéos."),
         "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Nous avons apporté des améliorations significatives à notre expérience de souvenirs, y compris la lecture automatique, le balayage vers le souvenir suivant et bien plus encore."),
+            "Nous avons apporté des améliorations significatives à l\'expérience des souvenirs, comme la lecture automatique, la glisse vers le souvenir suivant et bien plus encore."),
         "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Avec un tas d\'améliorations internes, il est maintenant beaucoup plus facile de voir tous les visages détectés, de donner des commentaires sur les visages similaires et d\'ajouter/supprimer des visages d\'une seule photo."),
+            "Avec un tas d\'améliorations sous le capot, il est maintenant beaucoup plus facile de voir tous les visages détectés, mettre des commentaires sur des visages similaires, et ajouter/supprimer des visages depuis une seule photo."),
         "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Vous recevrez maintenant une notification optionnelle pour tous les anniversaires que vous avez sauvegardés sur Ente, ainsi qu\'une collection de leurs meilleures photos."),
+            "Vous recevrez maintenant une notification de désinscription pour tous les anniversaires que vous avez enregistrés sur Ente, ainsi qu\'une collection de leurs meilleures photos."),
         "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Plus besoin d\'attendre que les téléchargements se terminent avant de pouvoir fermer l\'application. Tous les téléchargements ont maintenant la capacité d\'être mis en pause à mi-chemin et de reprendre là où vous vous êtes arrêté."),
+            "Plus besoin d\'attendre la fin des chargements/téléchargements avant de pouvoir fermer l\'application. Tous peuvent maintenant être mis en pause en cours de route et reprendre à partir de là où ça s\'est arrêté."),
         "cLTitle1": MessageLookupByLibrary.simpleMessage(
-            "Téléchargement de fichiers vidéo volumineux"),
-        "cLTitle2": MessageLookupByLibrary.simpleMessage(
-            "Téléchargement en arrière-plan"),
+            "Envoi de gros fichiers vidéo"),
+        "cLTitle2":
+            MessageLookupByLibrary.simpleMessage("Charger en arrière-plan"),
         "cLTitle3": MessageLookupByLibrary.simpleMessage(
             "Lecture automatique des souvenirs"),
         "cLTitle4": MessageLookupByLibrary.simpleMessage(
-            "Reconnaissance faciale améliorée"),
+            "Amélioration de la reconnaissance faciale"),
         "cLTitle5": MessageLookupByLibrary.simpleMessage(
-            "Notifications d\'anniversaire"),
-        "cLTitle6":
-            MessageLookupByLibrary.simpleMessage("Téléchargements reprenables"),
+            "Notifications d’anniversaire"),
+        "cLTitle6": MessageLookupByLibrary.simpleMessage(
+            "Reprise des chargements et téléchargements"),
         "cachedData":
             MessageLookupByLibrary.simpleMessage("Données mises en cache"),
         "calculating":
@@ -871,6 +886,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Appareil non trouvé"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Le savais-tu ?"),
+        "different": MessageLookupByLibrary.simpleMessage("Différent(e)"),
         "disableAutoLock": MessageLookupByLibrary.simpleMessage(
             "Désactiver le verrouillage automatique"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
@@ -1169,6 +1185,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "L\'authentification biométrique est désactivée. Veuillez verrouiller et déverrouiller votre écran pour l\'activer."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("Ok"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Ignorer"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Ignorer"),
         "ignored": MessageLookupByLibrary.simpleMessage("ignoré"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1190,6 +1207,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Clé de secours non valide"),
         "indexedItems":
             MessageLookupByLibrary.simpleMessage("Éléments indexés"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "L\'indexation est en pause. Elle reprendra automatiquement lorsque l\'appareil sera prêt. Celui-ci est considéré comme prêt lorsque le niveau de batterie, sa santé et son état thermique sont dans une plage saine."),
         "ineligible": MessageLookupByLibrary.simpleMessage("Non compatible"),
         "info": MessageLookupByLibrary.simpleMessage("Info"),
         "insecureDevice":
@@ -1377,6 +1396,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Sélectionnez le type de souvenirs que vous souhaitez voir sur votre écran d\'accueil."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Boutique"),
+        "merge": MessageLookupByLibrary.simpleMessage("Fusionner"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Fusionner avec existant"),
         "mergedPhotos":
@@ -1519,6 +1539,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Ou sélectionner un email existant"),
         "orPickFromYourContacts": MessageLookupByLibrary.simpleMessage(
             "ou choisissez parmi vos contacts"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("Autres visages détectés"),
         "pair": MessageLookupByLibrary.simpleMessage("Associer"),
         "pairWithPin":
             MessageLookupByLibrary.simpleMessage("Appairer avec le code PIN"),
@@ -1657,6 +1679,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Lien public créé"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Lien public activé"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("En file d\'attente"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Liens rapides"),
         "radius": MessageLookupByLibrary.simpleMessage("Rayon"),
@@ -1774,6 +1797,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportBug": MessageLookupByLibrary.simpleMessage("Signaler un bogue"),
         "resendEmail":
             MessageLookupByLibrary.simpleMessage("Renvoyer l\'email"),
+        "reset": MessageLookupByLibrary.simpleMessage("Réinitialiser"),
         "resetIgnoredFiles": MessageLookupByLibrary.simpleMessage(
             "Réinitialiser les fichiers ignorés"),
         "resetPasswordTitle": MessageLookupByLibrary.simpleMessage(
@@ -1802,7 +1826,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Faire pivoter à droite"),
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Stockage sécurisé"),
+        "same": MessageLookupByLibrary.simpleMessage("Identique"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("Même personne ?"),
         "save": MessageLookupByLibrary.simpleMessage("Sauvegarder"),
+        "saveAsAnotherPerson": MessageLookupByLibrary.simpleMessage(
+            "Enregistrer comme une autre personne"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Enregistrer les modifications avant de quitter ?"),
@@ -1974,8 +2002,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Partage..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("Dates et heure de décalage"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Afficher moins de visages"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Afficher les souvenirs"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Afficher plus de visages"),
         "showPerson":
             MessageLookupByLibrary.simpleMessage("Montrer la personne"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
@@ -2104,6 +2136,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "Le lien que vous essayez d\'accéder a expiré."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Les groupes de personnes ne seront plus affichés dans la section personnes. Les photos resteront intactes."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Les groupes de personnes ne seront plus affichés dans la section personnes. Les photos resteront intactes."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "La clé de récupération que vous avez entrée est incorrecte"),
@@ -2307,6 +2343,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Oui, supprimer"),
         "yesDiscardChanges": MessageLookupByLibrary.simpleMessage(
             "Oui, ignorer les modifications"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Oui, ignorer"),
         "yesLogout":
             MessageLookupByLibrary.simpleMessage("Oui, se déconnecter"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Oui, supprimer"),

--- a/mobile/apps/photos/lib/generated/intl/messages_gu.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_gu.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'gu';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_he.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_he.dart
@@ -114,8 +114,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "שלחנו דוא\"ל ל<green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: 'לפני ${count} שנה', other: 'לפני ${count} שנים')}";
 
@@ -910,7 +908,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weHaveSendEmailTo": m114,
         "weakStrength": MessageLookupByLibrary.simpleMessage("חלשה"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("ברוך שובך!"),
-        "wishThemAHappyBirthday": m115,
         "yearly": MessageLookupByLibrary.simpleMessage("שנתי"),
         "yearsAgo": m116,
         "yes": MessageLookupByLibrary.simpleMessage("כן"),

--- a/mobile/apps/photos/lib/generated/intl/messages_hi.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_hi.dart
@@ -20,8 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'hi';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -107,7 +105,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "verify": MessageLookupByLibrary.simpleMessage("सत्यापित करें"),
         "verifyEmail":
             MessageLookupByLibrary.simpleMessage("ईमेल सत्यापित करें"),
-        "wishThemAHappyBirthday": m115,
         "yourAccountHasBeenDeleted": MessageLookupByLibrary.simpleMessage(
             "आपका अकाउंट डिलीट कर दिया गया है")
       };

--- a/mobile/apps/photos/lib/generated/intl/messages_hu.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_hu.dart
@@ -20,27 +20,738 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'hu';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m8(count) =>
+      "${Intl.plural(count, zero: 'Nincsenek résztvevők', one: '1 résztvevő', other: '${count} résztvevők')}";
+
+  static String m13(user) =>
+      "${user} nem tud több fotót hozzáadni ehhez az albumhoz.\n\nTovábbra is el tudja távolítani az általa hozzáadott meglévő fotókat";
+
+  static String m14(isFamilyMember, storageAmountInGb) =>
+      "${Intl.select(isFamilyMember, {
+            'true':
+                'A családod eddig ${storageAmountInGb} GB tárhelyet igényelt',
+            'false': 'Eddig ${storageAmountInGb} GB tárhelyet igényelt',
+            'other': 'Eddig ${storageAmountInGb} GB tárhelyet igényelt!',
+          })}";
+
+  static String m21(count) =>
+      "${Intl.plural(count, one: 'Elem ${count} törlése', other: 'Elemek ${count} törlése')}";
+
+  static String m24(albumName) =>
+      "Ez eltávolítja a(z) „${albumName}” eléréséhez szükséges nyilvános linket.";
+
+  static String m25(supportEmail) =>
+      "Kérjük küldjön egy e-mailt a fiók regisztrálásakor megadott címről a következőre címre: ${supportEmail}";
+
+  static String m27(count, formattedSize) =>
+      "${count} fájl, ${formattedSize} mindegyik";
+
+  static String m31(email) =>
+      "${email} címnek nincs Ente fiókja.\n\nKüldjön nekik meghívót fotók megosztására.";
+
+  static String m37(storageAmountInGB) =>
+      "${storageAmountInGB} GB minden alkalommal, amikor valaki fizetős csomagra fizet elő és felhasználja a kódodat";
+
+  static String m44(count) => "${Intl.plural(count, other: '${count} elem')}";
+
+  static String m47(expiryTime) => "Hivatkozás lejár ${expiryTime} ";
+
+  static String m50(count, formattedCount) =>
+      "${Intl.plural(count, zero: 'nincsenek emlékek', one: '${formattedCount} emlék', other: '${formattedCount} emlékek')}";
+
+  static String m55(familyAdminEmail) =>
+      "Kérjük, vegye fel a kapcsolatot a ${familyAdminEmail} e-mail címmel a kód módosításához.";
+
+  static String m57(passwordStrengthValue) =>
+      "Jelszó erőssége: ${passwordStrengthValue}";
+
+  static String m73(storageInGB) =>
+      "3. Mindketten ${storageInGB} GB* ingyenes tárhelyet kaptok";
+
+  static String m74(userEmail) =>
+      "${userEmail} felhasználó el lesz távolítva ebből a megosztott albumból\n\nAz általa hozzáadott összes fotó is eltávolításra kerül az albumból.";
+
+  static String m80(count) => "${count} kiválasztott";
+
+  static String m81(count, yourCount) =>
+      "${count} kiválasztott (${yourCount} a tiéd)";
+
+  static String m83(verificationID) =>
+      "Itt az ellenőrző azonosítóm: ${verificationID} az ente.io-hoz.";
+
+  static String m84(verificationID) =>
+      "Szia, meg tudnád erősíteni, hogy ez az ente.io ellenőrző azonosítód? ${verificationID}";
+
+  static String m85(referralCode, referralStorageInGB) =>
+      "Add meg a következő ajánlási kódot: ${referralCode}\n\nAlkalmazd a Beállítások → Általános → Ajánlások menüpontban, hogy ${referralStorageInGB} GB ingyenes tárhelyet kapj, miután regisztráltál egy fizetős csomagra\n\nhttps://ente.io";
+
+  static String m86(numberOfPeople) =>
+      "${Intl.plural(numberOfPeople, zero: 'Megosztás adott személyekkel', one: '1 személlyel megosztva', other: '${numberOfPeople} személlyel megosztva')}";
+
+  static String m88(fileType) =>
+      "Ez a ${fileType} fájl törlődni fog az eszközéről.";
+
+  static String m89(fileType) =>
+      "Ez a ${fileType} fájltípus megtalálható mind az Enterben, mind az eszközödön.";
+
+  static String m90(fileType) => "Ez a ${fileType} fájl törlődik az Ente-ből.";
+
+  static String m93(storageAmountInGB) => "${storageAmountInGB} GB";
+
+  static String m99(storageAmountInGB) =>
+      "Emellett ${storageAmountInGB} GB-ot kapnak";
+
+  static String m100(email) => "Ez ${email} ellenőrző azonosítója";
+
+  static String m111(email) => "${email} ellenőrzése";
+
+  static String m114(email) =>
+      "E-mailt küldtünk a következő címre: <green>${email}</green>";
+
+  static String m116(count) =>
+      "${Intl.plural(count, one: '${count} évvel ezelőtt', other: '${count} évekkel ezelőtt')}";
+
+  static String m118(storageSaved) =>
+      "Sikeresen felszabadítottál ${storageSaved} tárhelyet!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "aNewVersionOfEnteIsAvailable": MessageLookupByLibrary.simpleMessage(
+            "Megjelent az Ente új verziója."),
+        "about": MessageLookupByLibrary.simpleMessage("Rólunk"),
+        "account": MessageLookupByLibrary.simpleMessage("Fiók"),
         "accountWelcomeBack":
             MessageLookupByLibrary.simpleMessage("Köszöntjük ismét!"),
+        "ackPasswordLostWarning": MessageLookupByLibrary.simpleMessage(
+            "Tudomásul veszem, hogy ha elveszítem a jelszavamat, elveszíthetem az adataimat, mivel adataim <underline>végponttól végpontig titkosítva vannak</underline>."),
+        "activeSessions":
+            MessageLookupByLibrary.simpleMessage("Bejelentkezések"),
+        "addANewEmail":
+            MessageLookupByLibrary.simpleMessage("Új email cím hozzáadása"),
+        "addCollaborator":
+            MessageLookupByLibrary.simpleMessage("Együttműködő hozzáadása"),
+        "addMore": MessageLookupByLibrary.simpleMessage("További hozzáadása"),
+        "addViewer": MessageLookupByLibrary.simpleMessage(
+            "Megtekintésre jogosult hozzáadása"),
+        "addedAs": MessageLookupByLibrary.simpleMessage("Hozzáadva mint"),
+        "addingToFavorites":
+            MessageLookupByLibrary.simpleMessage("Hozzáadás a kedvencekhez..."),
+        "advancedSettings": MessageLookupByLibrary.simpleMessage("Haladó"),
+        "after1Day": MessageLookupByLibrary.simpleMessage("Egy nap mólva"),
+        "after1Hour": MessageLookupByLibrary.simpleMessage("Egy óra múlva"),
+        "after1Month": MessageLookupByLibrary.simpleMessage("Egy hónap múlva"),
+        "after1Week": MessageLookupByLibrary.simpleMessage("Egy hét múlva"),
+        "after1Year": MessageLookupByLibrary.simpleMessage("Egy év múlva"),
+        "albumOwner": MessageLookupByLibrary.simpleMessage("Tulajdonos"),
+        "albumParticipantsCount": m8,
+        "albumUpdated": MessageLookupByLibrary.simpleMessage("Album módosítva"),
+        "albums": MessageLookupByLibrary.simpleMessage("Album"),
+        "allClear": MessageLookupByLibrary.simpleMessage("✨ Minden tiszta"),
+        "allowAddPhotosDescription": MessageLookupByLibrary.simpleMessage(
+            "Engedélyezd a linkkel rendelkező személyeknek, hogy ők is hozzáadhassanak fotókat a megosztott albumhoz."),
+        "allowAddingPhotos": MessageLookupByLibrary.simpleMessage(
+            "Fotók hozzáadásának engedélyezése"),
+        "allowDownloads":
+            MessageLookupByLibrary.simpleMessage("Letöltések engedélyezése"),
+        "apply": MessageLookupByLibrary.simpleMessage("Alkalmaz"),
+        "applyCodeTitle":
+            MessageLookupByLibrary.simpleMessage("Kód alkalmazása"),
+        "archive": MessageLookupByLibrary.simpleMessage("Archívum"),
+        "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
+            "Biztos benne, hogy kijelentkezik?"),
         "askDeleteReason":
             MessageLookupByLibrary.simpleMessage("Miért törli a fiókját?"),
+        "authToChangeEmailVerificationSetting":
+            MessageLookupByLibrary.simpleMessage(
+                "Kérjük, hitelesítse magát az e-mail-cím ellenőrzésének módosításához"),
+        "authToChangeYourEmail": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, hitelesítse magát az e-mail címének módosításához"),
+        "authToChangeYourPassword": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, hitelesítse magát a jelszó módosításához"),
+        "authToInitiateAccountDeletion": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, hitelesítse magát a fiók törlésének megkezdéséhez"),
+        "authToViewTrashedFiles": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, hitelesítse magát a kukába helyezett fájlok megtekintéséhez"),
+        "authToViewYourHiddenFiles": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, hitelesítse magát a rejtett fájlok megtekintéséhez"),
+        "backedUpFolders": MessageLookupByLibrary.simpleMessage(
+            "Biztonsági másolatban lévő mappák"),
+        "backup": MessageLookupByLibrary.simpleMessage("Biztonsági mentés"),
+        "backupOverMobileData": MessageLookupByLibrary.simpleMessage(
+            "Biztonsági mentés mobil adatkapcsolaton keresztül"),
+        "backupSettings": MessageLookupByLibrary.simpleMessage(
+            "Biztonsági mentés beállításai"),
+        "backupStatus":
+            MessageLookupByLibrary.simpleMessage("Biztonsági mentés állapota"),
+        "backupStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "Azok az elemek jelennek meg itt, amelyekről biztonsági másolat készült"),
+        "backupVideos": MessageLookupByLibrary.simpleMessage("Tartalék videók"),
+        "canNotOpenBody": MessageLookupByLibrary.simpleMessage(
+            "Sajnálom, ez az album nem nyitható meg ebben az applikációban."),
+        "canNotOpenTitle":
+            MessageLookupByLibrary.simpleMessage("Album nem nyitható meg"),
+        "canOnlyRemoveFilesOwnedByYou": MessageLookupByLibrary.simpleMessage(
+            "Csak a saját tulajdonú fájlokat távolíthatja el"),
         "cancel": MessageLookupByLibrary.simpleMessage("Mégse"),
+        "cannotAddMorePhotosAfterBecomingViewer": m13,
+        "cannotDeleteSharedFiles": MessageLookupByLibrary.simpleMessage(
+            "Nem lehet törölni a megosztott fájlokat"),
+        "change": MessageLookupByLibrary.simpleMessage("Módosítás"),
+        "changeEmail":
+            MessageLookupByLibrary.simpleMessage("E-mail cím módosítása"),
+        "changePassword":
+            MessageLookupByLibrary.simpleMessage("Jelszó megváltoztatása"),
+        "changePasswordTitle":
+            MessageLookupByLibrary.simpleMessage("Jelszó megváltoztatása"),
+        "changePermissions":
+            MessageLookupByLibrary.simpleMessage("Engedélyek módosítása?"),
+        "changeYourReferralCode":
+            MessageLookupByLibrary.simpleMessage("Módosítsa ajánló kódját"),
+        "checkForUpdates":
+            MessageLookupByLibrary.simpleMessage("Frissítések ellenőrzése"),
+        "checkInboxAndSpamFolder": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, ellenőrizze beérkező leveleit (és spam mappát) az ellenőrzés befejezéséhez"),
+        "checkStatus":
+            MessageLookupByLibrary.simpleMessage("Állapot ellenőrzése"),
+        "checking": MessageLookupByLibrary.simpleMessage("Ellenőrzés..."),
+        "claimFreeStorage": MessageLookupByLibrary.simpleMessage(
+            "Igényeljen ingyenes tárhelyet"),
+        "claimMore": MessageLookupByLibrary.simpleMessage("Igényelj többet!"),
+        "claimed": MessageLookupByLibrary.simpleMessage("Megszerezve!"),
+        "claimedStorageSoFar": m14,
+        "clearIndexes": MessageLookupByLibrary.simpleMessage("Indexek törlése"),
+        "codeAppliedPageTitle":
+            MessageLookupByLibrary.simpleMessage("Kód alkalmazva"),
+        "codeChangeLimitReached": MessageLookupByLibrary.simpleMessage(
+            "Sajnáljuk, elérted a kódmódosítások maximális számát."),
+        "codeCopiedToClipboard":
+            MessageLookupByLibrary.simpleMessage("A kód a vágólapra másolva"),
+        "codeUsedByYou":
+            MessageLookupByLibrary.simpleMessage("Ön által használt kód"),
+        "collabLinkSectionDescription": MessageLookupByLibrary.simpleMessage(
+            "Hozzon létre egy hivatkozást, amely lehetővé teszi az emberek számára, hogy fotókat adhassanak hozzá és tekintsenek meg megosztott albumában anélkül, hogy Ente alkalmazásra vagy fiókra lenne szükségük. Kiválóan alkalmas rendezvényfotók gyűjtésére."),
+        "collaborativeLink":
+            MessageLookupByLibrary.simpleMessage("Együttműködési hivatkozás"),
+        "collaborator": MessageLookupByLibrary.simpleMessage("Együttműködő"),
+        "collaboratorsCanAddPhotosAndVideosToTheSharedAlbum":
+            MessageLookupByLibrary.simpleMessage(
+                "Az együttműködők hozzá adhatnak fotókat és videókat a megosztott albumban."),
+        "collectPhotos": MessageLookupByLibrary.simpleMessage("Fotók gyűjtése"),
+        "confirm": MessageLookupByLibrary.simpleMessage("Megerősítés"),
+        "confirmAccountDeletion": MessageLookupByLibrary.simpleMessage(
+            "Felhasználó Törlés Megerősítés"),
+        "confirmDeletePrompt": MessageLookupByLibrary.simpleMessage(
+            "Igen, szeretném véglegesen törölni ezt a felhasználót, minden adattal, az összes platformon."),
+        "confirmPassword":
+            MessageLookupByLibrary.simpleMessage("Jelszó megerősítés"),
+        "confirmRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Helyreállítási kulcs megerősítése"),
+        "confirmYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Erősítse meg helyreállítási kulcsát"),
+        "contactSupport": MessageLookupByLibrary.simpleMessage(
+            "Lépj kapcsolatba az Ügyfélszolgálattal"),
+        "continueLabel": MessageLookupByLibrary.simpleMessage("Folytatás"),
+        "copyLink": MessageLookupByLibrary.simpleMessage("Hivatkozás másolása"),
+        "copypasteThisCodentoYourAuthenticatorApp":
+            MessageLookupByLibrary.simpleMessage(
+                "Kód Másolása-Beillesztése az ön autentikátor alkalmazásába"),
+        "createAccount":
+            MessageLookupByLibrary.simpleMessage("Felhasználó létrehozás"),
+        "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
+            "Hosszan nyomva tartva kiválaszthatod a fotókat, majd a + jelre kattintva albumot hozhatsz létre"),
+        "createNewAccount":
+            MessageLookupByLibrary.simpleMessage("Új felhasználó létrehozás"),
+        "createPublicLink": MessageLookupByLibrary.simpleMessage(
+            "Nyilvános hivatkozás létrehozása"),
+        "creatingLink":
+            MessageLookupByLibrary.simpleMessage("Link létrehozása..."),
+        "criticalUpdateAvailable":
+            MessageLookupByLibrary.simpleMessage("Kritikus frissítés elérhető"),
+        "custom": MessageLookupByLibrary.simpleMessage("Egyéni"),
+        "decrypting": MessageLookupByLibrary.simpleMessage("Dekódolás..."),
         "deleteAccount": MessageLookupByLibrary.simpleMessage("Fiók törlése"),
         "deleteAccountFeedbackPrompt": MessageLookupByLibrary.simpleMessage(
             "Sajnáljuk, hogy távozik. Kérjük, ossza meg velünk visszajelzéseit, hogy segítsen nekünk a fejlődésben."),
+        "deleteAccountPermanentlyButton": MessageLookupByLibrary.simpleMessage(
+            "Felhasználó Végleges Törlése"),
+        "deleteAlbum": MessageLookupByLibrary.simpleMessage("Album törlése"),
+        "deleteAlbumDialog": MessageLookupByLibrary.simpleMessage(
+            "Törli az ebben az albumban található fotókat (és videókat) az <bold>összes</bold> többi albumból is, amelynek részét képezik?"),
+        "deleteEmailRequest": MessageLookupByLibrary.simpleMessage(
+            "Kérem küldjön egy emailt a regisztrált email címéről, erre az emailcímre: <warning>account-deletion@ente.io</warning>."),
+        "deleteFromBoth":
+            MessageLookupByLibrary.simpleMessage("Törlés mindkettőből"),
+        "deleteFromDevice":
+            MessageLookupByLibrary.simpleMessage("Törlés az eszközről"),
+        "deleteFromEnte":
+            MessageLookupByLibrary.simpleMessage("Törlés az Ente-ből"),
+        "deleteItemCount": m21,
+        "deletePhotos": MessageLookupByLibrary.simpleMessage("Fotók törlése"),
+        "deleteReason1": MessageLookupByLibrary.simpleMessage(
+            "Hiányoznak olyan funkciók, amikre szükségem lenne"),
+        "deleteReason2": MessageLookupByLibrary.simpleMessage(
+            "Az applikáció vagy egy adott funkció nem úgy működik ahogy kellene"),
+        "deleteReason3": MessageLookupByLibrary.simpleMessage(
+            "Találtam egy jobb szolgáltatót"),
+        "deleteReason4":
+            MessageLookupByLibrary.simpleMessage("Nincs a listán az ok"),
+        "deleteRequestSLAText": MessageLookupByLibrary.simpleMessage(
+            "A kérése 72 órán belül feldolgozásra kerül."),
+        "deleteSharedAlbum":
+            MessageLookupByLibrary.simpleMessage("Törli a megosztott albumot?"),
+        "deleteSharedAlbumDialogBody": MessageLookupByLibrary.simpleMessage(
+            "Az album mindenki számára törlődik.\n\nElveszíti a hozzáférést az albumban található, mások tulajdonában lévő megosztott fotókhoz."),
+        "details": MessageLookupByLibrary.simpleMessage("Részletek"),
+        "deviceLockExplanation": MessageLookupByLibrary.simpleMessage(
+            "Disable the device screen lock when Ente is in the foreground and there is a backup in progress. This is normally not needed, but may help big uploads and initial imports of large libraries complete faster."),
+        "disableAutoLock":
+            MessageLookupByLibrary.simpleMessage("Automatikus zár letiltása"),
+        "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
+            "A nézők továbbra is készíthetnek képernyőképeket, vagy menthetnek másolatot a fotóidról külső eszközök segítségével"),
+        "disableDownloadWarningTitle":
+            MessageLookupByLibrary.simpleMessage("Kérjük, vedd figyelembe"),
+        "disableLinkMessage": m24,
+        "discover": MessageLookupByLibrary.simpleMessage("Felfedezés"),
+        "discover_babies": MessageLookupByLibrary.simpleMessage("Babák"),
+        "discover_celebrations":
+            MessageLookupByLibrary.simpleMessage("Ünnepségek"),
+        "discover_food": MessageLookupByLibrary.simpleMessage("Étel"),
+        "discover_greenery": MessageLookupByLibrary.simpleMessage("Lomb"),
+        "discover_hills": MessageLookupByLibrary.simpleMessage("Dombok"),
+        "discover_identity":
+            MessageLookupByLibrary.simpleMessage("Személyazonosság"),
+        "discover_memes": MessageLookupByLibrary.simpleMessage("Mémek"),
+        "discover_notes": MessageLookupByLibrary.simpleMessage("Jegyzetek"),
+        "discover_pets": MessageLookupByLibrary.simpleMessage("Kisállatok"),
+        "discover_receipts": MessageLookupByLibrary.simpleMessage("Nyugták"),
+        "discover_screenshots":
+            MessageLookupByLibrary.simpleMessage("Képernyőképek"),
+        "discover_selfies": MessageLookupByLibrary.simpleMessage("Szelfik"),
+        "discover_sunset": MessageLookupByLibrary.simpleMessage("Napnyugta"),
+        "discover_visiting_cards":
+            MessageLookupByLibrary.simpleMessage("Névjegykártyák"),
+        "discover_wallpapers":
+            MessageLookupByLibrary.simpleMessage("Háttérképek"),
+        "doThisLater": MessageLookupByLibrary.simpleMessage("Később"),
+        "done": MessageLookupByLibrary.simpleMessage("Kész"),
+        "downloading": MessageLookupByLibrary.simpleMessage("Letöltés..."),
+        "dropSupportEmail": m25,
+        "duplicateItemsGroup": m27,
+        "eligible": MessageLookupByLibrary.simpleMessage("jogosult"),
         "email": MessageLookupByLibrary.simpleMessage("E-mail"),
+        "emailAlreadyRegistered":
+            MessageLookupByLibrary.simpleMessage("Az email cím már foglalt."),
+        "emailNoEnteAccount": m31,
+        "emailNotRegistered":
+            MessageLookupByLibrary.simpleMessage("Nem regisztrált email cím."),
+        "emailVerificationToggle":
+            MessageLookupByLibrary.simpleMessage("E-mail cím ellenőrzése"),
+        "encryption": MessageLookupByLibrary.simpleMessage("Titkosítás"),
+        "encryptionKeys":
+            MessageLookupByLibrary.simpleMessage("Titkosító kulcsok"),
+        "entePhotosPerm": MessageLookupByLibrary.simpleMessage(
+            "Az Entének <i>engedélyre van szüksége </i>, hogy tárolhassa fotóit"),
+        "enterCode": MessageLookupByLibrary.simpleMessage("Kód beírása"),
+        "enterCodeDescription": MessageLookupByLibrary.simpleMessage(
+            "Add meg a barátod által megadott kódot, hogy mindkettőtöknek ingyenes tárhelyet igényelhess"),
+        "enterEmail": MessageLookupByLibrary.simpleMessage("Email megadása"),
+        "enterNewPasswordToEncrypt": MessageLookupByLibrary.simpleMessage(
+            "Adjon meg egy új jelszót, amellyel titkosíthatjuk adatait"),
+        "enterPassword":
+            MessageLookupByLibrary.simpleMessage("Adja meg a jelszót"),
+        "enterPasswordToEncrypt": MessageLookupByLibrary.simpleMessage(
+            "Adjon meg egy jelszót, amellyel titkosíthatjuk adatait"),
+        "enterReferralCode":
+            MessageLookupByLibrary.simpleMessage("Adja meg az ajánló kódot"),
+        "enterThe6digitCodeFromnyourAuthenticatorApp":
+            MessageLookupByLibrary.simpleMessage(
+                "Írja be a 6 számjegyű kódot a hitelesítő alkalmazásból"),
         "enterValidEmail": MessageLookupByLibrary.simpleMessage(
             "Kérjük, adjon meg egy érvényes e-mail címet."),
         "enterYourEmailAddress":
             MessageLookupByLibrary.simpleMessage("Adja meg az e-mail címét"),
+        "enterYourNewEmailAddress":
+            MessageLookupByLibrary.simpleMessage("Add meg az új email címed"),
+        "enterYourPassword":
+            MessageLookupByLibrary.simpleMessage("Adja meg a jelszavát"),
+        "enterYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Adja meg visszaállítási kulcsát"),
+        "expiredLinkInfo": MessageLookupByLibrary.simpleMessage(
+            "Ez a link lejárt. Kérjük, válasszon új lejárati időt, vagy tiltsa le a link lejáratát."),
+        "exportYourData":
+            MessageLookupByLibrary.simpleMessage("Adatok exportálása"),
+        "failedToApplyCode": MessageLookupByLibrary.simpleMessage(
+            "Nem sikerült alkalmazni a kódot"),
+        "failedToFetchReferralDetails": MessageLookupByLibrary.simpleMessage(
+            "Nem sikerült lekérni a hivatkozási adatokat. Kérjük, próbálja meg később."),
+        "failedToLoadAlbums": MessageLookupByLibrary.simpleMessage(
+            "Nem sikerült betölteni az albumokat"),
+        "faq": MessageLookupByLibrary.simpleMessage("GY. I. K."),
         "feedback": MessageLookupByLibrary.simpleMessage("Visszajelzés"),
+        "forgotPassword":
+            MessageLookupByLibrary.simpleMessage("Elfelejtett jelszó"),
+        "freeStorageClaimed":
+            MessageLookupByLibrary.simpleMessage("Ingyenes tárhely igénylése"),
+        "freeStorageOnReferralSuccess": m37,
+        "freeStorageUsable": MessageLookupByLibrary.simpleMessage(
+            "Ingyenesen használható tárhely"),
+        "freeUpDeviceSpace":
+            MessageLookupByLibrary.simpleMessage("Szabadítson fel tárhelyet"),
+        "freeUpDeviceSpaceDesc": MessageLookupByLibrary.simpleMessage(
+            "Takarítson meg helyet az eszközén a már mentett fájlok törlésével."),
+        "generatingEncryptionKeys": MessageLookupByLibrary.simpleMessage(
+            "Titkosítási kulcs generálása..."),
+        "help": MessageLookupByLibrary.simpleMessage("Segítség"),
+        "hidden": MessageLookupByLibrary.simpleMessage("Rejtett"),
+        "howItWorks": MessageLookupByLibrary.simpleMessage("Hogyan működik"),
+        "howToViewShareeVerificationID": MessageLookupByLibrary.simpleMessage(
+            "Kérje meg őket, hogy hosszan nyomják meg az e-mail címüket a beállítások képernyőn, és ellenőrizzék, hogy a két eszköz azonosítója megegyezik-e."),
+        "ignoreUpdate":
+            MessageLookupByLibrary.simpleMessage("Figyelem kívül hagyás"),
+        "importing": MessageLookupByLibrary.simpleMessage("Importálás..."),
+        "incorrectPasswordTitle":
+            MessageLookupByLibrary.simpleMessage("Érvénytelen jelszó"),
+        "incorrectRecoveryKeyBody": MessageLookupByLibrary.simpleMessage(
+            "A megadott visszaállítási kulcs hibás"),
+        "incorrectRecoveryKeyTitle":
+            MessageLookupByLibrary.simpleMessage("Hibás visszaállítási kulcs"),
+        "indexedItems": MessageLookupByLibrary.simpleMessage("Indexelt elemek"),
+        "insecureDevice":
+            MessageLookupByLibrary.simpleMessage("Nem biztonságos eszköz"),
+        "installManually":
+            MessageLookupByLibrary.simpleMessage("Manuális telepítés"),
         "invalidEmailAddress":
             MessageLookupByLibrary.simpleMessage("Érvénytelen e-mail cím"),
+        "invalidKey": MessageLookupByLibrary.simpleMessage("Érvénytelen kulcs"),
+        "invalidRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "A megadott helyreállítási kulcs érvénytelen. Kérjük, győződjön meg róla, hogy 24 szót tartalmaz, és ellenőrizze mindegyik helyesírását.\n\nHa régebbi helyreállítási kódot adott meg, győződjön meg arról, hogy az 64 karakter hosszú, és ellenőrizze mindegyiket."),
+        "inviteToEnte":
+            MessageLookupByLibrary.simpleMessage("Meghívás az Ente-re"),
+        "inviteYourFriends":
+            MessageLookupByLibrary.simpleMessage("Hívd meg a barátaidat"),
+        "itemCount": m44,
+        "itemsWillBeRemovedFromAlbum": MessageLookupByLibrary.simpleMessage(
+            "A kiválasztott elemek eltávolításra kerülnek ebből az albumból."),
+        "keepPhotos": MessageLookupByLibrary.simpleMessage("Fotók megőrzése"),
+        "kindlyHelpUsWithThisInformation": MessageLookupByLibrary.simpleMessage(
+            "Legyen kedves segítsen, ezzel az információval"),
+        "linkDeviceLimit":
+            MessageLookupByLibrary.simpleMessage("Készülékkorlát"),
+        "linkEnabled": MessageLookupByLibrary.simpleMessage("Engedélyezett"),
+        "linkExpired": MessageLookupByLibrary.simpleMessage("Lejárt"),
+        "linkExpiresOn": m47,
+        "linkExpiry": MessageLookupByLibrary.simpleMessage("Link lejárata"),
+        "linkHasExpired": MessageLookupByLibrary.simpleMessage(
+            "A hivatkozás érvényességi ideje lejárt"),
+        "linkNeverExpires": MessageLookupByLibrary.simpleMessage("Soha"),
+        "loadingModel":
+            MessageLookupByLibrary.simpleMessage("Modellek letöltése..."),
+        "lockButtonLabel": MessageLookupByLibrary.simpleMessage("Zárolás"),
+        "logInLabel": MessageLookupByLibrary.simpleMessage("Bejelentkezés"),
+        "loginTerms": MessageLookupByLibrary.simpleMessage(
+            "A bejelentkezés gombra kattintva elfogadom az <u-terms>szolgáltatási feltételeket</u-terms> és az <u-policy>adatvédelmi irányelveket</u-policy>"),
+        "logout": MessageLookupByLibrary.simpleMessage("Kijelentkezés"),
+        "lostDevice":
+            MessageLookupByLibrary.simpleMessage("Elveszett a készüléked?"),
+        "machineLearning": MessageLookupByLibrary.simpleMessage("Gépi tanulás"),
+        "magicSearch":
+            MessageLookupByLibrary.simpleMessage("Varázslatos keresés"),
+        "manage": MessageLookupByLibrary.simpleMessage("Kezelés"),
+        "manageDeviceStorage": MessageLookupByLibrary.simpleMessage(
+            "Eszköz gyorsítótárának kezelése"),
+        "manageDeviceStorageDesc": MessageLookupByLibrary.simpleMessage(
+            "Tekintse át és törölje a helyi gyorsítótárat."),
+        "manageLink":
+            MessageLookupByLibrary.simpleMessage("Hivatkozás kezelése"),
+        "manageParticipants": MessageLookupByLibrary.simpleMessage("Kezelés"),
+        "manageSubscription":
+            MessageLookupByLibrary.simpleMessage("Előfizetés kezelése"),
+        "memoryCount": m50,
+        "mlConsent":
+            MessageLookupByLibrary.simpleMessage("Gépi tanulás engedélyezése"),
+        "mlConsentConfirmation": MessageLookupByLibrary.simpleMessage(
+            "Értem, és szeretném engedélyezni a gépi tanulást"),
+        "mlConsentDescription": MessageLookupByLibrary.simpleMessage(
+            "Ha engedélyezi a gépi tanulást, az Ente olyan információkat fog kinyerni, mint az arc geometriája, a fájlokból, beleértve azokat is, amelyeket Önnel megosztott.\n\nEz az Ön eszközén fog megtörténni, és minden generált biometrikus információ végponttól végpontig titkosítva lesz."),
+        "mlConsentPrivacy": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, kattintson ide az adatvédelmi irányelveinkben található további részletekért erről a funkcióról."),
+        "mlConsentTitle": MessageLookupByLibrary.simpleMessage(
+            "Engedélyezi a gépi tanulást?"),
+        "mlIndexingDescription": MessageLookupByLibrary.simpleMessage(
+            "Kérjük, vegye figyelembe, hogy a gépi tanulás nagyobb sávszélességet és akkumulátorhasználatot eredményez, amíg az összes elem indexelése meg nem történik. A gyorsabb indexelés érdekében érdemes lehet asztali alkalmazást használni, mivel minden eredmény automatikusan szinkronizálódik."),
+        "moderateStrength": MessageLookupByLibrary.simpleMessage("Közepes"),
+        "movedToTrash":
+            MessageLookupByLibrary.simpleMessage("Áthelyezve a kukába"),
+        "never": MessageLookupByLibrary.simpleMessage("Soha"),
+        "newAlbum": MessageLookupByLibrary.simpleMessage("Új album"),
+        "noDeviceLimit": MessageLookupByLibrary.simpleMessage("Egyik sem"),
+        "noDeviceThatCanBeDeleted": MessageLookupByLibrary.simpleMessage(
+            "Nincsenek törölhető fájlok ezen az eszközön."),
+        "noDuplicates":
+            MessageLookupByLibrary.simpleMessage("✨ Nincsenek duplikátumok"),
+        "noRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Nincs visszaállítási kulcsa?"),
+        "noRecoveryKeyNoDecryption": MessageLookupByLibrary.simpleMessage(
+            "Az általunk használt végpontok közötti titkosítás miatt, az adatait nem lehet dekódolni a jelszava, vagy visszaállítási kulcsa nélkül"),
+        "ok": MessageLookupByLibrary.simpleMessage("Rendben"),
+        "onlyFamilyAdminCanChangeCode": m55,
+        "oops": MessageLookupByLibrary.simpleMessage("Hoppá"),
+        "oopsSomethingWentWrong":
+            MessageLookupByLibrary.simpleMessage("Hoppá, valami hiba történt"),
+        "orPickAnExistingOne":
+            MessageLookupByLibrary.simpleMessage("Vagy válasszon egy létezőt"),
+        "password": MessageLookupByLibrary.simpleMessage("Jelszó"),
+        "passwordChangedSuccessfully":
+            MessageLookupByLibrary.simpleMessage("Jelszó módosítása sikeres!"),
+        "passwordLock":
+            MessageLookupByLibrary.simpleMessage("Kóddal történő lezárás"),
+        "passwordStrength": m57,
+        "passwordWarning": MessageLookupByLibrary.simpleMessage(
+            "Ezt a jelszót nem tároljuk, így ha elfelejti, <underline>nem tudjuk visszafejteni adatait</underline>"),
+        "pendingItems":
+            MessageLookupByLibrary.simpleMessage("függőben lévő elemek"),
+        "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage(
+            "Az emberek, akik a kódodat használják"),
+        "photoGridSize":
+            MessageLookupByLibrary.simpleMessage("Rács méret beállátás"),
+        "photoSmallCase": MessageLookupByLibrary.simpleMessage("fénykép"),
+        "pleaseTryAgain":
+            MessageLookupByLibrary.simpleMessage("Kérjük, próbálja meg újra"),
+        "pleaseWait": MessageLookupByLibrary.simpleMessage("Kérem várjon..."),
+        "privacy": MessageLookupByLibrary.simpleMessage("Adatvédelem"),
+        "privacyPolicyTitle":
+            MessageLookupByLibrary.simpleMessage("Adatvédelmi irányelvek"),
+        "publicLinkEnabled": MessageLookupByLibrary.simpleMessage(
+            "Nyilvános hivatkozás engedélyezve"),
+        "rateUs": MessageLookupByLibrary.simpleMessage("Értékeljen minket"),
+        "recover": MessageLookupByLibrary.simpleMessage("Visszaállít"),
+        "recoverAccount":
+            MessageLookupByLibrary.simpleMessage("Fiók visszaállítása"),
+        "recoverButton": MessageLookupByLibrary.simpleMessage("Visszaállít"),
+        "recoveryKey":
+            MessageLookupByLibrary.simpleMessage("Visszaállítási kulcs"),
+        "recoveryKeyCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
+            "A helyreállítási kulcs a vágólapra másolva"),
+        "recoveryKeyOnForgotPassword": MessageLookupByLibrary.simpleMessage(
+            "Ha elfelejti jelszavát, csak ezzel a kulccsal tudja visszaállítani adatait."),
+        "recoveryKeySaveDescription": MessageLookupByLibrary.simpleMessage(
+            "Ezt a kulcsot nem tároljuk, kérjük, őrizze meg ezt a 24 szavas kulcsot egy biztonságos helyen."),
+        "recoveryKeySuccessBody": MessageLookupByLibrary.simpleMessage(
+            "Nagyszerű! A helyreállítási kulcs érvényes. Köszönjük az igazolást.\n\nNe felejtsen el biztonsági másolatot készíteni helyreállítási kulcsáról."),
+        "recoveryKeyVerified": MessageLookupByLibrary.simpleMessage(
+            "A helyreállítási kulcs ellenőrizve"),
+        "recoveryKeyVerifyReason": MessageLookupByLibrary.simpleMessage(
+            "A helyreállítási kulcs az egyetlen módja annak, hogy visszaállítsa fényképeit, ha elfelejti jelszavát. A helyreállítási kulcsot a Beállítások > Fiók menüpontban találhatja meg.\n\nKérjük, írja be ide helyreállítási kulcsát annak ellenőrzéséhez, hogy megfelelően mentette-e el."),
+        "recoverySuccessful":
+            MessageLookupByLibrary.simpleMessage("Sikeres visszaállítás!"),
+        "recreatePasswordBody": MessageLookupByLibrary.simpleMessage(
+            "A jelenlegi eszköz nem elég erős a jelszavának ellenőrzéséhez, de újra tudjuk úgy generálni, hogy az minden eszközzel működjön.\n\nKérjük, jelentkezzen be helyreállítási kulcsával, és állítsa be újra jelszavát (ha szeretné, újra használhatja ugyanazt)."),
+        "recreatePasswordTitle":
+            MessageLookupByLibrary.simpleMessage("Új jelszó létrehozása"),
+        "referralStep1": MessageLookupByLibrary.simpleMessage(
+            "1. Add meg ezt a kódot a barátaidnak"),
+        "referralStep2": MessageLookupByLibrary.simpleMessage(
+            "2. Fizetős csomagra fizetnek elő"),
+        "referralStep3": m73,
+        "referralsAreCurrentlyPaused": MessageLookupByLibrary.simpleMessage(
+            "Az ajánlások jelenleg szünetelnek"),
+        "remindToEmptyDeviceTrash": MessageLookupByLibrary.simpleMessage(
+            "A felszabadult hely igényléséhez ürítsd ki a „Nemrég törölt” részt a „Beállítások” -> „Tárhely” menüpontban."),
+        "remindToEmptyEnteTrash": MessageLookupByLibrary.simpleMessage(
+            "Ürítsd ki a \"Kukát\" is, hogy visszaszerezd a felszabadult helyet."),
+        "remove": MessageLookupByLibrary.simpleMessage("Eltávolítás"),
+        "removeDuplicates": MessageLookupByLibrary.simpleMessage(
+            "Távolítsa el a duplikációkat"),
+        "removeDuplicatesDesc": MessageLookupByLibrary.simpleMessage(
+            "Tekintse át és távolítsa el a pontos másolatokat tartalmazó fájlokat."),
+        "removeFromAlbum":
+            MessageLookupByLibrary.simpleMessage("Eltávolítás az albumból"),
+        "removeFromAlbumTitle":
+            MessageLookupByLibrary.simpleMessage("Eltávolítás az albumból?"),
+        "removeLink":
+            MessageLookupByLibrary.simpleMessage("Hivatkozás eltávolítása"),
+        "removeParticipant":
+            MessageLookupByLibrary.simpleMessage("Résztvevő eltávolítása"),
+        "removeParticipantBody": m74,
+        "removePublicLink": MessageLookupByLibrary.simpleMessage(
+            "Nyilvános hivatkozás eltávolítása"),
+        "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
+            "Néhány eltávolítandó elemet mások adtak hozzá, és elveszíted a hozzáférésedet hozzájuk."),
+        "removeWithQuestionMark":
+            MessageLookupByLibrary.simpleMessage("Eltávolítás?"),
+        "removingFromFavorites": MessageLookupByLibrary.simpleMessage(
+            "Eltávolítás a kedvencek közül..."),
+        "resendEmail":
+            MessageLookupByLibrary.simpleMessage("E-mail újraküldése"),
+        "resetPasswordTitle":
+            MessageLookupByLibrary.simpleMessage("Jelszó visszaállítása"),
+        "retry": MessageLookupByLibrary.simpleMessage("Újrapróbálkozás"),
+        "saveKey": MessageLookupByLibrary.simpleMessage("Mentés"),
+        "saveYourRecoveryKeyIfYouHaventAlready":
+            MessageLookupByLibrary.simpleMessage(
+                "Mentse el visszaállítási kulcsát, ha még nem tette"),
+        "scanCode": MessageLookupByLibrary.simpleMessage("Kód beolvasása"),
+        "scanThisBarcodeWithnyourAuthenticatorApp":
+            MessageLookupByLibrary.simpleMessage(
+                "Olvassa le ezt a QR kódot az autentikátor alkalmazásával"),
+        "selectAll": MessageLookupByLibrary.simpleMessage("Összes kijelölése"),
+        "selectFoldersForBackup": MessageLookupByLibrary.simpleMessage(
+            "Mappák kiválasztása biztonsági mentéshez"),
+        "selectReason": MessageLookupByLibrary.simpleMessage("Válasszon okot"),
+        "selectedFoldersWillBeEncryptedAndBackedUp":
+            MessageLookupByLibrary.simpleMessage(
+                "A kiválasztott mappák titkosítva lesznek, és biztonsági másolat készül róluk."),
+        "selectedPhotos": m80,
+        "selectedPhotosWithYours": m81,
+        "sendEmail": MessageLookupByLibrary.simpleMessage("Email küldése"),
+        "sendInvite": MessageLookupByLibrary.simpleMessage("Meghívó küldése"),
+        "sendLink": MessageLookupByLibrary.simpleMessage("Hivatkozás küldése"),
+        "setAPassword":
+            MessageLookupByLibrary.simpleMessage("Állítson be egy jelszót"),
+        "setPasswordTitle":
+            MessageLookupByLibrary.simpleMessage("Jelszó beállítás"),
+        "setupComplete": MessageLookupByLibrary.simpleMessage("Beállítás kész"),
+        "shareALink":
+            MessageLookupByLibrary.simpleMessage("Hivatkozás megosztása"),
+        "shareMyVerificationID": m83,
+        "shareTextConfirmOthersVerificationID": m84,
+        "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
+            "Töltsd le az Ente-t, hogy könnyen megoszthassunk eredeti minőségű fotókat és videókat\n\nhttps://ente.io"),
+        "shareTextReferralCode": m85,
+        "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
+            "Megosztás nem Ente felhasználókkal"),
+        "shareWithPeopleSectionTitle": m86,
+        "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
+            "Hozzon létre megosztott és együttműködő albumokat más Ente-felhasználókkal, beleértve az ingyenes csomagokat használó felhasználókat is."),
+        "sharing": MessageLookupByLibrary.simpleMessage("Megosztás..."),
+        "showMemories":
+            MessageLookupByLibrary.simpleMessage("Emlékek megjelenítése"),
+        "signUpTerms": MessageLookupByLibrary.simpleMessage(
+            "Elfogadom az <u-terms>szolgáltatási feltételeket</u-terms> és az <u-policy>adatvédelmi irányelveket</u-policy>"),
+        "singleFileDeleteFromDevice": m88,
+        "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
+            "Az összes albumból törlésre kerül."),
+        "singleFileInBothLocalAndRemote": m89,
+        "singleFileInRemoteOnly": m90,
+        "skip": MessageLookupByLibrary.simpleMessage("Kihagyás"),
+        "someoneSharingAlbumsWithYouShouldSeeTheSameId":
+            MessageLookupByLibrary.simpleMessage(
+                "Valaki, aki megoszt Önnel albumokat, ugyanazt az azonosítót fogja látni az eszközén."),
+        "somethingWentWrong":
+            MessageLookupByLibrary.simpleMessage("Valami hiba történt"),
+        "somethingWentWrongPleaseTryAgain":
+            MessageLookupByLibrary.simpleMessage(
+                "Valami félre sikerült, próbálja újból"),
+        "sorry": MessageLookupByLibrary.simpleMessage("Sajnálom"),
+        "sorryCouldNotAddToFavorites": MessageLookupByLibrary.simpleMessage(
+            "Sajnálom, nem sikerült hozzáadni a kedvencekhez!"),
+        "sorryCouldNotRemoveFromFavorites":
+            MessageLookupByLibrary.simpleMessage(
+                "Sajnálom, nem sikerült eltávolítani a kedvencek közül!"),
+        "sorryWeCouldNotGenerateSecureKeysOnThisDevicennplease":
+            MessageLookupByLibrary.simpleMessage(
+                "Sajnáljuk, nem tudtunk biztonságos kulcsokat generálni ezen az eszközön.\n\nkérjük, regisztráljon egy másik eszközről."),
+        "status": MessageLookupByLibrary.simpleMessage("Állapot"),
+        "storageInGB": m93,
+        "strongStrength": MessageLookupByLibrary.simpleMessage("Erős"),
+        "subscribe": MessageLookupByLibrary.simpleMessage("Előfizetés"),
+        "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
+            "A megosztás engedélyezéséhez aktív fizetős előfizetésre van szükség."),
+        "success": MessageLookupByLibrary.simpleMessage("Sikeres"),
+        "tapToCopy":
+            MessageLookupByLibrary.simpleMessage("érintse meg másoláshoz"),
+        "tapToEnterCode":
+            MessageLookupByLibrary.simpleMessage("Koppintson a kód beírásához"),
+        "terminate": MessageLookupByLibrary.simpleMessage("Megszakít"),
+        "terminateSession":
+            MessageLookupByLibrary.simpleMessage("Megszakítja bejelentkezést?"),
+        "terms": MessageLookupByLibrary.simpleMessage("Feltételek"),
+        "termsOfServicesTitle":
+            MessageLookupByLibrary.simpleMessage("Használati feltételek"),
+        "theDownloadCouldNotBeCompleted":
+            MessageLookupByLibrary.simpleMessage("A letöltés nem fejezhető be"),
+        "theyAlsoGetXGb": m99,
+        "thisCanBeUsedToRecoverYourAccountIfYou":
+            MessageLookupByLibrary.simpleMessage(
+                "Ezzel tudja visszaállítani felhasználóját ha elveszítené a kétlépcsős azonosítóját"),
+        "thisDevice": MessageLookupByLibrary.simpleMessage("Ez az eszköz"),
+        "thisIsPersonVerificationId": m100,
+        "thisIsYourVerificationId":
+            MessageLookupByLibrary.simpleMessage("Ez az ellenőrző azonosítód"),
+        "thisWillLogYouOutOfTheFollowingDevice":
+            MessageLookupByLibrary.simpleMessage(
+                "Ezzel kijelentkezik az alábbi eszközről:"),
+        "thisWillLogYouOutOfThisDevice": MessageLookupByLibrary.simpleMessage(
+            "Ezzel kijelentkezik az eszközről!"),
+        "toResetVerifyEmail": MessageLookupByLibrary.simpleMessage(
+            "A Jelszó visszaállításához, kérjük először erősítse meg emailcímét."),
+        "total": MessageLookupByLibrary.simpleMessage("összesen"),
+        "trash": MessageLookupByLibrary.simpleMessage("Kuka"),
+        "tryAgain": MessageLookupByLibrary.simpleMessage("Próbáld újra"),
+        "twofactorAuthenticationPageTitle":
+            MessageLookupByLibrary.simpleMessage(
+                "Kétlépcsős hitelesítés (2FA)"),
+        "twofactorSetup": MessageLookupByLibrary.simpleMessage(
+            "Kétlépcsős azonosító beállítás"),
+        "unavailableReferralCode": MessageLookupByLibrary.simpleMessage(
+            "Sajnáljuk, ez a kód nem érhető el."),
+        "uncategorized":
+            MessageLookupByLibrary.simpleMessage("Kategorizálatlan"),
+        "unselectAll":
+            MessageLookupByLibrary.simpleMessage("Összes kijelölés törlése"),
+        "update": MessageLookupByLibrary.simpleMessage("Frissítés"),
+        "updateAvailable":
+            MessageLookupByLibrary.simpleMessage("Elérhető frissítés"),
+        "updatingFolderSelection": MessageLookupByLibrary.simpleMessage(
+            "Mappakijelölés frissítése..."),
+        "usableReferralStorageInfo": MessageLookupByLibrary.simpleMessage(
+            "A felhasználható tárhelyet a jelenlegi előfizetése korlátozza. A feleslegesen igényelt tárhely automatikusan felhasználhatóvá válik, amikor frissítesz a csomagodra."),
+        "useRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Helyreállítási kulcs használata"),
+        "verificationId":
+            MessageLookupByLibrary.simpleMessage("Ellenőrző azonosító"),
         "verify": MessageLookupByLibrary.simpleMessage("Hitelesítés"),
-        "wishThemAHappyBirthday": m115
+        "verifyEmail":
+            MessageLookupByLibrary.simpleMessage("Emailcím megerősítés"),
+        "verifyEmailID": m111,
+        "verifyPassword":
+            MessageLookupByLibrary.simpleMessage("Jelszó megerősítése"),
+        "verifyingRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Helyreállítási kulcs ellenőrzése..."),
+        "videoSmallCase": MessageLookupByLibrary.simpleMessage("videó"),
+        "viewLargeFiles": MessageLookupByLibrary.simpleMessage("Nagy fájlok"),
+        "viewLargeFilesDesc": MessageLookupByLibrary.simpleMessage(
+            "Tekintse meg a legtöbb tárhelyet foglaló fájlokat."),
+        "viewRecoveryKey": MessageLookupByLibrary.simpleMessage(
+            "Helyreállítási kulcs megtekintése"),
+        "viewer": MessageLookupByLibrary.simpleMessage("Néző"),
+        "waitingForWifi":
+            MessageLookupByLibrary.simpleMessage("Várakozás a WiFi-re..."),
+        "weAreOpenSource":
+            MessageLookupByLibrary.simpleMessage("Nyílt forráskódúak vagyunk!"),
+        "weHaveSendEmailTo": m114,
+        "weakStrength": MessageLookupByLibrary.simpleMessage("Gyenge"),
+        "welcomeBack":
+            MessageLookupByLibrary.simpleMessage("Köszöntjük ismét!"),
+        "yearsAgo": m116,
+        "yesConvertToViewer":
+            MessageLookupByLibrary.simpleMessage("Igen, alakítsa nézővé"),
+        "yesDelete": MessageLookupByLibrary.simpleMessage("Igen, törlés"),
+        "yesLogout":
+            MessageLookupByLibrary.simpleMessage("Igen, kijelentkezés"),
+        "yesRemove": MessageLookupByLibrary.simpleMessage("Igen, eltávolítás"),
+        "you": MessageLookupByLibrary.simpleMessage("Te"),
+        "youAreOnTheLatestVersion": MessageLookupByLibrary.simpleMessage(
+            "Ön a legújabb verziót használja"),
+        "youCanAtMaxDoubleYourStorage": MessageLookupByLibrary.simpleMessage(
+            "* Maximum megduplázhatod a tárhelyed"),
+        "youCannotShareWithYourself":
+            MessageLookupByLibrary.simpleMessage("Nem oszthatod meg magaddal"),
+        "youHaveSuccessfullyFreedUp": m118,
+        "yourAccountHasBeenDeleted":
+            MessageLookupByLibrary.simpleMessage("A felhasználód törlődött"),
+        "youveNoDuplicateFilesThatCanBeCleared":
+            MessageLookupByLibrary.simpleMessage(
+                "Nincsenek törölhető duplikált fájljaid")
       };
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_id.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_id.dart
@@ -181,8 +181,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Kami telah mengirimkan email ke <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, other: '${count} tahun lalu')}";
 
@@ -1482,7 +1480,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Selamat datang kembali!"),
         "whatsNew": MessageLookupByLibrary.simpleMessage("Hal yang baru"),
-        "wishThemAHappyBirthday": m115,
         "yearly": MessageLookupByLibrary.simpleMessage("Tahunan"),
         "yearsAgo": m116,
         "yes": MessageLookupByLibrary.simpleMessage("Ya"),

--- a/mobile/apps/photos/lib/generated/intl/messages_it.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_it.dart
@@ -317,8 +317,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Abbiamo inviato una mail a <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} anno fa', other: '${count} anni fa')}";
 
@@ -571,30 +569,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "blackFridaySale":
             MessageLookupByLibrary.simpleMessage("Offerta del Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
-        "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Dopo la versione beta dello streaming video e il lavoro sui caricamenti e download ripresi, abbiamo ora aumentato il limite di caricamento file a 10GB. Questo è ora disponibile sia nelle app desktop che mobili."),
-        "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "I caricamenti in background sono ora supportati anche su iOS, oltre ai dispositivi Android. Non è necessario aprire l\'app per eseguire il backup delle tue foto e video più recenti."),
-        "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Abbiamo apportato miglioramenti significativi alla nostra esperienza dei ricordi, inclusa la riproduzione automatica, scorrimento al ricordo successivo e molto altro."),
-        "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Insieme a un sacco di miglioramenti interni, ora è molto più facile vedere tutti i volti rilevati, fornire feedback sui volti simili e aggiungere/rimuovere volti da una singola foto."),
-        "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Ora riceverai una notifica opzionale per tutti i compleanni che hai salvato su Ente, insieme a una raccolta delle loro migliori foto."),
-        "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Non più attese per il completamento di caricamenti/download prima di poter chiudere l\'app. Tutti i caricamenti e download ora hanno la capacità di essere messi in pausa a metà e ripresi da dove hai lasciato."),
-        "cLTitle1": MessageLookupByLibrary.simpleMessage(
-            "Caricamento di file video di grandi dimensioni"),
-        "cLTitle2":
-            MessageLookupByLibrary.simpleMessage("Caricamento in background"),
-        "cLTitle3": MessageLookupByLibrary.simpleMessage(
-            "Riproduzione automatica dei ricordi"),
-        "cLTitle4": MessageLookupByLibrary.simpleMessage(
-            "Riconoscimento facciale migliorato"),
-        "cLTitle5":
-            MessageLookupByLibrary.simpleMessage("Notifiche di compleanno"),
-        "cLTitle6": MessageLookupByLibrary.simpleMessage(
-            "Caricamenti e download ripresi"),
         "cachedData": MessageLookupByLibrary.simpleMessage("Dati nella cache"),
         "calculating": MessageLookupByLibrary.simpleMessage("Calcolando..."),
         "canNotOpenBody": MessageLookupByLibrary.simpleMessage(
@@ -2240,7 +2214,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Un contatto fidato può aiutare a recuperare i tuoi dati."),
         "widgets": MessageLookupByLibrary.simpleMessage("Widget"),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("anno"),
         "yearly": MessageLookupByLibrary.simpleMessage("Annuale"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_ja.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ja.dart
@@ -265,8 +265,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "<green>${email}</green>にメールを送りました";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) => "${Intl.plural(count, other: '${count} 年前')}";
 
   static String m117(name) => "あなたと${name}";
@@ -461,24 +459,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "birthday": MessageLookupByLibrary.simpleMessage("誕生日"),
         "blackFridaySale": MessageLookupByLibrary.simpleMessage("ブラックフライデーセール"),
         "blog": MessageLookupByLibrary.simpleMessage("ブログ"),
-        "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "動画ストリーミングベータ版と再開可能なアップロード・ダウンロードの作業により、ファイルアップロード制限を10GBに増加しました。これはデスクトップとモバイルアプリの両方で利用可能です。"),
-        "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "バックグラウンドアップロードがAndroidデバイスに加えてiOSでもサポートされるようになりました。最新の写真や動画をバックアップするためにアプリを開く必要がありません。"),
-        "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "自動再生、次のメモリーへのスワイプなど、メモリー体験に大幅な改善を加えました。"),
-        "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "多くの内部改善とともに、検出されたすべての顔を確認し、類似した顔にフィードバックを提供し、1枚の写真から顔を追加/削除することがはるかに簡単になりました。"),
-        "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Enteに保存したすべての誕生日について、その人のベスト写真のコレクションとともに、オプトアウト通知を受け取るようになります。"),
-        "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "アプリを閉じる前にアップロード/ダウンロードの完了を待つ必要がなくなりました。すべてのアップロードとダウンロードは途中で一時停止し、中断したところから再開できるようになりました。"),
-        "cLTitle1": MessageLookupByLibrary.simpleMessage("大きな動画ファイルのアップロード"),
-        "cLTitle2": MessageLookupByLibrary.simpleMessage("バックグラウンドアップロード"),
-        "cLTitle3": MessageLookupByLibrary.simpleMessage("メモリーの自動再生"),
-        "cLTitle4": MessageLookupByLibrary.simpleMessage("顔認識の改善"),
-        "cLTitle5": MessageLookupByLibrary.simpleMessage("誕生日通知"),
-        "cLTitle6": MessageLookupByLibrary.simpleMessage("再開可能なアップロードとダウンロード"),
         "cachedData": MessageLookupByLibrary.simpleMessage("キャッシュデータ"),
         "calculating": MessageLookupByLibrary.simpleMessage("計算中..."),
         "canNotOpenBody": MessageLookupByLibrary.simpleMessage(
@@ -1824,7 +1804,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("最新情報"),
         "whyAddTrustContact":
             MessageLookupByLibrary.simpleMessage("信頼する連絡先は、データの復旧が必要な際に役立ちます。"),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("年"),
         "yearly": MessageLookupByLibrary.simpleMessage("年額"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_km.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_km.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'km';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_ko.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ko.dart
@@ -20,8 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ko';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -43,7 +41,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "invalidEmailAddress":
             MessageLookupByLibrary.simpleMessage("잘못된 이메일 주소"),
         "verify": MessageLookupByLibrary.simpleMessage("인증"),
-        "wishThemAHappyBirthday": m115,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("계정이 삭제되었습니다.")
       };

--- a/mobile/apps/photos/lib/generated/intl/messages_ku.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ku.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ku';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_lt.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_lt.dart
@@ -319,7 +319,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Išsiuntėme laišką adresu <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Palinkėkite ${name} su gimtadieniu! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: 'prieš ${count} metus', other: 'prieš ${count} metų')}";
@@ -570,6 +570,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Kurti atsargines vaizdo įrašų kopijas"),
         "beach": MessageLookupByLibrary.simpleMessage("Smėlis ir jūra"),
         "birthday": MessageLookupByLibrary.simpleMessage("Gimtadienis"),
+        "birthdayNotifications":
+            MessageLookupByLibrary.simpleMessage("Gimtadienio pranešimai"),
+        "birthdays": MessageLookupByLibrary.simpleMessage("Gimtadieniai"),
         "blackFridaySale": MessageLookupByLibrary.simpleMessage(
             "Juodojo penktadienio išpardavimas"),
         "blog": MessageLookupByLibrary.simpleMessage("Tinklaraštis"),
@@ -1095,6 +1098,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "guestView": MessageLookupByLibrary.simpleMessage("Svečio peržiūra"),
         "guestViewEnablePreSteps": MessageLookupByLibrary.simpleMessage(
             "Kad įjungtumėte svečio peržiūrą, sistemos nustatymuose nustatykite įrenginio prieigos kodą arba ekrano užraktą."),
+        "happyBirthday":
+            MessageLookupByLibrary.simpleMessage("Su gimtadieniu! 🥳"),
         "hearUsExplanation": MessageLookupByLibrary.simpleMessage(
             "Mes nesekame programų diegimų. Mums padėtų, jei pasakytumėte, kur mus radote."),
         "hearUsWhereTitle": MessageLookupByLibrary.simpleMessage(
@@ -1612,6 +1617,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "reassignedToName": m69,
         "reassigningLoading":
             MessageLookupByLibrary.simpleMessage("Perskirstoma..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "Gaukite priminimus, kai yra kažkieno gimtadienis. Paliesdami pranešimą, pateksite į gimtadienio šventės asmens nuotraukas."),
         "recover": MessageLookupByLibrary.simpleMessage("Atkurti"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Atkurti paskyrą"),

--- a/mobile/apps/photos/lib/generated/intl/messages_lv.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_lv.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'lv';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_ml.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ml.dart
@@ -20,8 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ml';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -138,7 +136,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("സങ്കേതക്കുറി ദൃഢീകരിക്കുക"),
         "weakStrength": MessageLookupByLibrary.simpleMessage("ദുർബലം"),
         "welcomeBack": MessageLookupByLibrary.simpleMessage("വീണ്ടും സ്വാഗതം!"),
-        "wishThemAHappyBirthday": m115,
         "yearly": MessageLookupByLibrary.simpleMessage("പ്രതിവർഷം")
       };
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_nl.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_nl.dart
@@ -322,7 +322,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "We hebben een e-mail gestuurd naar <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Wens ${name} een fijne verjaardag! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, other: '${count} jaar geleden')}";
@@ -425,6 +425,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Alle herinneringen bewaard"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Alle groepen voor deze persoon worden gereset, en je verliest alle suggesties die voor deze persoon zijn gedaan"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Alle naamloze groepen worden samengevoegd met de geselecteerde persoon. Dit kan nog steeds ongedaan worden gemaakt vanuit het geschiedenisoverzicht van de persoon."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "Dit is de eerste in de groep. Andere geselecteerde foto\'s worden automatisch verschoven op basis van deze nieuwe datum"),
         "allow": MessageLookupByLibrary.simpleMessage("Toestaan"),
@@ -477,6 +480,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "archiveAlbum":
             MessageLookupByLibrary.simpleMessage("Album archiveren"),
         "archiving": MessageLookupByLibrary.simpleMessage("Archiveren..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Is dit "),
+        "areYouSureRemoveThisFaceFromPerson": MessageLookupByLibrary.simpleMessage(
+            "Weet je zeker dat je dit gezicht van deze persoon wilt verwijderen?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Weet u zeker dat u het familie abonnement wilt verlaten?"),
@@ -487,8 +493,16 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Weet u zeker dat u uw abonnement wilt wijzigen?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Weet u zeker dat u wilt afsluiten?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Weet je zeker dat je deze personen wilt negeren?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Weet je zeker dat je deze persoon wilt negeren?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Weet je zeker dat je wilt uitloggen?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Weet je zeker dat je ze wilt samenvoegen?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "Weet u zeker dat u wilt verlengen?"),
         "areYouSureYouWantToResetThisPerson":
@@ -569,6 +583,9 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Back-up video\'s"),
         "beach": MessageLookupByLibrary.simpleMessage("Zand en zee"),
         "birthday": MessageLookupByLibrary.simpleMessage("Verjaardag"),
+        "birthdayNotifications":
+            MessageLookupByLibrary.simpleMessage("Meldingen over verjaardagen"),
+        "birthdays": MessageLookupByLibrary.simpleMessage("Verjaardagen"),
         "blackFridaySale":
             MessageLookupByLibrary.simpleMessage("Black Friday-aanbieding"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
@@ -1096,6 +1113,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "guestView": MessageLookupByLibrary.simpleMessage("Gasten weergave"),
         "guestViewEnablePreSteps": MessageLookupByLibrary.simpleMessage(
             "Om gasten weergave in te schakelen, moet u een toegangscode of schermvergrendeling instellen in uw systeeminstellingen."),
+        "happyBirthday":
+            MessageLookupByLibrary.simpleMessage("Fijne verjaardag! 🥳"),
         "hearUsExplanation": MessageLookupByLibrary.simpleMessage(
             "Wij gebruiken geen tracking. Het zou helpen als je ons vertelt waar je ons gevonden hebt!"),
         "hearUsWhereTitle": MessageLookupByLibrary.simpleMessage(
@@ -1122,6 +1141,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "Biometrische verificatie is uitgeschakeld. Vergrendel en ontgrendel uw scherm om het in te schakelen."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("Oké"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Negeren"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Negeren"),
         "ignored": MessageLookupByLibrary.simpleMessage("genegeerd"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1324,6 +1344,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Selecteer het soort herinneringen dat je wilt zien op je beginscherm."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
+        "merge": MessageLookupByLibrary.simpleMessage("Samenvoegen"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Samenvoegen met bestaand"),
         "mergedPhotos":
@@ -1463,6 +1484,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Of kies een bestaande"),
         "orPickFromYourContacts":
             MessageLookupByLibrary.simpleMessage("of kies uit je contacten"),
+        "otherDetectedFaces": MessageLookupByLibrary.simpleMessage(
+            "Andere gedetecteerde gezichten"),
         "pair": MessageLookupByLibrary.simpleMessage("Koppelen"),
         "pairWithPin": MessageLookupByLibrary.simpleMessage("Koppelen met PIN"),
         "pairingComplete":
@@ -1594,6 +1617,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Publieke link aangemaakt"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Publieke link ingeschakeld"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("In wachtrij"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Snelle links"),
         "radius": MessageLookupByLibrary.simpleMessage("Straal"),
@@ -1606,6 +1630,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "reassignedToName": m69,
         "reassigningLoading":
             MessageLookupByLibrary.simpleMessage("Opnieuw toewijzen..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "Ontvang herinneringen wanneer iemand jarig is. Als je op de melding drukt, krijg je foto\'s van de jarige."),
         "recover": MessageLookupByLibrary.simpleMessage("Herstellen"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Account herstellen"),
@@ -1708,6 +1734,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportBug": MessageLookupByLibrary.simpleMessage("Fout melden"),
         "resendEmail":
             MessageLookupByLibrary.simpleMessage("E-mail opnieuw versturen"),
+        "reset": MessageLookupByLibrary.simpleMessage("Reset"),
         "resetIgnoredFiles":
             MessageLookupByLibrary.simpleMessage("Reset genegeerde bestanden"),
         "resetPasswordTitle":
@@ -1736,6 +1763,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Veilig opgeslagen"),
         "save": MessageLookupByLibrary.simpleMessage("Opslaan"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("Opslaan als ander persoon"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Wijzigingen opslaan voor verlaten?"),
@@ -1897,8 +1926,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Delen..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("Verschuif datum en tijd"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Minder gezichten weergeven"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Toon herinneringen"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Minder gezichten weergeven"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Toon persoon"),
         "signOutFromOtherDevices":
             MessageLookupByLibrary.simpleMessage("Log uit op andere apparaten"),
@@ -2021,6 +2054,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "De link die je probeert te openen is verlopen."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "De groepen worden niet meer getoond in de personen sectie. Foto\'s blijven ongemoeid."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "De persoon wordt niet meer getoond in de personen sectie. Foto\'s blijven ongemoeid."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "De ingevoerde herstelsleutel is onjuist"),
@@ -2219,6 +2256,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Ja, verwijderen"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Ja, wijzigingen negeren"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Ja, negeer"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("Ja, log uit"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Ja, verwijderen"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("Ja, verlengen"),

--- a/mobile/apps/photos/lib/generated/intl/messages_or.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_or.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'or';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_pl.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_pl.dart
@@ -234,8 +234,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Wysłaliśmy wiadomość na adres <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} rok temu', other: '${count} lata temu')}";
 
@@ -1949,7 +1947,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Co nowego"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Zaufany kontakt może pomóc w odzyskaniu Twoich danych."),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("r"),
         "yearly": MessageLookupByLibrary.simpleMessage("Rocznie"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_pt_BR.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_pt_BR.dart
@@ -316,7 +316,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "Enviamos um e-mail à <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Deseje um feliz aniversário a ${name}! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} ano atrás', other: '${count} anos atrás')}";
@@ -420,6 +420,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Todas as memórias preservadas"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Todos os agrupamentos dessa pessoa serão redefinidos, e você perderá todas as sugestões feitas por essa pessoa."),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Todos os grupos sem nome serão mesclados numa pessoa selecionada. Isso ainda pode ser desfeito no histórico de sugestões da pessoa."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "Este é o primeiro do grupo. As outras fotos selecionadas serão automaticamente alteradas para esta nova data"),
         "allow": MessageLookupByLibrary.simpleMessage("Permitir"),
@@ -471,6 +474,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "archive": MessageLookupByLibrary.simpleMessage("Arquivo"),
         "archiveAlbum": MessageLookupByLibrary.simpleMessage("Arquivar álbum"),
         "archiving": MessageLookupByLibrary.simpleMessage("Arquivando..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Eles são "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Deseja mesmo remover o rosto desta pessoa?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Você tem certeza que queira sair do plano familiar?"),
@@ -480,8 +487,16 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Deseja trocar de plano?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Tem certeza de que queira sair?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Você deseja mesmo ignorar estas pessoas?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Você deseja mesmo ignorar esta pessoa?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Você tem certeza que quer encerrar sessão?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Você desejar mesmo mesclá-los?"),
         "areYouSureYouWantToRenew":
             MessageLookupByLibrary.simpleMessage("Deseja renovar?"),
         "areYouSureYouWantToResetThisPerson":
@@ -572,29 +587,28 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Promoção Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
         "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Com a versão beta de streaming de vídeo e o trabalho em uploads e downloads resumíveis, agora aumentamos o limite de upload de arquivos para 10GB. Isso já está disponível nos aplicativos desktop e móvel."),
+            "De volta na transmissão de vídeo beta, e trabalhando em envios e downloads retomáveis, nós aumentamos o limite de envio de arquivos para 10 GB. Isso está disponível em ambos a versão móvel e a versão para desktop."),
         "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Os uploads em segundo plano agora também são suportados no iOS, além dos dispositivos Android. Não é necessário abrir o aplicativo para fazer backup de suas fotos e vídeos mais recentes."),
+            "Envios de fundo agora são suportados no iOS também, para assemelhar-se aos dispositivos Android. Não precisa abrir o aplicativo para salvar em segurança as fotos e vídeos mais recentes."),
         "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Fizemos melhorias significativas em nossa experiência de memórias, incluindo reprodução automática, deslizar para a próxima memória e muito mais."),
+            "Fizemos melhorias significantes para a experiência de memórias, incluindo reprodução automática, deslizar para a próxima memória e mais."),
         "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Junto com várias melhorias internas, agora é muito mais fácil ver todos os rostos detectados, fornecer feedback sobre rostos similares e adicionar/remover rostos de uma única foto."),
+            "Ao lado de outras melhorias, agora ficou mais fácil para detectar rostos, fornecer comentários em rostos similares, e adicionar/remover rostos de uma foto."),
         "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Agora você receberá uma notificação opcional para todos os aniversários que salvou no Ente, junto com uma coleção de suas melhores fotos."),
+            "Você receberá uma notificação opcional para todos os aniversários salvos no Ente, além de uma coleção de melhores fotos."),
         "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Não é mais necessário esperar que uploads/downloads sejam concluídos antes de fechar o aplicativo. Todos os uploads e downloads agora podem ser pausados no meio do caminho e retomados de onde você parou."),
+            "Nada de esperar os envios/downloads terminarem para fechar o aplicativo. Todos os envios e downloads agora possuem a habilidade de ser pausado na metade do processo, e retomar de onde você parou."),
         "cLTitle1": MessageLookupByLibrary.simpleMessage(
-            "Upload de arquivos de vídeo grandes"),
-        "cLTitle2":
-            MessageLookupByLibrary.simpleMessage("Upload em segundo plano"),
-        "cLTitle3": MessageLookupByLibrary.simpleMessage(
-            "Reprodução automática de memórias"),
+            "Enviando arquivos de vídeo grandes"),
+        "cLTitle2": MessageLookupByLibrary.simpleMessage("Envio de fundo"),
+        "cLTitle3":
+            MessageLookupByLibrary.simpleMessage("Reproduzir memórias auto."),
         "cLTitle4": MessageLookupByLibrary.simpleMessage(
-            "Reconhecimento facial aprimorado"),
+            "Reconhecimento Facial Melhorado"),
         "cLTitle5":
             MessageLookupByLibrary.simpleMessage("Notificações de aniversário"),
         "cLTitle6": MessageLookupByLibrary.simpleMessage(
-            "Uploads e downloads resumíveis"),
+            "Envios e downloads retomáveis"),
         "cachedData":
             MessageLookupByLibrary.simpleMessage("Dados armazenados em cache"),
         "calculating": MessageLookupByLibrary.simpleMessage("Calculando..."),
@@ -847,6 +861,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Dispositivo não encontrado"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Você sabia?"),
+        "different": MessageLookupByLibrary.simpleMessage("Diferente"),
         "disableAutoLock": MessageLookupByLibrary.simpleMessage(
             "Desativar bloqueio automático"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
@@ -1140,6 +1155,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "A autenticação biométrica está desativada. Bloqueie e desbloqueie sua tela para ativá-la."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("OK"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Ignorar"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Ignorar"),
         "ignored": MessageLookupByLibrary.simpleMessage("ignorado"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1159,6 +1175,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "incorrectRecoveryKeyTitle": MessageLookupByLibrary.simpleMessage(
             "Chave de recuperação incorreta"),
         "indexedItems": MessageLookupByLibrary.simpleMessage("Itens indexados"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "A indexação foi pausada. Ela retomará automaticamente quando o dispositivo estiver pronto. O dispositivo é considerado pronto quando o nível de bateria, saúde da bateria, e estado térmico estejam num alcance saudável."),
         "ineligible": MessageLookupByLibrary.simpleMessage("Inelegível"),
         "info": MessageLookupByLibrary.simpleMessage("Info"),
         "insecureDevice":
@@ -1344,6 +1362,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Selecione os tipos de memórias que deseje vê-las na sua tela inicial."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Produtos"),
+        "merge": MessageLookupByLibrary.simpleMessage("Mesclar"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Juntar com o existente"),
         "mergedPhotos": MessageLookupByLibrary.simpleMessage("Fotos mescladas"),
@@ -1483,6 +1502,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ou escolha um existente"),
         "orPickFromYourContacts": MessageLookupByLibrary.simpleMessage(
             "ou escolher dos seus contatos"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("Outros rostos detectados"),
         "pair": MessageLookupByLibrary.simpleMessage("Parear"),
         "pairWithPin": MessageLookupByLibrary.simpleMessage("Parear com PIN"),
         "pairingComplete":
@@ -1613,6 +1634,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Link público criado"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Link público ativo"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("Na fila"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Links rápidos"),
         "radius": MessageLookupByLibrary.simpleMessage("Raio"),
@@ -1723,6 +1745,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportABug": MessageLookupByLibrary.simpleMessage("Informar um erro"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Informar erro"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("Reenviar e-mail"),
+        "reset": MessageLookupByLibrary.simpleMessage("Redefinir"),
         "resetIgnoredFiles": MessageLookupByLibrary.simpleMessage(
             "Redefinir arquivos ignorados"),
         "resetPasswordTitle":
@@ -1752,7 +1775,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Girar para a direita"),
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Armazenado com segurança"),
+        "same": MessageLookupByLibrary.simpleMessage("Igual"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("Mesma pessoa?"),
         "save": MessageLookupByLibrary.simpleMessage("Salvar"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("Salvar como outra pessoa"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Salvar mudanças antes de sair?"),
@@ -1906,7 +1933,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharedPhotoNotifications":
             MessageLookupByLibrary.simpleMessage("Novas fotos compartilhadas"),
         "sharedPhotoNotificationsExplanation": MessageLookupByLibrary.simpleMessage(
-            "Receber notificações quando alguém adicionar uma foto a um álbum compartilhado que você faz parte"),
+            "Receba notificações caso alguém adicione uma foto a um álbum compartilhado que você faz parte"),
         "sharedWith": m87,
         "sharedWithMe":
             MessageLookupByLibrary.simpleMessage("Compartilhado comigo"),
@@ -1915,8 +1942,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Compartilhando..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("Alterar as datas e horas"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Exibir menos rostos"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Mostrar memórias"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Exibir mais rostos"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Mostrar pessoa"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
             "Sair da conta em outros dispositivos"),
@@ -2041,6 +2072,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "O link que você está tentando acessar já expirou."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Os grupos de pessoa não serão exibidos na seção de pessoa. As fotos permanecerão intactas."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "A pessoa não será exibida na seção de pessoas. As fotos permanecerão intactas."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "A chave de recuperação inserida está incorreta"),
@@ -2237,6 +2272,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Sim, excluir"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Sim, descartar alterações"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Sim, ignorar"),
         "yesLogout":
             MessageLookupByLibrary.simpleMessage("Sim, encerrar sessão"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Sim, excluir"),

--- a/mobile/apps/photos/lib/generated/intl/messages_pt_PT.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_pt_PT.dart
@@ -317,7 +317,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Enviamos um e-mail para <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Envie um \"Felicidades\" a ${name}! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} ano atrás', other: '${count} anos atrás')}";
@@ -339,7 +339,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("A conta já está ajustada."),
         "accountOwnerPersonAppbarTitle": m0,
         "accountWelcomeBack":
-            MessageLookupByLibrary.simpleMessage("Bem-vindo de volta!"),
+            MessageLookupByLibrary.simpleMessage("Boas-vindas de volta!"),
         "ackPasswordLostWarning": MessageLookupByLibrary.simpleMessage(
             "Eu entendo que se eu perder a minha palavra-passe, posso perder os meus dados já que esses dados são <underline> encriptados de ponta a ponta</underline>."),
         "actionNotSupportedOnFavouritesAlbum":
@@ -423,6 +423,9 @@ class MessageLookup extends MessageLookupByLibrary {
             "Todas as memórias preservadas"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Todos os agrupamentos para esta pessoa serão reiniciados e perderá todas as sugestões feitas para esta pessoa"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Todos os grupos sem título serão fundidos na pessoa selecionada. Isso pode ser desfeito no histórico geral das sugestões da pessoa."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "Este é o primeiro neste grupo. Outras fotos selecionadas serão automaticamente alteradas para a nova data"),
         "allow": MessageLookupByLibrary.simpleMessage("Permitir"),
@@ -437,7 +440,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "allowPeopleToAddPhotos": MessageLookupByLibrary.simpleMessage(
             "Permitir que as pessoas adicionem fotos"),
         "allowPermBody": MessageLookupByLibrary.simpleMessage(
-            "Por favor, permita o acesso às suas fotos para que Ente possa mostrá-las e fazer backup na Fototeca."),
+            "Favor, permite acesso às fotos nas Definições para que Ente possa exibi-las e fazer backup na Fototeca."),
         "allowPermTitle":
             MessageLookupByLibrary.simpleMessage("Garanta acesso às fotos"),
         "androidBiometricHint":
@@ -475,6 +478,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "archive": MessageLookupByLibrary.simpleMessage("............"),
         "archiveAlbum": MessageLookupByLibrary.simpleMessage("Arquivar álbum"),
         "archiving": MessageLookupByLibrary.simpleMessage("Arquivar..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Eles são "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Tem a certeza que queira remover o rosto desta pessoa?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Tem certeza que deseja sair do plano familiar?"),
@@ -485,8 +492,16 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Tem a certeza de que pretende alterar o seu plano?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Tem certeza de que deseja sair?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Tem a certeza que quer ignorar estas pessoas?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Tem a certeza que quer ignorar esta pessoa?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Tem certeza que deseja terminar a sessão?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Tem a certeza que quer fundi-los?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "Tem a certeza de que pretende renovar?"),
         "areYouSureYouWantToResetThisPerson":
@@ -495,7 +510,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "askCancelReason": MessageLookupByLibrary.simpleMessage(
             "A sua subscrição foi cancelada. Gostaria de partilhar o motivo?"),
         "askDeleteReason": MessageLookupByLibrary.simpleMessage(
-            "Qual o principal motivo pelo qual está a eliminar a conta?"),
+            "Por que quer eliminar a sua conta?"),
         "askYourLovedOnesToShare": MessageLookupByLibrary.simpleMessage(
             "Peça aos seus entes queridos para partilharem"),
         "atAFalloutShelter":
@@ -576,27 +591,26 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Promoção Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
         "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Na sequência da versão beta de transmissão de vídeo e do trabalho em envios e transferências retomáveis, agora aumentámos o limite de envio de ficheiros para 10GB. Isto está agora disponível tanto nas aplicações de computador como móveis."),
+            "De volta aos vídeos em direto (beta), e a trabalhar em envios e transferências retomáveis, nós aumentamos o limite de envio de ficheiros para 10 GB. Isto está disponível para dispositivos Móveis e para Desktop."),
         "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Os envios em segundo plano agora também são suportados no iOS, além dos dispositivos Android. Não é necessário abrir a aplicação para fazer uma cópia de segurança das suas fotografias e vídeos mais recentes."),
+            "Envios de fundo agora fornecerem suporte ao iOS. Para combinar com os aparelhos Android. Não precisa abrir a aplicação para fazer backup das fotos e vídeos recentes."),
         "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Fizemos melhorias significativas na nossa experiência de memórias, incluindo reprodução automática, deslizar para a próxima memória e muito mais."),
+            "Nós fizemos melhorias significativas para a experiência das memórias, incluindo revisão automática, arrastar até a próxima memória e muito mais."),
         "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Juntamente com várias melhorias internas, agora é muito mais fácil ver todas as faces detectadas, fornecer comentários sobre faces similares e adicionar/remover faces de uma única fotografia."),
+            "Junto a outras mudanças, agora facilitou a maneira de ver todos os rostos detetados, fornecer comentários para rostos similares, e adicionar ou remover rostos de uma foto única."),
         "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Agora receberá uma notificação opcional para todos os aniversários que guardou no Ente, juntamente com uma colecção das suas melhores fotografias."),
+            "Ganhará uma notificação para todos os aniversários que salvaste no Ente, além de uma coleção das melhores fotos."),
         "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Já não é necessário esperar que os envios/transferências sejam concluídos antes de poder fechar a aplicação. Todos os envios e transferências têm agora a capacidade de serem pausados a meio e retomados de onde parou."),
+            "Sem mais aguardar até que os envios e transferências sejam concluídos para fechar a aplicação. Todos os envios e transferências podem ser pausados a qualquer momento, e retomar onde parou."),
         "cLTitle1": MessageLookupByLibrary.simpleMessage(
-            "Envio de ficheiros de vídeo grandes"),
-        "cLTitle2":
-            MessageLookupByLibrary.simpleMessage("Envio em segundo plano"),
+            "A Enviar Ficheiros de Vídeo Grandes"),
+        "cLTitle2": MessageLookupByLibrary.simpleMessage("Envio de Fundo"),
         "cLTitle3": MessageLookupByLibrary.simpleMessage(
-            "Reprodução automática de memórias"),
+            "Revisão automática de memórias"),
         "cLTitle4": MessageLookupByLibrary.simpleMessage(
-            "Reconhecimento facial melhorado"),
+            "Reconhecimento Facial Melhorado"),
         "cLTitle5":
-            MessageLookupByLibrary.simpleMessage("Notificações de aniversário"),
+            MessageLookupByLibrary.simpleMessage("Notificações de Felicidade"),
         "cLTitle6": MessageLookupByLibrary.simpleMessage(
             "Envios e transferências retomáveis"),
         "cachedData": MessageLookupByLibrary.simpleMessage("Dados em cache"),
@@ -624,7 +638,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "cannotAddMorePhotosAfterBecomingViewer": m13,
         "cannotDeleteSharedFiles": MessageLookupByLibrary.simpleMessage(
             "Não é possível eliminar ficheiros partilhados"),
-        "castAlbum": MessageLookupByLibrary.simpleMessage("Transfere Álbum"),
+        "castAlbum": MessageLookupByLibrary.simpleMessage("Transferir Álbum"),
         "castIPMismatchBody": MessageLookupByLibrary.simpleMessage(
             "Certifique-se de estar na mesma rede que a TV."),
         "castIPMismatchTitle":
@@ -647,7 +661,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "checkForUpdates":
             MessageLookupByLibrary.simpleMessage("Procurar atualizações"),
         "checkInboxAndSpamFolder": MessageLookupByLibrary.simpleMessage(
-            "Verifique a sua caixa de entrada (e spam) para concluir a verificação"),
+            "Revê a sua caixa de entrada (e de spam) para concluir a verificação"),
         "checkStatus": MessageLookupByLibrary.simpleMessage("Verificar status"),
         "checking": MessageLookupByLibrary.simpleMessage("A verificar..."),
         "checkingModels":
@@ -708,11 +722,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "confirm": MessageLookupByLibrary.simpleMessage("Confirmar"),
         "confirm2FADisable": MessageLookupByLibrary.simpleMessage(
             "Tem a certeza de que pretende desativar a autenticação de dois fatores?"),
-        "confirmAccountDeletion": MessageLookupByLibrary.simpleMessage(
-            "Confirmar eliminação de conta"),
+        "confirmAccountDeletion":
+            MessageLookupByLibrary.simpleMessage("Eliminar Conta"),
         "confirmAddingTrustedContact": m17,
         "confirmDeletePrompt": MessageLookupByLibrary.simpleMessage(
-            "Sim, pretendo apagar permanentemente esta conta e os respetivos dados em todas as aplicações."),
+            "Sim, quero permanentemente eliminar esta conta com os dados."),
         "confirmPassword":
             MessageLookupByLibrary.simpleMessage("Confirmar palavra-passe"),
         "confirmPlanChange": MessageLookupByLibrary.simpleMessage(
@@ -757,7 +771,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Criar link colaborativo"),
         "createCollage": MessageLookupByLibrary.simpleMessage("Criar coleção"),
         "createNewAccount":
-            MessageLookupByLibrary.simpleMessage("Criar nova conta"),
+            MessageLookupByLibrary.simpleMessage("Criar conta nova"),
         "createOrSelectAlbum":
             MessageLookupByLibrary.simpleMessage("Criar ou selecionar álbum"),
         "createPublicLink":
@@ -786,9 +800,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "delete": MessageLookupByLibrary.simpleMessage("Apagar"),
         "deleteAccount": MessageLookupByLibrary.simpleMessage("Eliminar conta"),
         "deleteAccountFeedbackPrompt": MessageLookupByLibrary.simpleMessage(
-            "Lamentamos a sua partida. Indique-nos a razão para podermos melhorar o serviço."),
+            "Lamentável a sua ida. Favor, partilhe o seu comentário para ajudar-nos a aprimorar."),
         "deleteAccountPermanentlyButton": MessageLookupByLibrary.simpleMessage(
-            "Excluir conta permanentemente"),
+            "Eliminar Conta Permanentemente"),
         "deleteAlbum": MessageLookupByLibrary.simpleMessage("Apagar álbum"),
         "deleteAlbumDialog": MessageLookupByLibrary.simpleMessage(
             "Eliminar também as fotos (e vídeos) presentes neste álbum de <bold>all</bold>  os outros álbuns de que fazem parte?"),
@@ -798,7 +812,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteConfirmDialogBody": MessageLookupByLibrary.simpleMessage(
             "Esta conta está ligada a outras aplicações Ente, se utilizar alguma. Os seus dados carregados, em todas as aplicações Ente, serão agendados para eliminação e a sua conta será permanentemente eliminada."),
         "deleteEmailRequest": MessageLookupByLibrary.simpleMessage(
-            "Envie um e-mail para <warning>accountt-deletion@ente.io</warning> a partir do seu endereço de email registrado."),
+            "Favor, envie um e-mail a <warning>account-deletion@ente.io</warning> do e-mail registado."),
         "deleteEmptyAlbums":
             MessageLookupByLibrary.simpleMessage("Apagar álbuns vazios"),
         "deleteEmptyAlbumsWithQuestionMark":
@@ -816,15 +830,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "deletePhotos": MessageLookupByLibrary.simpleMessage("Apagar fotos"),
         "deleteProgress": m23,
         "deleteReason1": MessageLookupByLibrary.simpleMessage(
-            "Falta uma funcionalidade-chave de que eu necessito"),
+            "Necessita uma funcionalidade-chave que quero"),
         "deleteReason2": MessageLookupByLibrary.simpleMessage(
-            "O aplicativo ou um determinado recurso não se comportou como era suposto"),
+            "A aplicação ou certa funcionalidade não comporta conforme o meu desejo"),
         "deleteReason3": MessageLookupByLibrary.simpleMessage(
-            "Encontrei outro serviço de que gosto mais"),
+            "Possuo outro serviço que acho melhor"),
         "deleteReason4":
-            MessageLookupByLibrary.simpleMessage("O motivo não está na lista"),
+            MessageLookupByLibrary.simpleMessage("A razão não está listada"),
         "deleteRequestSLAText": MessageLookupByLibrary.simpleMessage(
-            "O seu pedido será processado dentro de 72 horas."),
+            "O pedido será revisto dentre 72 horas."),
         "deleteSharedAlbum": MessageLookupByLibrary.simpleMessage(
             "Excluir álbum compartilhado?"),
         "deleteSharedAlbumDialogBody": MessageLookupByLibrary.simpleMessage(
@@ -848,6 +862,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Dispositivo não encontrado"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Você sabia?"),
+        "different": MessageLookupByLibrary.simpleMessage("Diferente"),
         "disableAutoLock": MessageLookupByLibrary.simpleMessage(
             "Desativar bloqueio automático"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
@@ -915,7 +930,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Edições para localização só serão vistas dentro do Ente"),
         "eligible": MessageLookupByLibrary.simpleMessage("elegível"),
-        "email": MessageLookupByLibrary.simpleMessage("Email"),
+        "email": MessageLookupByLibrary.simpleMessage("E-mail"),
         "emailAlreadyRegistered":
             MessageLookupByLibrary.simpleMessage("E-mail já em utilização."),
         "emailChangedTo": m29,
@@ -954,7 +969,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Ente pode criptografar e preservar arquivos apenas se você conceder acesso a eles"),
         "entePhotosPerm": MessageLookupByLibrary.simpleMessage(
-            "Ente <i>precisa de permissão para</i> preservar suas fotos"),
+            "Ente <i>precisa da permissão para</i> preservar as suas fotos"),
         "enteSubscriptionPitch": MessageLookupByLibrary.simpleMessage(
             "O Ente preserva as suas memórias, para que estejam sempre disponíveis, mesmo que perca o seu dispositivo."),
         "enteSubscriptionShareWithFamily": MessageLookupByLibrary.simpleMessage(
@@ -985,7 +1000,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Introduzir o código de 6 dígitos da\nsua aplicação de autenticação"),
         "enterValidEmail": MessageLookupByLibrary.simpleMessage(
-            "Por favor, insira um endereço de email válido."),
+            "Favor, introduz um e-mail válido."),
         "enterYourEmailAddress":
             MessageLookupByLibrary.simpleMessage("Introduza o seu e-mail"),
         "enterYourNewEmailAddress":
@@ -993,7 +1008,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "enterYourPassword": MessageLookupByLibrary.simpleMessage(
             "Introduza a sua palavra-passe"),
         "enterYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Insira a sua chave de recuperação"),
+            "Introduz a sua chave de recuperação"),
         "error": MessageLookupByLibrary.simpleMessage("Erro"),
         "everywhere": MessageLookupByLibrary.simpleMessage("em todo o lado"),
         "exif": MessageLookupByLibrary.simpleMessage("EXIF"),
@@ -1046,7 +1061,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "faqs": MessageLookupByLibrary.simpleMessage("Perguntas frequentes"),
         "favorite": MessageLookupByLibrary.simpleMessage("Favorito"),
         "feastingWithThem": m34,
-        "feedback": MessageLookupByLibrary.simpleMessage("Opinião"),
+        "feedback": MessageLookupByLibrary.simpleMessage("Comentário"),
         "file": MessageLookupByLibrary.simpleMessage("Ficheiro"),
         "fileFailedToSaveToGallery": MessageLookupByLibrary.simpleMessage(
             "Falha ao guardar o ficheiro na galeria"),
@@ -1073,8 +1088,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "food": MessageLookupByLibrary.simpleMessage("Culinária saborosa"),
         "forYourMemories":
             MessageLookupByLibrary.simpleMessage("para suas memórias"),
-        "forgotPassword": MessageLookupByLibrary.simpleMessage(
-            "Esqueceu-se da palavra-passe"),
+        "forgotPassword":
+            MessageLookupByLibrary.simpleMessage("Não recordo a palavra-passe"),
         "foundFaces":
             MessageLookupByLibrary.simpleMessage("Rostos encontrados"),
         "freeStorageClaimed": MessageLookupByLibrary.simpleMessage(
@@ -1141,6 +1156,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "A autenticação biométrica está desativada. Por favor, bloqueie e desbloqueie o ecrã para ativá-la."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("OK"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Ignorar"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Ignorar"),
         "ignored": MessageLookupByLibrary.simpleMessage("ignorado"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1156,10 +1172,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "incorrectRecoveryKey": MessageLookupByLibrary.simpleMessage(
             "Chave de recuperação incorreta"),
         "incorrectRecoveryKeyBody": MessageLookupByLibrary.simpleMessage(
-            "A chave de recuperação inserida está incorreta"),
+            "A chave de recuperação introduzida está incorreta"),
         "incorrectRecoveryKeyTitle": MessageLookupByLibrary.simpleMessage(
             "Chave de recuperação incorreta"),
         "indexedItems": MessageLookupByLibrary.simpleMessage("Itens indexados"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "A indexação foi interrompida. Ele será retomado se o dispositivo estiver pronto. O dispositivo é considerado pronto se o nível de bateria, saúde da bateria, e estado térmico esteja num estado saudável."),
         "ineligible": MessageLookupByLibrary.simpleMessage("Inelegível"),
         "info": MessageLookupByLibrary.simpleMessage("Info"),
         "insecureDevice":
@@ -1167,7 +1185,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "installManually":
             MessageLookupByLibrary.simpleMessage("Instalar manualmente"),
         "invalidEmailAddress":
-            MessageLookupByLibrary.simpleMessage("Endereço de email inválido"),
+            MessageLookupByLibrary.simpleMessage("E-mail inválido"),
         "invalidEndpoint":
             MessageLookupByLibrary.simpleMessage("Endpoint inválido"),
         "invalidEndpointMessage": MessageLookupByLibrary.simpleMessage(
@@ -1204,7 +1222,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "keepPhotos": MessageLookupByLibrary.simpleMessage("Manter fotos"),
         "kiloMeterUnit": MessageLookupByLibrary.simpleMessage("km"),
         "kindlyHelpUsWithThisInformation": MessageLookupByLibrary.simpleMessage(
-            "Por favor, ajude-nos com esta informação"),
+            "Ajude-nos com esta informação"),
         "language": MessageLookupByLibrary.simpleMessage("Idioma"),
         "lastTimeWithThem": m45,
         "lastUpdated":
@@ -1346,6 +1364,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Seleciona os tipos de memórias que adoraria ver no seu ecrã inicial."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Produtos"),
+        "merge": MessageLookupByLibrary.simpleMessage("Fundir"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Juntar com o existente"),
         "mergedPhotos":
@@ -1430,10 +1449,10 @@ class MessageLookup extends MessageLookupByLibrary {
             "Nenhuma foto encontrada aqui"),
         "noQuickLinksSelected": MessageLookupByLibrary.simpleMessage(
             "Nenhum link rápido selecionado"),
-        "noRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Não tem chave de recuperação?"),
+        "noRecoveryKey":
+            MessageLookupByLibrary.simpleMessage("Sem chave de recuperação?"),
         "noRecoveryKeyNoDecryption": MessageLookupByLibrary.simpleMessage(
-            "Devido à natureza do nosso protocolo de criptografia de ponta a ponta, os seus dados não podem ser descriptografados sem a sua palavra-passe ou a sua chave de recuperação"),
+            "Por conta da natureza do nosso protocolo de encriptação, os seus dados não podem ser desencriptados sem a sua palavra-passe ou chave de recuperação."),
         "noResults": MessageLookupByLibrary.simpleMessage("Nenhum resultado"),
         "noResultsFound": MessageLookupByLibrary.simpleMessage(
             "Não foram encontrados resultados"),
@@ -1448,7 +1467,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "nothingToSeeHere":
             MessageLookupByLibrary.simpleMessage("Nada para ver aqui! 👀"),
         "notifications": MessageLookupByLibrary.simpleMessage("Notificações"),
-        "ok": MessageLookupByLibrary.simpleMessage("Ok"),
+        "ok": MessageLookupByLibrary.simpleMessage("OK"),
         "onDevice": MessageLookupByLibrary.simpleMessage("No dispositivo"),
         "onEnte": MessageLookupByLibrary.simpleMessage(
             "Em <branding>ente</branding>"),
@@ -1461,7 +1480,7 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Obtém lembretes de memórias deste dia em anos passados."),
         "onlyFamilyAdminCanChangeCode": m55,
         "onlyThem": MessageLookupByLibrary.simpleMessage("Apenas eles"),
-        "oops": MessageLookupByLibrary.simpleMessage("Oops"),
+        "oops": MessageLookupByLibrary.simpleMessage("Ops"),
         "oopsCouldNotSaveEdits": MessageLookupByLibrary.simpleMessage(
             "Oops, não foi possível guardar as edições"),
         "oopsSomethingWentWrong":
@@ -1484,6 +1503,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ou escolha um já existente"),
         "orPickFromYourContacts": MessageLookupByLibrary.simpleMessage(
             "ou selecione dos seus contactos"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("Outros rostos detetados"),
         "pair": MessageLookupByLibrary.simpleMessage("Emparelhar"),
         "pairWithPin":
             MessageLookupByLibrary.simpleMessage("Emparelhar com PIN"),
@@ -1615,6 +1636,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Link público criado"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Link público ativado"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("Em fila"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Links rápidos"),
         "radius": MessageLookupByLibrary.simpleMessage("Raio"),
@@ -1653,7 +1675,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "A sua chave de recuperação é a única forma de recuperar as suas fotografias se se esquecer da sua palavra-passe. Pode encontrar a sua chave de recuperação em Definições > Conta.\n\n\nIntroduza aqui a sua chave de recuperação para verificar se a guardou corretamente."),
         "recoveryReady": m71,
         "recoverySuccessful":
-            MessageLookupByLibrary.simpleMessage("Recuperação bem sucedida!"),
+            MessageLookupByLibrary.simpleMessage("Recuperação com êxito!"),
         "recoveryWarning": MessageLookupByLibrary.simpleMessage(
             "Um contacto de confiança está a tentar acessar a sua conta"),
         "recoveryWarningBody": m72,
@@ -1713,7 +1735,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removeWithQuestionMark":
             MessageLookupByLibrary.simpleMessage("Remover?"),
         "removeYourselfAsTrustedContact": MessageLookupByLibrary.simpleMessage(
-            "Retirar convosco dos contactos de confiança"),
+            "Retirar-vos dos contactos de confiança"),
         "removingFromFavorites":
             MessageLookupByLibrary.simpleMessage("Removendo dos favoritos..."),
         "rename": MessageLookupByLibrary.simpleMessage("Renomear"),
@@ -1725,6 +1747,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportABug": MessageLookupByLibrary.simpleMessage("Reporte um bug"),
         "reportBug": MessageLookupByLibrary.simpleMessage("Reportar bug"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("Reenviar e-mail"),
+        "reset": MessageLookupByLibrary.simpleMessage("Redefinir"),
         "resetIgnoredFiles":
             MessageLookupByLibrary.simpleMessage("Repor ficheiros ignorados"),
         "resetPasswordTitle":
@@ -1754,7 +1777,11 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Rodar para a direita"),
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Armazenado com segurança"),
+        "same": MessageLookupByLibrary.simpleMessage("Igual"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("A mesma pessoa?"),
         "save": MessageLookupByLibrary.simpleMessage("Guardar"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("Guardar como outra pessoa"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Guardar as alterações antes de sair?"),
@@ -1817,7 +1844,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectAll": MessageLookupByLibrary.simpleMessage("Selecionar tudo"),
         "selectAllShort": MessageLookupByLibrary.simpleMessage("Tudo"),
         "selectCoverPhoto":
-            MessageLookupByLibrary.simpleMessage("Selecione Foto para Capa"),
+            MessageLookupByLibrary.simpleMessage("Selecionar Foto para Capa"),
         "selectDate": MessageLookupByLibrary.simpleMessage("Selecionar data"),
         "selectFoldersForBackup": MessageLookupByLibrary.simpleMessage(
             "Selecionar pastas para cópia de segurança"),
@@ -1835,8 +1862,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Selecionar uma data e hora a todos"),
         "selectPersonToLink": MessageLookupByLibrary.simpleMessage(
             "Selecione uma pessoa para ligar-se"),
-        "selectReason":
-            MessageLookupByLibrary.simpleMessage("Selecionar motivo"),
+        "selectReason": MessageLookupByLibrary.simpleMessage("Diz a razão"),
         "selectStartOfRange": MessageLookupByLibrary.simpleMessage(
             "Selecionar início de intervalo"),
         "selectTime": MessageLookupByLibrary.simpleMessage("Selecionar tempo"),
@@ -1860,7 +1886,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectedPhotosWithYours": m81,
         "selfiesWithThem": m82,
         "send": MessageLookupByLibrary.simpleMessage("Enviar"),
-        "sendEmail": MessageLookupByLibrary.simpleMessage("Enviar email"),
+        "sendEmail": MessageLookupByLibrary.simpleMessage("Enviar e-mail"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Enviar convite"),
         "sendLink": MessageLookupByLibrary.simpleMessage("Enviar link"),
         "serverEndpoint":
@@ -1919,8 +1945,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Partilhar..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("Mude as Datas e Horas"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Mostrar menos rostos"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Mostrar memórias"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Mostrar mais rostos"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Mostrar pessoa"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
             "Terminar sessão noutros dispositivos"),
@@ -1952,7 +1982,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Ocorreu um erro"),
         "somethingWentWrongPleaseTryAgain":
             MessageLookupByLibrary.simpleMessage(
-                "Ocorreu um erro. Tente novamente"),
+                "Algo correu mal. Favor, tentar de novo"),
         "sorry": MessageLookupByLibrary.simpleMessage("Desculpe"),
         "sorryBackupFailedDesc": MessageLookupByLibrary.simpleMessage(
             "Perdão, mas não podemos fazer backup deste ficheiro agora, tentaremos mais tarde."),
@@ -2024,8 +2054,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "syncing": MessageLookupByLibrary.simpleMessage("Sincronizando..."),
         "systemTheme": MessageLookupByLibrary.simpleMessage("Sistema"),
         "tapToCopy": MessageLookupByLibrary.simpleMessage("toque para copiar"),
-        "tapToEnterCode":
-            MessageLookupByLibrary.simpleMessage("Toque para inserir código"),
+        "tapToEnterCode": MessageLookupByLibrary.simpleMessage(
+            "Tocar para introduzir código"),
         "tapToUnlock":
             MessageLookupByLibrary.simpleMessage("Toque para desbloquear"),
         "tapToUpload":
@@ -2033,9 +2063,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "tapToUploadIsIgnoredDue": m98,
         "tempErrorContactSupportIfPersists": MessageLookupByLibrary.simpleMessage(
             "Parece que algo correu mal. Por favor, tente novamente mais tarde. Se o erro persistir, entre em contacto com a nossa equipa de suporte."),
-        "terminate": MessageLookupByLibrary.simpleMessage("Terminar"),
+        "terminate": MessageLookupByLibrary.simpleMessage("Desconectar"),
         "terminateSession":
-            MessageLookupByLibrary.simpleMessage("Terminar sessão?"),
+            MessageLookupByLibrary.simpleMessage("Desconectar?"),
         "terms": MessageLookupByLibrary.simpleMessage("Termos"),
         "termsOfServicesTitle": MessageLookupByLibrary.simpleMessage("Termos"),
         "thankYou": MessageLookupByLibrary.simpleMessage("Obrigado"),
@@ -2046,6 +2076,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "A ligação que está a tentar acessar já expirou."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Os grupos de pessoa não aparecerão mais na secção de pessoas. As Fotos permanecerão intocadas."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "As pessoas não aparecerão mais na secção de pessoas. As fotos permanecerão intocadas."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "A chave de recuperação inserida está incorreta"),
@@ -2064,7 +2098,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "thisCanBeUsedToRecoverYourAccountIfYou":
             MessageLookupByLibrary.simpleMessage(
                 "Isto pode ser usado para recuperar sua conta se você perder seu segundo fator"),
-        "thisDevice": MessageLookupByLibrary.simpleMessage("Este dispositivo"),
+        "thisDevice": MessageLookupByLibrary.simpleMessage("Este aparelho"),
         "thisEmailIsAlreadyInUse":
             MessageLookupByLibrary.simpleMessage("Este email já está em uso"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
@@ -2079,9 +2113,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "thisWeekXYearsAgo": m101,
         "thisWillLogYouOutOfTheFollowingDevice":
             MessageLookupByLibrary.simpleMessage(
-                "Irá desconectar a sua conta do seguinte dispositivo:"),
+                "Isto desconectará-vos dos aparelhos a seguir:"),
         "thisWillLogYouOutOfThisDevice": MessageLookupByLibrary.simpleMessage(
-            "Irá desconectar a sua conta do seu dispositivo!"),
+            "Isto desconectará-vos deste aparelho!"),
         "thisWillMakeTheDateAndTimeOfAllSelected":
             MessageLookupByLibrary.simpleMessage(
                 "Isto fará a data e hora de todas as fotos o mesmo."),
@@ -2095,7 +2129,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "toHideAPhotoOrVideo": MessageLookupByLibrary.simpleMessage(
             "Para ocultar uma foto ou um vídeo"),
         "toResetVerifyEmail": MessageLookupByLibrary.simpleMessage(
-            "Para redefinir a sua palavra-passe, verifique primeiro o seu e-mail."),
+            "Para redefinir a palavra-passe, favor, verifique o seu e-mail."),
         "todaysLogs": MessageLookupByLibrary.simpleMessage("Logs de hoje"),
         "tooManyIncorrectAttempts": MessageLookupByLibrary.simpleMessage(
             "Muitas tentativas incorretas"),
@@ -2178,7 +2212,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "verificationId":
             MessageLookupByLibrary.simpleMessage("ID de Verificação"),
         "verify": MessageLookupByLibrary.simpleMessage("Verificar"),
-        "verifyEmail": MessageLookupByLibrary.simpleMessage("Verificar email"),
+        "verifyEmail": MessageLookupByLibrary.simpleMessage("Verificar e-mail"),
         "verifyEmailID": m111,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Verificar"),
         "verifyPasskey":
@@ -2241,6 +2275,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Sim, apagar"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Sim, rejeitar alterações"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Sim, ignorar"),
         "yesLogout":
             MessageLookupByLibrary.simpleMessage("Sim, terminar sessão"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Sim, remover"),

--- a/mobile/apps/photos/lib/generated/intl/messages_ro.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ro.dart
@@ -232,8 +232,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "Am trimis un e-mail la <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: 'acum ${count} an', other: 'acum ${count} de ani')}";
 
@@ -1969,7 +1967,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Noutăți"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Contactul de încredere vă poate ajuta la recuperarea datelor."),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("an"),
         "yearly": MessageLookupByLibrary.simpleMessage("Anual"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_ru.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ru.dart
@@ -83,6 +83,9 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m21(count) =>
       "${Intl.plural(count, one: 'Удалить ${count} элемент', other: 'Удалить ${count} элементов')}";
 
+  static String m22(count) =>
+      "Также удалить фото (и видео), находящиеся в этих ${count} альбомах, из <bold>всех</bold> других альбомов, частью которых они являются?";
+
   static String m23(currentlyDeleting, totalCount) =>
       "Удаление ${currentlyDeleting} / ${totalCount}";
 
@@ -97,6 +100,9 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m27(count, formattedSize) =>
       "${count} файлов, по ${formattedSize} каждый";
+
+  static String m28(name) =>
+      "Этот адрес электронной почты уже связан с ${name}.";
 
   static String m29(newEmail) => "Электронная почта изменена на ${newEmail}";
 
@@ -222,6 +228,8 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m78(snapshotLength, searchLength) =>
       "Несоответствие длины разделов: ${snapshotLength} != ${searchLength}";
 
+  static String m79(count) => "${count} выбрано";
+
   static String m80(count) => "${count} выбрано";
 
   static String m81(count, yourCount) =>
@@ -304,12 +312,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m111(email) => "Подтвердить ${email}";
 
+  static String m112(name) => "Посмотреть ${name} для отмены привязки";
+
   static String m113(count) =>
       "${Intl.plural(count, zero: 'Добавлено 0 зрителей', one: 'Добавлен 1 зритель', other: 'Добавлено ${count} зрителей')}";
 
   static String m114(email) => "Мы отправили письмо на <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Поздравляем ${name} с днем ​​рождения! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} год назад', other: '${count} лет назад')}";
@@ -333,12 +343,17 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("С возвращением!"),
         "ackPasswordLostWarning": MessageLookupByLibrary.simpleMessage(
             "Я понимаю, что если я потеряю пароль, я могу потерять свои данные, так как они <underline>защищены сквозным шифрованием</underline>."),
+        "actionNotSupportedOnFavouritesAlbum":
+            MessageLookupByLibrary.simpleMessage(
+                "Действие не поддерживается в альбоме «Избранное»"),
         "activeSessions":
             MessageLookupByLibrary.simpleMessage("Активные сеансы"),
         "add": MessageLookupByLibrary.simpleMessage("Добавить"),
         "addAName": MessageLookupByLibrary.simpleMessage("Добавить имя"),
         "addANewEmail": MessageLookupByLibrary.simpleMessage(
             "Добавьте новую электронную почту"),
+        "addAlbumWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Добавьте виджет альбома на главный экран и вернитесь сюда, чтобы настроить его."),
         "addCollaborator":
             MessageLookupByLibrary.simpleMessage("Добавить соавтора"),
         "addCollaborators": m1,
@@ -349,6 +364,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addLocation":
             MessageLookupByLibrary.simpleMessage("Добавить местоположение"),
         "addLocationButton": MessageLookupByLibrary.simpleMessage("Добавить"),
+        "addMemoriesWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Добавьте виджет воспоминаний на главный экран и вернитесь сюда, чтобы настроить его."),
         "addMore": MessageLookupByLibrary.simpleMessage("Добавить ещё"),
         "addName": MessageLookupByLibrary.simpleMessage("Добавить имя"),
         "addNameOrMerge":
@@ -360,6 +377,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Подробности дополнений"),
         "addOnValidTill": m3,
         "addOns": MessageLookupByLibrary.simpleMessage("Дополнения"),
+        "addParticipants":
+            MessageLookupByLibrary.simpleMessage("Добавить участников"),
+        "addPeopleWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Добавьте виджет людей на главный экран и вернитесь сюда, чтобы настроить его."),
         "addPhotos": MessageLookupByLibrary.simpleMessage("Добавить фото"),
         "addSelected":
             MessageLookupByLibrary.simpleMessage("Добавить выбранные"),
@@ -391,11 +412,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "albumTitle": MessageLookupByLibrary.simpleMessage("Название альбома"),
         "albumUpdated": MessageLookupByLibrary.simpleMessage("Альбом обновлён"),
         "albums": MessageLookupByLibrary.simpleMessage("Альбомы"),
+        "albumsWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Выберите альбомы, которые вы хотите видеть на главном экране."),
         "allClear": MessageLookupByLibrary.simpleMessage("✨ Всё чисто"),
         "allMemoriesPreserved":
             MessageLookupByLibrary.simpleMessage("Все воспоминания сохранены"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "Все группы этого человека будут сброшены, и вы потеряете все предложения для него"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Все неназванные группы будут объединены в выбранного человека. Это можно отменить в обзоре истории предложений для данного человека."),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "Это первое фото в группе. Остальные выбранные фото автоматически сместятся на основе новой даты"),
         "allow": MessageLookupByLibrary.simpleMessage("Разрешить"),
@@ -449,6 +475,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "archiveAlbum":
             MessageLookupByLibrary.simpleMessage("Архивировать альбом"),
         "archiving": MessageLookupByLibrary.simpleMessage("Архивация..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Они "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Вы уверены, что хотите удалить лицо этого человека?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
                 "Вы уверены, что хотите покинуть семейный тариф?"),
@@ -459,8 +489,16 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Вы уверены, что хотите сменить тариф?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
             "Вы уверены, что хотите выйти?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Вы уверены, что хотите игнорировать этих людей?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Вы уверены, что хотите игнорировать этого человека?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Вы уверены, что хотите выйти?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Вы уверены, что хотите их объединить?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
             "Вы уверены, что хотите продлить?"),
         "areYouSureYouWantToResetThisPerson":
@@ -542,21 +580,24 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Резервное копирование видео"),
         "beach": MessageLookupByLibrary.simpleMessage("Песок и море"),
         "birthday": MessageLookupByLibrary.simpleMessage("День рождения"),
+        "birthdayNotifications":
+            MessageLookupByLibrary.simpleMessage("Уведомления о днях рождения"),
+        "birthdays": MessageLookupByLibrary.simpleMessage("Дни рождения"),
         "blackFridaySale": MessageLookupByLibrary.simpleMessage(
             "Распродажа в \"Черную пятницу\""),
         "blog": MessageLookupByLibrary.simpleMessage("Блог"),
         "cLDesc1": MessageLookupByLibrary.simpleMessage(
-            "Вслед за бета-версией потокового видео и работой над возобновляемыми загрузками и скачиваниями, мы увеличили лимит загрузки файлов до 10ГБ. Это теперь доступно как в настольных, так и в мобильных приложениях."),
+            "В результате бета-тестирования потоковой передачи видео и работы над возобновляемыми загрузками и скачиваниями мы увеличили лимит загружаемых файлов до 10 ГБ. Теперь это доступно как в настольных, так и в мобильных приложениях."),
         "cLDesc2": MessageLookupByLibrary.simpleMessage(
-            "Фоновые загрузки теперь также поддерживаются на iOS, в дополнение к устройствам Android. Больше не нужно открывать приложение для резервного копирования ваших последних фото и видео."),
+            "Фоновая загрузка теперь поддерживается не только на устройствах Android, но и на iOS. Не нужно открывать приложение для резервного копирования последних фотографий и видео."),
         "cLDesc3": MessageLookupByLibrary.simpleMessage(
-            "Мы внесли значительные улучшения в наш опыт воспоминаний, включая автовоспроизведение, пролистывание к следующему воспоминанию и многое другое."),
+            "Мы внесли значительные улучшения в работу с воспоминаниями, включая автовоспроизведение, переход к следующему воспоминанию и многое другое."),
         "cLDesc4": MessageLookupByLibrary.simpleMessage(
-            "Наряду с множеством внутренних улучшений, теперь гораздо проще увидеть все обнаруженные лица, предоставить обратную связь о похожих лицах и добавить/удалить лица с одной фотографии."),
+            "Наряду с рядом внутренних улучшений теперь стало гораздо проще просматривать все обнаруженные лица, оставлять отзывы о похожих лицах, а также добавлять/удалять лица с одной фотографии."),
         "cLDesc5": MessageLookupByLibrary.simpleMessage(
-            "Теперь вы будете получать опциональные уведомления обо всех днях рождения, которые вы сохранили в Ente, вместе с коллекцией их лучших фотографий."),
+            "Теперь вы будете получать уведомления о всех днях рождениях, которые вы сохранили на Ente, а также коллекцию их лучших фотографий."),
         "cLDesc6": MessageLookupByLibrary.simpleMessage(
-            "Больше не нужно ждать завершения загрузок/скачиваний перед закрытием приложения. Все загрузки и скачивания теперь могут быть приостановлены на полпути и возобновлены с того места, где вы остановились."),
+            "Больше не нужно ждать завершения загрузки/скачивания, прежде чем закрыть приложение. Все загрузки и скачивания теперь можно приостановить и возобновить с того места, где вы остановились."),
         "cLTitle1": MessageLookupByLibrary.simpleMessage(
             "Загрузка больших видеофайлов"),
         "cLTitle2": MessageLookupByLibrary.simpleMessage("Фоновая загрузка"),
@@ -640,6 +681,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "click": MessageLookupByLibrary.simpleMessage("• Нажмите"),
         "clickOnTheOverflowMenu": MessageLookupByLibrary.simpleMessage(
             "• Нажмите на меню дополнительных действий"),
+        "clickToInstallOurBestVersionYet": MessageLookupByLibrary.simpleMessage(
+            "Нажмите, чтобы установить нашу лучшую версию"),
         "close": MessageLookupByLibrary.simpleMessage("Закрыть"),
         "clubByCaptureTime": MessageLookupByLibrary.simpleMessage(
             "Группировать по времени съёмки"),
@@ -786,6 +829,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteItemCount": m21,
         "deleteLocation":
             MessageLookupByLibrary.simpleMessage("Удалить местоположение"),
+        "deleteMultipleAlbumDialog": m22,
         "deletePhotos": MessageLookupByLibrary.simpleMessage("Удалить фото"),
         "deleteProgress": m23,
         "deleteReason1": MessageLookupByLibrary.simpleMessage(
@@ -821,6 +865,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Устройство не найдено"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Знаете ли вы?"),
+        "different": MessageLookupByLibrary.simpleMessage("Разные"),
         "disableAutoLock":
             MessageLookupByLibrary.simpleMessage("Отключить автоблокировку"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
@@ -873,6 +918,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "duplicateFileCountWithStorageSaved": m26,
         "duplicateItemsGroup": m27,
         "edit": MessageLookupByLibrary.simpleMessage("Редактировать"),
+        "editEmailAlreadyLinked": m28,
         "editLocation":
             MessageLookupByLibrary.simpleMessage("Изменить местоположение"),
         "editLocationTagTitle":
@@ -959,6 +1005,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Пожалуйста, введите действительный адрес электронной почты."),
         "enterYourEmailAddress": MessageLookupByLibrary.simpleMessage(
             "Введите адрес вашей электронной почты"),
+        "enterYourNewEmailAddress": MessageLookupByLibrary.simpleMessage(
+            "Введите ваш новый адрес электронной почты"),
         "enterYourPassword":
             MessageLookupByLibrary.simpleMessage("Введите ваш пароль"),
         "enterYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
@@ -1080,6 +1128,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "guestView": MessageLookupByLibrary.simpleMessage("Гостевой просмотр"),
         "guestViewEnablePreSteps": MessageLookupByLibrary.simpleMessage(
             "Для включения гостевого просмотра, пожалуйста, настройте код или блокировку экрана в настройках устройства."),
+        "happyBirthday":
+            MessageLookupByLibrary.simpleMessage("С днём рождения! 🥳"),
         "hearUsExplanation": MessageLookupByLibrary.simpleMessage(
             "Мы не отслеживаем установки приложений. Нам поможет, если скажете, как вы нас нашли!"),
         "hearUsWhereTitle": MessageLookupByLibrary.simpleMessage(
@@ -1107,6 +1157,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "Биометрическая аутентификация отключена. Пожалуйста, заблокируйте и разблокируйте экран, чтобы включить её."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("Хорошо"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Игнорировать"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Игнорировать"),
         "ignored": MessageLookupByLibrary.simpleMessage("игнорируется"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -1126,6 +1177,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Неверный ключ восстановления"),
         "indexedItems":
             MessageLookupByLibrary.simpleMessage("Проиндексированные элементы"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "Индексирование приостановлено. Оно автоматически возобновится, когда устройство будет готово. Устройство считается готовым, когда уровень заряда батареи, её состояние и температура находятся в пределах нормы."),
         "ineligible": MessageLookupByLibrary.simpleMessage("Неподходящий"),
         "info": MessageLookupByLibrary.simpleMessage("Информация"),
         "insecureDevice":
@@ -1220,6 +1273,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "livePhotos": MessageLookupByLibrary.simpleMessage("Живые фото"),
         "loadMessage1": MessageLookupByLibrary.simpleMessage(
             "Вы можете поделиться подпиской с вашей семьёй"),
+        "loadMessage2": MessageLookupByLibrary.simpleMessage(
+            "На сегодняшний день мы сохранили более 200 миллионов воспоминаний"),
         "loadMessage3": MessageLookupByLibrary.simpleMessage(
             "Мы храним 3 копии ваших данных, одну из них — в бункере"),
         "loadMessage4": MessageLookupByLibrary.simpleMessage(
@@ -1277,6 +1332,8 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Нажмите с удержанием на электронную почту для подтверждения сквозного шифрования."),
         "longpressOnAnItemToViewInFullscreen": MessageLookupByLibrary.simpleMessage(
             "Нажмите с удержанием на элемент для просмотра в полноэкранном режиме"),
+        "lookBackOnYourMemories": MessageLookupByLibrary.simpleMessage(
+            "Оглянитесь на ваши воспоминания 🌄"),
         "loopVideoOff":
             MessageLookupByLibrary.simpleMessage("Видео не зациклено"),
         "loopVideoOn": MessageLookupByLibrary.simpleMessage("Видео зациклено"),
@@ -1305,8 +1362,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
         "me": MessageLookupByLibrary.simpleMessage("Я"),
+        "memories": MessageLookupByLibrary.simpleMessage("Воспоминания"),
+        "memoriesWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Выберите, какие воспоминания вы хотите видеть на главном экране."),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("Мерч"),
+        "merge": MessageLookupByLibrary.simpleMessage("Объединить"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Объединить с существующим"),
         "mergedPhotos":
@@ -1362,6 +1423,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "newLocation":
             MessageLookupByLibrary.simpleMessage("Новое местоположение"),
         "newPerson": MessageLookupByLibrary.simpleMessage("Новый человек"),
+        "newPhotosEmoji": MessageLookupByLibrary.simpleMessage(" новая 📸"),
         "newRange": MessageLookupByLibrary.simpleMessage("Новый диапазон"),
         "newToEnte": MessageLookupByLibrary.simpleMessage("Впервые в Ente"),
         "newest": MessageLookupByLibrary.simpleMessage("Недавние"),
@@ -1416,6 +1478,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "onEnte":
             MessageLookupByLibrary.simpleMessage("В <branding>ente</branding>"),
         "onTheRoad": MessageLookupByLibrary.simpleMessage("Снова в пути"),
+        "onThisDay": MessageLookupByLibrary.simpleMessage("В этот день"),
+        "onThisDayMemories":
+            MessageLookupByLibrary.simpleMessage("В этот день воспоминания"),
+        "onThisDayNotificationExplanation": MessageLookupByLibrary.simpleMessage(
+            "Получайте напоминания о воспоминаниях, связанных с этим днем в прошлые годы."),
         "onlyFamilyAdminCanChangeCode": m55,
         "onlyThem": MessageLookupByLibrary.simpleMessage("Только он(а)"),
         "oops": MessageLookupByLibrary.simpleMessage("Ой"),
@@ -1442,6 +1509,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Или выберите существующую"),
         "orPickFromYourContacts": MessageLookupByLibrary.simpleMessage(
             "или выберите из ваших контактов"),
+        "otherDetectedFaces":
+            MessageLookupByLibrary.simpleMessage("Другие найденные лица"),
         "pair": MessageLookupByLibrary.simpleMessage("Подключить"),
         "pairWithPin": MessageLookupByLibrary.simpleMessage("Подключить с PIN"),
         "pairingComplete":
@@ -1462,6 +1531,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Надёжность пароля определяется его длиной, используемыми символами и присутствием среди 10000 самых популярных паролей"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "Мы не храним этот пароль, поэтому, если вы его забудете, <underline>мы не сможем расшифровать ваши данные</underline>"),
+        "pastYearsMemories":
+            MessageLookupByLibrary.simpleMessage("Воспоминания прошлых лет"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Платёжные данные"),
         "paymentFailed":
@@ -1476,6 +1547,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "people": MessageLookupByLibrary.simpleMessage("Люди"),
         "peopleUsingYourCode":
             MessageLookupByLibrary.simpleMessage("Люди, использующие ваш код"),
+        "peopleWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Выберите людей, которых вы хотите видеть на главном экране."),
         "permDeleteWarning": MessageLookupByLibrary.simpleMessage(
             "Все элементы в корзине будут удалены навсегда\n\nЭто действие нельзя отменить"),
         "permanentlyDelete":
@@ -1571,6 +1644,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Публичная ссылка создана"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Публичная ссылка включена"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "queued": MessageLookupByLibrary.simpleMessage("В очереди"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Быстрые ссылки"),
         "radius": MessageLookupByLibrary.simpleMessage("Радиус"),
@@ -1584,6 +1658,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "reassignedToName": m69,
         "reassigningLoading":
             MessageLookupByLibrary.simpleMessage("Переназначение..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "Получайте напоминания, когда у кого-то день рождения. Нажатие на уведомление перенесет вас к фотографиям именинника."),
         "recover": MessageLookupByLibrary.simpleMessage("Восстановить"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Восстановить аккаунт"),
@@ -1688,6 +1764,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportBug": MessageLookupByLibrary.simpleMessage("Сообщить об ошибке"),
         "resendEmail":
             MessageLookupByLibrary.simpleMessage("Отправить письмо повторно"),
+        "reset": MessageLookupByLibrary.simpleMessage("Сбросить"),
         "resetIgnoredFiles":
             MessageLookupByLibrary.simpleMessage("Сбросить игнорируемые файлы"),
         "resetPasswordTitle":
@@ -1715,7 +1792,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "rotateRight": MessageLookupByLibrary.simpleMessage("Повернуть вправо"),
         "safelyStored":
             MessageLookupByLibrary.simpleMessage("Надёжно сохранены"),
+        "same": MessageLookupByLibrary.simpleMessage("Такой же"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("Тот же человек?"),
         "save": MessageLookupByLibrary.simpleMessage("Сохранить"),
+        "saveAsAnotherPerson": MessageLookupByLibrary.simpleMessage(
+            "Сохранить как другого человека"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage(
                 "Сохранить изменения перед выходом?"),
@@ -1805,6 +1886,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Выберите своё лицо"),
         "selectYourPlan":
             MessageLookupByLibrary.simpleMessage("Выберите тариф"),
+        "selectedAlbums": m79,
         "selectedFilesAreNotOnEnte": MessageLookupByLibrary.simpleMessage(
             "Выбранные файлы отсутствуют в Ente"),
         "selectedFoldersWillBeEncryptedAndBackedUp":
@@ -1881,8 +1963,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharing": MessageLookupByLibrary.simpleMessage("Отправка..."),
         "shiftDatesAndTime":
             MessageLookupByLibrary.simpleMessage("Сместить даты и время"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Показывать меньше лиц"),
         "showMemories":
             MessageLookupByLibrary.simpleMessage("Показывать воспоминания"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Показывать больше лиц"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Показать человека"),
         "signOutFromOtherDevices":
             MessageLookupByLibrary.simpleMessage("Выйти с других устройств"),
@@ -1898,6 +1984,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "singleFileInBothLocalAndRemote": m89,
         "singleFileInRemoteOnly": m90,
         "skip": MessageLookupByLibrary.simpleMessage("Пропустить"),
+        "smartMemories":
+            MessageLookupByLibrary.simpleMessage("Умные воспоминания"),
         "social": MessageLookupByLibrary.simpleMessage("Социальные сети"),
         "someItemsAreInBothEnteAndYourDevice": MessageLookupByLibrary.simpleMessage(
             "Некоторые элементы находятся как в Ente, так и на вашем устройстве."),
@@ -1913,6 +2001,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Что-то пошло не так. Пожалуйста, попробуйте снова"),
         "sorry": MessageLookupByLibrary.simpleMessage("Извините"),
+        "sorryBackupFailedDesc": MessageLookupByLibrary.simpleMessage(
+            "К сожалению, мы не смогли сделать резервную копию этого файла сейчас, мы повторим попытку позже."),
         "sorryCouldNotAddToFavorites": MessageLookupByLibrary.simpleMessage(
             "Извините, не удалось добавить в избранное!"),
         "sorryCouldNotRemoveFromFavorites":
@@ -1924,6 +2014,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "sorryWeCouldNotGenerateSecureKeysOnThisDevicennplease":
             MessageLookupByLibrary.simpleMessage(
                 "К сожалению, мы не смогли сгенерировать безопасные ключи на этом устройстве.\n\nПожалуйста, зарегистрируйтесь с другого устройства."),
+        "sorryWeHadToPauseYourBackups": MessageLookupByLibrary.simpleMessage(
+            "Извините, нам пришлось приостановить резервное копирование"),
         "sort": MessageLookupByLibrary.simpleMessage("Сортировать"),
         "sortAlbumsBy": MessageLookupByLibrary.simpleMessage("Сортировать по"),
         "sortNewestFirst":
@@ -2003,6 +2095,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
                 "Срок действия ссылки, к которой вы обращаетесь, истёк."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Группы людей больше не будут отображаться в разделе людей. Фотографии останутся нетронутыми."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Человек больше не будет отображаться в разделе людей. Фотографии останутся нетронутыми."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
                 "Введённый вами ключ восстановления неверен"),
@@ -2149,6 +2245,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Проверка ключа восстановления..."),
         "videoInfo": MessageLookupByLibrary.simpleMessage("Информация о видео"),
         "videoSmallCase": MessageLookupByLibrary.simpleMessage("видео"),
+        "videoStreaming":
+            MessageLookupByLibrary.simpleMessage("Потоковое видео"),
         "videos": MessageLookupByLibrary.simpleMessage("Видео"),
         "viewActiveSessions":
             MessageLookupByLibrary.simpleMessage("Просмотр активных сессий"),
@@ -2161,6 +2259,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "viewLargeFilesDesc": MessageLookupByLibrary.simpleMessage(
             "Узнайте, какие файлы занимают больше всего места."),
         "viewLogs": MessageLookupByLibrary.simpleMessage("Просмотреть логи"),
+        "viewPersonToUnlink": m112,
         "viewRecoveryKey":
             MessageLookupByLibrary.simpleMessage("Увидеть ключ восстановления"),
         "viewer": MessageLookupByLibrary.simpleMessage("Зритель"),
@@ -2183,6 +2282,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Что нового"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Доверенный контакт может помочь в восстановлении ваших данных."),
+        "widgets": MessageLookupByLibrary.simpleMessage("Виджеты"),
         "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("год"),
         "yearly": MessageLookupByLibrary.simpleMessage("Ежегодно"),
@@ -2194,6 +2294,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Да, удалить"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Да, отменить изменения"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Да, игнорировать"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("Да, выйти"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Да, удалить"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("Да, продлить"),

--- a/mobile/apps/photos/lib/generated/intl/messages_sl.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_sl.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'sl';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_sr.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_sr.dart
@@ -20,23 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'sr';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
-        "areThey": MessageLookupByLibrary.simpleMessage("Are they "),
-        "areYouSureRemoveThisFaceFromPerson":
-            MessageLookupByLibrary.simpleMessage(
-                "Are you sure you want to remove this face from this person?"),
-        "otherDetectedFaces":
-            MessageLookupByLibrary.simpleMessage("Other detected faces"),
-        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
-        "saveAsAnotherPerson":
-            MessageLookupByLibrary.simpleMessage("Save as another person"),
-        "showLessFaces":
-            MessageLookupByLibrary.simpleMessage("Show less faces"),
-        "showMoreFaces":
-            MessageLookupByLibrary.simpleMessage("Show more faces"),
-        "wishThemAHappyBirthday": m115
-      };
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_sv.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_sv.dart
@@ -101,8 +101,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "Vi har skickat ett e-postmeddelande till <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, other: '${count} år sedan')}";
 
@@ -153,10 +151,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "appVersion": m9,
         "apply": MessageLookupByLibrary.simpleMessage("Verkställ"),
         "applyCodeTitle": MessageLookupByLibrary.simpleMessage("Använd kod"),
-        "areThey": MessageLookupByLibrary.simpleMessage("Are they "),
-        "areYouSureRemoveThisFaceFromPerson":
-            MessageLookupByLibrary.simpleMessage(
-                "Are you sure you want to remove this face from this person?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
             "Är du säker på att du vill logga ut?"),
         "askDeleteReason": MessageLookupByLibrary.simpleMessage(
@@ -453,8 +447,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Oj, något gick fel"),
         "orPickAnExistingOne":
             MessageLookupByLibrary.simpleMessage("Eller välj en befintlig"),
-        "otherDetectedFaces":
-            MessageLookupByLibrary.simpleMessage("Other detected faces"),
         "passkey": MessageLookupByLibrary.simpleMessage("Nyckel"),
         "password": MessageLookupByLibrary.simpleMessage("Lösenord"),
         "passwordChangedSuccessfully":
@@ -477,7 +469,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Integritetspolicy"),
         "publicLinkEnabled":
             MessageLookupByLibrary.simpleMessage("Offentlig länk aktiverad"),
-        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
         "rateUsOnStore": m68,
         "recover": MessageLookupByLibrary.simpleMessage("Återställ"),
         "recoverAccount":
@@ -536,8 +527,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Återställ till standard"),
         "retry": MessageLookupByLibrary.simpleMessage("Försök igen"),
         "save": MessageLookupByLibrary.simpleMessage("Spara"),
-        "saveAsAnotherPerson":
-            MessageLookupByLibrary.simpleMessage("Save as another person"),
         "saveCopy": MessageLookupByLibrary.simpleMessage("Spara kopia"),
         "saveKey": MessageLookupByLibrary.simpleMessage("Spara nyckel"),
         "saveYourRecoveryKeyIfYouHaventAlready":
@@ -589,11 +578,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Dela ditt första album"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Skapa delade och samarbetande album med andra Ente användare, inklusive användare med gratisnivån."),
-        "showLessFaces":
-            MessageLookupByLibrary.simpleMessage("Show less faces"),
         "showMemories": MessageLookupByLibrary.simpleMessage("Visa minnen"),
-        "showMoreFaces":
-            MessageLookupByLibrary.simpleMessage("Show more faces"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Visa person"),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
             "Jag samtycker till <u-terms>användarvillkoren</u-terms> och <u-policy>integritetspolicyn</u-policy>"),
@@ -706,7 +691,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("Välkommen tillbaka!"),
         "whatsNew": MessageLookupByLibrary.simpleMessage("Nyheter"),
-        "wishThemAHappyBirthday": m115,
         "yearsAgo": m116,
         "yes": MessageLookupByLibrary.simpleMessage("Ja"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Ja, avbryt"),

--- a/mobile/apps/photos/lib/generated/intl/messages_ta.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ta.dart
@@ -20,8 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ta';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -57,7 +55,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectReason": MessageLookupByLibrary.simpleMessage(
             "காரணத்தைத் தேர்ந்தெடுக்கவும்"),
         "verify": MessageLookupByLibrary.simpleMessage("சரிபார்க்கவும்"),
-        "wishThemAHappyBirthday": m115,
         "yourAccountHasBeenDeleted":
             MessageLookupByLibrary.simpleMessage("உங்கள் கணக்கு நீக்கப்பட்டது")
       };

--- a/mobile/apps/photos/lib/generated/intl/messages_te.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_te.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'te';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_th.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_th.dart
@@ -45,8 +45,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "เราได้ส่งจดหมายไปยัง <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "accountWelcomeBack":
@@ -347,7 +345,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "weakStrength": MessageLookupByLibrary.simpleMessage("อ่อน"),
         "welcomeBack":
             MessageLookupByLibrary.simpleMessage("ยินดีต้อนรับกลับมา!"),
-        "wishThemAHappyBirthday": m115,
         "you": MessageLookupByLibrary.simpleMessage("คุณ"),
         "youCanManageYourLinksInTheShareTab":
             MessageLookupByLibrary.simpleMessage(

--- a/mobile/apps/photos/lib/generated/intl/messages_ti.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_ti.dart
@@ -20,9 +20,6 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'ti';
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static Map<String, Function> _notInlinedMessages(_) =>
-      <String, Function>{"wishThemAHappyBirthday": m115};
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{};
 }

--- a/mobile/apps/photos/lib/generated/intl/messages_tr.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_tr.dart
@@ -320,8 +320,6 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m114(email) =>
       "E-postayı <green>${email}</green> adresine gönderdik";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, other: '${count} yıl önce')}";
 
@@ -2161,7 +2159,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Tekrardan hoşgeldin!"),
         "whatsNew": MessageLookupByLibrary.simpleMessage("Yenilikler"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage("."),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("yıl"),
         "yearly": MessageLookupByLibrary.simpleMessage("Yıllık"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_uk.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_uk.dart
@@ -226,8 +226,6 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m114(email) => "Ми надіслали листа на <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
-
   static String m116(count) =>
       "${Intl.plural(count, one: '${count} рік тому', other: '${count} років тому')}";
 
@@ -1933,7 +1931,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Що нового"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Довірений контакт може допомогти у відновленні ваших даних."),
-        "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("рік"),
         "yearly": MessageLookupByLibrary.simpleMessage("Щороку"),
         "yearsAgo": m116,

--- a/mobile/apps/photos/lib/generated/intl/messages_vi.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_vi.dart
@@ -20,12 +20,25 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'vi';
 
+  static String m0(title) => "${title} (Tôi)";
+
+  static String m1(count) =>
+      "${Intl.plural(count, zero: 'Thêm cộng tác viên', one: 'Thêm cộng tác viên', other: 'Thêm cộng tác viên')}";
+
+  static String m2(count) =>
+      "${Intl.plural(count, one: 'Thêm mục', other: 'Thêm các mục')}";
+
   static String m3(storageAmount, endDate) =>
-      "Gói bổ sung ${storageAmount} của bạn có hiệu lực đến ${endDate}";
+      "Gói bổ sung ${storageAmount} áp dụng đến ${endDate}";
+
+  static String m4(count) =>
+      "${Intl.plural(count, zero: 'Thêm người xem', one: 'Thêm người xem', other: 'Thêm người xem')}";
 
   static String m5(emailOrName) => "Được thêm bởi ${emailOrName}";
 
   static String m6(albumName) => "Đã thêm thành công vào ${albumName}";
+
+  static String m7(name) => "Ngưỡng mộ ${name}";
 
   static String m8(count) =>
       "${Intl.plural(count, zero: 'Không có người tham gia', one: '1 người tham gia', other: '${count} Người tham gia')}";
@@ -35,87 +48,120 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m10(freeAmount, storageUnit) =>
       "${freeAmount} ${storageUnit} còn trống";
 
+  static String m11(name) => "Ngắm cảnh với ${name}";
+
   static String m12(paymentProvider) =>
-      "Vui lòng hủy đăng ký hiện tại của bạn từ ${paymentProvider} trước";
+      "Vui lòng hủy gói hiện tại của bạn từ ${paymentProvider} trước";
 
   static String m13(user) =>
-      "${user} sẽ không thể thêm ảnh mới vào album này\n\nHọ vẫn có thể xóa các ảnh đã thêm trước đó";
+      "${user} sẽ không thể thêm ảnh vào album này\n\nHọ vẫn có thể xóa ảnh đã thêm bởi họ";
 
   static String m14(isFamilyMember, storageAmountInGb) =>
       "${Intl.select(isFamilyMember, {
             'true':
-                'Gia đình bạn đã yêu cầu ${storageAmountInGb} GB cho đến nay',
-            'false': 'Bạn đã yêu cầu ${storageAmountInGb} GB cho đến nay',
-            'other': 'Bạn đã yêu cầu ${storageAmountInGb} GB cho đến nay!',
+                'Gia đình bạn đã nhận thêm ${storageAmountInGb} GB tính đến hiện tại',
+            'false':
+                'Bạn đã nhận thêm ${storageAmountInGb} GB tính đến hiện tại',
+            'other':
+                'Bạn đã nhận thêm ${storageAmountInGb} GB tính đến hiện tại!',
           })}";
 
   static String m15(albumName) =>
-      "Liên kết hợp tác đã được tạo cho ${albumName}";
+      "Liên kết cộng tác đã được tạo cho ${albumName}";
 
   static String m16(count) =>
-      "${Intl.plural(count, zero: 'Đã thêm 0 cộng tác viên', one: 'Đã thêm 1 cộng tác viên', other: 'Đã thêm ${count} cộng tác viên')}";
+      "${Intl.plural(count, zero: 'Chưa có cộng tác viên', one: 'Đã thêm 1 cộng tác viên', other: 'Đã thêm ${count} cộng tác viên')}";
 
   static String m17(email, numOfDays) =>
       "Bạn sắp thêm ${email} làm liên hệ tin cậy. Họ sẽ có thể khôi phục tài khoản của bạn nếu bạn không hoạt động trong ${numOfDays} ngày.";
 
   static String m18(familyAdminEmail) =>
-      "Vui lòng liên hệ với <green>${familyAdminEmail}</green> để quản lý đăng ký của bạn";
+      "Vui lòng liên hệ <green>${familyAdminEmail}</green> để quản lý gói của bạn";
 
   static String m19(provider) =>
-      "Vui lòng liên hệ với chúng tôi tại support@ente.io để quản lý đăng ký ${provider} của bạn.";
+      "Vui lòng liên hệ với chúng tôi qua support@ente.io để quản lý gói ${provider} của bạn.";
 
   static String m20(endpoint) => "Đã kết nối với ${endpoint}";
 
   static String m21(count) =>
       "${Intl.plural(count, one: 'Xóa ${count} mục', other: 'Xóa ${count} mục')}";
 
+  static String m22(count) =>
+      "Xóa luôn các tấm ảnh (và video) có trong ${count} album khỏi <bold>toàn bộ</bold> album khác cũng đang chứa chúng?";
+
   static String m23(currentlyDeleting, totalCount) =>
       "Đang xóa ${currentlyDeleting} / ${totalCount}";
 
   static String m24(albumName) =>
-      "Điều này sẽ xóa liên kết công khai để truy cập \"${albumName}\".";
+      "Xóa liên kết công khai dùng để truy cập \"${albumName}\".";
 
   static String m25(supportEmail) =>
       "Vui lòng gửi email đến ${supportEmail} từ địa chỉ email đã đăng ký của bạn";
 
   static String m26(count, storageSaved) =>
-      "Bạn đã dọn dẹp ${Intl.plural(count, other: '${count} tệp trùng lặp')}, tiết kiệm (${storageSaved}!)";
+      "Bạn đã dọn dẹp ${Intl.plural(count, other: '${count} tệp bị trùng lặp')}, lấy lại (${storageSaved}!)";
 
   static String m27(count, formattedSize) =>
       "${count} tệp, ${formattedSize} mỗi tệp";
 
-  static String m29(newEmail) => "Email đã được thay đổi thành ${newEmail}";
+  static String m28(name) => "Email này đã được liên kết với ${name} trước.";
+
+  static String m29(newEmail) => "Email đã được đổi thành ${newEmail}";
+
+  static String m30(email) => "${email} chưa có tài khoản Ente.";
 
   static String m31(email) =>
-      "${email} không có tài khoản Ente.\n\nGửi cho họ một lời mời để chia sẻ ảnh.";
+      "${email} không có tài khoản Ente.\n\nGửi họ một lời mời để chia sẻ ảnh.";
 
-  static String m33(text) => "Extra photos found for ${text}";
+  static String m32(name) => "Yêu mến ${name}";
+
+  static String m33(text) => "Tìm thấy ảnh bổ sung cho ${text}";
+
+  static String m34(name) => "Tiệc tùng với ${name}";
 
   static String m35(count, formattedNumber) =>
-      "${Intl.plural(count, one: '1 tệp', other: '${formattedNumber} tệp')} trên thiết bị này đã được sao lưu an toàn";
+      "${Intl.plural(count, other: '${formattedNumber} tệp')} trên thiết bị này đã được sao lưu an toàn";
 
   static String m36(count, formattedNumber) =>
-      "${Intl.plural(count, one: '1 tệp', other: '${formattedNumber} tệp')} trong album này đã được sao lưu an toàn";
+      "${Intl.plural(count, other: '${formattedNumber} tệp')} trong album này đã được sao lưu an toàn";
 
   static String m37(storageAmountInGB) =>
       "${storageAmountInGB} GB mỗi khi ai đó đăng ký gói trả phí và áp dụng mã của bạn";
 
-  static String m38(endDate) => "Dùng thử miễn phí có hiệu lực đến ${endDate}";
+  static String m38(endDate) => "Dùng thử miễn phí áp dụng đến ${endDate}";
+
+  static String m39(count) =>
+      "Bạn vẫn có thể truy cập ${Intl.plural(count, one: 'chúng', other: 'chúng')} trên Ente miễn là bạn có một gói đăng ký";
 
   static String m40(sizeInMBorGB) => "Giải phóng ${sizeInMBorGB}";
 
   static String m41(count, formattedSize) =>
-      "${Intl.plural(count, one: 'Nó có thể được xóa khỏi thiết bị để giải phóng ${formattedSize}', other: 'Chúng có thể được xóa khỏi thiết bị để giải phóng ${formattedSize}')}";
+      "${Intl.plural(count, one: 'Có thể xóa khỏi thiết bị để giải phóng ${formattedSize}', other: 'Có thể xóa khỏi thiết bị để giải phóng ${formattedSize}')}";
 
   static String m42(currentlyProcessing, totalCount) =>
       "Đang xử lý ${currentlyProcessing} / ${totalCount}";
 
+  static String m43(name) => "Leo núi với ${name}";
+
   static String m44(count) => "${Intl.plural(count, other: '${count} mục')}";
+
+  static String m45(name) => "Lần cuối với ${name}";
 
   static String m46(email) =>
       "${email} đã mời bạn trở thành một liên hệ tin cậy";
 
   static String m47(expiryTime) => "Liên kết sẽ hết hạn vào ${expiryTime}";
+
+  static String m48(email) => "Liên kết người với ${email}";
+
+  static String m49(personName, email) =>
+      "Việc này sẽ liên kết ${personName} với ${email}";
+
+  static String m50(count, formattedCount) =>
+      "${Intl.plural(count, zero: 'chưa có ảnh', other: '${formattedCount} ảnh')}";
+
+  static String m51(count) =>
+      "${Intl.plural(count, one: 'Di chuyển mục', other: 'Di chuyển các mục')}";
 
   static String m52(albumName) => "Đã di chuyển thành công đến ${albumName}";
 
@@ -126,23 +172,39 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m55(familyAdminEmail) =>
       "Vui lòng liên hệ ${familyAdminEmail} để thay đổi mã của bạn.";
 
+  static String m56(name) => "Quẩy với ${name}";
+
   static String m57(passwordStrengthValue) =>
       "Độ mạnh mật khẩu: ${passwordStrengthValue}";
 
   static String m58(providerName) =>
-      "Vui lòng nói chuyện với bộ phận hỗ trợ ${providerName} nếu bạn đã bị tính phí";
+      "Vui lòng trao đổi với bộ phận hỗ trợ ${providerName} nếu bạn đã bị tính phí";
+
+  static String m59(name, age) => "${name} đã ${age} tuổi!";
+
+  static String m60(name, age) => "${name} sắp ${age} tuổi";
+
+  static String m61(count) =>
+      "${Intl.plural(count, zero: 'Chưa có ảnh', one: '1 ảnh', other: '${count} ảnh')}";
+
+  static String m62(count) =>
+      "${Intl.plural(count, zero: 'Chưa có ảnh', one: '1 ảnh', other: '${count} ảnh')}";
 
   static String m63(endDate) =>
-      "Dùng thử miễn phí có hiệu lực đến ${endDate}.\nBạn có thể chọn gói trả phí sau đó.";
+      "Dùng thử miễn phí áp dụng đến ${endDate}.\nBạn có thể chọn gói trả phí sau đó.";
 
   static String m64(toEmail) =>
       "Vui lòng gửi email cho chúng tôi tại ${toEmail}";
 
-  static String m65(toEmail) => "Vui lòng gửi nhật ký đến \n${toEmail}";
+  static String m65(toEmail) => "Vui lòng gửi file log đến \n${toEmail}";
+
+  static String m66(name) => "Làm dáng với ${name}";
 
   static String m67(folderName) => "Đang xử lý ${folderName}...";
 
   static String m68(storeName) => "Đánh giá chúng tôi trên ${storeName}";
+
+  static String m69(name) => "Đã chỉ định lại bạn thành ${name}";
 
   static String m70(days, email) =>
       "Bạn có thể truy cập tài khoản sau ${days} ngày. Một thông báo sẽ được gửi đến ${email}.";
@@ -154,12 +216,14 @@ class MessageLookup extends MessageLookupByLibrary {
       "${email} đang cố gắng khôi phục tài khoản của bạn.";
 
   static String m73(storageInGB) =>
-      "3. Cả hai bạn đều nhận ${storageInGB} GB* miễn phí";
+      "3. Cả hai nhận thêm ${storageInGB} GB* miễn phí";
 
   static String m74(userEmail) =>
       "${userEmail} sẽ bị xóa khỏi album chia sẻ này\n\nBất kỳ ảnh nào được thêm bởi họ cũng sẽ bị xóa khỏi album";
 
-  static String m75(endDate) => "Đăng ký sẽ được gia hạn vào ${endDate}";
+  static String m75(endDate) => "Gia hạn gói vào ${endDate}";
+
+  static String m76(name) => "Đi bộ với ${name}";
 
   static String m77(count) =>
       "${Intl.plural(count, other: '${count} kết quả được tìm thấy')}";
@@ -167,10 +231,14 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m78(snapshotLength, searchLength) =>
       "Độ dài các phần không khớp: ${snapshotLength} != ${searchLength}";
 
+  static String m79(count) => "${count} đã chọn";
+
   static String m80(count) => "${count} đã chọn";
 
   static String m81(count, yourCount) =>
-      "${count} đã chọn (${yourCount} của bạn)";
+      "${count} đã chọn (${yourCount} là của bạn)";
+
+  static String m82(name) => "Selfie với ${name}";
 
   static String m83(verificationID) =>
       "Đây là ID xác minh của tôi: ${verificationID} cho ente.io.";
@@ -179,7 +247,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Chào, bạn có thể xác nhận rằng đây là ID xác minh ente.io của bạn: ${verificationID}";
 
   static String m85(referralCode, referralStorageInGB) =>
-      "Mã giới thiệu Ente: ${referralCode} \n\nÁp dụng nó trong Cài đặt → Chung → Giới thiệu để nhận ${referralStorageInGB} GB miễn phí sau khi bạn đăng ký gói trả phí\n\nhttps://ente.io";
+      "Mã giới thiệu Ente: ${referralCode} \n\nÁp dụng nó trong Cài đặt → Chung → Giới thiệu để nhận thêm ${referralStorageInGB} GB miễn phí sau khi bạn đăng ký gói trả phí\n\nhttps://ente.io";
 
   static String m86(numberOfPeople) =>
       "${Intl.plural(numberOfPeople, zero: 'Chia sẻ với những người cụ thể', one: 'Chia sẻ với 1 người', other: 'Chia sẻ với ${numberOfPeople} người')}";
@@ -194,16 +262,20 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m90(fileType) => "Tệp ${fileType} này sẽ bị xóa khỏi Ente.";
 
+  static String m91(name) => "Chơi thể thao với ${name}";
+
+  static String m92(name) => "Tập trung vào ${name}";
+
   static String m93(storageAmountInGB) => "${storageAmountInGB} GB";
 
   static String m94(
           usedAmount, usedStorageUnit, totalAmount, totalStorageUnit) =>
-      "${usedAmount} ${usedStorageUnit} trong tổng số ${totalAmount} ${totalStorageUnit} đã sử dụng";
+      "${usedAmount} ${usedStorageUnit} trên ${totalAmount} ${totalStorageUnit} đã sử dụng";
 
   static String m95(id) =>
-      "ID ${id} của bạn đã được liên kết với một tài khoản Ente khác.\nNếu bạn muốn sử dụng ID ${id} này với tài khoản này, vui lòng liên hệ với bộ phận hỗ trợ của chúng tôi.";
+      "ID ${id} của bạn đã được liên kết với một tài khoản Ente khác.\nNếu bạn muốn sử dụng ID ${id} này với tài khoản này, vui lòng liên hệ bộ phận hỗ trợ của chúng tôi.";
 
-  static String m96(endDate) => "Đăng ký của bạn sẽ bị hủy vào ${endDate}";
+  static String m96(endDate) => "Gói của bạn sẽ bị hủy vào ${endDate}";
 
   static String m97(completed, total) =>
       "${completed}/${total} kỷ niệm đã được lưu giữ";
@@ -216,30 +288,46 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m100(email) => "Đây là ID xác minh của ${email}";
 
+  static String m101(count) =>
+      "${Intl.plural(count, one: 'Tuần này, ${count} năm trước', other: 'Tuần này, ${count} năm trước')}";
+
+  static String m102(dateFormat) => "${dateFormat} qua các năm";
+
   static String m103(count) =>
-      "${Intl.plural(count, zero: 'Soon', one: '1 day', other: '${count} days')}";
+      "${Intl.plural(count, zero: 'Sắp tới', one: '1 ngày', other: '${count} ngày')}";
+
+  static String m104(year) => "Phượt năm ${year}";
+
+  static String m105(location) => "Phượt ở ${location}";
 
   static String m106(email) =>
-      "Bạn đã được mời làm người liên hệ thừa kế bởi ${email}.";
+      "Bạn đã được mời làm người thừa kế của ${email}.";
 
   static String m107(galleryType) =>
-      "Loại thư viện ${galleryType} không được hỗ trợ để đổi tên";
+      "Loại thư viện ${galleryType} không được hỗ trợ đổi tên";
 
   static String m108(ignoreReason) => "Tải lên bị bỏ qua do ${ignoreReason}";
 
   static String m109(count) => "Đang lưu giữ ${count} kỷ niệm...";
 
-  static String m110(endDate) => "Có hiệu lực đến ${endDate}";
+  static String m110(endDate) => "Áp dụng đến ${endDate}";
 
   static String m111(email) => "Xác minh ${email}";
+
+  static String m112(name) => "Xem ${name} để hủy liên kết";
+
+  static String m113(count) =>
+      "${Intl.plural(count, zero: 'Chưa thêm người xem', one: 'Đã thêm 1 người xem', other: 'Đã thêm ${count} người xem')}";
 
   static String m114(email) =>
       "Chúng tôi đã gửi một email đến <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "Chúc ${name} sinh nhật vui vẻ! 🎉";
 
   static String m116(count) =>
       "${Intl.plural(count, other: '${count} năm trước')}";
+
+  static String m117(name) => "Bạn và ${name}";
 
   static String m118(storageSaved) =>
       "Bạn đã giải phóng thành công ${storageSaved}!";
@@ -247,30 +335,40 @@ class MessageLookup extends MessageLookupByLibrary {
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "aNewVersionOfEnteIsAvailable":
-            MessageLookupByLibrary.simpleMessage("Có phiên bản mới của Ente."),
+            MessageLookupByLibrary.simpleMessage("Ente có phiên bản mới."),
         "about": MessageLookupByLibrary.simpleMessage("Giới thiệu"),
         "acceptTrustInvite":
             MessageLookupByLibrary.simpleMessage("Chấp nhận lời mời"),
         "account": MessageLookupByLibrary.simpleMessage("Tài khoản"),
         "accountIsAlreadyConfigured":
             MessageLookupByLibrary.simpleMessage("Tài khoản đã được cấu hình."),
+        "accountOwnerPersonAppbarTitle": m0,
         "accountWelcomeBack":
             MessageLookupByLibrary.simpleMessage("Chào mừng bạn trở lại!"),
         "ackPasswordLostWarning": MessageLookupByLibrary.simpleMessage(
             "Tôi hiểu rằng nếu tôi mất mật khẩu, tôi có thể mất dữ liệu của mình vì dữ liệu của tôi được <underline>mã hóa đầu cuối</underline>."),
+        "actionNotSupportedOnFavouritesAlbum":
+            MessageLookupByLibrary.simpleMessage(
+                "Hành động không áp dụng trong album Đã thích"),
         "activeSessions":
             MessageLookupByLibrary.simpleMessage("Phiên hoạt động"),
         "add": MessageLookupByLibrary.simpleMessage("Thêm"),
         "addAName": MessageLookupByLibrary.simpleMessage("Thêm một tên"),
         "addANewEmail":
             MessageLookupByLibrary.simpleMessage("Thêm một email mới"),
+        "addAlbumWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Thêm tiện ích album vào màn hình chính và quay lại đây để tùy chỉnh."),
         "addCollaborator":
             MessageLookupByLibrary.simpleMessage("Thêm cộng tác viên"),
+        "addCollaborators": m1,
         "addFiles": MessageLookupByLibrary.simpleMessage("Thêm tệp"),
         "addFromDevice":
             MessageLookupByLibrary.simpleMessage("Thêm từ thiết bị"),
+        "addItem": m2,
         "addLocation": MessageLookupByLibrary.simpleMessage("Thêm vị trí"),
         "addLocationButton": MessageLookupByLibrary.simpleMessage("Thêm"),
+        "addMemoriesWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Thêm tiện ích kỷ niệm vào màn hình chính và quay lại đây để tùy chỉnh."),
         "addMore": MessageLookupByLibrary.simpleMessage("Thêm nữa"),
         "addName": MessageLookupByLibrary.simpleMessage("Thêm tên"),
         "addNameOrMerge":
@@ -281,8 +379,12 @@ class MessageLookup extends MessageLookupByLibrary {
             "Chi tiết về tiện ích mở rộng"),
         "addOnValidTill": m3,
         "addOns": MessageLookupByLibrary.simpleMessage("Tiện ích mở rộng"),
+        "addParticipants":
+            MessageLookupByLibrary.simpleMessage("Thêm người tham gia"),
+        "addPeopleWidgetPrompt": MessageLookupByLibrary.simpleMessage(
+            "Thêm tiện ích người vào màn hình chính và quay lại đây để tùy chỉnh."),
         "addPhotos": MessageLookupByLibrary.simpleMessage("Thêm ảnh"),
-        "addSelected": MessageLookupByLibrary.simpleMessage("Thêm đã chọn"),
+        "addSelected": MessageLookupByLibrary.simpleMessage("Thêm mục đã chọn"),
         "addToAlbum": MessageLookupByLibrary.simpleMessage("Thêm vào album"),
         "addToEnte": MessageLookupByLibrary.simpleMessage("Thêm vào Ente"),
         "addToHiddenAlbum":
@@ -290,6 +392,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "addTrustedContact":
             MessageLookupByLibrary.simpleMessage("Thêm liên hệ tin cậy"),
         "addViewer": MessageLookupByLibrary.simpleMessage("Thêm người xem"),
+        "addViewers": m4,
         "addYourPhotosNow": MessageLookupByLibrary.simpleMessage(
             "Thêm ảnh của bạn ngay bây giờ"),
         "addedAs": MessageLookupByLibrary.simpleMessage("Đã thêm như"),
@@ -297,6 +400,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "addedSuccessfullyTo": m6,
         "addingToFavorites": MessageLookupByLibrary.simpleMessage(
             "Đang thêm vào mục yêu thích..."),
+        "admiringThem": m7,
         "advanced": MessageLookupByLibrary.simpleMessage("Nâng cao"),
         "advancedSettings": MessageLookupByLibrary.simpleMessage("Nâng cao"),
         "after1Day": MessageLookupByLibrary.simpleMessage("Sau 1 ngày"),
@@ -310,14 +414,21 @@ class MessageLookup extends MessageLookupByLibrary {
         "albumUpdated":
             MessageLookupByLibrary.simpleMessage("Album đã được cập nhật"),
         "albums": MessageLookupByLibrary.simpleMessage("Album"),
-        "allClear": MessageLookupByLibrary.simpleMessage("✨ Tất cả đã rõ"),
+        "albumsWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Chọn những album bạn muốn thấy trên màn hình chính của mình."),
+        "allClear": MessageLookupByLibrary.simpleMessage("✨ Tất cả đã xong"),
         "allMemoriesPreserved": MessageLookupByLibrary.simpleMessage(
             "Tất cả kỷ niệm đã được lưu giữ"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
-            "Tất cả các nhóm cho người này sẽ được đặt lại, và bạn sẽ mất tất cả các gợi ý đã được đưa ra cho người này"),
+            "Tất cả nhóm của người này sẽ được đặt lại, và bạn sẽ mất tất cả các gợi ý đã được tạo ra cho người này"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Tất cả nhóm không có tên sẽ được hợp nhất vào người đã chọn. Điều này vẫn có thể được hoàn tác từ tổng quan lịch sử đề xuất của người đó."),
+        "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
+            "Đây là ảnh đầu tiên trong nhóm. Các ảnh được chọn khác sẽ tự động thay đổi dựa theo ngày mới này"),
         "allow": MessageLookupByLibrary.simpleMessage("Cho phép"),
         "allowAddPhotosDescription": MessageLookupByLibrary.simpleMessage(
-            "Cho phép người có liên kết cũng thêm ảnh vào album chia sẻ."),
+            "Cho phép người có liên kết thêm ảnh vào album chia sẻ."),
         "allowAddingPhotos":
             MessageLookupByLibrary.simpleMessage("Cho phép thêm ảnh"),
         "allowAppToOpenSharedAlbumLinks": MessageLookupByLibrary.simpleMessage(
@@ -351,6 +462,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Android, iOS, Web, Desktop"),
         "androidSignInTitle":
             MessageLookupByLibrary.simpleMessage("Yêu cầu xác thực"),
+        "appIcon": MessageLookupByLibrary.simpleMessage("Biểu tượng ứng dụng"),
         "appLock": MessageLookupByLibrary.simpleMessage("Khóa ứng dụng"),
         "appLockDescriptions": MessageLookupByLibrary.simpleMessage(
             "Chọn giữa màn hình khóa mặc định của thiết bị và màn hình khóa tùy chỉnh với PIN hoặc mật khẩu."),
@@ -359,63 +471,75 @@ class MessageLookup extends MessageLookupByLibrary {
         "apply": MessageLookupByLibrary.simpleMessage("Áp dụng"),
         "applyCodeTitle": MessageLookupByLibrary.simpleMessage("Áp dụng mã"),
         "appstoreSubscription":
-            MessageLookupByLibrary.simpleMessage("Đăng ký AppStore"),
+            MessageLookupByLibrary.simpleMessage("Gói AppStore"),
         "archive": MessageLookupByLibrary.simpleMessage("Lưu trữ"),
         "archiveAlbum": MessageLookupByLibrary.simpleMessage("Lưu trữ album"),
         "archiving": MessageLookupByLibrary.simpleMessage("Đang lưu trữ..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("Họ có phải là "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Bạn có chắc muốn xóa khuôn mặt này khỏi người này không?"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage(
-                "Bạn có chắc chắn muốn rời khỏi kế hoạch gia đình không?"),
-        "areYouSureYouWantToCancel": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn hủy không?"),
+                "Bạn có chắc muốn rời khỏi gói gia đình không?"),
+        "areYouSureYouWantToCancel":
+            MessageLookupByLibrary.simpleMessage("Bạn có chắc muốn hủy không?"),
         "areYouSureYouWantToChangeYourPlan":
             MessageLookupByLibrary.simpleMessage(
-                "Bạn có chắc chắn muốn thay đổi gói của mình không?"),
+                "Bạn có chắc muốn thay đổi gói của mình không?"),
         "areYouSureYouWantToExit": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn thoát không?"),
+            "Bạn có chắc muốn thoát không?"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage(
+                "Bạn có chắc muốn bỏ qua những người này?"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Bạn có chắc muốn bỏ qua người này?"),
         "areYouSureYouWantToLogout": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn đăng xuất không?"),
+            "Bạn có chắc muốn đăng xuất không?"),
+        "areYouSureYouWantToMergeThem": MessageLookupByLibrary.simpleMessage(
+            "Bạn có chắc muốn hợp nhất họ?"),
         "areYouSureYouWantToRenew": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn gia hạn không?"),
+            "Bạn có chắc muốn gia hạn không?"),
         "areYouSureYouWantToResetThisPerson":
             MessageLookupByLibrary.simpleMessage(
-                "Bạn có chắc chắn muốn đặt lại người này không?"),
+                "Bạn có chắc muốn đặt lại người này không?"),
         "askCancelReason": MessageLookupByLibrary.simpleMessage(
-            "Đăng ký của bạn đã bị hủy. Bạn có muốn chia sẻ lý do không?"),
+            "Gói của bạn đã bị hủy. Bạn có muốn chia sẻ lý do không?"),
         "askDeleteReason": MessageLookupByLibrary.simpleMessage(
             "Lý do chính bạn xóa tài khoản là gì?"),
         "askYourLovedOnesToShare": MessageLookupByLibrary.simpleMessage(
-            "Hãy yêu cầu những người thân yêu của bạn chia sẻ"),
+            "Hãy gợi ý những người thân yêu của bạn chia sẻ"),
         "atAFalloutShelter":
-            MessageLookupByLibrary.simpleMessage("tại một nơi trú ẩn"),
+            MessageLookupByLibrary.simpleMessage("ở hầm trú ẩn hạt nhân"),
         "authToChangeEmailVerificationSetting":
             MessageLookupByLibrary.simpleMessage(
-                "Vui lòng xác thực để thay đổi cài đặt xác minh email"),
+                "Vui lòng xác thực để đổi cài đặt xác minh email"),
         "authToChangeLockscreenSetting": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để thay đổi cài đặt màn hình khóa"),
+            "Vui lòng xác thực để thay đổi cài đặt khóa màn hình"),
         "authToChangeYourEmail": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để thay đổi email của bạn"),
+            "Vui lòng xác thực để đổi email"),
         "authToChangeYourPassword": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để thay đổi mật khẩu của bạn"),
+            "Vui lòng xác thực để đổi mật khẩu"),
         "authToConfigureTwofactorAuthentication":
             MessageLookupByLibrary.simpleMessage(
-                "Vui lòng xác thực để cấu hình xác thực hai yếu tố"),
+                "Vui lòng xác thực để cấu hình xác thực 2 bước"),
         "authToInitiateAccountDeletion": MessageLookupByLibrary.simpleMessage(
             "Vui lòng xác thực để bắt đầu xóa tài khoản"),
         "authToManageLegacy": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để quản lý các liên hệ tin cậy của bạn"),
+            "Vui lòng xác thực để quản lý các liên hệ tin cậy"),
         "authToViewPasskey": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem khóa truy cập của bạn"),
+            "Vui lòng xác thực để xem khóa truy cập"),
         "authToViewTrashedFiles": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem các tệp đã xóa của bạn"),
+            "Vui lòng xác thực để xem các tệp đã xóa"),
         "authToViewYourActiveSessions": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem các phiên hoạt động của bạn"),
+            "Vui lòng xác thực để xem các phiên hoạt động"),
         "authToViewYourHiddenFiles": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem các tệp ẩn của bạn"),
+            "Vui lòng xác thực để xem các tệp ẩn"),
         "authToViewYourMemories": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem kỷ niệm của bạn"),
+            "Vui lòng xác thực để xem kỷ niệm"),
         "authToViewYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xác thực để xem khóa khôi phục của bạn"),
+            "Vui lòng xác thực để xem mã khôi phục"),
         "authenticating":
             MessageLookupByLibrary.simpleMessage("Đang xác thực..."),
         "authenticationFailedPleaseTryAgain":
@@ -426,10 +550,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "autoCastDialogBody": MessageLookupByLibrary.simpleMessage(
             "Bạn sẽ thấy các thiết bị Cast có sẵn ở đây."),
         "autoCastiOSPermission": MessageLookupByLibrary.simpleMessage(
-            "Hãy chắc chắn rằng quyền Mạng cục bộ đã được bật cho ứng dụng Ente Photos, trong Cài đặt."),
+            "Hãy chắc rằng quyền Mạng cục bộ đã được bật cho ứng dụng Ente Photos, trong Cài đặt."),
         "autoLock": MessageLookupByLibrary.simpleMessage("Khóa tự động"),
         "autoLockFeatureDescription": MessageLookupByLibrary.simpleMessage(
-            "Thời gian sau đó ứng dụng sẽ khóa khi được đưa vào nền"),
+            "Sau thời gian này, ứng dụng sẽ khóa sau khi được chạy ở chế độ nền"),
         "autoLogoutMessage": MessageLookupByLibrary.simpleMessage(
             "Do sự cố kỹ thuật, bạn đã bị đăng xuất. Chúng tôi xin lỗi vì sự bất tiện."),
         "autoPair": MessageLookupByLibrary.simpleMessage("Ghép nối tự động"),
@@ -439,12 +563,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "availableStorageSpace": m10,
         "backedUpFolders":
             MessageLookupByLibrary.simpleMessage("Thư mục đã sao lưu"),
+        "backgroundWithThem": m11,
         "backup": MessageLookupByLibrary.simpleMessage("Sao lưu"),
         "backupFailed":
             MessageLookupByLibrary.simpleMessage("Sao lưu thất bại"),
-        "backupFile": MessageLookupByLibrary.simpleMessage("Tệp sao lưu"),
-        "backupOverMobileData":
-            MessageLookupByLibrary.simpleMessage("Sao lưu qua dữ liệu di động"),
+        "backupFile": MessageLookupByLibrary.simpleMessage("Sao lưu tệp"),
+        "backupOverMobileData": MessageLookupByLibrary.simpleMessage(
+            "Sao lưu bằng dữ liệu di động"),
         "backupSettings":
             MessageLookupByLibrary.simpleMessage("Cài đặt sao lưu"),
         "backupStatus":
@@ -452,15 +577,42 @@ class MessageLookup extends MessageLookupByLibrary {
         "backupStatusDescription": MessageLookupByLibrary.simpleMessage(
             "Các mục đã được sao lưu sẽ hiển thị ở đây"),
         "backupVideos": MessageLookupByLibrary.simpleMessage("Sao lưu video"),
+        "beach": MessageLookupByLibrary.simpleMessage("Cát và biển"),
         "birthday": MessageLookupByLibrary.simpleMessage("Sinh nhật"),
+        "birthdayNotifications":
+            MessageLookupByLibrary.simpleMessage("Thông báo sinh nhật"),
+        "birthdays": MessageLookupByLibrary.simpleMessage("Sinh nhật"),
         "blackFridaySale":
             MessageLookupByLibrary.simpleMessage("Giảm giá Black Friday"),
         "blog": MessageLookupByLibrary.simpleMessage("Blog"),
-        "cachedData": MessageLookupByLibrary.simpleMessage("Dữ liệu đã lưu"),
+        "cLDesc1": MessageLookupByLibrary.simpleMessage(
+            "Sau bản beta phát trực tuyến video và làm việc trên các bản có thể tiếp tục tải lên và tải xuống, chúng tôi hiện đã tăng giới hạn tải lên tệp tới 10 GB. Tính năng này hiện khả dụng trên cả ứng dụng dành cho máy tính để bàn và di động."),
+        "cLDesc2": MessageLookupByLibrary.simpleMessage(
+            "Tải lên trong nền hiện đã hỗ trợ trên iOS và Android. Không cần phải mở ứng dụng để sao lưu ảnh và video mới nhất của bạn."),
+        "cLDesc3": MessageLookupByLibrary.simpleMessage(
+            "Chúng tôi đã có những cải tiến đáng kể cho trải nghiệm kỷ niệm, bao gồm phát tự động, vuốt đến kỷ niệm tiếp theo và nhiều tính năng khác."),
+        "cLDesc4": MessageLookupByLibrary.simpleMessage(
+            "Cùng với một loạt cải tiến nội bộ, giờ đây bạn có thể dễ dàng xem tất cả khuôn mặt đã phát hiện, cung cấp phản hồi về các khuôn mặt giống nhau và thêm/xóa khuôn mặt khỏi một bức ảnh."),
+        "cLDesc5": MessageLookupByLibrary.simpleMessage(
+            "Bây giờ bạn sẽ nhận được thông báo tùy-chọn cho tất cả các ngày sinh nhật mà bạn đã lưu trên Ente, cùng với bộ sưu tập những bức ảnh đẹp nhất của họ."),
+        "cLDesc6": MessageLookupByLibrary.simpleMessage(
+            "Không còn phải chờ tải lên/tải xuống xong mới có thể đóng ứng dụng. Tất cả các tải lên và tải xuống hiện có thể tạm dừng giữa chừng và tiếp tục từ nơi bạn đã dừng lại."),
+        "cLTitle1":
+            MessageLookupByLibrary.simpleMessage("Tải lên tệp video lớn"),
+        "cLTitle2": MessageLookupByLibrary.simpleMessage("Tải lên trong nền"),
+        "cLTitle3":
+            MessageLookupByLibrary.simpleMessage("Tự động phát kỷ niệm"),
+        "cLTitle4": MessageLookupByLibrary.simpleMessage(
+            "Cải thiện nhận diện khuôn mặt"),
+        "cLTitle5": MessageLookupByLibrary.simpleMessage("Thông báo sinh nhật"),
+        "cLTitle6": MessageLookupByLibrary.simpleMessage(
+            "Tiếp tục tải lên và tải xuống"),
+        "cachedData": MessageLookupByLibrary.simpleMessage(
+            "Dữ liệu đã lưu trong bộ nhớ đệm"),
         "calculating":
             MessageLookupByLibrary.simpleMessage("Đang tính toán..."),
         "canNotOpenBody": MessageLookupByLibrary.simpleMessage(
-            "Xin lỗi, album này không thể mở trong ứng dụng."),
+            "Rất tiếc, album này không thể mở trong ứng dụng."),
         "canNotOpenTitle":
             MessageLookupByLibrary.simpleMessage("Không thể mở album này"),
         "canNotUploadToAlbumsOwnedByOthers":
@@ -475,23 +627,22 @@ class MessageLookup extends MessageLookupByLibrary {
         "cancelAccountRecovery":
             MessageLookupByLibrary.simpleMessage("Hủy khôi phục"),
         "cancelAccountRecoveryBody": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn hủy khôi phục không?"),
+            "Bạn có chắc muốn hủy khôi phục không?"),
         "cancelOtherSubscription": m12,
-        "cancelSubscription":
-            MessageLookupByLibrary.simpleMessage("Hủy đăng ký"),
+        "cancelSubscription": MessageLookupByLibrary.simpleMessage("Hủy gói"),
         "cannotAddMorePhotosAfterBecomingViewer": m13,
         "cannotDeleteSharedFiles": MessageLookupByLibrary.simpleMessage(
             "Không thể xóa các tệp đã chia sẻ"),
         "castAlbum": MessageLookupByLibrary.simpleMessage("Phát album"),
         "castIPMismatchBody": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng đảm bảo bạn đang ở trên cùng một mạng với TV."),
+            "Hãy chắc rằng bạn đang dùng chung mạng với TV."),
         "castIPMismatchTitle":
             MessageLookupByLibrary.simpleMessage("Không thể phát album"),
         "castInstruction": MessageLookupByLibrary.simpleMessage(
             "Truy cập cast.ente.io trên thiết bị bạn muốn ghép nối.\n\nNhập mã dưới đây để phát album trên TV của bạn."),
         "centerPoint": MessageLookupByLibrary.simpleMessage("Điểm trung tâm"),
         "change": MessageLookupByLibrary.simpleMessage("Thay đổi"),
-        "changeEmail": MessageLookupByLibrary.simpleMessage("Thay đổi email"),
+        "changeEmail": MessageLookupByLibrary.simpleMessage("Đổi email"),
         "changeLocationOfSelectedItems": MessageLookupByLibrary.simpleMessage(
             "Thay đổi vị trí của các mục đã chọn?"),
         "changePassword": MessageLookupByLibrary.simpleMessage("Đổi mật khẩu"),
@@ -508,41 +659,43 @@ class MessageLookup extends MessageLookupByLibrary {
         "checkStatus":
             MessageLookupByLibrary.simpleMessage("Kiểm tra trạng thái"),
         "checking": MessageLookupByLibrary.simpleMessage("Đang kiểm tra..."),
-        "checkingModels": MessageLookupByLibrary.simpleMessage(
-            "Đang kiểm tra các mô hình..."),
-        "claimFreeStorage":
-            MessageLookupByLibrary.simpleMessage("Yêu cầu lưu trữ miễn phí"),
-        "claimMore": MessageLookupByLibrary.simpleMessage("Yêu cầu thêm!"),
-        "claimed": MessageLookupByLibrary.simpleMessage("Đã yêu cầu"),
+        "checkingModels":
+            MessageLookupByLibrary.simpleMessage("Đang kiểm tra mô hình..."),
+        "city": MessageLookupByLibrary.simpleMessage("Trong thành phố"),
+        "claimFreeStorage": MessageLookupByLibrary.simpleMessage(
+            "Nhận thêm dung lượng miễn phí"),
+        "claimMore": MessageLookupByLibrary.simpleMessage("Nhận thêm!"),
+        "claimed": MessageLookupByLibrary.simpleMessage("Đã nhận"),
         "claimedStorageSoFar": m14,
         "cleanUncategorized":
             MessageLookupByLibrary.simpleMessage("Dọn dẹp chưa phân loại"),
         "cleanUncategorizedDescription": MessageLookupByLibrary.simpleMessage(
-            "Xóa tất cả các tệp từ chưa phân loại có mặt trong các album khác"),
+            "Xóa khỏi mục Chưa phân loại với tất cả tệp đang xuất hiện trong các album khác"),
         "clearCaches": MessageLookupByLibrary.simpleMessage("Xóa bộ nhớ cache"),
         "clearIndexes": MessageLookupByLibrary.simpleMessage("Xóa chỉ mục"),
         "click": MessageLookupByLibrary.simpleMessage("• Nhấn"),
         "clickOnTheOverflowMenu":
-            MessageLookupByLibrary.simpleMessage("• Nhấn vào menu thả xuống"),
+            MessageLookupByLibrary.simpleMessage("• Nhấn vào menu xổ xuống"),
+        "clickToInstallOurBestVersionYet": MessageLookupByLibrary.simpleMessage(
+            "Nhấn để cài đặt phiên bản tốt nhất"),
         "close": MessageLookupByLibrary.simpleMessage("Đóng"),
         "clubByCaptureTime":
-            MessageLookupByLibrary.simpleMessage("Nhóm theo thời gian chụp"),
+            MessageLookupByLibrary.simpleMessage("Xếp theo thời gian chụp"),
         "clubByFileName":
-            MessageLookupByLibrary.simpleMessage("Nhóm theo tên tệp"),
+            MessageLookupByLibrary.simpleMessage("Xếp theo tên tệp"),
         "clusteringProgress":
             MessageLookupByLibrary.simpleMessage("Tiến trình phân cụm"),
         "codeAppliedPageTitle":
             MessageLookupByLibrary.simpleMessage("Mã đã được áp dụng"),
         "codeChangeLimitReached": MessageLookupByLibrary.simpleMessage(
-            "Xin lỗi, bạn đã đạt giới hạn thay đổi mã."),
+            "Rất tiếc, bạn đã đạt hạn mức thay đổi mã."),
         "codeCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
-            "Mã đã được sao chép vào clipboard"),
-        "codeUsedByYou":
-            MessageLookupByLibrary.simpleMessage("Mã được sử dụng bởi bạn"),
+            "Mã đã được sao chép vào bộ nhớ tạm"),
+        "codeUsedByYou": MessageLookupByLibrary.simpleMessage("Mã bạn đã dùng"),
         "collabLinkSectionDescription": MessageLookupByLibrary.simpleMessage(
             "Tạo một liên kết để cho phép mọi người thêm và xem ảnh trong album chia sẻ của bạn mà không cần ứng dụng hoặc tài khoản Ente. Tuyệt vời để thu thập ảnh sự kiện."),
         "collaborativeLink":
-            MessageLookupByLibrary.simpleMessage("Liên kết hợp tác"),
+            MessageLookupByLibrary.simpleMessage("Liên kết cộng tác"),
         "collaborativeLinkCreatedFor": m15,
         "collaborator": MessageLookupByLibrary.simpleMessage("Cộng tác viên"),
         "collaboratorsCanAddPhotosAndVideosToTheSharedAlbum":
@@ -562,20 +715,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "configuration": MessageLookupByLibrary.simpleMessage("Cấu hình"),
         "confirm": MessageLookupByLibrary.simpleMessage("Xác nhận"),
         "confirm2FADisable": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn vô hiệu hóa xác thực hai yếu tố không?"),
+            "Bạn có chắc muốn tắt xác thực 2 bước không?"),
         "confirmAccountDeletion":
             MessageLookupByLibrary.simpleMessage("Xác nhận xóa tài khoản"),
         "confirmAddingTrustedContact": m17,
         "confirmDeletePrompt": MessageLookupByLibrary.simpleMessage(
-            "Có, tôi muốn xóa vĩnh viễn tài khoản này và dữ liệu của nó trên tất cả các ứng dụng."),
+            "Có, tôi muốn xóa vĩnh viễn tài khoản này và tất cả dữ liệu của nó."),
         "confirmPassword":
             MessageLookupByLibrary.simpleMessage("Xác nhận mật khẩu"),
         "confirmPlanChange":
             MessageLookupByLibrary.simpleMessage("Xác nhận thay đổi gói"),
         "confirmRecoveryKey":
-            MessageLookupByLibrary.simpleMessage("Xác nhận khóa khôi phục"),
+            MessageLookupByLibrary.simpleMessage("Xác nhận mã khôi phục"),
         "confirmYourRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Xác nhận khóa khôi phục của bạn"),
+            "Xác nhận mã khôi phục của bạn"),
         "connectToDevice":
             MessageLookupByLibrary.simpleMessage("Kết nối với thiết bị"),
         "contactFamilyAdmin": m18,
@@ -594,19 +747,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "copyLink": MessageLookupByLibrary.simpleMessage("Sao chép liên kết"),
         "copypasteThisCodentoYourAuthenticatorApp":
             MessageLookupByLibrary.simpleMessage(
-                "Sao chép-dán mã này\ntới ứng dụng xác thực của bạn"),
+                "Chép & dán mã này\nvào ứng dụng xác thực của bạn"),
         "couldNotBackUpTryLater": MessageLookupByLibrary.simpleMessage(
             "Chúng tôi không thể sao lưu dữ liệu của bạn.\nChúng tôi sẽ thử lại sau."),
         "couldNotFreeUpSpace": MessageLookupByLibrary.simpleMessage(
-            "Không thể giải phóng không gian"),
+            "Không thể giải phóng dung lượng"),
         "couldNotUpdateSubscription":
-            MessageLookupByLibrary.simpleMessage("Không thể cập nhật đăng ký"),
+            MessageLookupByLibrary.simpleMessage("Không thể cập nhật gói"),
         "count": MessageLookupByLibrary.simpleMessage("Số lượng"),
         "crashReporting": MessageLookupByLibrary.simpleMessage("Báo cáo sự cố"),
         "create": MessageLookupByLibrary.simpleMessage("Tạo"),
         "createAccount": MessageLookupByLibrary.simpleMessage("Tạo tài khoản"),
         "createAlbumActionHint": MessageLookupByLibrary.simpleMessage(
-            "Nhấn giữ để chọn ảnh và nhấp + để tạo album"),
+            "Nhấn giữ để chọn ảnh và nhấn + để tạo album"),
         "createCollaborativeLink":
             MessageLookupByLibrary.simpleMessage("Tạo liên kết cộng tác"),
         "createCollage": MessageLookupByLibrary.simpleMessage("Tạo ảnh ghép"),
@@ -621,8 +774,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "criticalUpdateAvailable":
             MessageLookupByLibrary.simpleMessage("Cập nhật quan trọng có sẵn"),
         "crop": MessageLookupByLibrary.simpleMessage("Cắt xén"),
+        "curatedMemories":
+            MessageLookupByLibrary.simpleMessage("Ký ức lưu giữ"),
         "currentUsageIs":
-            MessageLookupByLibrary.simpleMessage("Sử dụng hiện tại là "),
+            MessageLookupByLibrary.simpleMessage("Dung lượng hiện tại "),
         "currentlyRunning": MessageLookupByLibrary.simpleMessage("đang chạy"),
         "custom": MessageLookupByLibrary.simpleMessage("Tùy chỉnh"),
         "customEndpoint": m20,
@@ -635,7 +790,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "decryptingVideo":
             MessageLookupByLibrary.simpleMessage("Đang giải mã video..."),
         "deduplicateFiles":
-            MessageLookupByLibrary.simpleMessage("Xóa trùng lặp tệp"),
+            MessageLookupByLibrary.simpleMessage("Xóa trùng lặp"),
         "delete": MessageLookupByLibrary.simpleMessage("Xóa"),
         "deleteAccount": MessageLookupByLibrary.simpleMessage("Xóa tài khoản"),
         "deleteAccountFeedbackPrompt": MessageLookupByLibrary.simpleMessage(
@@ -644,12 +799,12 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Xóa tài khoản vĩnh viễn"),
         "deleteAlbum": MessageLookupByLibrary.simpleMessage("Xóa album"),
         "deleteAlbumDialog": MessageLookupByLibrary.simpleMessage(
-            "Cũng xóa các ảnh (và video) có trong album này từ <bold>tất cả</bold> các album khác mà chúng là một phần của?"),
+            "Xóa luôn các tấm ảnh (và video) có trong album này khỏi <bold>toàn bộ</bold> album khác cũng đang chứa chúng?"),
         "deleteAlbumsDialogBody": MessageLookupByLibrary.simpleMessage(
-            "Điều này sẽ xóa tất cả album trống. Điều này hữu ích khi bạn muốn giảm bớt sự lộn xộn trong danh sách album của mình."),
+            "Tất cả album trống sẽ bị xóa. Sẽ hữu ích khi bạn muốn giảm bớt sự lộn xộn trong danh sách album của mình."),
         "deleteAll": MessageLookupByLibrary.simpleMessage("Xóa tất cả"),
         "deleteConfirmDialogBody": MessageLookupByLibrary.simpleMessage(
-            "Tài khoản này được liên kết với các ứng dụng Ente khác, nếu bạn sử dụng bất kỳ. Dữ liệu bạn đã tải lên, trên tất cả các ứng dụng Ente, sẽ được lên lịch để xóa, và tài khoản của bạn sẽ bị xóa vĩnh viễn."),
+            "Tài khoản này được liên kết với các ứng dụng Ente khác, nếu bạn có dùng. Dữ liệu bạn đã tải lên, trên tất cả ứng dụng Ente, sẽ được lên lịch để xóa, và tài khoản của bạn sẽ bị xóa vĩnh viễn."),
         "deleteEmailRequest": MessageLookupByLibrary.simpleMessage(
             "Vui lòng gửi email đến <warning>account-deletion@ente.io</warning> từ địa chỉ email đã đăng ký của bạn."),
         "deleteEmptyAlbums":
@@ -663,80 +818,81 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteFromEnte": MessageLookupByLibrary.simpleMessage("Xóa khỏi Ente"),
         "deleteItemCount": m21,
         "deleteLocation": MessageLookupByLibrary.simpleMessage("Xóa vị trí"),
+        "deleteMultipleAlbumDialog": m22,
         "deletePhotos": MessageLookupByLibrary.simpleMessage("Xóa ảnh"),
         "deleteProgress": m23,
         "deleteReason1": MessageLookupByLibrary.simpleMessage(
             "Nó thiếu một tính năng quan trọng mà tôi cần"),
         "deleteReason2": MessageLookupByLibrary.simpleMessage(
-            "Ứng dụng hoặc một tính năng nhất định không hoạt động như tôi nghĩ"),
+            "Ứng dụng hoặc một tính năng nhất định không hoạt động như tôi muốn"),
         "deleteReason3": MessageLookupByLibrary.simpleMessage(
-            "Tôi đã tìm thấy một dịch vụ khác mà tôi thích hơn"),
+            "Tôi tìm thấy một dịch vụ khác mà tôi thích hơn"),
         "deleteReason4": MessageLookupByLibrary.simpleMessage(
-            "Lý do của tôi không có trong danh sách"),
+            "Lý do không có trong danh sách"),
         "deleteRequestSLAText": MessageLookupByLibrary.simpleMessage(
             "Yêu cầu của bạn sẽ được xử lý trong vòng 72 giờ."),
         "deleteSharedAlbum":
             MessageLookupByLibrary.simpleMessage("Xóa album chia sẻ?"),
         "deleteSharedAlbumDialogBody": MessageLookupByLibrary.simpleMessage(
-            "Album sẽ bị xóa cho tất cả mọi người\n\nBạn sẽ mất quyền truy cập vào các ảnh chia sẻ trong album này mà thuộc sở hữu của người khác"),
+            "Album sẽ bị xóa với tất cả mọi người\n\nBạn sẽ mất quyền truy cập vào các ảnh chia sẻ trong album này mà thuộc sở hữu của người khác"),
         "deselectAll": MessageLookupByLibrary.simpleMessage("Bỏ chọn tất cả"),
-        "designedToOutlive": MessageLookupByLibrary.simpleMessage(
-            "Được thiết kế để tồn tại lâu hơn"),
+        "designedToOutlive":
+            MessageLookupByLibrary.simpleMessage("Được thiết kế để trường tồn"),
         "details": MessageLookupByLibrary.simpleMessage("Chi tiết"),
         "developerSettings":
             MessageLookupByLibrary.simpleMessage("Cài đặt Nhà phát triển"),
         "developerSettingsWarning": MessageLookupByLibrary.simpleMessage(
-            "Bạn có chắc chắn muốn thay đổi cài đặt Nhà phát triển không?"),
+            "Bạn có chắc muốn thay đổi cài đặt Nhà phát triển không?"),
         "deviceCodeHint": MessageLookupByLibrary.simpleMessage("Nhập mã"),
         "deviceFilesAutoUploading": MessageLookupByLibrary.simpleMessage(
             "Các tệp được thêm vào album thiết bị này sẽ tự động được tải lên Ente."),
         "deviceLock": MessageLookupByLibrary.simpleMessage("Khóa thiết bị"),
         "deviceLockExplanation": MessageLookupByLibrary.simpleMessage(
-            "Vô hiệu hóa khóa màn hình thiết bị khi Ente đang ở chế độ nền và có một bản sao lưu đang diễn ra. Điều này thường không cần thiết, nhưng có thể giúp các tải lên lớn và nhập khẩu ban đầu của các thư viện lớn hoàn thành nhanh hơn."),
+            "Vô hiệu hóa khóa màn hình thiết bị khi Ente đang ở chế độ nền và có một bản sao lưu đang diễn ra. Điều này thường không cần thiết, nhưng có thể giúp tải lên các tệp lớn và tệp nhập của các thư viện lớn xong nhanh hơn."),
         "deviceNotFound":
             MessageLookupByLibrary.simpleMessage("Không tìm thấy thiết bị"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("Bạn có biết?"),
+        "different": MessageLookupByLibrary.simpleMessage("Khác"),
         "disableAutoLock":
             MessageLookupByLibrary.simpleMessage("Vô hiệu hóa khóa tự động"),
         "disableDownloadWarningBody": MessageLookupByLibrary.simpleMessage(
-            "Người xem vẫn có thể chụp màn hình hoặc lưu bản sao ảnh của bạn bằng các công cụ bên ngoài"),
+            "Người xem vẫn có thể chụp ảnh màn hình hoặc sao chép ảnh của bạn bằng các công cụ bên ngoài"),
         "disableDownloadWarningTitle":
             MessageLookupByLibrary.simpleMessage("Xin lưu ý"),
         "disableLinkMessage": m24,
-        "disableTwofactor": MessageLookupByLibrary.simpleMessage(
-            "Vô hiệu hóa xác thực hai yếu tố"),
+        "disableTwofactor":
+            MessageLookupByLibrary.simpleMessage("Tắt xác thực 2 bước"),
         "disablingTwofactorAuthentication":
             MessageLookupByLibrary.simpleMessage(
-                "Đang vô hiệu hóa xác thực hai yếu tố..."),
+                "Đang vô hiệu hóa xác thực 2 bước..."),
         "discord": MessageLookupByLibrary.simpleMessage("Discord"),
         "discover": MessageLookupByLibrary.simpleMessage("Khám phá"),
-        "discover_babies": MessageLookupByLibrary.simpleMessage("Trẻ em"),
+        "discover_babies": MessageLookupByLibrary.simpleMessage("Em bé"),
         "discover_celebrations":
             MessageLookupByLibrary.simpleMessage("Lễ kỷ niệm"),
         "discover_food": MessageLookupByLibrary.simpleMessage("Thức ăn"),
         "discover_greenery": MessageLookupByLibrary.simpleMessage("Cây cối"),
         "discover_hills": MessageLookupByLibrary.simpleMessage("Đồi"),
-        "discover_identity": MessageLookupByLibrary.simpleMessage("Danh tính"),
-        "discover_memes": MessageLookupByLibrary.simpleMessage("Hình ảnh chế"),
+        "discover_identity": MessageLookupByLibrary.simpleMessage("Nhận dạng"),
+        "discover_memes": MessageLookupByLibrary.simpleMessage("Meme"),
         "discover_notes": MessageLookupByLibrary.simpleMessage("Ghi chú"),
         "discover_pets": MessageLookupByLibrary.simpleMessage("Thú cưng"),
         "discover_receipts": MessageLookupByLibrary.simpleMessage("Biên lai"),
         "discover_screenshots":
             MessageLookupByLibrary.simpleMessage("Ảnh chụp màn hình"),
-        "discover_selfies":
-            MessageLookupByLibrary.simpleMessage("Ảnh tự sướng"),
+        "discover_selfies": MessageLookupByLibrary.simpleMessage("Selfie"),
         "discover_sunset": MessageLookupByLibrary.simpleMessage("Hoàng hôn"),
-        "discover_visiting_cards":
-            MessageLookupByLibrary.simpleMessage("Thẻ thăm"),
+        "discover_visiting_cards": MessageLookupByLibrary.simpleMessage("Thẻ"),
         "discover_wallpapers": MessageLookupByLibrary.simpleMessage("Hình nền"),
         "dismiss": MessageLookupByLibrary.simpleMessage("Bỏ qua"),
         "distanceInKMUnit": MessageLookupByLibrary.simpleMessage("km"),
         "doNotSignOut": MessageLookupByLibrary.simpleMessage("Không đăng xuất"),
-        "doThisLater": MessageLookupByLibrary.simpleMessage("Làm điều này sau"),
+        "doThisLater": MessageLookupByLibrary.simpleMessage("Để sau"),
         "doYouWantToDiscardTheEditsYouHaveMade":
             MessageLookupByLibrary.simpleMessage(
-                "Bạn có muốn bỏ qua các chỉnh sửa bạn đã thực hiện không?"),
+                "Bạn có muốn bỏ qua các chỉnh sửa đã thực hiện không?"),
         "done": MessageLookupByLibrary.simpleMessage("Xong"),
+        "dontSave": MessageLookupByLibrary.simpleMessage("Không lưu"),
         "doubleYourStorage": MessageLookupByLibrary.simpleMessage(
             "Gấp đôi dung lượng lưu trữ của bạn"),
         "download": MessageLookupByLibrary.simpleMessage("Tải xuống"),
@@ -748,41 +904,45 @@ class MessageLookup extends MessageLookupByLibrary {
         "duplicateFileCountWithStorageSaved": m26,
         "duplicateItemsGroup": m27,
         "edit": MessageLookupByLibrary.simpleMessage("Chỉnh sửa"),
+        "editEmailAlreadyLinked": m28,
         "editLocation":
             MessageLookupByLibrary.simpleMessage("Chỉnh sửa vị trí"),
         "editLocationTagTitle":
             MessageLookupByLibrary.simpleMessage("Chỉnh sửa vị trí"),
         "editPerson": MessageLookupByLibrary.simpleMessage("Chỉnh sửa người"),
+        "editTime": MessageLookupByLibrary.simpleMessage("Chỉnh sửa thời gian"),
         "editsSaved":
             MessageLookupByLibrary.simpleMessage("Chỉnh sửa đã được lưu"),
         "editsToLocationWillOnlyBeSeenWithinEnte":
             MessageLookupByLibrary.simpleMessage(
-                "Các chỉnh sửa cho vị trí sẽ chỉ được thấy trong Ente"),
+                "Các chỉnh sửa vị trí sẽ chỉ thấy được trong Ente"),
         "eligible": MessageLookupByLibrary.simpleMessage("đủ điều kiện"),
         "email": MessageLookupByLibrary.simpleMessage("Email"),
         "emailAlreadyRegistered":
-            MessageLookupByLibrary.simpleMessage("Email đã được đăng kí."),
+            MessageLookupByLibrary.simpleMessage("Email đã được đăng ký."),
         "emailChangedTo": m29,
+        "emailDoesNotHaveEnteAccount": m30,
         "emailNoEnteAccount": m31,
         "emailNotRegistered":
-            MessageLookupByLibrary.simpleMessage("Email chưa được đăng kí."),
+            MessageLookupByLibrary.simpleMessage("Email chưa được đăng ký."),
         "emailVerificationToggle":
             MessageLookupByLibrary.simpleMessage("Xác minh email"),
         "emailYourLogs":
-            MessageLookupByLibrary.simpleMessage("Gửi nhật ký qua email"),
+            MessageLookupByLibrary.simpleMessage("Gửi log qua email"),
+        "embracingThem": m32,
         "emergencyContacts":
             MessageLookupByLibrary.simpleMessage("Liên hệ khẩn cấp"),
-        "empty": MessageLookupByLibrary.simpleMessage("Rỗng"),
+        "empty": MessageLookupByLibrary.simpleMessage("Xóa sạch"),
         "emptyTrash":
-            MessageLookupByLibrary.simpleMessage("Làm rỗng thùng rác?"),
+            MessageLookupByLibrary.simpleMessage("Xóa sạch thùng rác?"),
         "enable": MessageLookupByLibrary.simpleMessage("Bật"),
         "enableMLIndexingDesc": MessageLookupByLibrary.simpleMessage(
-            "Ente hỗ trợ học máy trên thiết bị cho nhận diện khuôn mặt, tìm kiếm ma thuật và các tính năng tìm kiếm nâng cao khác"),
+            "Ente hỗ trợ học máy trên-thiết-bị nhằm nhận diện khuôn mặt, tìm kiếm vi diệu và các tính năng tìm kiếm nâng cao khác"),
         "enableMachineLearningBanner": MessageLookupByLibrary.simpleMessage(
-            "Bật học máy cho tìm kiếm ma thuật và nhận diện khuôn mặt"),
+            "Bật học máy để tìm kiếm vi diệu và nhận diện khuôn mặt"),
         "enableMaps": MessageLookupByLibrary.simpleMessage("Kích hoạt Bản đồ"),
         "enableMapsDesc": MessageLookupByLibrary.simpleMessage(
-            "Điều này sẽ hiển thị ảnh của bạn trên bản đồ thế giới.\n\nBản đồ này được lưu trữ bởi Open Street Map, và vị trí chính xác của ảnh của bạn sẽ không bao giờ được chia sẻ.\n\nBạn có thể vô hiệu hóa tính năng này bất cứ lúc nào từ Cài đặt."),
+            "Ảnh của bạn sẽ hiển thị trên bản đồ thế giới.\n\nBản đồ được lưu trữ bởi OpenStreetMap, và vị trí chính xác ảnh của bạn không bao giờ được chia sẻ.\n\nBạn có thể tắt tính năng này bất cứ lúc nào từ Cài đặt."),
         "enabled": MessageLookupByLibrary.simpleMessage("Đã bật"),
         "encryptingBackup":
             MessageLookupByLibrary.simpleMessage("Đang mã hóa sao lưu..."),
@@ -794,28 +954,28 @@ class MessageLookup extends MessageLookupByLibrary {
             "Mã hóa đầu cuối theo mặc định"),
         "enteCanEncryptAndPreserveFilesOnlyIfYouGrant":
             MessageLookupByLibrary.simpleMessage(
-                "Ente có thể mã hóa và lưu giữ tệp chỉ nếu bạn cấp quyền truy cập cho chúng"),
+                "Ente chỉ có thể mã hóa và lưu giữ tệp nếu bạn cấp quyền truy cập chúng"),
         "entePhotosPerm": MessageLookupByLibrary.simpleMessage(
             "Ente <i>cần quyền để</i> lưu giữ ảnh của bạn"),
         "enteSubscriptionPitch": MessageLookupByLibrary.simpleMessage(
-            "Ente lưu giữ kỷ niệm của bạn, vì vậy chúng luôn có sẵn cho bạn, ngay cả khi bạn mất thiết bị."),
+            "Ente lưu giữ kỷ niệm của bạn, vì vậy chúng luôn có sẵn, ngay cả khi bạn mất thiết bị."),
         "enteSubscriptionShareWithFamily": MessageLookupByLibrary.simpleMessage(
-            "Gia đình bạn cũng có thể được thêm vào gói của bạn."),
+            "Bạn có thể thêm gia đình vào gói của mình."),
         "enterAlbumName":
             MessageLookupByLibrary.simpleMessage("Nhập tên album"),
         "enterCode": MessageLookupByLibrary.simpleMessage("Nhập mã"),
         "enterCodeDescription": MessageLookupByLibrary.simpleMessage(
-            "Nhập mã do bạn bè cung cấp để nhận lưu trữ miễn phí cho cả hai bạn"),
+            "Nhập mã do bạn bè cung cấp để nhận thêm dung lượng miễn phí cho cả hai"),
         "enterDateOfBirth":
             MessageLookupByLibrary.simpleMessage("Sinh nhật (tùy chọn)"),
         "enterEmail": MessageLookupByLibrary.simpleMessage("Nhập email"),
         "enterFileName": MessageLookupByLibrary.simpleMessage("Nhập tên tệp"),
         "enterName": MessageLookupByLibrary.simpleMessage("Nhập tên"),
         "enterNewPasswordToEncrypt": MessageLookupByLibrary.simpleMessage(
-            "Nhập mật khẩu mới mà chúng tôi có thể sử dụng để mã hóa dữ liệu của bạn"),
+            "Vui lòng nhập một mật khẩu mới để mã hóa dữ liệu của bạn"),
         "enterPassword": MessageLookupByLibrary.simpleMessage("Nhập mật khẩu"),
         "enterPasswordToEncrypt": MessageLookupByLibrary.simpleMessage(
-            "Nhập mật khẩu mà chúng tôi có thể sử dụng để mã hóa dữ liệu của bạn"),
+            "Vui lòng nhập một mật khẩu dùng để mã hóa dữ liệu của bạn"),
         "enterPersonName":
             MessageLookupByLibrary.simpleMessage("Nhập tên người"),
         "enterPin": MessageLookupByLibrary.simpleMessage("Nhập PIN"),
@@ -823,23 +983,25 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Nhập mã giới thiệu"),
         "enterThe6digitCodeFromnyourAuthenticatorApp":
             MessageLookupByLibrary.simpleMessage(
-                "Nhập mã 6 chữ số từ\ntới ứng dụng xác thực của bạn"),
+                "Nhập mã 6 chữ số từ\nứng dụng xác thực của bạn"),
         "enterValidEmail": MessageLookupByLibrary.simpleMessage(
             "Vui lòng nhập một địa chỉ email hợp lệ."),
         "enterYourEmailAddress":
             MessageLookupByLibrary.simpleMessage("Nhập địa chỉ email của bạn"),
+        "enterYourNewEmailAddress": MessageLookupByLibrary.simpleMessage(
+            "Nhập địa chỉ email mới của bạn"),
         "enterYourPassword":
             MessageLookupByLibrary.simpleMessage("Nhập mật khẩu của bạn"),
         "enterYourRecoveryKey":
-            MessageLookupByLibrary.simpleMessage("Nhập khóa khôi phục của bạn"),
+            MessageLookupByLibrary.simpleMessage("Nhập mã khôi phục của bạn"),
         "error": MessageLookupByLibrary.simpleMessage("Lỗi"),
         "everywhere": MessageLookupByLibrary.simpleMessage("mọi nơi"),
-        "exif": MessageLookupByLibrary.simpleMessage("EXIF"),
+        "exif": MessageLookupByLibrary.simpleMessage("Exif"),
         "existingUser":
             MessageLookupByLibrary.simpleMessage("Người dùng hiện tại"),
         "expiredLinkInfo": MessageLookupByLibrary.simpleMessage(
             "Liên kết này đã hết hạn. Vui lòng chọn thời gian hết hạn mới hoặc tắt tính năng hết hạn liên kết."),
-        "exportLogs": MessageLookupByLibrary.simpleMessage("Xuất nhật ký"),
+        "exportLogs": MessageLookupByLibrary.simpleMessage("Xuất file log"),
         "exportYourData":
             MessageLookupByLibrary.simpleMessage("Xuất dữ liệu của bạn"),
         "extraPhotosFound":
@@ -850,6 +1012,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "faceRecognition":
             MessageLookupByLibrary.simpleMessage("Nhận diện khuôn mặt"),
         "faces": MessageLookupByLibrary.simpleMessage("Khuôn mặt"),
+        "failed": MessageLookupByLibrary.simpleMessage("Không thành công"),
         "failedToApplyCode":
             MessageLookupByLibrary.simpleMessage("Không thể áp dụng mã"),
         "failedToCancel":
@@ -867,19 +1030,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "failedToPlayVideo":
             MessageLookupByLibrary.simpleMessage("Không thể phát video"),
         "failedToRefreshStripeSubscription":
-            MessageLookupByLibrary.simpleMessage("Không thể làm mới đăng ký"),
+            MessageLookupByLibrary.simpleMessage("Không thể làm mới gói"),
         "failedToRenew":
             MessageLookupByLibrary.simpleMessage("Gia hạn không thành công"),
         "failedToVerifyPaymentStatus": MessageLookupByLibrary.simpleMessage(
             "Không thể xác minh trạng thái thanh toán"),
         "familyPlanOverview": MessageLookupByLibrary.simpleMessage(
-            "Thêm 5 thành viên gia đình vào gói hiện tại của bạn mà không phải trả thêm phí.\n\nMỗi thành viên có không gian riêng tư của mình và không thể xem tệp của nhau trừ khi được chia sẻ.\n\nGói gia đình có sẵn cho khách hàng có đăng ký Ente trả phí.\n\nĐăng ký ngay để bắt đầu!"),
+            "Thêm 5 thành viên gia đình vào gói hiện tại của bạn mà không phải trả thêm phí.\n\nMỗi thành viên có không gian riêng tư của mình và không thể xem tệp của nhau trừ khi được chia sẻ.\n\nGói gia đình có sẵn cho người dùng Ente gói trả phí.\n\nĐăng ký ngay để bắt đầu!"),
         "familyPlanPortalTitle":
             MessageLookupByLibrary.simpleMessage("Gia đình"),
         "familyPlans": MessageLookupByLibrary.simpleMessage("Gói gia đình"),
         "faq": MessageLookupByLibrary.simpleMessage("Câu hỏi thường gặp"),
         "faqs": MessageLookupByLibrary.simpleMessage("Câu hỏi thường gặp"),
-        "favorite": MessageLookupByLibrary.simpleMessage("Yêu thích"),
+        "favorite": MessageLookupByLibrary.simpleMessage("Thích"),
+        "feastingWithThem": m34,
         "feedback": MessageLookupByLibrary.simpleMessage("Phản hồi"),
         "file": MessageLookupByLibrary.simpleMessage("Tệp"),
         "fileFailedToSaveToGallery": MessageLookupByLibrary.simpleMessage(
@@ -898,52 +1062,57 @@ class MessageLookup extends MessageLookupByLibrary {
         "filesDeleted": MessageLookupByLibrary.simpleMessage("Tệp đã bị xóa"),
         "filesSavedToGallery": MessageLookupByLibrary.simpleMessage(
             "Các tệp đã được lưu vào thư viện"),
-        "findPeopleByName": MessageLookupByLibrary.simpleMessage(
-            "Tìm người nhanh chóng theo tên"),
+        "findPeopleByName":
+            MessageLookupByLibrary.simpleMessage("Tìm nhanh người theo tên"),
         "findThemQuickly":
             MessageLookupByLibrary.simpleMessage("Tìm họ nhanh chóng"),
         "flip": MessageLookupByLibrary.simpleMessage("Lật"),
+        "food": MessageLookupByLibrary.simpleMessage("Ăn chơi"),
         "forYourMemories":
             MessageLookupByLibrary.simpleMessage("cho những kỷ niệm của bạn"),
         "forgotPassword": MessageLookupByLibrary.simpleMessage("Quên mật khẩu"),
         "foundFaces":
             MessageLookupByLibrary.simpleMessage("Đã tìm thấy khuôn mặt"),
         "freeStorageClaimed":
-            MessageLookupByLibrary.simpleMessage("Lưu trữ miễn phí đã yêu cầu"),
+            MessageLookupByLibrary.simpleMessage("Dung lượng miễn phí đã nhận"),
         "freeStorageOnReferralSuccess": m37,
         "freeStorageUsable": MessageLookupByLibrary.simpleMessage(
-            "Lưu trữ miễn phí có thể sử dụng"),
+            "Dung lượng miễn phí có thể dùng"),
         "freeTrial": MessageLookupByLibrary.simpleMessage("Dùng thử miễn phí"),
         "freeTrialValidTill": m38,
+        "freeUpAccessPostDelete": m39,
         "freeUpAmount": m40,
         "freeUpDeviceSpace": MessageLookupByLibrary.simpleMessage(
-            "Giải phóng không gian thiết bị"),
+            "Giải phóng dung lượng thiết bị"),
         "freeUpDeviceSpaceDesc": MessageLookupByLibrary.simpleMessage(
-            "Tiết kiệm không gian trên thiết bị của bạn bằng cách xóa các tệp đã được sao lưu."),
+            "Tiết kiệm dung lượng thiết bị của bạn bằng cách xóa các tệp đã được sao lưu."),
         "freeUpSpace":
-            MessageLookupByLibrary.simpleMessage("Giải phóng không gian"),
+            MessageLookupByLibrary.simpleMessage("Giải phóng dung lượng"),
         "freeUpSpaceSaving": m41,
         "gallery": MessageLookupByLibrary.simpleMessage("Thư viện"),
         "galleryMemoryLimitInfo": MessageLookupByLibrary.simpleMessage(
-            "Tối đa 1000 kỷ niệm được hiển thị trong thư viện"),
+            "Mỗi thư viện chứa tối đa 1000 ảnh"),
         "general": MessageLookupByLibrary.simpleMessage("Chung"),
         "generatingEncryptionKeys":
-            MessageLookupByLibrary.simpleMessage("Đang tạo khóa mã hóa..."),
+            MessageLookupByLibrary.simpleMessage("Đang mã hóa..."),
         "genericProgress": m42,
         "goToSettings": MessageLookupByLibrary.simpleMessage("Đi đến cài đặt"),
         "googlePlayId": MessageLookupByLibrary.simpleMessage("ID Google Play"),
         "grantFullAccessPrompt": MessageLookupByLibrary.simpleMessage(
             "Vui lòng cho phép truy cập vào tất cả ảnh trong ứng dụng Cài đặt"),
         "grantPermission": MessageLookupByLibrary.simpleMessage("Cấp quyền"),
+        "greenery": MessageLookupByLibrary.simpleMessage("Cây cối"),
         "groupNearbyPhotos":
-            MessageLookupByLibrary.simpleMessage("Nhóm ảnh gần đó"),
+            MessageLookupByLibrary.simpleMessage("Nhóm ảnh gần nhau"),
         "guestView": MessageLookupByLibrary.simpleMessage("Chế độ khách"),
         "guestViewEnablePreSteps": MessageLookupByLibrary.simpleMessage(
             "Để bật chế độ khách, vui lòng thiết lập mã khóa thiết bị hoặc khóa màn hình trong cài đặt hệ thống của bạn."),
+        "happyBirthday":
+            MessageLookupByLibrary.simpleMessage("Chúc mừng sinh nhật! 🥳"),
         "hearUsExplanation": MessageLookupByLibrary.simpleMessage(
-            "Chúng tôi không theo dõi cài đặt ứng dụng. Sẽ rất hữu ích nếu bạn cho chúng tôi biết bạn đã tìm thấy chúng ở đâu!"),
+            "Chúng tôi không theo dõi cài đặt ứng dụng, nên nếu bạn bật mí bạn tìm thấy chúng tôi từ đâu sẽ rất hữu ích!"),
         "hearUsWhereTitle": MessageLookupByLibrary.simpleMessage(
-            "Bạn đã nghe về Ente từ đâu? (tùy chọn)"),
+            "Bạn biết Ente từ đâu? (tùy chọn)"),
         "help": MessageLookupByLibrary.simpleMessage("Trợ giúp"),
         "hidden": MessageLookupByLibrary.simpleMessage("Ẩn"),
         "hide": MessageLookupByLibrary.simpleMessage("Ẩn"),
@@ -955,36 +1124,42 @@ class MessageLookup extends MessageLookupByLibrary {
         "hideSharedItemsFromHomeGallery": MessageLookupByLibrary.simpleMessage(
             "Ẩn các mục được chia sẻ khỏi thư viện chính"),
         "hiding": MessageLookupByLibrary.simpleMessage("Đang ẩn..."),
+        "hikingWithThem": m43,
         "hostedAtOsmFrance":
             MessageLookupByLibrary.simpleMessage("Được lưu trữ tại OSM Pháp"),
         "howItWorks": MessageLookupByLibrary.simpleMessage("Cách hoạt động"),
         "howToViewShareeVerificationID": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng yêu cầu họ nhấn giữ địa chỉ email của họ trên màn hình cài đặt, và xác minh rằng các ID trên cả hai thiết bị khớp nhau."),
+            "Hãy chỉ họ nhấn giữ địa chỉ email của họ trên màn hình cài đặt, và xác minh rằng ID trên cả hai thiết bị khớp nhau."),
         "iOSGoToSettingsDescription": MessageLookupByLibrary.simpleMessage(
-            "Xác thực sinh trắc học chưa được thiết lập trên thiết bị của bạn. Vui lòng kích hoạt Touch ID hoặc Face ID trên điện thoại của bạn."),
+            "Xác thực sinh trắc học chưa được thiết lập trên thiết bị của bạn. Vui lòng kích hoạt Touch ID hoặc Face ID."),
         "iOSLockOut": MessageLookupByLibrary.simpleMessage(
             "Xác thực sinh trắc học đã bị vô hiệu hóa. Vui lòng khóa và mở khóa màn hình của bạn để kích hoạt lại."),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("OK"),
+        "ignore": MessageLookupByLibrary.simpleMessage("Bỏ qua"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("Bỏ qua"),
         "ignored": MessageLookupByLibrary.simpleMessage("bỏ qua"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
             "Một số tệp trong album này bị bỏ qua khi tải lên vì chúng đã bị xóa trước đó từ Ente."),
         "imageNotAnalyzed": MessageLookupByLibrary.simpleMessage(
             "Hình ảnh chưa được phân tích"),
-        "immediately": MessageLookupByLibrary.simpleMessage("Ngay lập tức"),
+        "immediately": MessageLookupByLibrary.simpleMessage("Lập tức"),
         "importing": MessageLookupByLibrary.simpleMessage("Đang nhập...."),
         "incorrectCode":
             MessageLookupByLibrary.simpleMessage("Mã không chính xác"),
         "incorrectPasswordTitle":
             MessageLookupByLibrary.simpleMessage("Mật khẩu không chính xác"),
         "incorrectRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục không chính xác"),
+            "Mã khôi phục không chính xác"),
         "incorrectRecoveryKeyBody": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục bạn nhập không chính xác"),
+            "Mã khôi phục bạn nhập không chính xác"),
         "incorrectRecoveryKeyTitle": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục không chính xác"),
+            "Mã khôi phục không chính xác"),
         "indexedItems":
             MessageLookupByLibrary.simpleMessage("Các mục đã lập chỉ mục"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "Lập chỉ mục bị tạm dừng. Nó sẽ tự động tiếp tục khi thiết bị đã sẵn sàng. Thiết bị được coi là sẵn sàng khi mức pin, tình trạng pin và trạng thái nhiệt độ nằm trong phạm vi tốt."),
+        "ineligible":
+            MessageLookupByLibrary.simpleMessage("Không đủ điều kiện"),
         "info": MessageLookupByLibrary.simpleMessage("Thông tin"),
         "insecureDevice":
             MessageLookupByLibrary.simpleMessage("Thiết bị không an toàn"),
@@ -996,59 +1171,68 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Điểm cuối không hợp lệ"),
         "invalidEndpointMessage": MessageLookupByLibrary.simpleMessage(
             "Xin lỗi, điểm cuối bạn nhập không hợp lệ. Vui lòng nhập một điểm cuối hợp lệ và thử lại."),
-        "invalidKey": MessageLookupByLibrary.simpleMessage("Khóa không hợp lệ"),
+        "invalidKey": MessageLookupByLibrary.simpleMessage("Mã không hợp lệ"),
         "invalidRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục bạn nhập không hợp lệ. Vui lòng đảm bảo nó chứa 24 từ, và kiểm tra chính tả của từng từ.\n\nNếu bạn đã nhập mã khôi phục cũ, hãy đảm bảo nó dài 64 ký tự, và kiểm tra từng ký tự."),
+            "Mã khôi phục không hợp lệ. Vui lòng đảm bảo nó chứa 24 từ, và đúng chính tả từng từ.\n\nNếu bạn nhập loại mã khôi phục cũ, hãy đảm bảo nó dài 64 ký tự, và kiểm tra từng ký tự."),
         "invite": MessageLookupByLibrary.simpleMessage("Mời"),
-        "inviteToEnte": MessageLookupByLibrary.simpleMessage("Mời đến Ente"),
+        "inviteToEnte":
+            MessageLookupByLibrary.simpleMessage("Mời sử dụng Ente"),
         "inviteYourFriends":
             MessageLookupByLibrary.simpleMessage("Mời bạn bè của bạn"),
         "inviteYourFriendsToEnte":
-            MessageLookupByLibrary.simpleMessage("Mời bạn bè của bạn đến Ente"),
+            MessageLookupByLibrary.simpleMessage("Mời bạn bè dùng Ente"),
         "itLooksLikeSomethingWentWrongPleaseRetryAfterSome":
             MessageLookupByLibrary.simpleMessage(
                 "Có vẻ như đã xảy ra sự cố. Vui lòng thử lại sau một thời gian. Nếu lỗi vẫn tiếp diễn, vui lòng liên hệ với đội ngũ hỗ trợ của chúng tôi."),
         "itemCount": m44,
         "itemsShowTheNumberOfDaysRemainingBeforePermanentDeletion":
             MessageLookupByLibrary.simpleMessage(
-                "Các mục cho biết số ngày còn lại trước khi xóa vĩnh viễn"),
+                "Các mục hiện số ngày còn lại trước khi xóa vĩnh viễn"),
         "itemsWillBeRemovedFromAlbum": MessageLookupByLibrary.simpleMessage(
             "Các mục đã chọn sẽ bị xóa khỏi album này"),
         "join": MessageLookupByLibrary.simpleMessage("Tham gia"),
         "joinAlbum": MessageLookupByLibrary.simpleMessage("Tham gia album"),
+        "joinAlbumConfirmationDialogBody": MessageLookupByLibrary.simpleMessage(
+            "Tham gia một album sẽ khiến email của bạn hiển thị với những người tham gia khác."),
         "joinAlbumSubtext":
             MessageLookupByLibrary.simpleMessage("để xem và thêm ảnh của bạn"),
-        "joinAlbumSubtextViewer":
-            MessageLookupByLibrary.simpleMessage("thêm vào album được chia sẻ"),
+        "joinAlbumSubtextViewer": MessageLookupByLibrary.simpleMessage(
+            "để thêm vào album được chia sẻ"),
         "joinDiscord": MessageLookupByLibrary.simpleMessage("Tham gia Discord"),
         "keepPhotos": MessageLookupByLibrary.simpleMessage("Giữ ảnh"),
         "kiloMeterUnit": MessageLookupByLibrary.simpleMessage("km"),
         "kindlyHelpUsWithThisInformation": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng giúp chúng tôi với thông tin này"),
+            "Mong bạn giúp chúng tôi thông tin này"),
         "language": MessageLookupByLibrary.simpleMessage("Ngôn ngữ"),
-        "lastUpdated":
-            MessageLookupByLibrary.simpleMessage("Cập nhật lần cuối"),
+        "lastTimeWithThem": m45,
+        "lastUpdated": MessageLookupByLibrary.simpleMessage("Mới cập nhật"),
+        "lastYearsTrip":
+            MessageLookupByLibrary.simpleMessage("Phượt năm ngoái"),
         "leave": MessageLookupByLibrary.simpleMessage("Rời"),
         "leaveAlbum": MessageLookupByLibrary.simpleMessage("Rời khỏi album"),
         "leaveFamily":
             MessageLookupByLibrary.simpleMessage("Rời khỏi gia đình"),
         "leaveSharedAlbum":
-            MessageLookupByLibrary.simpleMessage("Rời khỏi album chia sẻ?"),
+            MessageLookupByLibrary.simpleMessage("Rời album được chia sẻ?"),
         "left": MessageLookupByLibrary.simpleMessage("Trái"),
         "legacy": MessageLookupByLibrary.simpleMessage("Thừa kế"),
         "legacyAccounts":
             MessageLookupByLibrary.simpleMessage("Tài khoản thừa kế"),
         "legacyInvite": m46,
         "legacyPageDesc": MessageLookupByLibrary.simpleMessage(
-            "Thừa kế cho phép các liên hệ tin cậy truy cập tài khoản của bạn khi bạn không hoạt động."),
+            "Thừa kế cho phép các liên hệ tin cậy truy cập tài khoản của bạn khi bạn qua đời."),
         "legacyPageDesc2": MessageLookupByLibrary.simpleMessage(
             "Các liên hệ tin cậy có thể khởi động quá trình khôi phục tài khoản, và nếu không bị chặn trong vòng 30 ngày, có thể đặt lại mật khẩu và truy cập tài khoản của bạn."),
-        "light": MessageLookupByLibrary.simpleMessage("Ánh sáng"),
+        "light": MessageLookupByLibrary.simpleMessage("Độ sáng"),
         "lightTheme": MessageLookupByLibrary.simpleMessage("Sáng"),
+        "link": MessageLookupByLibrary.simpleMessage("Liên kết"),
         "linkCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
-            "Liên kết đã được sao chép vào clipboard"),
+            "Liên kết đã được sao chép vào bộ nhớ tạm"),
         "linkDeviceLimit":
             MessageLookupByLibrary.simpleMessage("Giới hạn thiết bị"),
+        "linkEmail": MessageLookupByLibrary.simpleMessage("Liên kết email"),
+        "linkEmailToContactBannerCaption":
+            MessageLookupByLibrary.simpleMessage("để chia sẻ nhanh hơn"),
         "linkEnabled": MessageLookupByLibrary.simpleMessage("Đã bật"),
         "linkExpired": MessageLookupByLibrary.simpleMessage("Hết hạn"),
         "linkExpiresOn": m47,
@@ -1057,25 +1241,32 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Liên kết đã hết hạn"),
         "linkNeverExpires":
             MessageLookupByLibrary.simpleMessage("Không bao giờ"),
-        "livePhotos": MessageLookupByLibrary.simpleMessage("Ảnh trực tiếp"),
+        "linkPerson": MessageLookupByLibrary.simpleMessage("Liên kết người"),
+        "linkPersonCaption": MessageLookupByLibrary.simpleMessage(
+            "để trải nghiệm chia sẻ tốt hơn"),
+        "linkPersonToEmail": m48,
+        "linkPersonToEmailConfirmation": m49,
+        "livePhotos": MessageLookupByLibrary.simpleMessage("Ảnh Live"),
         "loadMessage1": MessageLookupByLibrary.simpleMessage(
-            "Bạn có thể chia sẻ đăng ký của mình với gia đình"),
+            "Bạn có thể chia sẻ gói của mình với gia đình"),
+        "loadMessage2": MessageLookupByLibrary.simpleMessage(
+            "Chúng tôi đã lưu giữ hơn 200 triệu kỷ niệm cho đến hiện tại"),
         "loadMessage3": MessageLookupByLibrary.simpleMessage(
-            "Chúng tôi giữ 3 bản sao dữ liệu của bạn, một trong nơi trú ẩn dưới lòng đất"),
+            "Chúng tôi giữ 3 bản sao dữ liệu của bạn, một cái lưu ở hầm trú ẩn hạt nhân"),
         "loadMessage4": MessageLookupByLibrary.simpleMessage(
             "Tất cả các ứng dụng của chúng tôi đều là mã nguồn mở"),
         "loadMessage5": MessageLookupByLibrary.simpleMessage(
-            "Mã nguồn và mật mã của chúng tôi đã được kiểm toán bên ngoài"),
+            "Mã nguồn và mã hóa của chúng tôi đã được kiểm nghiệm ngoại bộ"),
         "loadMessage6": MessageLookupByLibrary.simpleMessage(
             "Bạn có thể chia sẻ liên kết đến album của mình với những người thân yêu"),
         "loadMessage7": MessageLookupByLibrary.simpleMessage(
-            "Các ứng dụng di động của chúng tôi chạy ngầm để mã hóa và sao lưu bất kỳ ảnh mới nào bạn chụp"),
+            "Các ứng dụng di động của chúng tôi chạy ngầm để mã hóa và sao lưu bất kỳ ảnh nào bạn mới chụp"),
         "loadMessage8": MessageLookupByLibrary.simpleMessage(
             "web.ente.io có một trình tải lên mượt mà"),
         "loadMessage9": MessageLookupByLibrary.simpleMessage(
-            "Chúng tôi sử dụng Xchacha20Poly1305 để mã hóa dữ liệu của bạn một cách an toàn"),
+            "Chúng tôi sử dụng Xchacha20Poly1305 để mã hóa dữ liệu của bạn"),
         "loadingExifData":
-            MessageLookupByLibrary.simpleMessage("Đang tải dữ liệu EXIF..."),
+            MessageLookupByLibrary.simpleMessage("Đang tải thông số Exif..."),
         "loadingGallery":
             MessageLookupByLibrary.simpleMessage("Đang tải thư viện..."),
         "loadingMessage":
@@ -1087,14 +1278,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "localGallery": MessageLookupByLibrary.simpleMessage("Thư viện cục bộ"),
         "localIndexing": MessageLookupByLibrary.simpleMessage("Chỉ mục cục bộ"),
         "localSyncErrorMessage": MessageLookupByLibrary.simpleMessage(
-            "Có vẻ như có điều gì đó không ổn vì đồng bộ hóa ảnh cục bộ đang mất nhiều thời gian hơn mong đợi. Vui lòng liên hệ với đội ngũ hỗ trợ của chúng tôi"),
+            "Có vẻ như có điều gì đó không ổn vì đồng bộ hóa ảnh cục bộ đang mất nhiều thời gian hơn mong đợi. Vui lòng liên hệ đội ngũ hỗ trợ của chúng tôi"),
         "location": MessageLookupByLibrary.simpleMessage("Vị trí"),
         "locationName": MessageLookupByLibrary.simpleMessage("Tên vị trí"),
         "locationTagFeatureDescription": MessageLookupByLibrary.simpleMessage(
-            "Một thẻ vị trí nhóm tất cả các ảnh được chụp trong một bán kính nào đó của một bức ảnh"),
+            "Một thẻ vị trí sẽ chia nhóm tất cả các ảnh được chụp trong một bán kính nào đó của một bức ảnh"),
         "locations": MessageLookupByLibrary.simpleMessage("Vị trí"),
         "lockButtonLabel": MessageLookupByLibrary.simpleMessage("Khóa"),
-        "lockscreen": MessageLookupByLibrary.simpleMessage("Màn hình khóa"),
+        "lockscreen": MessageLookupByLibrary.simpleMessage("Khóa màn hình"),
         "logInLabel": MessageLookupByLibrary.simpleMessage("Đăng nhập"),
         "loggingOut": MessageLookupByLibrary.simpleMessage("Đang đăng xuất..."),
         "loginSessionExpired":
@@ -1102,78 +1293,89 @@ class MessageLookup extends MessageLookupByLibrary {
         "loginSessionExpiredDetails": MessageLookupByLibrary.simpleMessage(
             "Phiên đăng nhập của bạn đã hết hạn. Vui lòng đăng nhập lại."),
         "loginTerms": MessageLookupByLibrary.simpleMessage(
-            "Bằng cách nhấp vào đăng nhập, tôi đồng ý với <u-terms>các điều khoản dịch vụ</u-terms> và <u-policy>chính sách bảo mật</u-policy>"),
+            "Nhấn vào đăng nhập, tôi đồng ý <u-terms>điều khoản</u-terms> và <u-policy>chính sách bảo mật</u-policy>"),
         "loginWithTOTP":
-            MessageLookupByLibrary.simpleMessage("Login with TOTP"),
+            MessageLookupByLibrary.simpleMessage("Đăng nhập bằng TOTP"),
         "logout": MessageLookupByLibrary.simpleMessage("Đăng xuất"),
         "logsDialogBody": MessageLookupByLibrary.simpleMessage(
-            "Điều này sẽ gửi nhật ký để giúp chúng tôi gỡ lỗi vấn đề của bạn. Vui lòng lưu ý rằng tên tệp sẽ được bao gồm để giúp theo dõi các vấn đề với các tệp cụ thể."),
+            "Gửi file log để chúng tôi có thể phân tích lỗi mà bạn gặp. Lưu ý rằng, trong nhật ký lỗi sẽ bao gồm tên các tệp để giúp theo dõi vấn đề với từng tệp cụ thể."),
         "longPressAnEmailToVerifyEndToEndEncryption":
             MessageLookupByLibrary.simpleMessage(
                 "Nhấn giữ một email để xác minh mã hóa đầu cuối."),
         "longpressOnAnItemToViewInFullscreen":
             MessageLookupByLibrary.simpleMessage(
-                "Nhấn và giữ vào một mục để xem toàn màn hình"),
+                "Nhấn giữ một mục để xem toàn màn hình"),
+        "lookBackOnYourMemories":
+            MessageLookupByLibrary.simpleMessage("Xem lại kỷ niệm của bạn 🌄"),
         "loopVideoOff":
             MessageLookupByLibrary.simpleMessage("Dừng phát video lặp lại"),
         "loopVideoOn":
             MessageLookupByLibrary.simpleMessage("Phát video lặp lại"),
         "lostDevice": MessageLookupByLibrary.simpleMessage("Mất thiết bị?"),
         "machineLearning": MessageLookupByLibrary.simpleMessage("Học máy"),
-        "magicSearch":
-            MessageLookupByLibrary.simpleMessage("Tìm kiếm ma thuật"),
+        "magicSearch": MessageLookupByLibrary.simpleMessage("Tìm kiếm vi diệu"),
         "magicSearchHint": MessageLookupByLibrary.simpleMessage(
-            "Tìm kiếm ma thuật cho phép tìm kiếm ảnh theo nội dung của chúng, ví dụ: \'hoa\', \'xe hơi đỏ\', \'tài liệu nhận dạng\'"),
+            "Tìm kiếm vi diệu cho phép tìm ảnh theo nội dung của chúng, ví dụ: \'xe hơi\', \'xe hơi đỏ\', \'Ferrari\'"),
         "manage": MessageLookupByLibrary.simpleMessage("Quản lý"),
         "manageDeviceStorage": MessageLookupByLibrary.simpleMessage(
             "Quản lý bộ nhớ đệm của thiết bị"),
         "manageDeviceStorageDesc": MessageLookupByLibrary.simpleMessage(
-            "Review and clear local cache storage."),
+            "Xem và xóa bộ nhớ đệm trên thiết bị."),
         "manageFamily":
             MessageLookupByLibrary.simpleMessage("Quản lý gia đình"),
         "manageLink": MessageLookupByLibrary.simpleMessage("Quản lý liên kết"),
         "manageParticipants": MessageLookupByLibrary.simpleMessage("Quản lý"),
         "manageSubscription":
-            MessageLookupByLibrary.simpleMessage("Quản lý đăng ký"),
+            MessageLookupByLibrary.simpleMessage("Quản lý gói"),
         "manualPairDesc": MessageLookupByLibrary.simpleMessage(
             "Ghép nối với PIN hoạt động với bất kỳ màn hình nào bạn muốn xem album của mình."),
-        "map": MessageLookupByLibrary.simpleMessage("Map"),
+        "map": MessageLookupByLibrary.simpleMessage("Bản đồ"),
         "maps": MessageLookupByLibrary.simpleMessage("Bản đồ"),
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
-        "merchandise": MessageLookupByLibrary.simpleMessage("Merchandise"),
+        "me": MessageLookupByLibrary.simpleMessage("Tôi"),
+        "memories": MessageLookupByLibrary.simpleMessage("Kỷ niệm"),
+        "memoriesWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Chọn những loại kỷ niệm bạn muốn thấy trên màn hình chính của mình."),
+        "memoryCount": m50,
+        "merchandise": MessageLookupByLibrary.simpleMessage("Vật phẩm"),
+        "merge": MessageLookupByLibrary.simpleMessage("Hợp nhất"),
         "mergeWithExisting":
             MessageLookupByLibrary.simpleMessage("Hợp nhất với người đã có"),
         "mergedPhotos": MessageLookupByLibrary.simpleMessage("Hợp nhất ảnh"),
-        "mlConsent": MessageLookupByLibrary.simpleMessage("Kích hoạt học máy"),
+        "mlConsent": MessageLookupByLibrary.simpleMessage("Bật học máy"),
         "mlConsentConfirmation": MessageLookupByLibrary.simpleMessage(
-            "Tôi hiểu và muốn kích hoạt học máy"),
+            "Tôi hiểu và muốn bật học máy"),
         "mlConsentDescription": MessageLookupByLibrary.simpleMessage(
-            "Nếu bạn kích hoạt học máy, Ente sẽ trích xuất thông tin như hình dạng khuôn mặt từ các tệp, bao gồm cả những tệp được chia sẻ với bạn.\n\nĐiều này sẽ xảy ra trên thiết bị của bạn, và bất kỳ thông tin sinh trắc học nào được tạo ra sẽ được mã hóa đầu cuối."),
+            "Nếu bạn bật học máy, Ente sẽ trích xuất thông tin như hình dạng khuôn mặt từ các tệp, gồm cả những tệp mà bạn được chia sẻ.\n\nViệc này sẽ diễn ra trên thiết bị của bạn, với mọi thông tin sinh trắc học tạo ra đều được mã hóa đầu cuối."),
         "mlConsentPrivacy": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng nhấp vào đây để biết thêm chi tiết về tính năng này trong chính sách quyền riêng tư của chúng tôi"),
-        "mlConsentTitle":
-            MessageLookupByLibrary.simpleMessage("Kích hoạt học máy?"),
+            "Vui lòng nhấn vào đây để biết thêm chi tiết về tính năng này trong chính sách quyền riêng tư của chúng tôi"),
+        "mlConsentTitle": MessageLookupByLibrary.simpleMessage("Bật học máy?"),
         "mlIndexingDescription": MessageLookupByLibrary.simpleMessage(
-            "Xin lưu ý rằng việc học máy sẽ dẫn đến việc sử dụng băng thông và pin cao hơn cho đến khi tất cả các mục được lập chỉ mục. Hãy xem xét việc sử dụng ứng dụng máy tính để bàn để lập chỉ mục nhanh hơn, tất cả kết quả sẽ được đồng bộ hóa tự động."),
+            "Lưu ý rằng việc học máy sẽ khiến tốn băng thông và pin nhiều hơn cho đến khi tất cả mục được lập chỉ mục. Hãy sử dụng ứng dụng máy tính để lập chỉ mục nhanh hơn. Mọi kết quả sẽ được tự động đồng bộ."),
         "mobileWebDesktop":
             MessageLookupByLibrary.simpleMessage("Di động, Web, Desktop"),
-        "moderateStrength": MessageLookupByLibrary.simpleMessage("Vừa phải"),
+        "moderateStrength": MessageLookupByLibrary.simpleMessage("Trung bình"),
         "modifyYourQueryOrTrySearchingFor":
             MessageLookupByLibrary.simpleMessage(
-                "Chỉnh sửa truy vấn của bạn, hoặc thử tìm kiếm cho"),
+                "Chỉnh sửa truy vấn của bạn, hoặc thử tìm kiếm"),
         "moments": MessageLookupByLibrary.simpleMessage("Khoảnh khắc"),
         "month": MessageLookupByLibrary.simpleMessage("tháng"),
-        "monthly": MessageLookupByLibrary.simpleMessage("Hàng tháng"),
+        "monthly": MessageLookupByLibrary.simpleMessage("Theo tháng"),
+        "moon": MessageLookupByLibrary.simpleMessage("Ánh trăng"),
         "moreDetails": MessageLookupByLibrary.simpleMessage("Thêm chi tiết"),
         "mostRecent": MessageLookupByLibrary.simpleMessage("Mới nhất"),
         "mostRelevant": MessageLookupByLibrary.simpleMessage("Liên quan nhất"),
+        "mountains": MessageLookupByLibrary.simpleMessage("Đồi núi"),
+        "moveItem": m51,
+        "moveSelectedPhotosToOneDate": MessageLookupByLibrary.simpleMessage(
+            "Di chuyển ảnh đã chọn đến một ngày"),
         "moveToAlbum": MessageLookupByLibrary.simpleMessage("Chuyển đến album"),
         "moveToHiddenAlbum":
             MessageLookupByLibrary.simpleMessage("Di chuyển đến album ẩn"),
         "movedSuccessfullyTo": m52,
         "movedToTrash":
-            MessageLookupByLibrary.simpleMessage("Đã chuyển vào thùng rác"),
+            MessageLookupByLibrary.simpleMessage("Đã cho vào thùng rác"),
         "movingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
             "Đang di chuyển tệp vào album..."),
         "name": MessageLookupByLibrary.simpleMessage("Tên"),
@@ -1187,21 +1389,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "newAlbum": MessageLookupByLibrary.simpleMessage("Album mới"),
         "newLocation": MessageLookupByLibrary.simpleMessage("Vị trí mới"),
         "newPerson": MessageLookupByLibrary.simpleMessage("Người mới"),
-        "newToEnte": MessageLookupByLibrary.simpleMessage("Mới đến Ente"),
+        "newPhotosEmoji": MessageLookupByLibrary.simpleMessage(" mới 📸"),
+        "newRange": MessageLookupByLibrary.simpleMessage("Phạm vi mới"),
+        "newToEnte": MessageLookupByLibrary.simpleMessage("Mới dùng Ente"),
         "newest": MessageLookupByLibrary.simpleMessage("Mới nhất"),
         "next": MessageLookupByLibrary.simpleMessage("Tiếp theo"),
         "no": MessageLookupByLibrary.simpleMessage("Không"),
-        "noAlbumsSharedByYouYet": MessageLookupByLibrary.simpleMessage(
-            "Chưa có album nào được chia sẻ bởi bạn"),
+        "noAlbumsSharedByYouYet":
+            MessageLookupByLibrary.simpleMessage("Bạn chưa chia sẻ album nào"),
         "noDeviceFound":
             MessageLookupByLibrary.simpleMessage("Không tìm thấy thiết bị"),
         "noDeviceLimit": MessageLookupByLibrary.simpleMessage("Không có"),
         "noDeviceThatCanBeDeleted": MessageLookupByLibrary.simpleMessage(
-            "Bạn không có tệp nào trên thiết bị này có thể bị xóa"),
+            "Bạn không có tệp nào có thể xóa trên thiết bị này"),
         "noDuplicates":
             MessageLookupByLibrary.simpleMessage("✨ Không có trùng lặp"),
+        "noEnteAccountExclamation":
+            MessageLookupByLibrary.simpleMessage("Chưa có tài khoản Ente!"),
         "noExifData":
-            MessageLookupByLibrary.simpleMessage("Không có dữ liệu EXIF"),
+            MessageLookupByLibrary.simpleMessage("Không có thông số Exif"),
         "noFacesFound":
             MessageLookupByLibrary.simpleMessage("Không tìm thấy khuôn mặt"),
         "noHiddenPhotosOrVideos":
@@ -1218,9 +1424,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "noQuickLinksSelected": MessageLookupByLibrary.simpleMessage(
             "Không có liên kết nhanh nào được chọn"),
         "noRecoveryKey":
-            MessageLookupByLibrary.simpleMessage("Không có khóa khôi phục?"),
+            MessageLookupByLibrary.simpleMessage("Không có mã khôi phục?"),
         "noRecoveryKeyNoDecryption": MessageLookupByLibrary.simpleMessage(
-            "Do tính chất của giao thức mã hóa đầu cuối của chúng tôi, dữ liệu của bạn không thể được giải mã mà không có mật khẩu hoặc khóa khôi phục của bạn"),
+            "Do tính chất của giao thức mã hóa đầu cuối, không thể giải mã dữ liệu của bạn mà không có mật khẩu hoặc mã khôi phục"),
         "noResults": MessageLookupByLibrary.simpleMessage("Không có kết quả"),
         "noResultsFound":
             MessageLookupByLibrary.simpleMessage("Không tìm thấy kết quả"),
@@ -1228,22 +1434,31 @@ class MessageLookup extends MessageLookupByLibrary {
         "noSystemLockFound": MessageLookupByLibrary.simpleMessage(
             "Không tìm thấy khóa hệ thống"),
         "notPersonLabel": m54,
-        "nothingSharedWithYouYet": MessageLookupByLibrary.simpleMessage(
-            "Chưa có gì được chia sẻ với bạn"),
+        "notThisPerson":
+            MessageLookupByLibrary.simpleMessage("Không phải người này?"),
+        "nothingSharedWithYouYet":
+            MessageLookupByLibrary.simpleMessage("Bạn chưa được chia sẻ gì"),
         "nothingToSeeHere": MessageLookupByLibrary.simpleMessage(
-            "Không có gì để xem ở đây! 👀"),
+            "Ở đây không có gì để xem! 👀"),
         "notifications": MessageLookupByLibrary.simpleMessage("Thông báo"),
         "ok": MessageLookupByLibrary.simpleMessage("Được"),
         "onDevice": MessageLookupByLibrary.simpleMessage("Trên thiết bị"),
         "onEnte": MessageLookupByLibrary.simpleMessage(
             "Trên <branding>ente</branding>"),
+        "onTheRoad": MessageLookupByLibrary.simpleMessage("Trên đường"),
+        "onThisDay": MessageLookupByLibrary.simpleMessage("Vào ngày này"),
+        "onThisDayMemories":
+            MessageLookupByLibrary.simpleMessage("Kỷ niệm hôm nay"),
+        "onThisDayNotificationExplanation":
+            MessageLookupByLibrary.simpleMessage(
+                "Nhắc về những kỷ niệm ngày này trong những năm trước."),
         "onlyFamilyAdminCanChangeCode": m55,
         "onlyThem": MessageLookupByLibrary.simpleMessage("Chỉ họ"),
-        "oops": MessageLookupByLibrary.simpleMessage("Ôi"),
-        "oopsCouldNotSaveEdits":
-            MessageLookupByLibrary.simpleMessage("Ôi, không thể lưu chỉnh sửa"),
+        "oops": MessageLookupByLibrary.simpleMessage("Ốiii!"),
+        "oopsCouldNotSaveEdits": MessageLookupByLibrary.simpleMessage(
+            "Ốiii, không thể lưu chỉnh sửa"),
         "oopsSomethingWentWrong": MessageLookupByLibrary.simpleMessage(
-            "Ôi, có điều gì đó không đúng"),
+            "Ốiii!, có điều gì đó không đúng"),
         "openAlbumInBrowser":
             MessageLookupByLibrary.simpleMessage("Mở album trong trình duyệt"),
         "openAlbumInBrowserTitle": MessageLookupByLibrary.simpleMessage(
@@ -1251,24 +1466,29 @@ class MessageLookup extends MessageLookupByLibrary {
         "openFile": MessageLookupByLibrary.simpleMessage("Mở tệp"),
         "openSettings": MessageLookupByLibrary.simpleMessage("Mở Cài đặt"),
         "openTheItem": MessageLookupByLibrary.simpleMessage("• Mở mục"),
-        "openstreetmapContributors":
-            MessageLookupByLibrary.simpleMessage("Nhà đóng góp OpenStreetMap"),
-        "optionalAsShortAsYouLike": MessageLookupByLibrary.simpleMessage(
-            "Tùy chọn, ngắn như bạn muốn..."),
+        "openstreetmapContributors": MessageLookupByLibrary.simpleMessage(
+            "Người đóng góp OpenStreetMap"),
+        "optionalAsShortAsYouLike":
+            MessageLookupByLibrary.simpleMessage("Tùy chọn, ngắn dài tùy ý..."),
         "orMergeWithExistingPerson":
             MessageLookupByLibrary.simpleMessage("Hoặc hợp nhất với hiện có"),
         "orPickAnExistingOne":
             MessageLookupByLibrary.simpleMessage("Hoặc chọn một cái có sẵn"),
+        "orPickFromYourContacts":
+            MessageLookupByLibrary.simpleMessage("hoặc chọn từ danh bạ"),
+        "otherDetectedFaces": MessageLookupByLibrary.simpleMessage(
+            "Những khuôn mặt khác được phát hiện"),
         "pair": MessageLookupByLibrary.simpleMessage("Ghép nối"),
         "pairWithPin": MessageLookupByLibrary.simpleMessage("Ghép nối với PIN"),
         "pairingComplete":
             MessageLookupByLibrary.simpleMessage("Ghép nối hoàn tất"),
-        "panorama": MessageLookupByLibrary.simpleMessage("Toàn cảnh"),
+        "panorama": MessageLookupByLibrary.simpleMessage("Panorama"),
+        "partyWithThem": m56,
         "passKeyPendingVerification":
             MessageLookupByLibrary.simpleMessage("Xác minh vẫn đang chờ"),
-        "passkey": MessageLookupByLibrary.simpleMessage("Mã khóa"),
+        "passkey": MessageLookupByLibrary.simpleMessage("Khóa truy cập"),
         "passkeyAuthTitle":
-            MessageLookupByLibrary.simpleMessage("Xác minh mã khóa"),
+            MessageLookupByLibrary.simpleMessage("Xác minh khóa truy cập"),
         "password": MessageLookupByLibrary.simpleMessage("Mật khẩu"),
         "passwordChangedSuccessfully": MessageLookupByLibrary.simpleMessage(
             "Đã thay đổi mật khẩu thành công"),
@@ -1278,13 +1498,15 @@ class MessageLookup extends MessageLookupByLibrary {
         "passwordStrengthInfo": MessageLookupByLibrary.simpleMessage(
             "Độ mạnh của mật khẩu được tính toán dựa trên độ dài của mật khẩu, các ký tự đã sử dụng và liệu mật khẩu có xuất hiện trong 10.000 mật khẩu được sử dụng nhiều nhất hay không"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
-            "Chúng tôi không lưu trữ mật khẩu này, vì vậy nếu bạn quên, <underline>chúng tôi không thể giải mã dữ liệu của bạn</underline>"),
+            "Chúng tôi không lưu trữ mật khẩu này, nên nếu bạn quên, <underline>chúng tôi không thể giải mã dữ liệu của bạn</underline>"),
+        "pastYearsMemories":
+            MessageLookupByLibrary.simpleMessage("Kỷ niệm năm ngoái"),
         "paymentDetails":
             MessageLookupByLibrary.simpleMessage("Chi tiết thanh toán"),
         "paymentFailed":
             MessageLookupByLibrary.simpleMessage("Thanh toán thất bại"),
         "paymentFailedMessage": MessageLookupByLibrary.simpleMessage(
-            "Rất tiếc, thanh toán của bạn đã thất bại. Vui lòng liên hệ với bộ phận hỗ trợ và chúng tôi sẽ giúp bạn!"),
+            "Rất tiếc, bạn đã thanh toán không thành công. Vui lòng liên hệ hỗ trợ và chúng tôi sẽ giúp bạn!"),
         "paymentFailedTalkToProvider": m58,
         "pendingItems":
             MessageLookupByLibrary.simpleMessage("Các mục đang chờ"),
@@ -1293,38 +1515,50 @@ class MessageLookup extends MessageLookupByLibrary {
         "people": MessageLookupByLibrary.simpleMessage("Người"),
         "peopleUsingYourCode":
             MessageLookupByLibrary.simpleMessage("Người dùng mã của bạn"),
+        "peopleWidgetDesc": MessageLookupByLibrary.simpleMessage(
+            "Chọn những người bạn muốn thấy trên màn hình chính của mình."),
         "permDeleteWarning": MessageLookupByLibrary.simpleMessage(
-            "Tất cả các mục trong thùng rác sẽ bị xóa vĩnh viễn\n\nHành động này không thể hoàn tác"),
+            "Tất cả các mục trong thùng rác sẽ bị xóa vĩnh viễn\n\nKhông thể hoàn tác thao tác này"),
         "permanentlyDelete":
             MessageLookupByLibrary.simpleMessage("Xóa vĩnh viễn"),
         "permanentlyDeleteFromDevice": MessageLookupByLibrary.simpleMessage(
             "Xóa vĩnh viễn khỏi thiết bị?"),
+        "personIsAge": m59,
         "personName": MessageLookupByLibrary.simpleMessage("Tên người"),
+        "personTurningAge": m60,
+        "pets": MessageLookupByLibrary.simpleMessage("Thú cưng"),
         "photoDescriptions": MessageLookupByLibrary.simpleMessage("Mô tả ảnh"),
         "photoGridSize":
             MessageLookupByLibrary.simpleMessage("Kích thước lưới ảnh"),
         "photoSmallCase": MessageLookupByLibrary.simpleMessage("ảnh"),
+        "photocountPhotos": m61,
         "photos": MessageLookupByLibrary.simpleMessage("Ảnh"),
         "photosAddedByYouWillBeRemovedFromTheAlbum":
             MessageLookupByLibrary.simpleMessage(
                 "Ảnh bạn đã thêm sẽ bị xóa khỏi album"),
+        "photosCount": m62,
+        "photosKeepRelativeTimeDifference":
+            MessageLookupByLibrary.simpleMessage(
+                "Ảnh giữ nguyên chênh lệch thời gian tương đối"),
         "pickCenterPoint":
             MessageLookupByLibrary.simpleMessage("Chọn điểm trung tâm"),
         "pinAlbum": MessageLookupByLibrary.simpleMessage("Ghim album"),
         "pinLock": MessageLookupByLibrary.simpleMessage("Khóa PIN"),
         "playOnTv": MessageLookupByLibrary.simpleMessage("Phát album trên TV"),
+        "playOriginal": MessageLookupByLibrary.simpleMessage("Phát tệp gốc"),
         "playStoreFreeTrialValidTill": m63,
+        "playStream": MessageLookupByLibrary.simpleMessage("Phát"),
         "playstoreSubscription":
-            MessageLookupByLibrary.simpleMessage("Đăng ký PlayStore"),
+            MessageLookupByLibrary.simpleMessage("Gói PlayStore"),
         "pleaseCheckYourInternetConnectionAndTryAgain":
             MessageLookupByLibrary.simpleMessage(
                 "Vui lòng kiểm tra kết nối internet của bạn và thử lại."),
         "pleaseContactSupportAndWeWillBeHappyToHelp":
             MessageLookupByLibrary.simpleMessage(
-                "Vui lòng liên hệ với support@ente.io và chúng tôi sẽ rất vui lòng giúp đỡ!"),
+                "Vui lòng liên hệ support@ente.io và chúng tôi rất sẵn sàng giúp đỡ!"),
         "pleaseContactSupportIfTheProblemPersists":
             MessageLookupByLibrary.simpleMessage(
-                "Vui lòng liên hệ với bộ phận hỗ trợ nếu vấn đề vẫn tiếp diễn"),
+                "Vui lòng liên hệ bộ phận hỗ trợ nếu vấn đề vẫn tiếp diễn"),
         "pleaseEmailUsAt": m64,
         "pleaseGrantPermissions":
             MessageLookupByLibrary.simpleMessage("Vui lòng cấp quyền"),
@@ -1343,16 +1577,20 @@ class MessageLookup extends MessageLookupByLibrary {
             "Vui lòng chờ, đang xóa album"),
         "pleaseWaitForSometimeBeforeRetrying":
             MessageLookupByLibrary.simpleMessage(
-                "Vui lòng chờ một thời gian trước khi thử lại"),
+                "Vui lòng chờ một chút trước khi thử lại"),
+        "pleaseWaitThisWillTakeAWhile": MessageLookupByLibrary.simpleMessage(
+            "Vui lòng chờ, có thể mất một lúc."),
+        "posingWithThem": m66,
         "preparingLogs":
-            MessageLookupByLibrary.simpleMessage("Đang chuẩn bị nhật ký..."),
+            MessageLookupByLibrary.simpleMessage("Đang ghi log..."),
         "preserveMore":
             MessageLookupByLibrary.simpleMessage("Lưu giữ nhiều hơn"),
         "pressAndHoldToPlayVideo":
-            MessageLookupByLibrary.simpleMessage("Nhấn và giữ để phát video"),
-        "pressAndHoldToPlayVideoDetailed": MessageLookupByLibrary.simpleMessage(
-            "Nhấn và giữ vào hình ảnh để phát video"),
-        "privacy": MessageLookupByLibrary.simpleMessage("Quyền riêng tư"),
+            MessageLookupByLibrary.simpleMessage("Nhấn giữ để phát video"),
+        "pressAndHoldToPlayVideoDetailed":
+            MessageLookupByLibrary.simpleMessage("Nhấn giữ ảnh để phát video"),
+        "previous": MessageLookupByLibrary.simpleMessage("Trước"),
+        "privacy": MessageLookupByLibrary.simpleMessage("Bảo mật"),
         "privacyPolicyTitle":
             MessageLookupByLibrary.simpleMessage("Chính sách bảo mật"),
         "privateBackups":
@@ -1361,17 +1599,29 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Chia sẻ riêng tư"),
         "proceed": MessageLookupByLibrary.simpleMessage("Tiếp tục"),
         "processed": MessageLookupByLibrary.simpleMessage("Đã xử lý"),
+        "processing": MessageLookupByLibrary.simpleMessage("Đang xử lý"),
         "processingImport": m67,
+        "processingVideos":
+            MessageLookupByLibrary.simpleMessage("Đang xử lý video"),
         "publicLinkCreated": MessageLookupByLibrary.simpleMessage(
             "Liên kết công khai đã được tạo"),
         "publicLinkEnabled": MessageLookupByLibrary.simpleMessage(
-            "Liên kết công khai đã được kích hoạt"),
+            "Liên kết công khai đã được bật"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("?"),
+        "queued": MessageLookupByLibrary.simpleMessage("Đang chờ"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("Liên kết nhanh"),
         "radius": MessageLookupByLibrary.simpleMessage("Bán kính"),
-        "raiseTicket": MessageLookupByLibrary.simpleMessage("Tạo vé"),
+        "raiseTicket": MessageLookupByLibrary.simpleMessage("Yêu cầu hỗ trợ"),
         "rateTheApp": MessageLookupByLibrary.simpleMessage("Đánh giá ứng dụng"),
         "rateUs": MessageLookupByLibrary.simpleMessage("Đánh giá chúng tôi"),
         "rateUsOnStore": m68,
+        "reassignMe":
+            MessageLookupByLibrary.simpleMessage("Chỉ định lại \"Tôi\""),
+        "reassignedToName": m69,
+        "reassigningLoading":
+            MessageLookupByLibrary.simpleMessage("Đang chỉ định lại..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "Nhắc khi đến sinh nhật của ai đó. Chạm vào thông báo sẽ đưa bạn đến ảnh của người sinh nhật."),
         "recover": MessageLookupByLibrary.simpleMessage("Khôi phục"),
         "recoverAccount":
             MessageLookupByLibrary.simpleMessage("Khôi phục tài khoản"),
@@ -1381,19 +1631,19 @@ class MessageLookup extends MessageLookupByLibrary {
         "recoveryInitiated": MessageLookupByLibrary.simpleMessage(
             "Quá trình khôi phục đã được khởi động"),
         "recoveryInitiatedDesc": m70,
-        "recoveryKey": MessageLookupByLibrary.simpleMessage("Khóa khôi phục"),
+        "recoveryKey": MessageLookupByLibrary.simpleMessage("Mã khôi phục"),
         "recoveryKeyCopiedToClipboard": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục đã được sao chép vào clipboard"),
+            "Đã sao chép mã khôi phục vào bộ nhớ tạm"),
         "recoveryKeyOnForgotPassword": MessageLookupByLibrary.simpleMessage(
-            "Nếu bạn quên mật khẩu, cách duy nhất để khôi phục dữ liệu của bạn là với khóa này."),
+            "Nếu bạn quên mật khẩu, cách duy nhất để khôi phục dữ liệu của bạn là dùng mã này."),
         "recoveryKeySaveDescription": MessageLookupByLibrary.simpleMessage(
-            "Chúng tôi không lưu trữ khóa này, vui lòng lưu khóa 24 từ này ở một nơi an toàn."),
+            "Chúng tôi không lưu trữ mã này, nên hãy lưu nó ở một nơi an toàn."),
         "recoveryKeySuccessBody": MessageLookupByLibrary.simpleMessage(
-            "Tuyệt vời! Khóa khôi phục của bạn hợp lệ. Cảm ơn bạn đã xác minh.\n\nVui lòng nhớ giữ khóa khôi phục của bạn được sao lưu an toàn."),
+            "Tuyệt! Mã khôi phục của bạn hợp lệ. Cảm ơn đã xác minh.\n\nNhớ lưu giữ mã khôi phục của bạn ở nơi an toàn."),
         "recoveryKeyVerified": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục đã được xác minh"),
+            "Mã khôi phục đã được xác minh"),
         "recoveryKeyVerifyReason": MessageLookupByLibrary.simpleMessage(
-            "Khóa khôi phục của bạn là cách duy nhất để khôi phục ảnh của bạn nếu bạn quên mật khẩu. Bạn có thể tìm thấy khóa khôi phục của mình trong Cài đặt > Tài khoản.\n\nVui lòng nhập khóa khôi phục của bạn ở đây để xác minh rằng bạn đã lưu nó đúng cách."),
+            "Mã khôi phục là cách duy nhất để khôi phục ảnh của bạn nếu bạn quên mật khẩu. Bạn có thể xem mã khôi phục của mình trong Cài đặt > Tài khoản.\n\nVui lòng nhập mã khôi phục của bạn ở đây để xác minh rằng bạn đã lưu nó đúng cách."),
         "recoveryReady": m71,
         "recoverySuccessful":
             MessageLookupByLibrary.simpleMessage("Khôi phục thành công!"),
@@ -1401,7 +1651,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Một liên hệ tin cậy đang cố gắng truy cập tài khoản của bạn"),
         "recoveryWarningBody": m72,
         "recreatePasswordBody": MessageLookupByLibrary.simpleMessage(
-            "Thiết bị hiện tại không đủ mạnh để xác minh mật khẩu của bạn, nhưng chúng tôi có thể tạo lại theo cách hoạt động với tất cả các thiết bị.\n\nVui lòng đăng nhập bằng khóa khôi phục của bạn và tạo lại mật khẩu (bạn có thể sử dụng lại mật khẩu cũ nếu muốn)."),
+            "Thiết bị hiện tại không đủ mạnh để xác minh mật khẩu của bạn, nhưng chúng tôi có thể tạo lại để nó hoạt động với tất cả thiết bị.\n\nVui lòng đăng nhập bằng mã khôi phục và tạo lại mật khẩu (bạn có thể dùng lại mật khẩu cũ nếu muốn)."),
         "recreatePasswordTitle":
             MessageLookupByLibrary.simpleMessage("Tạo lại mật khẩu"),
         "reddit": MessageLookupByLibrary.simpleMessage("Reddit"),
@@ -1409,7 +1659,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Nhập lại mật khẩu"),
         "reenterPin": MessageLookupByLibrary.simpleMessage("Nhập lại PIN"),
         "referFriendsAnd2xYourPlan": MessageLookupByLibrary.simpleMessage(
-            "Giới thiệu bạn bè và gấp đôi gói của bạn"),
+            "Giới thiệu bạn bè và ×2 gói của bạn"),
         "referralStep1": MessageLookupByLibrary.simpleMessage(
             "1. Đưa mã này cho bạn bè của bạn"),
         "referralStep2":
@@ -1421,24 +1671,25 @@ class MessageLookup extends MessageLookupByLibrary {
         "rejectRecovery":
             MessageLookupByLibrary.simpleMessage("Từ chối khôi phục"),
         "remindToEmptyDeviceTrash": MessageLookupByLibrary.simpleMessage(
-            "Cũng hãy xóa \"Đã xóa gần đây\" từ \"Cài đặt\" -> \"Lưu trữ\" để chiếm không gian đã giải phóng"),
+            "Hãy xóa luôn \"Đã xóa gần đây\" từ \"Cài đặt\" -> \"Lưu trữ\" để lấy lại dung lượng đã giải phóng"),
         "remindToEmptyEnteTrash": MessageLookupByLibrary.simpleMessage(
-            "Cũng hãy xóa \"Thùng rác\" của bạn để chiếm không gian đã giải phóng"),
-        "remoteImages": MessageLookupByLibrary.simpleMessage("Hình ảnh từ xa"),
+            "Hãy xóa luôn \"Thùng rác\" của bạn để lấy lại dung lượng đã giải phóng"),
+        "remoteImages":
+            MessageLookupByLibrary.simpleMessage("Hình ảnh bên ngoài"),
         "remoteThumbnails":
-            MessageLookupByLibrary.simpleMessage("Hình thu nhỏ từ xa"),
-        "remoteVideos": MessageLookupByLibrary.simpleMessage("Video từ xa"),
+            MessageLookupByLibrary.simpleMessage("Hình thu nhỏ bên ngoài"),
+        "remoteVideos": MessageLookupByLibrary.simpleMessage("Video bên ngoài"),
         "remove": MessageLookupByLibrary.simpleMessage("Xóa"),
         "removeDuplicates":
             MessageLookupByLibrary.simpleMessage("Xóa trùng lặp"),
         "removeDuplicatesDesc": MessageLookupByLibrary.simpleMessage(
-            "Xem xét và xóa các tệp là bản sao chính xác."),
+            "Xem và xóa các tệp bị trùng lặp."),
         "removeFromAlbum":
             MessageLookupByLibrary.simpleMessage("Xóa khỏi album"),
         "removeFromAlbumTitle":
             MessageLookupByLibrary.simpleMessage("Xóa khỏi album?"),
         "removeFromFavorite":
-            MessageLookupByLibrary.simpleMessage("Xóa khỏi yêu thích"),
+            MessageLookupByLibrary.simpleMessage("Xóa khỏi mục đã thích"),
         "removeInvite": MessageLookupByLibrary.simpleMessage("Gỡ bỏ lời mời"),
         "removeLink": MessageLookupByLibrary.simpleMessage("Xóa liên kết"),
         "removeParticipant":
@@ -1451,7 +1702,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "removePublicLinks":
             MessageLookupByLibrary.simpleMessage("Xóa liên kết công khai"),
         "removeShareItemsWarning": MessageLookupByLibrary.simpleMessage(
-            "Một số mục bạn đang xóa đã được thêm bởi người khác, và bạn sẽ mất quyền truy cập vào chúng"),
+            "Vài mục mà bạn đang xóa được thêm bởi người khác, và bạn sẽ mất quyền truy cập vào chúng"),
         "removeWithQuestionMark": MessageLookupByLibrary.simpleMessage("Xóa?"),
         "removeYourselfAsTrustedContact": MessageLookupByLibrary.simpleMessage(
             "Gỡ bỏ bạn khỏi liên hệ tin cậy"),
@@ -1461,81 +1712,88 @@ class MessageLookup extends MessageLookupByLibrary {
         "renameAlbum": MessageLookupByLibrary.simpleMessage("Đổi tên album"),
         "renameFile": MessageLookupByLibrary.simpleMessage("Đổi tên tệp"),
         "renewSubscription":
-            MessageLookupByLibrary.simpleMessage("Gia hạn đăng ký"),
+            MessageLookupByLibrary.simpleMessage("Gia hạn gói"),
         "renewsOn": m75,
-        "reportABug": MessageLookupByLibrary.simpleMessage("Báo cáo lỗi"),
-        "reportBug": MessageLookupByLibrary.simpleMessage("Báo cáo lỗi"),
+        "reportABug": MessageLookupByLibrary.simpleMessage("Báo lỗi"),
+        "reportBug": MessageLookupByLibrary.simpleMessage("Báo lỗi"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("Gửi lại email"),
+        "reset": MessageLookupByLibrary.simpleMessage("Đặt lại"),
         "resetIgnoredFiles":
             MessageLookupByLibrary.simpleMessage("Đặt lại các tệp bị bỏ qua"),
         "resetPasswordTitle":
             MessageLookupByLibrary.simpleMessage("Đặt lại mật khẩu"),
-        "resetPerson": MessageLookupByLibrary.simpleMessage("Đặt lại người"),
+        "resetPerson": MessageLookupByLibrary.simpleMessage("Xóa"),
         "resetToDefault":
-            MessageLookupByLibrary.simpleMessage("Đặt lại về mặc định"),
+            MessageLookupByLibrary.simpleMessage("Đặt lại mặc định"),
         "restore": MessageLookupByLibrary.simpleMessage("Khôi phục"),
         "restoreToAlbum":
             MessageLookupByLibrary.simpleMessage("Khôi phục vào album"),
         "restoringFiles":
             MessageLookupByLibrary.simpleMessage("Đang khôi phục tệp..."),
         "resumableUploads":
-            MessageLookupByLibrary.simpleMessage("Tải lên có thể tiếp tục"),
+            MessageLookupByLibrary.simpleMessage("Cho phép tải lên tiếp tục"),
         "retry": MessageLookupByLibrary.simpleMessage("Thử lại"),
         "review": MessageLookupByLibrary.simpleMessage("Xem lại"),
         "reviewDeduplicateItems": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng xem xét và xóa các mục mà bạn cho là trùng lặp."),
-        "reviewSuggestions":
-            MessageLookupByLibrary.simpleMessage("Xem xét gợi ý"),
+            "Vui lòng xem qua và xóa các mục mà bạn tin là trùng lặp."),
+        "reviewSuggestions": MessageLookupByLibrary.simpleMessage("Xem gợi ý"),
         "right": MessageLookupByLibrary.simpleMessage("Phải"),
+        "roadtripWithThem": m76,
         "rotate": MessageLookupByLibrary.simpleMessage("Xoay"),
         "rotateLeft": MessageLookupByLibrary.simpleMessage("Xoay trái"),
         "rotateRight": MessageLookupByLibrary.simpleMessage("Xoay phải"),
         "safelyStored": MessageLookupByLibrary.simpleMessage("Lưu trữ an toàn"),
+        "same": MessageLookupByLibrary.simpleMessage("Chính xác"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("Cùng một người?"),
         "save": MessageLookupByLibrary.simpleMessage("Lưu"),
+        "saveAsAnotherPerson":
+            MessageLookupByLibrary.simpleMessage("Lưu như một người khác"),
+        "saveChangesBeforeLeavingQuestion":
+            MessageLookupByLibrary.simpleMessage("Lưu thay đổi trước khi rời?"),
         "saveCollage": MessageLookupByLibrary.simpleMessage("Lưu ảnh ghép"),
         "saveCopy": MessageLookupByLibrary.simpleMessage("Lưu bản sao"),
-        "saveKey": MessageLookupByLibrary.simpleMessage("Lưu khóa"),
+        "saveKey": MessageLookupByLibrary.simpleMessage("Lưu mã"),
         "savePerson": MessageLookupByLibrary.simpleMessage("Lưu người"),
         "saveYourRecoveryKeyIfYouHaventAlready":
             MessageLookupByLibrary.simpleMessage(
-                "Lưu khóa khôi phục của bạn nếu bạn chưa làm"),
+                "Lưu mã khôi phục của bạn nếu bạn chưa làm"),
         "saving": MessageLookupByLibrary.simpleMessage("Đang lưu..."),
         "savingEdits":
             MessageLookupByLibrary.simpleMessage("Đang lưu chỉnh sửa..."),
         "scanCode": MessageLookupByLibrary.simpleMessage("Quét mã"),
         "scanThisBarcodeWithnyourAuthenticatorApp":
             MessageLookupByLibrary.simpleMessage(
-                "Quét mã vạch này bằng\ntới ứng dụng xác thực của bạn"),
+                "Quét mã vạch này bằng\nứng dụng xác thực của bạn"),
         "search": MessageLookupByLibrary.simpleMessage("Tìm kiếm"),
         "searchAlbumsEmptySection":
             MessageLookupByLibrary.simpleMessage("Album"),
         "searchByAlbumNameHint":
             MessageLookupByLibrary.simpleMessage("Tên album"),
         "searchByExamples": MessageLookupByLibrary.simpleMessage(
-            "• Tên album (ví dụ: \"Camera\")\n• Loại tệp (ví dụ: \"Video\", \".gif\")\n• Năm và tháng (ví dụ: \"2022\", \"Tháng Một\")\n• Ngày lễ (ví dụ: \"Giáng Sinh\")\n• Mô tả ảnh (ví dụ: “#vui”)"),
+            "• Tên album (vd: \"Camera\")\n• Loại tệp (vd: \"Video\", \".gif\")\n• Năm và tháng (vd: \"2022\", \"Tháng Một\")\n• Ngày lễ (vd: \"Giáng Sinh\")\n• Mô tả ảnh (vd: “#vui”)"),
         "searchCaptionEmptySection": MessageLookupByLibrary.simpleMessage(
-            "Thêm mô tả như \"#chuyến đi\" trong thông tin ảnh để nhanh chóng tìm thấy chúng ở đây"),
+            "Thêm mô tả như \"#phượt\" trong thông tin ảnh để tìm nhanh thấy chúng ở đây"),
         "searchDatesEmptySection": MessageLookupByLibrary.simpleMessage(
             "Tìm kiếm theo ngày, tháng hoặc năm"),
         "searchDiscoverEmptySection": MessageLookupByLibrary.simpleMessage(
             "Hình ảnh sẽ được hiển thị ở đây sau khi hoàn tất xử lý và đồng bộ"),
         "searchFaceEmptySection": MessageLookupByLibrary.simpleMessage(
-            "Người sẽ được hiển thị ở đây khi việc lập chỉ mục hoàn tất"),
+            "Người sẽ được hiển thị ở đây khi quá trình xử lý hoàn tất"),
         "searchFileTypesAndNamesEmptySection":
             MessageLookupByLibrary.simpleMessage("Loại tệp và tên"),
         "searchHint1": MessageLookupByLibrary.simpleMessage(
             "Tìm kiếm nhanh, trên thiết bị"),
         "searchHint2":
-            MessageLookupByLibrary.simpleMessage("Ngày tháng, mô tả ảnh"),
+            MessageLookupByLibrary.simpleMessage("Ngày chụp, mô tả ảnh"),
         "searchHint3":
             MessageLookupByLibrary.simpleMessage("Album, tên tệp và loại"),
         "searchHint4": MessageLookupByLibrary.simpleMessage("Vị trí"),
         "searchHint5": MessageLookupByLibrary.simpleMessage(
-            "Sắp có: Nhận diện khuôn mặt & tìm kiếm ma thuật ✨"),
+            "Sắp ra mắt: Nhận diện khuôn mặt & tìm kiếm vi diệu ✨"),
         "searchLocationEmptySection": MessageLookupByLibrary.simpleMessage(
-            "Nhóm ảnh được chụp trong một bán kính nào đó của một bức ảnh"),
+            "Ảnh nhóm được chụp trong một bán kính nào đó của một bức ảnh"),
         "searchPeopleEmptySection": MessageLookupByLibrary.simpleMessage(
-            "Mời mọi người, và bạn sẽ thấy tất cả ảnh được chia sẻ bởi họ ở đây"),
+            "Mời mọi người, và bạn sẽ thấy tất cả ảnh mà họ chia sẻ ở đây"),
         "searchPersonsEmptySection": MessageLookupByLibrary.simpleMessage(
             "Người sẽ được hiển thị ở đây sau khi hoàn tất xử lý và đồng bộ"),
         "searchResultCount": m77,
@@ -1552,6 +1810,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectAllShort": MessageLookupByLibrary.simpleMessage("Tất cả"),
         "selectCoverPhoto":
             MessageLookupByLibrary.simpleMessage("Chọn ảnh bìa"),
+        "selectDate": MessageLookupByLibrary.simpleMessage("Chọn ngày"),
         "selectFoldersForBackup":
             MessageLookupByLibrary.simpleMessage("Chọn thư mục để sao lưu"),
         "selectItemsToAdd":
@@ -1561,9 +1820,21 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Chọn ứng dụng email"),
         "selectMorePhotos":
             MessageLookupByLibrary.simpleMessage("Chọn thêm ảnh"),
+        "selectOneDateAndTime":
+            MessageLookupByLibrary.simpleMessage("Chọn một ngày và giờ"),
+        "selectOneDateAndTimeForAll": MessageLookupByLibrary.simpleMessage(
+            "Chọn một ngày và giờ cho tất cả"),
+        "selectPersonToLink":
+            MessageLookupByLibrary.simpleMessage("Chọn người để liên kết"),
         "selectReason": MessageLookupByLibrary.simpleMessage("Chọn lý do"),
+        "selectStartOfRange":
+            MessageLookupByLibrary.simpleMessage("Chọn phạm vi bắt đầu"),
+        "selectTime": MessageLookupByLibrary.simpleMessage("Chọn thời gian"),
+        "selectYourFace":
+            MessageLookupByLibrary.simpleMessage("Chọn khuôn mặt bạn"),
         "selectYourPlan":
             MessageLookupByLibrary.simpleMessage("Chọn gói của bạn"),
+        "selectedAlbums": m79,
         "selectedFilesAreNotOnEnte": MessageLookupByLibrary.simpleMessage(
             "Các tệp đã chọn không có trên Ente"),
         "selectedFoldersWillBeEncryptedAndBackedUp":
@@ -1571,9 +1842,13 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Các thư mục đã chọn sẽ được mã hóa và sao lưu"),
         "selectedItemsWillBeDeletedFromAllAlbumsAndMoved":
             MessageLookupByLibrary.simpleMessage(
-                "Các mục đã chọn sẽ bị xóa khỏi tất cả các album và chuyển vào thùng rác."),
+                "Các tệp đã chọn sẽ bị xóa khỏi tất cả album và cho vào thùng rác."),
+        "selectedItemsWillBeRemovedFromThisPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "Các mục đã chọn sẽ bị xóa khỏi người này, nhưng không bị xóa khỏi thư viện của bạn."),
         "selectedPhotos": m80,
         "selectedPhotosWithYours": m81,
+        "selfiesWithThem": m82,
         "send": MessageLookupByLibrary.simpleMessage("Gửi"),
         "sendEmail": MessageLookupByLibrary.simpleMessage("Gửi email"),
         "sendInvite": MessageLookupByLibrary.simpleMessage("Gửi lời mời"),
@@ -1601,23 +1876,23 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Chia sẻ một liên kết"),
         "shareAlbumHint": MessageLookupByLibrary.simpleMessage(
             "Mở album và nhấn nút chia sẻ ở góc trên bên phải để chia sẻ."),
-        "shareAnAlbumNow": MessageLookupByLibrary.simpleMessage(
-            "Chia sẻ một album ngay bây giờ"),
+        "shareAnAlbumNow":
+            MessageLookupByLibrary.simpleMessage("Chia sẻ ngay một album"),
         "shareLink": MessageLookupByLibrary.simpleMessage("Chia sẻ liên kết"),
         "shareMyVerificationID": m83,
         "shareOnlyWithThePeopleYouWant": MessageLookupByLibrary.simpleMessage(
-            "Chia sẻ chỉ với những người bạn muốn"),
+            "Chỉ chia sẻ với những người bạn muốn"),
         "shareTextConfirmOthersVerificationID": m84,
         "shareTextRecommendUsingEnte": MessageLookupByLibrary.simpleMessage(
             "Tải Ente để chúng ta có thể dễ dàng chia sẻ ảnh và video chất lượng gốc\n\nhttps://ente.io"),
         "shareTextReferralCode": m85,
         "shareWithNonenteUsers": MessageLookupByLibrary.simpleMessage(
-            "Chia sẻ với người dùng không phải Ente"),
+            "Chia sẻ với người không dùng Ente"),
         "shareWithPeopleSectionTitle": m86,
         "shareYourFirstAlbum": MessageLookupByLibrary.simpleMessage(
             "Chia sẻ album đầu tiên của bạn"),
         "sharedAlbumSectionDescription": MessageLookupByLibrary.simpleMessage(
-            "Tạo album chia sẻ và hợp tác với các người dùng Ente khác, bao gồm cả người dùng trên các gói miễn phí."),
+            "Tạo album chia sẻ và cộng tác với người dùng Ente khác, bao gồm cả người dùng các gói miễn phí."),
         "sharedByMe": MessageLookupByLibrary.simpleMessage("Chia sẻ bởi tôi"),
         "sharedByYou":
             MessageLookupByLibrary.simpleMessage("Được chia sẻ bởi bạn"),
@@ -1629,25 +1904,32 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharedWithMe": MessageLookupByLibrary.simpleMessage("Chia sẻ với tôi"),
         "sharedWithYou":
             MessageLookupByLibrary.simpleMessage("Được chia sẻ với bạn"),
-        "sharing": MessageLookupByLibrary.simpleMessage("Chia sẻ..."),
-        "showMemories":
-            MessageLookupByLibrary.simpleMessage("Hiển thị kỷ niệm"),
+        "sharing": MessageLookupByLibrary.simpleMessage("Đang chia sẻ..."),
+        "shiftDatesAndTime":
+            MessageLookupByLibrary.simpleMessage("Di chuyển ngày và giờ"),
+        "showLessFaces":
+            MessageLookupByLibrary.simpleMessage("Hiện ít khuôn mặt hơn"),
+        "showMemories": MessageLookupByLibrary.simpleMessage("Xem lại kỷ niệm"),
+        "showMoreFaces":
+            MessageLookupByLibrary.simpleMessage("Hiện nhiều khuôn mặt hơn"),
         "showPerson": MessageLookupByLibrary.simpleMessage("Hiện người"),
         "signOutFromOtherDevices": MessageLookupByLibrary.simpleMessage(
-            "Đăng xuất từ các thiết bị khác"),
+            "Đăng xuất khỏi các thiết bị khác"),
         "signOutOtherBody": MessageLookupByLibrary.simpleMessage(
-            "Nếu bạn nghĩ rằng ai đó có thể biết mật khẩu của bạn, bạn có thể buộc tất cả các thiết bị khác đang sử dụng tài khoản của bạn đăng xuất."),
-        "signOutOtherDevices":
-            MessageLookupByLibrary.simpleMessage("Đăng xuất các thiết bị khác"),
+            "Nếu bạn nghĩ rằng ai đó biết mật khẩu của bạn, hãy ép tài khoản của bạn đăng xuất khỏi tất cả thiết bị khác đang sử dụng."),
+        "signOutOtherDevices": MessageLookupByLibrary.simpleMessage(
+            "Đăng xuất khỏi các thiết bị khác"),
         "signUpTerms": MessageLookupByLibrary.simpleMessage(
-            "Tôi đồng ý với <u-terms>các điều khoản dịch vụ</u-terms> và <u-policy>chính sách bảo mật</u-policy>"),
+            "Tôi đồng ý <u-terms>điều khoản</u-terms> và <u-policy>chính sách bảo mật</u-policy>"),
         "singleFileDeleteFromDevice": m88,
         "singleFileDeleteHighlight": MessageLookupByLibrary.simpleMessage(
-            "Nó sẽ bị xóa khỏi tất cả các album."),
+            "Nó sẽ bị xóa khỏi tất cả album."),
         "singleFileInBothLocalAndRemote": m89,
         "singleFileInRemoteOnly": m90,
         "skip": MessageLookupByLibrary.simpleMessage("Bỏ qua"),
-        "social": MessageLookupByLibrary.simpleMessage("Xã hội"),
+        "smartMemories":
+            MessageLookupByLibrary.simpleMessage("Gợi nhớ kỷ niệm"),
+        "social": MessageLookupByLibrary.simpleMessage("Mạng xã hội"),
         "someItemsAreInBothEnteAndYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Một số mục có trên cả Ente và thiết bị của bạn."),
@@ -1663,6 +1945,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Có gì đó không ổn, vui lòng thử lại"),
         "sorry": MessageLookupByLibrary.simpleMessage("Xin lỗi"),
+        "sorryBackupFailedDesc": MessageLookupByLibrary.simpleMessage(
+            "Rất tiếc, không thể sao lưu tệp vào lúc này, chúng tôi sẽ thử lại sau."),
         "sorryCouldNotAddToFavorites": MessageLookupByLibrary.simpleMessage(
             "Xin lỗi, không thể thêm vào mục yêu thích!"),
         "sorryCouldNotRemoveFromFavorites":
@@ -1670,10 +1954,12 @@ class MessageLookup extends MessageLookupByLibrary {
                 "Xin lỗi, không thể xóa khỏi mục yêu thích!"),
         "sorryTheCodeYouveEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
-                "Xin lỗi, mã bạn đã nhập không chính xác"),
+                "Rất tiếc, mã bạn nhập không chính xác"),
         "sorryWeCouldNotGenerateSecureKeysOnThisDevicennplease":
             MessageLookupByLibrary.simpleMessage(
-                "Xin lỗi, chúng tôi không thể tạo khóa an toàn trên thiết bị này.\n\nVui lòng đăng ký từ một thiết bị khác."),
+                "Rất tiếc, chúng tôi không thể tạo khóa an toàn trên thiết bị này.\n\nVui lòng đăng ký từ một thiết bị khác."),
+        "sorryWeHadToPauseYourBackups": MessageLookupByLibrary.simpleMessage(
+            "Rất tiếc, chúng tôi phải dừng sao lưu cho bạn"),
         "sort": MessageLookupByLibrary.simpleMessage("Sắp xếp"),
         "sortAlbumsBy": MessageLookupByLibrary.simpleMessage("Sắp xếp theo"),
         "sortNewestFirst":
@@ -1681,6 +1967,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "sortOldestFirst":
             MessageLookupByLibrary.simpleMessage("Cũ nhất trước"),
         "sparkleSuccess": MessageLookupByLibrary.simpleMessage("✨ Thành công"),
+        "sportsWithThem": m91,
+        "spotlightOnThem": m92,
+        "spotlightOnYourself":
+            MessageLookupByLibrary.simpleMessage("Tập trung vào bản thân bạn"),
         "startAccountRecoveryTitle":
             MessageLookupByLibrary.simpleMessage("Bắt đầu khôi phục"),
         "startBackup": MessageLookupByLibrary.simpleMessage("Bắt đầu sao lưu"),
@@ -1694,35 +1984,37 @@ class MessageLookup extends MessageLookupByLibrary {
         "storageBreakupYou": MessageLookupByLibrary.simpleMessage("Bạn"),
         "storageInGB": m93,
         "storageLimitExceeded":
-            MessageLookupByLibrary.simpleMessage("Vượt quá giới hạn lưu trữ"),
+            MessageLookupByLibrary.simpleMessage("Đã vượt hạn mức lưu trữ"),
         "storageUsageInfo": m94,
+        "streamDetails": MessageLookupByLibrary.simpleMessage("Chi tiết phát"),
         "strongStrength": MessageLookupByLibrary.simpleMessage("Mạnh"),
         "subAlreadyLinkedErrMessage": m95,
         "subWillBeCancelledOn": m96,
-        "subscribe": MessageLookupByLibrary.simpleMessage("Đăng ký"),
+        "subscribe": MessageLookupByLibrary.simpleMessage("Đăng ký gói"),
         "subscribeToEnableSharing": MessageLookupByLibrary.simpleMessage(
-            "Bạn cần một đăng ký trả phí hoạt động để kích hoạt chia sẻ."),
-        "subscription": MessageLookupByLibrary.simpleMessage("Đăng ký"),
+            "Bạn phải dùng gói trả phí mới có thể chia sẻ."),
+        "subscription": MessageLookupByLibrary.simpleMessage("Gói đăng ký"),
         "success": MessageLookupByLibrary.simpleMessage("Thành công"),
         "successfullyArchived":
             MessageLookupByLibrary.simpleMessage("Lưu trữ thành công"),
         "successfullyHid":
             MessageLookupByLibrary.simpleMessage("Đã ẩn thành công"),
         "successfullyUnarchived":
-            MessageLookupByLibrary.simpleMessage("Khôi phục thành công"),
+            MessageLookupByLibrary.simpleMessage("Bỏ lưu trữ thành công"),
         "successfullyUnhid":
             MessageLookupByLibrary.simpleMessage("Đã hiện thành công"),
         "suggestFeatures":
-            MessageLookupByLibrary.simpleMessage("Gợi ý tính năng"),
+            MessageLookupByLibrary.simpleMessage("Đề xuất tính năng"),
+        "sunrise": MessageLookupByLibrary.simpleMessage("Đường chân trời"),
         "support": MessageLookupByLibrary.simpleMessage("Hỗ trợ"),
         "syncProgress": m97,
         "syncStopped":
             MessageLookupByLibrary.simpleMessage("Đồng bộ hóa đã dừng"),
         "syncing": MessageLookupByLibrary.simpleMessage("Đang đồng bộ hóa..."),
-        "systemTheme": MessageLookupByLibrary.simpleMessage("Hệ thống"),
-        "tapToCopy": MessageLookupByLibrary.simpleMessage("chạm để sao chép"),
+        "systemTheme": MessageLookupByLibrary.simpleMessage("Giống hệ thống"),
+        "tapToCopy": MessageLookupByLibrary.simpleMessage("nhấn để sao chép"),
         "tapToEnterCode":
-            MessageLookupByLibrary.simpleMessage("Chạm để nhập mã"),
+            MessageLookupByLibrary.simpleMessage("Nhấn để nhập mã"),
         "tapToUnlock": MessageLookupByLibrary.simpleMessage("Nhấn để mở khóa"),
         "tapToUpload": MessageLookupByLibrary.simpleMessage("Nhấn để tải lên"),
         "tapToUploadIsIgnoredDue": m98,
@@ -1736,61 +2028,76 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Điều khoản"),
         "thankYou": MessageLookupByLibrary.simpleMessage("Cảm ơn bạn"),
         "thankYouForSubscribing":
-            MessageLookupByLibrary.simpleMessage("Cảm ơn bạn đã đăng ký!"),
+            MessageLookupByLibrary.simpleMessage("Cảm ơn bạn đã đăng ký gói!"),
         "theDownloadCouldNotBeCompleted": MessageLookupByLibrary.simpleMessage(
-            "Tải xuống không thể hoàn tất"),
+            "Không thể hoàn tất tải xuống"),
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage(
-                "Liên kết bạn đang cố gắng truy cập đã hết hạn."),
+                "Liên kết mà bạn truy cập đã hết hạn."),
+        "thePersonGroupsWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Nhóm người sẽ không được hiển thị trong phần người nữa. Ảnh sẽ vẫn được giữ nguyên."),
+        "thePersonWillNotBeDisplayed": MessageLookupByLibrary.simpleMessage(
+            "Người sẽ không được hiển thị trong phần người nữa. Ảnh sẽ vẫn được giữ nguyên."),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage(
-                "Khóa khôi phục bạn đã nhập không chính xác"),
+                "Mã khôi phục bạn nhập không chính xác"),
         "theme": MessageLookupByLibrary.simpleMessage("Chủ đề"),
         "theseItemsWillBeDeletedFromYourDevice":
             MessageLookupByLibrary.simpleMessage(
                 "Các mục này sẽ bị xóa khỏi thiết bị của bạn."),
         "theyAlsoGetXGb": m99,
         "theyWillBeDeletedFromAllAlbums": MessageLookupByLibrary.simpleMessage(
-            "Chúng sẽ bị xóa khỏi tất cả các album."),
+            "Nó sẽ bị xóa khỏi tất cả album."),
         "thisActionCannotBeUndone": MessageLookupByLibrary.simpleMessage(
-            "Hành động này không thể hoàn tác"),
+            "Không thể hoàn tác thao tác này"),
         "thisAlbumAlreadyHDACollaborativeLink":
             MessageLookupByLibrary.simpleMessage(
-                "Album này đã có một liên kết hợp tác"),
+                "Album này đã có một liên kết cộng tác"),
         "thisCanBeUsedToRecoverYourAccountIfYou":
             MessageLookupByLibrary.simpleMessage(
-                "Điều này có thể được sử dụng để khôi phục tài khoản của bạn nếu bạn mất yếu tố thứ hai"),
+                "Chúng có thể giúp khôi phục tài khoản của bạn nếu bạn mất xác thực 2 bước"),
         "thisDevice": MessageLookupByLibrary.simpleMessage("Thiết bị này"),
         "thisEmailIsAlreadyInUse":
             MessageLookupByLibrary.simpleMessage("Email này đã được sử dụng"),
         "thisImageHasNoExifData": MessageLookupByLibrary.simpleMessage(
-            "Hình ảnh này không có dữ liệu exif"),
+            "Ảnh này không có thông số Exif"),
+        "thisIsMeExclamation":
+            MessageLookupByLibrary.simpleMessage("Đây là tôi!"),
         "thisIsPersonVerificationId": m100,
         "thisIsYourVerificationId":
             MessageLookupByLibrary.simpleMessage("Đây là ID xác minh của bạn"),
+        "thisWeekThroughTheYears":
+            MessageLookupByLibrary.simpleMessage("Tuần này qua các năm"),
+        "thisWeekXYearsAgo": m101,
         "thisWillLogYouOutOfTheFollowingDevice":
             MessageLookupByLibrary.simpleMessage(
-                "Điều này sẽ đăng xuất bạn khỏi thiết bị sau:"),
+                "Bạn cũng sẽ đăng xuất khỏi những thiết bị sau:"),
         "thisWillLogYouOutOfThisDevice": MessageLookupByLibrary.simpleMessage(
-            "Điều này sẽ đăng xuất bạn khỏi thiết bị này!"),
+            "Bạn sẽ đăng xuất khỏi thiết bị này!"),
+        "thisWillMakeTheDateAndTimeOfAllSelected":
+            MessageLookupByLibrary.simpleMessage(
+                "Thao tác này sẽ làm cho ngày và giờ của tất cả ảnh được chọn đều giống nhau."),
         "thisWillRemovePublicLinksOfAllSelectedQuickLinks":
             MessageLookupByLibrary.simpleMessage(
-                "Điều này sẽ xóa liên kết công khai của tất cả các liên kết nhanh đã chọn."),
+                "Liên kết công khai của tất cả các liên kết nhanh đã chọn sẽ bị xóa."),
+        "throughTheYears": m102,
         "toEnableAppLockPleaseSetupDevicePasscodeOrScreen":
             MessageLookupByLibrary.simpleMessage(
                 "Để bật khóa ứng dụng, vui lòng thiết lập mã khóa thiết bị hoặc khóa màn hình trong cài đặt hệ thống của bạn."),
         "toHideAPhotoOrVideo":
             MessageLookupByLibrary.simpleMessage("Để ẩn một ảnh hoặc video"),
         "toResetVerifyEmail": MessageLookupByLibrary.simpleMessage(
-            "Để đặt lại mật khẩu của bạn, vui lòng xác minh email của bạn trước."),
-        "todaysLogs": MessageLookupByLibrary.simpleMessage("Nhật ký hôm nay"),
-        "tooManyIncorrectAttempts": MessageLookupByLibrary.simpleMessage(
-            "Quá nhiều lần thử không chính xác"),
+            "Để đặt lại mật khẩu, vui lòng xác minh email của bạn trước."),
+        "todaysLogs": MessageLookupByLibrary.simpleMessage("Log hôm nay"),
+        "tooManyIncorrectAttempts":
+            MessageLookupByLibrary.simpleMessage("Thử sai nhiều lần"),
         "total": MessageLookupByLibrary.simpleMessage("tổng"),
-        "totalSize": MessageLookupByLibrary.simpleMessage("Tổng kích thước"),
+        "totalSize": MessageLookupByLibrary.simpleMessage("Tổng dung lượng"),
         "trash": MessageLookupByLibrary.simpleMessage("Thùng rác"),
         "trashDaysLeft": m103,
         "trim": MessageLookupByLibrary.simpleMessage("Cắt"),
+        "tripInYear": m104,
+        "tripToLocation": m105,
         "trustedContacts":
             MessageLookupByLibrary.simpleMessage("Liên hệ tin cậy"),
         "trustedInviteBody": m106,
@@ -1799,34 +2106,33 @@ class MessageLookup extends MessageLookupByLibrary {
             "Bật sao lưu để tự động tải lên các tệp được thêm vào thư mục thiết bị này lên Ente."),
         "twitter": MessageLookupByLibrary.simpleMessage("Twitter"),
         "twoMonthsFreeOnYearlyPlans": MessageLookupByLibrary.simpleMessage(
-            "2 tháng miễn phí cho các gói hàng năm"),
-        "twofactor":
-            MessageLookupByLibrary.simpleMessage("Xác thực hai yếu tố"),
+            "Nhận 2 tháng miễn phí với các gói theo năm"),
+        "twofactor": MessageLookupByLibrary.simpleMessage("Xác thực 2 bước"),
         "twofactorAuthenticationHasBeenDisabled":
             MessageLookupByLibrary.simpleMessage(
-                "Xác thực hai yếu tố đã bị vô hiệu hóa"),
+                "Xác thực 2 bước đã bị vô hiệu hóa"),
         "twofactorAuthenticationPageTitle":
-            MessageLookupByLibrary.simpleMessage("Xác thực hai yếu tố"),
+            MessageLookupByLibrary.simpleMessage("Xác thực 2 bước"),
         "twofactorAuthenticationSuccessfullyReset":
             MessageLookupByLibrary.simpleMessage(
-                "Xác thực hai yếu tố đã được đặt lại thành công"),
+                "Xác thực 2 bước đã được đặt lại thành công"),
         "twofactorSetup":
-            MessageLookupByLibrary.simpleMessage("Cài đặt hai yếu tố"),
+            MessageLookupByLibrary.simpleMessage("Cài đặt xác minh 2 bước"),
         "typeOfGallerGallerytypeIsNotSupportedForRename": m107,
-        "unarchive": MessageLookupByLibrary.simpleMessage("Khôi phục"),
+        "unarchive": MessageLookupByLibrary.simpleMessage("Bỏ lưu trữ"),
         "unarchiveAlbum":
-            MessageLookupByLibrary.simpleMessage("Khôi phục album"),
+            MessageLookupByLibrary.simpleMessage("Bỏ lưu trữ album"),
         "unarchiving":
-            MessageLookupByLibrary.simpleMessage("Đang khôi phục..."),
+            MessageLookupByLibrary.simpleMessage("Đang bỏ lưu trữ..."),
         "unavailableReferralCode": MessageLookupByLibrary.simpleMessage(
-            "Xin lỗi, mã này không khả dụng."),
+            "Rất tiếc, mã này không khả dụng."),
         "uncategorized": MessageLookupByLibrary.simpleMessage("Chưa phân loại"),
         "unhide": MessageLookupByLibrary.simpleMessage("Hiện lại"),
         "unhideToAlbum":
-            MessageLookupByLibrary.simpleMessage("Hiện lại vào album"),
+            MessageLookupByLibrary.simpleMessage("Hiện lại trong album"),
         "unhiding": MessageLookupByLibrary.simpleMessage("Đang hiện..."),
-        "unhidingFilesToAlbum":
-            MessageLookupByLibrary.simpleMessage("Đang hiện lại tệp vào album"),
+        "unhidingFilesToAlbum": MessageLookupByLibrary.simpleMessage(
+            "Đang hiện lại tệp trong album"),
         "unlock": MessageLookupByLibrary.simpleMessage("Mở khóa"),
         "unpinAlbum": MessageLookupByLibrary.simpleMessage("Bỏ ghim album"),
         "unselectAll": MessageLookupByLibrary.simpleMessage("Bỏ chọn tất cả"),
@@ -1843,20 +2149,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "uploadingSingleMemory":
             MessageLookupByLibrary.simpleMessage("Đang lưu giữ 1 kỷ niệm..."),
         "upto50OffUntil4thDec": MessageLookupByLibrary.simpleMessage(
-            "Giảm tới 50%, đến ngày 4 tháng 12."),
+            "Giảm tới 50%, đến ngày 4 Tháng 12."),
         "usableReferralStorageInfo": MessageLookupByLibrary.simpleMessage(
-            "Lưu trữ có thể sử dụng bị giới hạn bởi gói hiện tại của bạn. Lưu trữ đã yêu cầu vượt quá sẽ tự động trở thành có thể sử dụng khi bạn nâng cấp gói của mình."),
-        "useAsCover": MessageLookupByLibrary.simpleMessage("Sử dụng làm bìa"),
+            "Dung lượng có thể dùng bị giới hạn bởi gói hiện tại của bạn. Dung lượng nhận thêm vượt hạn mức sẽ tự động có thể dùng khi bạn nâng cấp gói."),
+        "useAsCover": MessageLookupByLibrary.simpleMessage("Đặt làm ảnh bìa"),
         "useDifferentPlayerInfo": MessageLookupByLibrary.simpleMessage(
-            "Phát video gặp vấn đề? Ấn giữ tại đây để thử một trình phát khác."),
-        "usePublicLinksForPeopleNotOnEnte": MessageLookupByLibrary.simpleMessage(
-            "Sử dụng liên kết công khai cho những người không có trên Ente"),
+            "Phát video gặp vấn đề? Nhấn giữ tại đây để thử một trình phát khác."),
+        "usePublicLinksForPeopleNotOnEnte":
+            MessageLookupByLibrary.simpleMessage(
+                "Dùng liên kết công khai cho những người không dùng Ente"),
         "useRecoveryKey":
-            MessageLookupByLibrary.simpleMessage("Sử dụng khóa khôi phục"),
+            MessageLookupByLibrary.simpleMessage("Dùng mã khôi phục"),
         "useSelectedPhoto":
             MessageLookupByLibrary.simpleMessage("Sử dụng ảnh đã chọn"),
-        "usedSpace":
-            MessageLookupByLibrary.simpleMessage("Không gian đã sử dụng"),
+        "usedSpace": MessageLookupByLibrary.simpleMessage("Dung lượng đã dùng"),
         "validTill": m110,
         "verificationFailedPleaseTryAgain":
             MessageLookupByLibrary.simpleMessage(
@@ -1867,14 +2173,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "verifyEmailID": m111,
         "verifyIDLabel": MessageLookupByLibrary.simpleMessage("Xác minh"),
         "verifyPasskey":
-            MessageLookupByLibrary.simpleMessage("Xác minh mã khóa"),
+            MessageLookupByLibrary.simpleMessage("Xác minh khóa truy cập"),
         "verifyPassword":
             MessageLookupByLibrary.simpleMessage("Xác minh mật khẩu"),
         "verifying": MessageLookupByLibrary.simpleMessage("Đang xác minh..."),
         "verifyingRecoveryKey": MessageLookupByLibrary.simpleMessage(
-            "Đang xác minh khóa khôi phục..."),
+            "Đang xác minh mã khôi phục..."),
         "videoInfo": MessageLookupByLibrary.simpleMessage("Thông tin video"),
         "videoSmallCase": MessageLookupByLibrary.simpleMessage("video"),
+        "videoStreaming":
+            MessageLookupByLibrary.simpleMessage("Video có thể phát"),
         "videos": MessageLookupByLibrary.simpleMessage("Video"),
         "viewActiveSessions":
             MessageLookupByLibrary.simpleMessage("Xem phiên hoạt động"),
@@ -1882,16 +2190,18 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Xem tiện ích mở rộng"),
         "viewAll": MessageLookupByLibrary.simpleMessage("Xem tất cả"),
         "viewAllExifData":
-            MessageLookupByLibrary.simpleMessage("Xem tất cả dữ liệu EXIF"),
+            MessageLookupByLibrary.simpleMessage("Xem thông số Exif"),
         "viewLargeFiles": MessageLookupByLibrary.simpleMessage("Tệp lớn"),
         "viewLargeFilesDesc": MessageLookupByLibrary.simpleMessage(
-            "Xem các tệp đang tiêu tốn nhiều dung lượng lưu trữ nhất."),
-        "viewLogs": MessageLookupByLibrary.simpleMessage("Xem nhật ký"),
+            "Xem các tệp đang chiếm nhiều dung lượng nhất."),
+        "viewLogs": MessageLookupByLibrary.simpleMessage("Xem log"),
+        "viewPersonToUnlink": m112,
         "viewRecoveryKey":
-            MessageLookupByLibrary.simpleMessage("Xem khóa khôi phục"),
+            MessageLookupByLibrary.simpleMessage("Xem mã khôi phục"),
         "viewer": MessageLookupByLibrary.simpleMessage("Người xem"),
+        "viewersSuccessfullyAdded": m113,
         "visitWebToManage": MessageLookupByLibrary.simpleMessage(
-            "Vui lòng truy cập web.ente.io để quản lý đăng ký của bạn"),
+            "Vui lòng truy cập web.ente.io để quản lý gói đăng ký"),
         "waitingForVerification":
             MessageLookupByLibrary.simpleMessage("Đang chờ xác minh..."),
         "waitingForWifi":
@@ -1901,7 +2211,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Chúng tôi là mã nguồn mở!"),
         "weDontSupportEditingPhotosAndAlbumsThatYouDont":
             MessageLookupByLibrary.simpleMessage(
-                "Chúng tôi không hỗ trợ chỉnh sửa ảnh và album mà bạn chưa sở hữu"),
+                "Chúng tôi chưa hỗ trợ chỉnh sửa ảnh và album không phải bạn sở hữu"),
         "weHaveSendEmailTo": m114,
         "weakStrength": MessageLookupByLibrary.simpleMessage("Yếu"),
         "welcomeBack":
@@ -1909,9 +2219,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("Có gì mới"),
         "whyAddTrustContact": MessageLookupByLibrary.simpleMessage(
             "Liên hệ tin cậy có thể giúp khôi phục dữ liệu của bạn."),
+        "widgets": MessageLookupByLibrary.simpleMessage("Tiện ích"),
         "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("năm"),
-        "yearly": MessageLookupByLibrary.simpleMessage("Hàng năm"),
+        "yearly": MessageLookupByLibrary.simpleMessage("Theo năm"),
         "yearsAgo": m116,
         "yes": MessageLookupByLibrary.simpleMessage("Có"),
         "yesCancel": MessageLookupByLibrary.simpleMessage("Có, hủy"),
@@ -1920,18 +2231,20 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesDelete": MessageLookupByLibrary.simpleMessage("Có, xóa"),
         "yesDiscardChanges":
             MessageLookupByLibrary.simpleMessage("Có, bỏ qua thay đổi"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("Có, bỏ qua"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("Có, đăng xuất"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("Có, xóa"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("Có, Gia hạn"),
         "yesResetPerson":
             MessageLookupByLibrary.simpleMessage("Có, đặt lại người"),
         "you": MessageLookupByLibrary.simpleMessage("Bạn"),
-        "youAreOnAFamilyPlan": MessageLookupByLibrary.simpleMessage(
-            "Bạn đang ở trên một kế hoạch gia đình!"),
+        "youAndThem": m117,
+        "youAreOnAFamilyPlan":
+            MessageLookupByLibrary.simpleMessage("Bạn đang dùng gói gia đình!"),
         "youAreOnTheLatestVersion": MessageLookupByLibrary.simpleMessage(
             "Bạn đang sử dụng phiên bản mới nhất"),
         "youCanAtMaxDoubleYourStorage": MessageLookupByLibrary.simpleMessage(
-            "* Bạn có thể tối đa gấp đôi lưu trữ của mình"),
+            "* Bạn có thể tối đa ×2 dung lượng của mình"),
         "youCanManageYourLinksInTheShareTab":
             MessageLookupByLibrary.simpleMessage(
                 "Bạn có thể quản lý các liên kết của mình trong tab chia sẻ."),
@@ -1939,7 +2252,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage(
                 "Bạn có thể thử tìm kiếm một truy vấn khác."),
         "youCannotDowngradeToThisPlan": MessageLookupByLibrary.simpleMessage(
-            "Bạn không thể hạ cấp xuống gói này"),
+            "Bạn không thể đổi xuống gói này"),
         "youCannotShareWithYourself": MessageLookupByLibrary.simpleMessage(
             "Bạn không thể chia sẻ với chính mình"),
         "youDontHaveAnyArchivedItems": MessageLookupByLibrary.simpleMessage(
@@ -1950,24 +2263,27 @@ class MessageLookup extends MessageLookupByLibrary {
         "yourMap": MessageLookupByLibrary.simpleMessage("Bản đồ của bạn"),
         "yourPlanWasSuccessfullyDowngraded":
             MessageLookupByLibrary.simpleMessage(
-                "Kế hoạch của bạn đã được hạ cấp thành công"),
+                "Gói của bạn đã được hạ cấp thành công"),
         "yourPlanWasSuccessfullyUpgraded": MessageLookupByLibrary.simpleMessage(
-            "Kế hoạch của bạn đã được nâng cấp thành công"),
-        "yourPurchaseWasSuccessful": MessageLookupByLibrary.simpleMessage(
-            "Mua hàng của bạn đã thành công"),
+            "Gói của bạn đã được nâng cấp thành công"),
+        "yourPurchaseWasSuccessful":
+            MessageLookupByLibrary.simpleMessage("Bạn đã giao dịch thành công"),
         "yourStorageDetailsCouldNotBeFetched":
             MessageLookupByLibrary.simpleMessage(
-                "Chi tiết lưu trữ của bạn không thể được lấy"),
+                "Không thể lấy chi tiết dung lượng của bạn"),
         "yourSubscriptionHasExpired":
-            MessageLookupByLibrary.simpleMessage("Đăng ký của bạn đã hết hạn"),
+            MessageLookupByLibrary.simpleMessage("Gói của bạn đã hết hạn"),
         "yourSubscriptionWasUpdatedSuccessfully":
             MessageLookupByLibrary.simpleMessage(
-                "Đăng ký của bạn đã được cập nhật thành công"),
+                "Gói của bạn đã được cập nhật thành công"),
         "yourVerificationCodeHasExpired": MessageLookupByLibrary.simpleMessage(
             "Mã xác minh của bạn đã hết hạn"),
+        "youveNoDuplicateFilesThatCanBeCleared":
+            MessageLookupByLibrary.simpleMessage(
+                "Bạn không có tệp nào bị trùng để xóa"),
         "youveNoFilesInThisAlbumThatCanBeDeleted":
             MessageLookupByLibrary.simpleMessage(
-                "Bạn không có tệp nào trong album này có thể bị xóa"),
+                "Bạn không có tệp nào có thể xóa trong album này"),
         "zoomOutToSeePhotos":
             MessageLookupByLibrary.simpleMessage("Phóng to để xem ảnh")
       };

--- a/mobile/apps/photos/lib/generated/intl/messages_zh.dart
+++ b/mobile/apps/photos/lib/generated/intl/messages_zh.dart
@@ -80,6 +80,9 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m21(count) =>
       "${Intl.plural(count, one: '删除 ${count} 个项目', other: '删除 ${count} 个项目')}";
 
+  static String m22(count) =>
+      "也删除这${count}个相册中的照片（和视频）从它们所在的<bold>所有</bold>其他相册中？";
+
   static String m23(currentlyDeleting, totalCount) =>
       "正在删除 ${currentlyDeleting} /共 ${totalCount}";
 
@@ -92,6 +95,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m27(count, formattedSize) =>
       "${count} 个文件，每个文件 ${formattedSize}";
+
+  static String m28(name) => "此电子邮件已与${name}关联。";
 
   static String m29(newEmail) => "电子邮件已更改为 ${newEmail}";
 
@@ -206,6 +211,8 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m78(snapshotLength, searchLength) =>
       "部分长度不匹配：${snapshotLength} != ${searchLength}";
 
+  static String m79(count) => "已选择 ${count} 个";
+
   static String m80(count) => "已选择 ${count} 个";
 
   static String m81(count, yourCount) => "选择了 ${count} 个 (您的 ${yourCount} 个)";
@@ -278,12 +285,14 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m111(email) => "验证 ${email}";
 
+  static String m112(name) => "查看${name}以解除关联";
+
   static String m113(count) =>
       "${Intl.plural(count, zero: '已添加0个查看者', one: '已添加1个查看者', other: '已添加 ${count} 个查看者')}";
 
   static String m114(email) => "我们已经发送邮件到 <green>${email}</green>";
 
-  static String m115(name) => "Wish \$${name} a happy birthday! 🎉";
+  static String m115(name) => "祝 ${name} 生日快乐！ 🎉";
 
   static String m116(count) => "${Intl.plural(count, other: '${count} 年前')}";
 
@@ -304,10 +313,14 @@ class MessageLookup extends MessageLookupByLibrary {
         "accountWelcomeBack": MessageLookupByLibrary.simpleMessage("欢迎回来！"),
         "ackPasswordLostWarning": MessageLookupByLibrary.simpleMessage(
             "我明白，如果我丢失密码，我可能会丢失我的数据，因为我的数据是 <underline>端到端加密的</underline>。"),
+        "actionNotSupportedOnFavouritesAlbum":
+            MessageLookupByLibrary.simpleMessage("收藏相册不支持此操作"),
         "activeSessions": MessageLookupByLibrary.simpleMessage("已登录的设备"),
         "add": MessageLookupByLibrary.simpleMessage("添加"),
         "addAName": MessageLookupByLibrary.simpleMessage("添加一个名称"),
         "addANewEmail": MessageLookupByLibrary.simpleMessage("添加新的电子邮件"),
+        "addAlbumWidgetPrompt":
+            MessageLookupByLibrary.simpleMessage("将相册小组件添加到您的主屏幕，然后返回此处进行自定义。"),
         "addCollaborator": MessageLookupByLibrary.simpleMessage("添加协作者"),
         "addCollaborators": m1,
         "addFiles": MessageLookupByLibrary.simpleMessage("添加文件"),
@@ -315,6 +328,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "addItem": m2,
         "addLocation": MessageLookupByLibrary.simpleMessage("添加地点"),
         "addLocationButton": MessageLookupByLibrary.simpleMessage("添加"),
+        "addMemoriesWidgetPrompt":
+            MessageLookupByLibrary.simpleMessage("将回忆小组件添加到您的主屏幕，然后返回此处进行自定义。"),
         "addMore": MessageLookupByLibrary.simpleMessage("添加更多"),
         "addName": MessageLookupByLibrary.simpleMessage("添加名称"),
         "addNameOrMerge": MessageLookupByLibrary.simpleMessage("添加名称或合并"),
@@ -323,6 +338,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "addOnPageSubtitle": MessageLookupByLibrary.simpleMessage("附加组件详情"),
         "addOnValidTill": m3,
         "addOns": MessageLookupByLibrary.simpleMessage("附加组件"),
+        "addParticipants": MessageLookupByLibrary.simpleMessage("添加参与者"),
+        "addPeopleWidgetPrompt":
+            MessageLookupByLibrary.simpleMessage("将人物小组件添加到您的主屏幕，然后返回此处进行自定义。"),
         "addPhotos": MessageLookupByLibrary.simpleMessage("添加照片"),
         "addSelected": MessageLookupByLibrary.simpleMessage("添加所选项"),
         "addToAlbum": MessageLookupByLibrary.simpleMessage("添加到相册"),
@@ -349,11 +367,16 @@ class MessageLookup extends MessageLookupByLibrary {
         "albumTitle": MessageLookupByLibrary.simpleMessage("相册标题"),
         "albumUpdated": MessageLookupByLibrary.simpleMessage("相册已更新"),
         "albums": MessageLookupByLibrary.simpleMessage("相册"),
+        "albumsWidgetDesc":
+            MessageLookupByLibrary.simpleMessage("选择您希望在主屏幕上看到的相册。"),
         "allClear": MessageLookupByLibrary.simpleMessage("✨ 全部清除"),
         "allMemoriesPreserved":
             MessageLookupByLibrary.simpleMessage("所有回忆都已保存"),
         "allPersonGroupingWillReset": MessageLookupByLibrary.simpleMessage(
             "此人的所有分组都将被重设，并且您将丢失针对此人的所有建议"),
+        "allUnnamedGroupsWillBeMergedIntoTheSelectedPerson":
+            MessageLookupByLibrary.simpleMessage(
+                "所有未命名组将合并到所选人物中。此操作仍可从该人物的建议历史概览中撤销。"),
         "allWillShiftRangeBasedOnFirst": MessageLookupByLibrary.simpleMessage(
             "这张照片是该组中的第一张。其他已选择的照片将根据此新日期自动调整。"),
         "allow": MessageLookupByLibrary.simpleMessage("允许"),
@@ -397,6 +420,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "archive": MessageLookupByLibrary.simpleMessage("存档"),
         "archiveAlbum": MessageLookupByLibrary.simpleMessage("存档相册"),
         "archiving": MessageLookupByLibrary.simpleMessage("正在存档..."),
+        "areThey": MessageLookupByLibrary.simpleMessage("他们是 "),
+        "areYouSureRemoveThisFaceFromPerson":
+            MessageLookupByLibrary.simpleMessage("您确定要从此人中移除这个人脸吗？"),
         "areYouSureThatYouWantToLeaveTheFamily":
             MessageLookupByLibrary.simpleMessage("您确定要离开家庭计划吗？"),
         "areYouSureYouWantToCancel":
@@ -405,8 +431,14 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("您确定要更改您的计划吗？"),
         "areYouSureYouWantToExit":
             MessageLookupByLibrary.simpleMessage("您确定要退出吗？"),
+        "areYouSureYouWantToIgnoreThesePersons":
+            MessageLookupByLibrary.simpleMessage("您确定要忽略这些人吗？"),
+        "areYouSureYouWantToIgnoreThisPerson":
+            MessageLookupByLibrary.simpleMessage("您确定要忽略此人吗？"),
         "areYouSureYouWantToLogout":
             MessageLookupByLibrary.simpleMessage("您确定要退出登录吗？"),
+        "areYouSureYouWantToMergeThem":
+            MessageLookupByLibrary.simpleMessage("您确定要合并他们吗？"),
         "areYouSureYouWantToRenew":
             MessageLookupByLibrary.simpleMessage("您确定要续费吗？"),
         "areYouSureYouWantToResetThisPerson":
@@ -477,8 +509,28 @@ class MessageLookup extends MessageLookupByLibrary {
         "backupVideos": MessageLookupByLibrary.simpleMessage("备份视频"),
         "beach": MessageLookupByLibrary.simpleMessage("沙滩与大海"),
         "birthday": MessageLookupByLibrary.simpleMessage("生日"),
+        "birthdayNotifications": MessageLookupByLibrary.simpleMessage("生日通知"),
+        "birthdays": MessageLookupByLibrary.simpleMessage("生日"),
         "blackFridaySale": MessageLookupByLibrary.simpleMessage("黑色星期五特惠"),
         "blog": MessageLookupByLibrary.simpleMessage("博客"),
+        "cLDesc1": MessageLookupByLibrary.simpleMessage(
+            "在视频流媒体测试版和可恢复上传与下载功能的基础上，我们现已将文件上传限制提高到10GB。此功能现已在桌面和移动应用程序中可用。"),
+        "cLDesc2": MessageLookupByLibrary.simpleMessage(
+            "现在 iOS 设备也支持后台上传，Android 设备早已支持。无需打开应用程序即可备份最新的照片和视频。"),
+        "cLDesc3": MessageLookupByLibrary.simpleMessage(
+            "我们对回忆体验进行了重大改进，包括自动播放、滑动到下一个回忆以及更多功能。"),
+        "cLDesc4": MessageLookupByLibrary.simpleMessage(
+            "除了多项底层改进外，现在可以更轻松地查看所有检测到的人脸，对相似人脸提供反馈，以及从单张照片中添加/删除人脸。"),
+        "cLDesc5": MessageLookupByLibrary.simpleMessage(
+            "您现在将收到 Ente 上保存的所有生日的可选退出通知，同时附上他们最佳照片的合集。"),
+        "cLDesc6": MessageLookupByLibrary.simpleMessage(
+            "无需等待上传/下载完成即可关闭应用程序。所有上传和下载现在都可以中途暂停，并从中断处继续。"),
+        "cLTitle1": MessageLookupByLibrary.simpleMessage("正在上传大型视频文件"),
+        "cLTitle2": MessageLookupByLibrary.simpleMessage("后台上传"),
+        "cLTitle3": MessageLookupByLibrary.simpleMessage("自动播放回忆"),
+        "cLTitle4": MessageLookupByLibrary.simpleMessage("改进的人脸识别"),
+        "cLTitle5": MessageLookupByLibrary.simpleMessage("生日通知"),
+        "cLTitle6": MessageLookupByLibrary.simpleMessage("可恢复的上传和下载"),
         "cachedData": MessageLookupByLibrary.simpleMessage("缓存数据"),
         "calculating": MessageLookupByLibrary.simpleMessage("正在计算..."),
         "canNotOpenBody":
@@ -534,6 +586,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "click": MessageLookupByLibrary.simpleMessage("• 点击"),
         "clickOnTheOverflowMenu":
             MessageLookupByLibrary.simpleMessage("• 点击溢出菜单"),
+        "clickToInstallOurBestVersionYet":
+            MessageLookupByLibrary.simpleMessage("点击安装我们迄今最好的版本"),
         "close": MessageLookupByLibrary.simpleMessage("关闭"),
         "clubByCaptureTime": MessageLookupByLibrary.simpleMessage("按拍摄时间分组"),
         "clubByFileName": MessageLookupByLibrary.simpleMessage("按文件名排序"),
@@ -608,6 +662,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "criticalUpdateAvailable":
             MessageLookupByLibrary.simpleMessage("可用的关键更新"),
         "crop": MessageLookupByLibrary.simpleMessage("裁剪"),
+        "curatedMemories": MessageLookupByLibrary.simpleMessage("精选回忆"),
         "currentUsageIs": MessageLookupByLibrary.simpleMessage("当前用量 "),
         "currentlyRunning": MessageLookupByLibrary.simpleMessage("目前正在运行"),
         "custom": MessageLookupByLibrary.simpleMessage("自定义"),
@@ -643,14 +698,13 @@ class MessageLookup extends MessageLookupByLibrary {
         "deleteFromEnte": MessageLookupByLibrary.simpleMessage("从 Ente 中删除"),
         "deleteItemCount": m21,
         "deleteLocation": MessageLookupByLibrary.simpleMessage("删除位置"),
+        "deleteMultipleAlbumDialog": m22,
         "deletePhotos": MessageLookupByLibrary.simpleMessage("删除照片"),
         "deleteProgress": m23,
-        "deleteReason1": MessageLookupByLibrary.simpleMessage("找不到我想要的功能"),
-        "deleteReason2":
-            MessageLookupByLibrary.simpleMessage("应用或某个功能没有按我的预期运行"),
-        "deleteReason3":
-            MessageLookupByLibrary.simpleMessage("我找到了另一个我喜欢的更好的服务"),
-        "deleteReason4": MessageLookupByLibrary.simpleMessage("我的原因未被列出"),
+        "deleteReason1": MessageLookupByLibrary.simpleMessage("缺少我所需的关键功能"),
+        "deleteReason2": MessageLookupByLibrary.simpleMessage("应用或某项功能未按预期运行"),
+        "deleteReason3": MessageLookupByLibrary.simpleMessage("我发现另一个产品更好用"),
+        "deleteReason4": MessageLookupByLibrary.simpleMessage("其他原因"),
         "deleteRequestSLAText":
             MessageLookupByLibrary.simpleMessage("您的请求将在 72 小时内处理。"),
         "deleteSharedAlbum": MessageLookupByLibrary.simpleMessage("要删除共享相册吗？"),
@@ -670,6 +724,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "当 Ente 置于前台且正在进行备份时将禁用设备屏幕锁定。这通常是不需要的，但可能有助于更快地完成大型上传和大型库的初始导入。"),
         "deviceNotFound": MessageLookupByLibrary.simpleMessage("未发现设备"),
         "didYouKnow": MessageLookupByLibrary.simpleMessage("您知道吗？"),
+        "different": MessageLookupByLibrary.simpleMessage("不同"),
         "disableAutoLock": MessageLookupByLibrary.simpleMessage("禁用自动锁定"),
         "disableDownloadWarningBody":
             MessageLookupByLibrary.simpleMessage("查看者仍然可以使用外部工具截图或保存您的照片副本"),
@@ -713,6 +768,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "duplicateFileCountWithStorageSaved": m26,
         "duplicateItemsGroup": m27,
         "edit": MessageLookupByLibrary.simpleMessage("编辑"),
+        "editEmailAlreadyLinked": m28,
         "editLocation": MessageLookupByLibrary.simpleMessage("编辑位置"),
         "editLocationTagTitle": MessageLookupByLibrary.simpleMessage("编辑位置"),
         "editPerson": MessageLookupByLibrary.simpleMessage("编辑人物"),
@@ -782,6 +838,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("请输入一个有效的电子邮件地址。"),
         "enterYourEmailAddress":
             MessageLookupByLibrary.simpleMessage("请输入您的电子邮件地址"),
+        "enterYourNewEmailAddress":
+            MessageLookupByLibrary.simpleMessage("输入您的新电子邮件地址"),
         "enterYourPassword": MessageLookupByLibrary.simpleMessage("输入您的密码"),
         "enterYourRecoveryKey":
             MessageLookupByLibrary.simpleMessage("输入您的恢复密钥"),
@@ -874,6 +932,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "guestView": MessageLookupByLibrary.simpleMessage("访客视图"),
         "guestViewEnablePreSteps":
             MessageLookupByLibrary.simpleMessage("要启用访客视图，请在系统设置中设置设备密码或屏幕锁。"),
+        "happyBirthday": MessageLookupByLibrary.simpleMessage("生日快乐！ 🥳"),
         "hearUsExplanation": MessageLookupByLibrary.simpleMessage(
             "我们不跟踪应用程序安装情况。如果您告诉我们您是在哪里找到我们的，将会有所帮助！"),
         "hearUsWhereTitle":
@@ -899,6 +958,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "iOSLockOut":
             MessageLookupByLibrary.simpleMessage("生物识别认证已禁用。请锁定并解锁您的屏幕以启用它。"),
         "iOSOkButton": MessageLookupByLibrary.simpleMessage("好的"),
+        "ignore": MessageLookupByLibrary.simpleMessage("忽略"),
         "ignoreUpdate": MessageLookupByLibrary.simpleMessage("忽略"),
         "ignored": MessageLookupByLibrary.simpleMessage("已忽略"),
         "ignoredFolderUploadReason": MessageLookupByLibrary.simpleMessage(
@@ -915,6 +975,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "incorrectRecoveryKeyTitle":
             MessageLookupByLibrary.simpleMessage("恢复密钥不正确"),
         "indexedItems": MessageLookupByLibrary.simpleMessage("已索引项目"),
+        "indexingPausedStatusDescription": MessageLookupByLibrary.simpleMessage(
+            "索引已暂停。待设备准备就绪后，索引将自动恢复。当设备的电池电量、电池健康度和温度状态处于健康范围内时，设备即被视为准备就绪。"),
         "ineligible": MessageLookupByLibrary.simpleMessage("不合格"),
         "info": MessageLookupByLibrary.simpleMessage("详情"),
         "insecureDevice": MessageLookupByLibrary.simpleMessage("设备不安全"),
@@ -989,6 +1051,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "linkPersonToEmailConfirmation": m49,
         "livePhotos": MessageLookupByLibrary.simpleMessage("实况照片"),
         "loadMessage1": MessageLookupByLibrary.simpleMessage("您可以与家庭分享您的订阅"),
+        "loadMessage2": MessageLookupByLibrary.simpleMessage("我们至今已保存超过2亿个回忆"),
         "loadMessage3":
             MessageLookupByLibrary.simpleMessage("我们保存你的3个数据副本，其中一个在地下安全屋中"),
         "loadMessage4": MessageLookupByLibrary.simpleMessage("我们所有的应用程序都是开源的"),
@@ -1035,6 +1098,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("长按电子邮件以验证端到端加密。"),
         "longpressOnAnItemToViewInFullscreen":
             MessageLookupByLibrary.simpleMessage("长按一个项目来全屏查看"),
+        "lookBackOnYourMemories":
+            MessageLookupByLibrary.simpleMessage("回顾你的回忆🌄"),
         "loopVideoOff": MessageLookupByLibrary.simpleMessage("循环播放视频关闭"),
         "loopVideoOn": MessageLookupByLibrary.simpleMessage("循环播放视频开启"),
         "lostDevice": MessageLookupByLibrary.simpleMessage("设备丢失？"),
@@ -1057,8 +1122,12 @@ class MessageLookup extends MessageLookupByLibrary {
         "mastodon": MessageLookupByLibrary.simpleMessage("Mastodon"),
         "matrix": MessageLookupByLibrary.simpleMessage("Matrix"),
         "me": MessageLookupByLibrary.simpleMessage("我"),
+        "memories": MessageLookupByLibrary.simpleMessage("回忆"),
+        "memoriesWidgetDesc":
+            MessageLookupByLibrary.simpleMessage("选择您希望在主屏幕上看到的回忆类型。"),
         "memoryCount": m50,
         "merchandise": MessageLookupByLibrary.simpleMessage("商品"),
+        "merge": MessageLookupByLibrary.simpleMessage("合并"),
         "mergeWithExisting": MessageLookupByLibrary.simpleMessage("与现有的合并"),
         "mergedPhotos": MessageLookupByLibrary.simpleMessage("已合并照片"),
         "mlConsent": MessageLookupByLibrary.simpleMessage("启用机器学习"),
@@ -1103,6 +1172,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "newAlbum": MessageLookupByLibrary.simpleMessage("新建相册"),
         "newLocation": MessageLookupByLibrary.simpleMessage("新位置"),
         "newPerson": MessageLookupByLibrary.simpleMessage("新人物"),
+        "newPhotosEmoji": MessageLookupByLibrary.simpleMessage(" 新 📸"),
         "newRange": MessageLookupByLibrary.simpleMessage("新起始图片"),
         "newToEnte": MessageLookupByLibrary.simpleMessage("初来 Ente"),
         "newest": MessageLookupByLibrary.simpleMessage("最新"),
@@ -1146,6 +1216,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "onEnte": MessageLookupByLibrary.simpleMessage(
             "在 <branding>ente</branding> 上"),
         "onTheRoad": MessageLookupByLibrary.simpleMessage("再次踏上旅途"),
+        "onThisDay": MessageLookupByLibrary.simpleMessage("这天"),
+        "onThisDayMemories": MessageLookupByLibrary.simpleMessage("这天的回忆"),
+        "onThisDayNotificationExplanation":
+            MessageLookupByLibrary.simpleMessage("接收关于往年这一天回忆的提醒。"),
         "onlyFamilyAdminCanChangeCode": m55,
         "onlyThem": MessageLookupByLibrary.simpleMessage("仅限他们"),
         "oops": MessageLookupByLibrary.simpleMessage("哎呀"),
@@ -1169,6 +1243,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("或者选择一个现有的"),
         "orPickFromYourContacts":
             MessageLookupByLibrary.simpleMessage("或从您的联系人中选择"),
+        "otherDetectedFaces": MessageLookupByLibrary.simpleMessage("其他检测到的人脸"),
         "pair": MessageLookupByLibrary.simpleMessage("配对"),
         "pairWithPin": MessageLookupByLibrary.simpleMessage("用 PIN 配对"),
         "pairingComplete": MessageLookupByLibrary.simpleMessage("配对完成"),
@@ -1187,6 +1262,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "密码强度的计算考虑了密码的长度、使用的字符以及密码是否出现在最常用的 10,000 个密码中"),
         "passwordWarning": MessageLookupByLibrary.simpleMessage(
             "我们不储存这个密码，所以如果忘记， <underline>我们将无法解密您的数据</underline>"),
+        "pastYearsMemories": MessageLookupByLibrary.simpleMessage("往年回忆"),
         "paymentDetails": MessageLookupByLibrary.simpleMessage("付款明细"),
         "paymentFailed": MessageLookupByLibrary.simpleMessage("支付失败"),
         "paymentFailedMessage": MessageLookupByLibrary.simpleMessage(
@@ -1196,6 +1272,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "pendingSync": MessageLookupByLibrary.simpleMessage("正在等待同步"),
         "people": MessageLookupByLibrary.simpleMessage("人物"),
         "peopleUsingYourCode": MessageLookupByLibrary.simpleMessage("使用您的代码的人"),
+        "peopleWidgetDesc":
+            MessageLookupByLibrary.simpleMessage("选择您希望在主屏幕上看到的人。"),
         "permDeleteWarning":
             MessageLookupByLibrary.simpleMessage("回收站中的所有项目将被永久删除\n\n此操作无法撤消"),
         "permanentlyDelete": MessageLookupByLibrary.simpleMessage("永久删除"),
@@ -1266,6 +1344,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "processingVideos": MessageLookupByLibrary.simpleMessage("正在处理视频"),
         "publicLinkCreated": MessageLookupByLibrary.simpleMessage("公共链接已创建"),
         "publicLinkEnabled": MessageLookupByLibrary.simpleMessage("公开链接已启用"),
+        "questionmark": MessageLookupByLibrary.simpleMessage("？"),
         "queued": MessageLookupByLibrary.simpleMessage("已入列"),
         "quickLinks": MessageLookupByLibrary.simpleMessage("快速链接"),
         "radius": MessageLookupByLibrary.simpleMessage("半径"),
@@ -1276,6 +1355,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "reassignMe": MessageLookupByLibrary.simpleMessage("重新分配“我”"),
         "reassignedToName": m69,
         "reassigningLoading": MessageLookupByLibrary.simpleMessage("正在重新分配..."),
+        "receiveRemindersOnBirthdays": MessageLookupByLibrary.simpleMessage(
+            "接收某人生日时的提醒。点击通知将带您查看生日人物的照片。"),
         "recover": MessageLookupByLibrary.simpleMessage("恢复"),
         "recoverAccount": MessageLookupByLibrary.simpleMessage("恢复账户"),
         "recoverButton": MessageLookupByLibrary.simpleMessage("恢复"),
@@ -1351,6 +1432,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "reportABug": MessageLookupByLibrary.simpleMessage("报告错误"),
         "reportBug": MessageLookupByLibrary.simpleMessage("报告错误"),
         "resendEmail": MessageLookupByLibrary.simpleMessage("重新发送电子邮件"),
+        "reset": MessageLookupByLibrary.simpleMessage("重设"),
         "resetIgnoredFiles": MessageLookupByLibrary.simpleMessage("重置忽略的文件"),
         "resetPasswordTitle": MessageLookupByLibrary.simpleMessage("重置密码"),
         "resetPerson": MessageLookupByLibrary.simpleMessage("移除"),
@@ -1370,7 +1452,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "rotateLeft": MessageLookupByLibrary.simpleMessage("向左旋转"),
         "rotateRight": MessageLookupByLibrary.simpleMessage("向右旋转"),
         "safelyStored": MessageLookupByLibrary.simpleMessage("安全存储"),
+        "same": MessageLookupByLibrary.simpleMessage("相同"),
+        "sameperson": MessageLookupByLibrary.simpleMessage("是同一个人？"),
         "save": MessageLookupByLibrary.simpleMessage("保存"),
+        "saveAsAnotherPerson": MessageLookupByLibrary.simpleMessage("另存为其他人物"),
         "saveChangesBeforeLeavingQuestion":
             MessageLookupByLibrary.simpleMessage("离开之前要保存更改吗？"),
         "saveCollage": MessageLookupByLibrary.simpleMessage("保存拼贴"),
@@ -1439,6 +1524,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "selectTime": MessageLookupByLibrary.simpleMessage("选择时间"),
         "selectYourFace": MessageLookupByLibrary.simpleMessage("选择你的脸"),
         "selectYourPlan": MessageLookupByLibrary.simpleMessage("选择您的计划"),
+        "selectedAlbums": m79,
         "selectedFilesAreNotOnEnte":
             MessageLookupByLibrary.simpleMessage("所选文件不在 Ente 上"),
         "selectedFoldersWillBeEncryptedAndBackedUp":
@@ -1497,7 +1583,9 @@ class MessageLookup extends MessageLookupByLibrary {
         "sharedWithYou": MessageLookupByLibrary.simpleMessage("已与您共享"),
         "sharing": MessageLookupByLibrary.simpleMessage("正在分享..."),
         "shiftDatesAndTime": MessageLookupByLibrary.simpleMessage("调整日期和时间"),
+        "showLessFaces": MessageLookupByLibrary.simpleMessage("显示较少人脸"),
         "showMemories": MessageLookupByLibrary.simpleMessage("显示回忆"),
+        "showMoreFaces": MessageLookupByLibrary.simpleMessage("显示更多人脸"),
         "showPerson": MessageLookupByLibrary.simpleMessage("显示人员"),
         "signOutFromOtherDevices":
             MessageLookupByLibrary.simpleMessage("从其他设备退出登录"),
@@ -1512,6 +1600,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "singleFileInBothLocalAndRemote": m89,
         "singleFileInRemoteOnly": m90,
         "skip": MessageLookupByLibrary.simpleMessage("跳过"),
+        "smartMemories": MessageLookupByLibrary.simpleMessage("智能回忆"),
         "social": MessageLookupByLibrary.simpleMessage("社交"),
         "someItemsAreInBothEnteAndYourDevice":
             MessageLookupByLibrary.simpleMessage("有些项目同时存在于 Ente 和您的设备中。"),
@@ -1523,6 +1612,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "somethingWentWrongPleaseTryAgain":
             MessageLookupByLibrary.simpleMessage("出了点问题，请重试"),
         "sorry": MessageLookupByLibrary.simpleMessage("抱歉"),
+        "sorryBackupFailedDesc":
+            MessageLookupByLibrary.simpleMessage("抱歉，我们目前无法备份此文件，我们将稍后重试。"),
         "sorryCouldNotAddToFavorites":
             MessageLookupByLibrary.simpleMessage("抱歉，无法添加到收藏！"),
         "sorryCouldNotRemoveFromFavorites":
@@ -1532,6 +1623,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "sorryWeCouldNotGenerateSecureKeysOnThisDevicennplease":
             MessageLookupByLibrary.simpleMessage(
                 "抱歉，我们无法在此设备上生成安全密钥。\n\n请使用其他设备注册。"),
+        "sorryWeHadToPauseYourBackups":
+            MessageLookupByLibrary.simpleMessage("抱歉，我们不得不暂停您的备份"),
         "sort": MessageLookupByLibrary.simpleMessage("排序"),
         "sortAlbumsBy": MessageLookupByLibrary.simpleMessage("排序方式"),
         "sortNewestFirst": MessageLookupByLibrary.simpleMessage("最新在前"),
@@ -1592,6 +1685,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("未能完成下载"),
         "theLinkYouAreTryingToAccessHasExpired":
             MessageLookupByLibrary.simpleMessage("您尝试访问的链接已过期。"),
+        "thePersonGroupsWillNotBeDisplayed":
+            MessageLookupByLibrary.simpleMessage("人物组将不再显示在人物部分。照片将保持不变。"),
+        "thePersonWillNotBeDisplayed":
+            MessageLookupByLibrary.simpleMessage("该人将不再显示在人物部分。照片将保持不变。"),
         "theRecoveryKeyYouEnteredIsIncorrect":
             MessageLookupByLibrary.simpleMessage("您输入的恢复密钥不正确"),
         "theme": MessageLookupByLibrary.simpleMessage("主题"),
@@ -1710,6 +1807,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("正在验证恢复密钥..."),
         "videoInfo": MessageLookupByLibrary.simpleMessage("视频详情"),
         "videoSmallCase": MessageLookupByLibrary.simpleMessage("视频"),
+        "videoStreaming": MessageLookupByLibrary.simpleMessage("可流媒体播放的视频"),
         "videos": MessageLookupByLibrary.simpleMessage("视频"),
         "viewActiveSessions": MessageLookupByLibrary.simpleMessage("查看活动会话"),
         "viewAddOnButton": MessageLookupByLibrary.simpleMessage("查看附加组件"),
@@ -1719,6 +1817,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "viewLargeFilesDesc":
             MessageLookupByLibrary.simpleMessage("查看占用存储空间最多的文件。"),
         "viewLogs": MessageLookupByLibrary.simpleMessage("查看日志"),
+        "viewPersonToUnlink": m112,
         "viewRecoveryKey": MessageLookupByLibrary.simpleMessage("查看恢复密钥"),
         "viewer": MessageLookupByLibrary.simpleMessage("查看者"),
         "viewersSuccessfullyAdded": m113,
@@ -1737,6 +1836,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "whatsNew": MessageLookupByLibrary.simpleMessage("更新日志"),
         "whyAddTrustContact":
             MessageLookupByLibrary.simpleMessage("可信联系人可以帮助恢复您的数据。"),
+        "widgets": MessageLookupByLibrary.simpleMessage("小组件"),
         "wishThemAHappyBirthday": m115,
         "yearShort": MessageLookupByLibrary.simpleMessage("年"),
         "yearly": MessageLookupByLibrary.simpleMessage("每年"),
@@ -1746,6 +1846,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "yesConvertToViewer": MessageLookupByLibrary.simpleMessage("是的，转换为查看者"),
         "yesDelete": MessageLookupByLibrary.simpleMessage("是的, 删除"),
         "yesDiscardChanges": MessageLookupByLibrary.simpleMessage("是的，放弃更改"),
+        "yesIgnore": MessageLookupByLibrary.simpleMessage("是的，忽略"),
         "yesLogout": MessageLookupByLibrary.simpleMessage("是的，退出登陆"),
         "yesRemove": MessageLookupByLibrary.simpleMessage("是，移除"),
         "yesRenew": MessageLookupByLibrary.simpleMessage("是的，续费"),

--- a/mobile/apps/photos/lib/generated/l10n.dart
+++ b/mobile/apps/photos/lib/generated/l10n.dart
@@ -12295,6 +12295,26 @@ class S {
       args: [],
     );
   }
+
+  /// `Unable to generate face thumbnails`
+  String get faceThumbnailGenerationFailed {
+    return Intl.message(
+      'Unable to generate face thumbnails',
+      name: 'faceThumbnailGenerationFailed',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Unable to analyze file`
+  String get fileAnalysisFailed {
+    return Intl.message(
+      'Unable to analyze file',
+      name: 'fileAnalysisFailed',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1788,5 +1788,7 @@
   "cLDesc5": "You will now receive an opt-out notification for all the birthdays your have saved on Ente, along with a collection of their best photos.",
   "cLTitle6": "Resumable Uploads and Downloads",
   "cLDesc6": "No more waiting for uploads/downloads to complete before you can close the app. All uploads and downloads now have the ability to be paused midway, and resume from where you left off.",
-  "indexingPausedStatusDescription": "Indexing is paused. It will automatically resume when the device is ready. The device is considered ready when its battery level, battery health, and thermal status are within a healthy range."
+  "indexingPausedStatusDescription": "Indexing is paused. It will automatically resume when the device is ready. The device is considered ready when its battery level, battery health, and thermal status are within a healthy range.",
+  "faceThumbnailGenerationFailed": "Unable to generate face thumbnails",
+  "fileAnalysisFailed": "Unable to analyze file"
 }

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -516,6 +516,7 @@ class MLService {
       final bool acceptedIssue =
           errorString.contains('ThumbnailRetrievalException') ||
               errorString.contains('InvalidImageFormatException') ||
+              errorString.contains('UnhandledExifOrientation') ||
               errorString.contains('FileSizeTooLargeForMobileIndexing');
       if (acceptedIssue) {
         _logger.severe(

--- a/mobile/apps/photos/lib/ui/viewer/file_details/file_info_faces_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/file_info_faces_item_widget.dart
@@ -351,6 +351,12 @@ class _FacesItemWidgetState extends State<FacesItemWidget> {
         defaultFaces.add(face);
       } else if (face.score >= kMinFaceDetectionScore) {
         remainingFaces.add(face);
+      } else if (face.score == -1.0) {
+        return _FaceDataResult(
+          defaultFaces: [],
+          remainingFaces: [],
+          errorReason: NoFacesReason.fileAnalysisFailed,
+        );
       }
     }
     if (defaultFaces.isEmpty && remainingFaces.isEmpty) {
@@ -433,6 +439,7 @@ enum NoFacesReason {
   fileNotAnalyzed,
   noFacesFound,
   faceThumbnailGenerationFailed,
+  fileAnalysisFailed,
 }
 
 String getNoFaceReasonText(BuildContext context, NoFacesReason reason) {
@@ -445,5 +452,7 @@ String getNoFaceReasonText(BuildContext context, NoFacesReason reason) {
       return S.of(context).noFacesFound;
     case NoFacesReason.faceThumbnailGenerationFailed:
       return "Unable to generate face thumbnails";
+    case NoFacesReason.fileAnalysisFailed:
+      return "File analysis failed";
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/file_details/file_info_faces_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/file_info_faces_item_widget.dart
@@ -451,8 +451,8 @@ String getNoFaceReasonText(BuildContext context, NoFacesReason reason) {
     case NoFacesReason.noFacesFound:
       return S.of(context).noFacesFound;
     case NoFacesReason.faceThumbnailGenerationFailed:
-      return "Unable to generate face thumbnails";
+      return S.of(context).faceThumbnailGenerationFailed;
     case NoFacesReason.fileAnalysisFailed:
-      return "File analysis failed";
+      return S.of(context).fileAnalysisFailed;
   }
 }

--- a/mobile/apps/photos/lib/utils/image_ml_util.dart
+++ b/mobile/apps/photos/lib/utils/image_ml_util.dart
@@ -65,6 +65,8 @@ Future<DecodedImage> decodeImageFromPath(
           await FlutterImageCompress.compressWithFile(
         imagePath,
         format: CompressFormat.jpeg,
+        minWidth: 8000, // High value to ensure image is not scaled down
+        minHeight: 8000, // High value to ensure image is not scaled down
       );
       final image = await decodeImageFromData(convertedData!);
       _logger.info('Conversion successful, jpeg decoded');

--- a/mobile/apps/photos/lib/utils/image_ml_util.dart
+++ b/mobile/apps/photos/lib/utils/image_ml_util.dart
@@ -65,8 +65,8 @@ Future<DecodedImage> decodeImageFromPath(
           await FlutterImageCompress.compressWithFile(
         imagePath,
         format: CompressFormat.jpeg,
-        minWidth: 8000, // High value to ensure image is not scaled down
-        minHeight: 8000, // High value to ensure image is not scaled down
+        minWidth: 20000, // High value to ensure image is not scaled down
+        minHeight: 20000, // High value to ensure image is not scaled down
       );
       final image = await decodeImageFromData(convertedData!);
       _logger.info('Conversion successful, jpeg decoded');

--- a/mobile/apps/photos/lib/utils/image_ml_util.dart
+++ b/mobile/apps/photos/lib/utils/image_ml_util.dart
@@ -70,6 +70,12 @@ Future<DecodedImage> decodeImageFromPath(
       );
       final image = await decodeImageFromData(convertedData!);
       _logger.info('Conversion successful, jpeg decoded');
+      if (image.width >= 20000 || image.height >= 20000) {
+        // Failing and storing empty result when the image dimensions are higher than max compression limits
+        _logger
+            .severe('Image res too high, W:${image.width} H:${image.height}');
+        throw Exception('Res too high W:${image.width} H:${image.height}');
+      }
       if (!includeRgbaBytes) {
         return DecodedImage(image);
       }

--- a/mobile/apps/photos/lib/utils/image_ml_util.dart
+++ b/mobile/apps/photos/lib/utils/image_ml_util.dart
@@ -4,6 +4,7 @@ import "dart:math" show exp, max, min, pi;
 import "dart:typed_data" show Float32List, Uint8List;
 import "dart:ui";
 
+import "package:exif_reader/exif_reader.dart";
 import 'package:flutter/painting.dart' as paint show decodeImageFromList;
 import "package:flutter_image_compress/flutter_image_compress.dart";
 import "package:logging/logging.dart";
@@ -47,14 +48,21 @@ Future<DecodedImage> decodeImageFromPath(
   String imagePath, {
   required bool includeRgbaBytes,
 }) async {
+  final imageData = await File(imagePath).readAsBytes();
+
+  final Map<String, IfdTag> exifData = await readExifFromBytes(imageData);
+  final int orientation =
+      exifData['Image Orientation']?.values.firstAsInt() ?? 1;
+  if (orientation > 1 && includeRgbaBytes) {
+    _logger.severe("Image EXIF orientation $orientation is not supported");
+    throw Exception(
+      'UnhandledExifOrientation: exif orientation $orientation',
+    );
+  }
+
+  late Image image;
   try {
-    final imageData = await File(imagePath).readAsBytes();
-    final image = await decodeImageFromData(imageData);
-    if (!includeRgbaBytes) {
-      return DecodedImage(image);
-    }
-    final rawRgbaBytes = await _getRawRgbaBytes(image);
-    return DecodedImage(image, rawRgbaBytes);
+    image = await decodeImageFromData(imageData);
   } catch (e, s) {
     final format = imagePath.split('.').last;
     _logger.info(
@@ -68,7 +76,7 @@ Future<DecodedImage> decodeImageFromPath(
         minWidth: 20000, // High value to ensure image is not scaled down
         minHeight: 20000, // High value to ensure image is not scaled down
       );
-      final image = await decodeImageFromData(convertedData!);
+      image = await decodeImageFromData(convertedData!);
       _logger.info('Conversion successful, jpeg decoded');
       if (image.width >= 20000 || image.height >= 20000) {
         // Failing and storing empty result when the image dimensions are higher than max compression limits
@@ -76,11 +84,6 @@ Future<DecodedImage> decodeImageFromPath(
             .severe('Image res too high, W:${image.width} H:${image.height}');
         throw Exception('Res too high W:${image.width} H:${image.height}');
       }
-      if (!includeRgbaBytes) {
-        return DecodedImage(image);
-      }
-      final rawRgbaBytes = await _getRawRgbaBytes(image);
-      return DecodedImage(image, rawRgbaBytes);
     } catch (e) {
       _logger.severe(
         'Error decoding image of format $format on ${Platform.isAndroid ? "Android" : "iOS"}',
@@ -92,6 +95,11 @@ Future<DecodedImage> decodeImageFromPath(
       );
     }
   }
+  if (!includeRgbaBytes) {
+    return DecodedImage(image);
+  }
+  final rawRgbaBytes = await _getRawRgbaBytes(image);
+  return DecodedImage(image, rawRgbaBytes);
 }
 
 /// Decodes [Uint8List] image data to an ui.[Image] object.


### PR DESCRIPTION
## Description

- Set a high minimum value for compression when original format can't be decoded. If there's an image with higher resolution we log it and locally fail indexing for that file.
- Check for EXIF orientation of image when starting ML analysis of that file. If there's a non-standard orientation we log that orientation and locally fail indexing for that file.

## Tests

- Confirmed that this doesn't give upscaled images
- Comfirmed that the decoding issue is not there on mobile
- Tested correct surfacing of `file analysis failed` button