### PR TITLE
[mob][photos] Fix duplicate people files

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/gallery/hooks/pick_person_avatar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/hooks/pick_person_avatar.dart
@@ -54,7 +54,7 @@ class PickPersonCoverPhotoWidget extends StatelessWidget {
     final result = await SearchService.instance
         .getClusterFilesForPersonID(personEntity.remoteID);
 
-    final List<EnteFile> resultFiles = [];
+    final resultFiles = <EnteFile>{};
     for (final e in result.entries) {
       resultFiles.addAll(e.value);
     }

--- a/mobile/apps/photos/lib/ui/viewer/people/people_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/people_page.dart
@@ -108,7 +108,7 @@ class _PeoplePageState extends State<PeoplePage> {
       );
       return [];
     }
-    final List<EnteFile> resultFiles = [];
+    final Set<EnteFile> resultFiles = {};
     for (final e in result.entries) {
       resultFiles.addAll(e.value);
     }


### PR DESCRIPTION
## Description

Prevent showing duplicate files in people page due to a face getting incorrectly tagged when a correct face is already there.