### PR TITLE
[mobile][photos] Fix Add to Album in search section

### DIFF
--- a/mobile/apps/photos/lib/models/search/search_types.dart
+++ b/mobile/apps/photos/lib/models/search/search_types.dart
@@ -187,11 +187,14 @@ extension SectionTypeExtensions on SectionType {
               try {
                 final Collection c =
                     await CollectionsService.instance.createAlbum(text);
-                unawaited(
-                  routeToPage(
-                    context,
-                    CollectionPage(CollectionWithThumbnail(c, null)),
-                  ),
+
+                // Close the dialog now so that it does not flash when leaving the album again.
+                Navigator.of(context).pop();
+
+                // ignore: unawaited_futures
+                await routeToPage(
+                  context,
+                  CollectionPage(CollectionWithThumbnail(c, null)),
                 );
               } catch (e, s) {
                 Logger("CreateNewAlbumIcon")

--- a/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
@@ -142,7 +142,7 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
         },
         showOnlyLoadingState: true,
         textCapitalization: TextCapitalization.words,
-        popnavAfterSubmission: false,
+        popnavAfterSubmission: true,
       );
       if (result is Exception) {
         await showGenericErrorDialog(


### PR DESCRIPTION
## Description
When creating a new album from the search tab, the album is created and then it pop back to the search screen after sometime. 

#### Before
https://github.com/user-attachments/assets/7e172227-5a35-4d7c-b0f3-e6afd46441ed

#### After

https://github.com/user-attachments/assets/c94eaac4-c51c-4dd3-a573-a8fd17221fec


## Tests
