### PR TITLE
[server] Make use_path_style_urls and disable_ssl configurable per bucket

### DIFF
--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -136,12 +136,11 @@ func (config *S3Config) initialize() {
 			Endpoint: aws.String(viper.GetString("s3." + dc + ".endpoint")),
 			Region:   aws.String(viper.GetString("s3." + dc + ".region")),
 		}
-		if usePathStyleURLs {
+		if usePathStyleURLs || viper.GetBool("s3." + dc + ".use_path_style_urls") || areLocalBuckets {
 			s3Config.S3ForcePathStyle = aws.Bool(true)
 		}
-		if areLocalBuckets {
+		if areLocalBuckets || viper.GetBool("s3." + dc + ".disable_ssl") {
 			s3Config.DisableSSL = aws.Bool(true)
-			s3Config.S3ForcePathStyle = aws.Bool(true)
 		}
 		s3Session, err := session.NewSession(&s3Config)
 		if err != nil {


### PR DESCRIPTION
## Description

I wanted to use a mix of local minio and remote buckets and therefore needed both the `use_path_style_urls` and `disable_ssl` settings to be configurable per bucket. These changes are backwards compatible with the "global" settings `use_path_style_urls` and `areLocalBuckets`.

## Tests

I'm running this code in my own self hosted museum instance.