### PR TITLE
[server][db] Tweak autovacuum threshold for trash table

### DIFF
--- a/server/migrations/102_trash_vaccume_and_analyze_threshold.down.sql
+++ b/server/migrations/102_trash_vaccume_and_analyze_threshold.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE trash RESET (
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_threshold
+    );

--- a/server/migrations/102_trash_vaccume_and_analyze_threshold.up.sql
+++ b/server/migrations/102_trash_vaccume_and_analyze_threshold.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE trash SET (
+    autovacuum_analyze_scale_factor = 0.01,  -- Trigger ANALYZE after 1% of rows change
+    autovacuum_vacuum_scale_factor = 0.02,   -- Trigger VACUUM after 2% of rows change
+    autovacuum_analyze_threshold = 1000,
+    autovacuum_vacuum_threshold = 1000
+);


### PR DESCRIPTION
## Description
Attempt to increase refresh rate for autovacuum to ensure that the query planner use the index.
Based on slow query logs, and analyze command, it looks like the index is not being used because the table stats are out of date. And the default auto_vacumm only runs after 10% of rows have changed. 

## Tests
Tested on local machine.
```
SELECT unnest(reloptions) AS option
FROM pg_class
WHERE relname = 'trash';
```

Once deployed, will monitor slow query logs and CPU usage.