### PR TITLE
[mob/photos] [fix] Handle duplicate fileID during addOrCopy

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -1648,17 +1648,27 @@ class CollectionsService {
     );
     final List<EnteFile> filesToCopy = [];
     final List<EnteFile> filesToAdd = [];
+    final Set<int> seenForAdd = {};
+    final Set<int> seenForCopy = {};
+
     for (final EnteFile file in othersFile) {
-      if (hashToUserFile.containsKey(file.hash ?? '')) {
-        final userFile = hashToUserFile[file.hash]!;
-        if (userFile.fileType == file.fileType) {
-          filesToAdd.add(userFile);
-        } else {
-          filesToCopy.add(file);
-        }
-      } else {
-        filesToCopy.add(file);
+      final userFile = hashToUserFile[file.hash ?? ''];
+      final bool shouldAdd =
+          userFile != null && userFile.fileType == file.fileType;
+      final targetList = shouldAdd ? filesToAdd : filesToCopy;
+      final seenSet = shouldAdd ? seenForAdd : seenForCopy;
+      final fileToProcess = shouldAdd ? userFile : file;
+      final uploadID = fileToProcess.uploadedFileID;
+
+      if (seenSet.contains(uploadID)) {
+        final action = shouldAdd ? "adding" : "copying";
+        _logger.warning(
+          "skip $action file $uploadID as it is already ${action}ed",
+        );
+        continue;
       }
+      targetList.add(fileToProcess);
+      seenSet.add(uploadID!);
     }
     return (filesToAdd, filesToCopy);
   }


### PR DESCRIPTION
## Description
If others file contains two files with same hash, we are returning same FileID twice for add or copy operation. This change fixes that behaviour.

## Tests
