### PR TITLE
Remove Deprecated Color References in Flutter 3.27/flutter_svg 2.0

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -82,7 +82,7 @@ class _AppState extends State<App>
                 UpdateService.instance.getLatestVersionInfo(),
               );
             },
-            barrierColor: Colors.black.withOpacity(0.85),
+            barrierColor: Colors.black.withValues(alpha: 0.85),
           );
         });
       }

--- a/mobile/apps/auth/lib/ente_theme_data.dart
+++ b/mobile/apps/auth/lib/ente_theme_data.dart
@@ -275,7 +275,7 @@ TextTheme _buildTextTheme(Color textColor) {
       fontWeight: FontWeight.w500,
     ),
     bodySmall: TextStyle(
-      color: textColor.withOpacity(0.4),
+      color: textColor.withValues(alpha: 0.4),
       fontSize: 10,
       fontWeight: FontWeight.w500,
     ),
@@ -343,7 +343,7 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(48, 48, 48, 0.5);
 
   Color get iconColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.75)
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.75)
       : const Color.fromRGBO(255, 255, 255, 1);
 
   Color get bgColorForQuestions => brightness == Brightness.light
@@ -354,7 +354,7 @@ extension CustomColorScheme on ColorScheme {
 
   Color get cupertinoPickerTopColor => brightness == Brightness.light
       ? const Color.fromARGB(255, 238, 238, 238)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.1);
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.1);
 
   Color get stepProgressUnselectedColor => brightness == Brightness.light
       ? const Color.fromRGBO(196, 196, 196, 0.6)
@@ -381,20 +381,20 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(20, 20, 20, 1);
 
   Color get galleryThumbDrawColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.8)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.5);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.8)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.5);
 
   Color get backupEnabledBgColor => brightness == Brightness.light
       ? const Color.fromRGBO(230, 230, 230, 0.95)
       : const Color.fromRGBO(10, 40, 40, 0.3);
 
   Color get dotsIndicatorActiveColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.5)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.5);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.5)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.5);
 
   Color get dotsIndicatorInactiveColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.12)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.12);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.12)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.12);
 
   Color get toastTextColor => brightness == Brightness.light
       ? const Color.fromRGBO(255, 255, 255, 1)
@@ -409,8 +409,8 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(100, 100, 100, 1);
 
   Color get themeSwitchInactiveIconColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.5)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.5);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.5)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.5);
 
   Color get searchResultsColor => brightness == Brightness.light
       ? const Color.fromRGBO(245, 245, 245, 1.0)
@@ -421,8 +421,8 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(150, 150, 150, 1);
 
   Color get searchResultsBackgroundColor => brightness == Brightness.light
-      ? Colors.black.withOpacity(0.32)
-      : Colors.black.withOpacity(0.64);
+      ? Colors.black.withValues(alpha: 0.32)
+      : Colors.black.withValues(alpha: 0.64);
 
   Color get codeCardBackgroundColor => brightness == Brightness.light
       ? const Color.fromRGBO(246, 246, 246, 1)

--- a/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
+++ b/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
@@ -332,7 +332,7 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
                                 },
                               );
                             },
-                            barrierColor: Colors.black.withOpacity(0.85),
+                            barrierColor: Colors.black.withValues(alpha: 0.85),
                             barrierDismissible: false,
                           );
                         },

--- a/mobile/apps/auth/lib/store/code_display_store.dart
+++ b/mobile/apps/auth/lib/store/code_display_store.dart
@@ -75,7 +75,7 @@ class CodeDisplayStore {
       builder: (BuildContext context) {
         return EditTagDialog(tag: tag);
       },
-      barrierColor: Colors.black.withOpacity(0.85),
+      barrierColor: Colors.black.withValues(alpha: 0.85),
       barrierDismissible: false,
     );
   }

--- a/mobile/apps/auth/lib/ui/account/sessions_page.dart
+++ b/mobile/apps/auth/lib/ui/account/sessions_page.dart
@@ -82,7 +82,7 @@ class _SessionsPageState extends State<SessionsPage> {
                           color: Theme.of(context)
                               .colorScheme
                               .onSurface
-                              .withOpacity(0.8),
+                              .withValues(alpha: 0.8),
                           fontSize: 14,
                         ),
                       ),
@@ -95,7 +95,7 @@ class _SessionsPageState extends State<SessionsPage> {
                           color: Theme.of(context)
                               .colorScheme
                               .onSurface
-                              .withOpacity(0.8),
+                              .withValues(alpha: 0.8),
                           fontSize: 12,
                         ),
                       ),

--- a/mobile/apps/auth/lib/ui/components/banner_widget.dart
+++ b/mobile/apps/auth/lib/ui/components/banner_widget.dart
@@ -54,12 +54,12 @@ class BannerWidget extends StatelessWidget {
         dashColor = const Color.fromRGBO(255, 191, 12, 1);
         boxShadow = [
           BoxShadow(
-            color: const Color(0xFFFDB816).withOpacity(0.1),
+            color: const Color(0xFFFDB816).withValues(alpha: 0.1),
             blurRadius: 50,
             spreadRadius: 80,
           ),
           BoxShadow(
-            color: const Color(0xFFFDB816).withOpacity(0.2),
+            color: const Color(0xFFFDB816).withValues(alpha: 0.2),
             blurRadius: 25,
           ),
         ];
@@ -71,12 +71,12 @@ class BannerWidget extends StatelessWidget {
         dashColor = const Color.fromRGBO(233, 233, 233, 1);
         boxShadow = [
           BoxShadow(
-            color: const Color.fromRGBO(78, 78, 78, 1).withOpacity(0.2),
+            color: const Color.fromRGBO(78, 78, 78, 1).withValues(alpha: 0.2),
             blurRadius: 50,
             spreadRadius: 100,
           ),
           BoxShadow(
-            color: const Color.fromRGBO(23, 22, 22, 0.30).withOpacity(0.1),
+            color: const Color.fromRGBO(23, 22, 22, 0.30).withValues(alpha: 0.1),
             blurRadius: 25,
           ),
         ];
@@ -87,12 +87,12 @@ class BannerWidget extends StatelessWidget {
         dashColor = const Color.fromRGBO(29, 185, 84, 1);
         boxShadow = [
           BoxShadow(
-            color: const Color.fromRGBO(38, 203, 95, 1).withOpacity(0.08),
+            color: const Color.fromRGBO(38, 203, 95, 1).withValues(alpha: 0.08),
             blurRadius: 50,
             spreadRadius: 100,
           ),
           BoxShadow(
-            color: const Color.fromRGBO(0, 0, 0, 0.50).withOpacity(0.08),
+            color: const Color.fromRGBO(0, 0, 0, 0.50).withValues(alpha: 0.08),
             blurRadius: 25,
           ),
         ];
@@ -103,12 +103,12 @@ class BannerWidget extends StatelessWidget {
         imagePath = "assets/discount.png";
         boxShadow = [
           BoxShadow(
-            color: const Color.fromRGBO(38, 203, 95, 1).withOpacity(0.08),
+            color: const Color.fromRGBO(38, 203, 95, 1).withValues(alpha: 0.08),
             blurRadius: 50,
             spreadRadius: 100,
           ),
           BoxShadow(
-            color: const Color.fromRGBO(0, 0, 0, 0.50).withOpacity(0.08),
+            color: const Color.fromRGBO(0, 0, 0, 0.50).withValues(alpha: 0.08),
             blurRadius: 25,
           ),
         ];

--- a/mobile/apps/auth/lib/ui/components/custom_icon_widget.dart
+++ b/mobile/apps/auth/lib/ui/components/custom_icon_widget.dart
@@ -28,7 +28,7 @@ class CustomIconWidget extends StatelessWidget {
                   width: 1.5,
                   color: getEnteColorScheme(context)
                       .tagChipSelectedColor
-                      .withOpacity(0.5),
+                      .withValues(alpha: 0.5),
                 ),
                 borderRadius: SmoothBorderRadius(
                   cornerRadius: 15.5,
@@ -102,7 +102,7 @@ class CustomIconWidget extends StatelessWidget {
           child: Icon(
             Icons.edit,
             size: 16,
-            color: Colors.black.withOpacity(0.9),
+            color: Colors.black.withValues(alpha: 0.9),
           ),
         ),
       ),

--- a/mobile/apps/auth/lib/ui/components/notification_warning_widget.dart
+++ b/mobile/apps/auth/lib/ui/components/notification_warning_widget.dart
@@ -52,7 +52,7 @@ class NotificationWidget extends StatelessWidget {
         subTextStyle = textTheme.miniMuted;
         strokeColorScheme = colorScheme;
         boxShadow = [
-          BoxShadow(color: Colors.black.withOpacity(0.25), blurRadius: 1),
+          BoxShadow(color: Colors.black.withValues(alpha: 0.25), blurRadius: 1),
         ];
         break;
 

--- a/mobile/apps/auth/lib/ui/home/coach_mark_widget.dart
+++ b/mobile/apps/auth/lib/ui/home/coach_mark_widget.dart
@@ -23,7 +23,7 @@ class CoachMarkWidget extends StatelessWidget {
           Expanded(
             child: Container(
               width: double.infinity,
-              color: Theme.of(context).colorScheme.surface.withOpacity(0.1),
+              color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.1),
               child: BackdropFilter(
                 filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
                 child: Row(

--- a/mobile/apps/auth/lib/ui/settings/about_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/about_section_widget.dart
@@ -77,7 +77,7 @@ class AboutSectionWidget extends StatelessWidget {
                               UpdateService.instance.getLatestVersionInfo(),
                             );
                           },
-                          barrierColor: Colors.black.withOpacity(0.85),
+                          barrierColor: Colors.black.withValues(alpha: 0.85),
                         );
                       } else {
                         showShortToast(

--- a/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
@@ -56,7 +56,7 @@ class AccountSectionWidget extends StatelessWidget {
               builder: (BuildContext context) {
                 return const ChangeEmailDialog();
               },
-              barrierColor: Colors.black.withOpacity(0.85),
+              barrierColor: Colors.black.withValues(alpha: 0.85),
               barrierDismissible: false,
             );
           }

--- a/mobile/apps/auth/lib/ui/settings/data/duplicate_code_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/duplicate_code_page.dart
@@ -83,7 +83,7 @@ class _DuplicateCodePageState extends State<DuplicateCodePage> {
                                     color: Theme.of(context)
                                         .iconTheme
                                         .color!
-                                        .withOpacity(0.7),
+                                        .withValues(alpha: 0.7),
                                   ),
                         ),
                         const Padding(padding: EdgeInsets.only(left: 4)),

--- a/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_confirm_password.dart
+++ b/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_confirm_password.dart
@@ -116,10 +116,10 @@ class _LockScreenConfirmPasswordState extends State<LockScreenConfirmPassword> {
                         shape: BoxShape.circle,
                         gradient: LinearGradient(
                           colors: [
-                            Colors.grey.shade500.withOpacity(0.2),
-                            Colors.grey.shade50.withOpacity(0.1),
-                            Colors.grey.shade400.withOpacity(0.2),
-                            Colors.grey.shade300.withOpacity(0.4),
+                            Colors.grey.shade500.withValues(alpha: 0.2),
+                            Colors.grey.shade50.withValues(alpha: 0.1),
+                            Colors.grey.shade400.withValues(alpha: 0.2),
+                            Colors.grey.shade300.withValues(alpha: 0.4),
                           ],
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,

--- a/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_confirm_pin.dart
+++ b/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_confirm_pin.dart
@@ -107,10 +107,10 @@ class _LockScreenConfirmPinState extends State<LockScreenConfirmPin> {
                     shape: BoxShape.circle,
                     gradient: LinearGradient(
                       colors: [
-                        Colors.grey.shade500.withOpacity(0.2),
-                        Colors.grey.shade50.withOpacity(0.1),
-                        Colors.grey.shade400.withOpacity(0.2),
-                        Colors.grey.shade300.withOpacity(0.4),
+                        Colors.grey.shade500.withValues(alpha: 0.2),
+                        Colors.grey.shade50.withValues(alpha: 0.1),
+                        Colors.grey.shade400.withValues(alpha: 0.2),
+                        Colors.grey.shade300.withValues(alpha: 0.4),
                       ],
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,

--- a/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_password.dart
+++ b/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_password.dart
@@ -127,10 +127,10 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
                         shape: BoxShape.circle,
                         gradient: LinearGradient(
                           colors: [
-                            Colors.grey.shade500.withOpacity(0.2),
-                            Colors.grey.shade50.withOpacity(0.1),
-                            Colors.grey.shade400.withOpacity(0.2),
-                            Colors.grey.shade300.withOpacity(0.4),
+                            Colors.grey.shade500.withValues(alpha: 0.2),
+                            Colors.grey.shade50.withValues(alpha: 0.1),
+                            Colors.grey.shade400.withValues(alpha: 0.2),
+                            Colors.grey.shade300.withValues(alpha: 0.4),
                           ],
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,

--- a/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_pin.dart
+++ b/mobile/apps/auth/lib/ui/settings/lock_screen/lock_screen_pin.dart
@@ -178,10 +178,10 @@ class _LockScreenPinState extends State<LockScreenPin> {
                     shape: BoxShape.circle,
                     gradient: LinearGradient(
                       colors: [
-                        Colors.grey.shade500.withOpacity(0.2),
-                        Colors.grey.shade50.withOpacity(0.1),
-                        Colors.grey.shade400.withOpacity(0.2),
-                        Colors.grey.shade300.withOpacity(0.4),
+                        Colors.grey.shade500.withValues(alpha: 0.2),
+                        Colors.grey.shade50.withValues(alpha: 0.1),
+                        Colors.grey.shade400.withValues(alpha: 0.2),
+                        Colors.grey.shade300.withValues(alpha: 0.4),
                       ],
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,

--- a/mobile/apps/auth/lib/ui/sort_option_menu.dart
+++ b/mobile/apps/auth/lib/ui/sort_option_menu.dart
@@ -35,7 +35,7 @@ class SortCodeMenuWidget extends StatelessWidget {
         text,
         style: Theme.of(context).textTheme.titleMedium!.copyWith(
               fontSize: 14,
-              color: Theme.of(context).iconTheme.color!.withOpacity(0.7),
+              color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.7),
             ),
       );
     }

--- a/mobile/apps/auth/lib/ui/tools/lock_screen.dart
+++ b/mobile/apps/auth/lib/ui/tools/lock_screen.dart
@@ -96,10 +96,10 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
                           shape: BoxShape.circle,
                           gradient: LinearGradient(
                             colors: [
-                              Colors.grey.shade500.withOpacity(0.2),
-                              Colors.grey.shade50.withOpacity(0.1),
-                              Colors.grey.shade400.withOpacity(0.2),
-                              Colors.grey.shade300.withOpacity(0.4),
+                              Colors.grey.shade500.withValues(alpha: 0.2),
+                              Colors.grey.shade50.withValues(alpha: 0.1),
+                              Colors.grey.shade400.withValues(alpha: 0.2),
+                              Colors.grey.shade300.withValues(alpha: 0.4),
                             ],
                             begin: Alignment.topCenter,
                             end: Alignment.bottomCenter,

--- a/mobile/apps/auth/lib/ui/two_factor_recovery_page.dart
+++ b/mobile/apps/auth/lib/ui/two_factor_recovery_page.dart
@@ -99,7 +99,7 @@ class _TwoFactorRecoveryPageState extends State<TwoFactorRecoveryPage> {
                     decoration: TextDecoration.underline,
                     fontSize: 12,
                     color:
-                        getEnteColorScheme(context).textBase.withOpacity(0.9),
+                        getEnteColorScheme(context).textBase.withValues(alpha: 0.9),
                   ),
                 ),
               ),

--- a/mobile/apps/auth/lib/ui/utils/icon_utils.dart
+++ b/mobile/apps/auth/lib/ui/utils/icon_utils.dart
@@ -189,10 +189,10 @@ class IconUtils {
     return _colorLuminance.putIfAbsent(color, () => color.computeLuminance());
   }
 
-  bool _isCloseToNeutralGrey(Color color, {double tolerance = 3}) {
-    return (color.red - color.green).abs() <= tolerance &&
-        (color.green - color.blue).abs() <= tolerance &&
-        (color.blue - color.red).abs() <= tolerance;
+  bool _isCloseToNeutralGrey(Color color, {double tolerance = 0.012}) {
+    return (color.r - color.g).abs() <= tolerance &&
+        (color.g - color.b).abs() <= tolerance &&
+        (color.b - color.r).abs() <= tolerance;
   }
 
   Future<void> _loadJson() async {

--- a/mobile/apps/photos/lib/ente_theme_data.dart
+++ b/mobile/apps/photos/lib/ente_theme_data.dart
@@ -206,7 +206,7 @@ TextTheme _buildTextTheme(Color textColor) {
       fontWeight: FontWeight.w500,
     ),
     bodySmall: TextStyle(
-      color: textColor.withOpacity(0.6),
+      color: textColor.withValues(alpha: 0.6),
       fontSize: 14,
       fontWeight: FontWeight.w500,
     ),
@@ -280,7 +280,7 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(48, 48, 48, 0.5);
 
   Color get iconColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.75)
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.75)
       : const Color.fromRGBO(255, 255, 255, 1);
 
   Color get bgColorForQuestions => brightness == Brightness.light
@@ -291,7 +291,7 @@ extension CustomColorScheme on ColorScheme {
 
   Color get cupertinoPickerTopColor => brightness == Brightness.light
       ? const Color.fromARGB(255, 238, 238, 238)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.1);
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.1);
 
   Color get stepProgressUnselectedColor => brightness == Brightness.light
       ? const Color.fromRGBO(196, 196, 196, 0.6)
@@ -302,20 +302,20 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(20, 20, 20, 1);
 
   Color get galleryThumbDrawColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.8)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.5);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.8)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.5);
 
   Color get backupEnabledBgColor => brightness == Brightness.light
       ? const Color.fromRGBO(230, 230, 230, 0.95)
       : const Color.fromRGBO(10, 40, 40, 0.3);
 
   Color get dotsIndicatorActiveColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.5)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.5);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.5)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.5);
 
   Color get dotsIndicatorInactiveColor => brightness == Brightness.light
-      ? const Color.fromRGBO(0, 0, 0, 1).withOpacity(0.12)
-      : const Color.fromRGBO(255, 255, 255, 1).withOpacity(0.12);
+      ? const Color.fromRGBO(0, 0, 0, 1).withValues(alpha: 0.12)
+      : const Color.fromRGBO(255, 255, 255, 1).withValues(alpha: 0.12);
 
   Color get toastTextColor => brightness == Brightness.light
       ? const Color.fromRGBO(255, 255, 255, 1)
@@ -338,8 +338,8 @@ extension CustomColorScheme on ColorScheme {
       : const Color.fromRGBO(150, 150, 150, 1);
 
   Color get searchResultsBackgroundColor => brightness == Brightness.light
-      ? Colors.black.withOpacity(0.32)
-      : Colors.black.withOpacity(0.64);
+      ? Colors.black.withValues(alpha: 0.32)
+      : Colors.black.withValues(alpha: 0.64);
 
   EnteTheme get enteTheme =>
       brightness == Brightness.light ? lightTheme : darkTheme;

--- a/mobile/apps/photos/lib/ui/account/sessions_page.dart
+++ b/mobile/apps/photos/lib/ui/account/sessions_page.dart
@@ -83,7 +83,7 @@ class _SessionsPageState extends State<SessionsPage> {
                           color: Theme.of(context)
                               .colorScheme
                               .onSurface
-                              .withOpacity(0.8),
+                              .withValues(alpha: 0.8),
                           fontSize: 14,
                         ),
                       ),
@@ -96,7 +96,7 @@ class _SessionsPageState extends State<SessionsPage> {
                           color: Theme.of(context)
                               .colorScheme
                               .onSurface
-                              .withOpacity(0.8),
+                              .withValues(alpha: 0.8),
                           fontSize: 12,
                         ),
                       ),

--- a/mobile/apps/photos/lib/ui/account/two_factor_recovery_page.dart
+++ b/mobile/apps/photos/lib/ui/account/two_factor_recovery_page.dart
@@ -102,7 +102,7 @@ class _TwoFactorRecoveryPageState extends State<TwoFactorRecoveryPage> {
                     decoration: TextDecoration.underline,
                     fontSize: 12,
                     color:
-                        getEnteColorScheme(context).textBase.withOpacity(0.9),
+                        getEnteColorScheme(context).textBase.withValues(alpha: 0.9),
                   ),
                 ),
               ),

--- a/mobile/apps/photos/lib/ui/account/two_factor_setup_page.dart
+++ b/mobile/apps/photos/lib/ui/account/two_factor_setup_page.dart
@@ -160,14 +160,14 @@ class _TwoFactorSetupPageState extends State<TwoFactorSetupPage>
             padding: const EdgeInsets.only(left: 10, right: 10),
             child: Container(
               padding: const EdgeInsets.all(16),
-              color: textColor.withOpacity(0.1),
+              color: textColor.withValues(alpha: 0.1),
               child: Center(
                 child: Text(
                   widget.secretCode,
                   style: TextStyle(
                     fontSize: 15,
                     fontFeatures: const [FontFeature.tabularFigures()],
-                    color: textColor.withOpacity(0.7),
+                    color: textColor.withValues(alpha: 0.7),
                   ),
                 ),
               ),
@@ -176,7 +176,7 @@ class _TwoFactorSetupPageState extends State<TwoFactorSetupPage>
           const Padding(padding: EdgeInsets.all(6)),
           Text(
             S.of(context).tapToCopy,
-            style: TextStyle(color: textColor.withOpacity(0.5)),
+            style: TextStyle(color: textColor.withValues(alpha: 0.5)),
           ),
         ],
       ),

--- a/mobile/apps/photos/lib/ui/collections/album/row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/row_item.dart
@@ -120,7 +120,7 @@ class AlbumRowItemWidget extends StatelessWidget {
                                 child: isSelected
                                     ? ColorFiltered(
                                         colorFilter: ColorFilter.mode(
-                                          Colors.black.withOpacity(
+                                          Colors.black.withValues(alpha: 
                                             0.4,
                                           ),
                                           BlendMode.darken,

--- a/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
@@ -28,7 +28,7 @@ class ArchivedCollectionsButton extends StatelessWidget {
         padding: const EdgeInsets.all(0),
         side: BorderSide(
           width: 0.5,
-          color: Theme.of(context).iconTheme.color!.withOpacity(0.24),
+          color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.24),
         ),
       ),
       child: SizedBox(

--- a/mobile/apps/photos/lib/ui/collections/button/hidden_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/hidden_button.dart
@@ -23,7 +23,7 @@ class HiddenCollectionsButtonWidget extends StatelessWidget {
         padding: const EdgeInsets.all(0),
         side: BorderSide(
           width: 0.5,
-          color: Theme.of(context).iconTheme.color!.withOpacity(0.24),
+          color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.24),
         ),
       ),
       child: SizedBox(

--- a/mobile/apps/photos/lib/ui/collections/button/trash_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/trash_button.dart
@@ -52,7 +52,7 @@ class _TrashSectionButtonState extends State<TrashSectionButton> {
         padding: const EdgeInsets.all(0),
         side: BorderSide(
           width: 0.5,
-          color: Theme.of(context).iconTheme.color!.withOpacity(0.24),
+          color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.24),
         ),
       ),
       child: SizedBox(

--- a/mobile/apps/photos/lib/ui/collections/button/uncategorized_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/uncategorized_button.dart
@@ -33,7 +33,7 @@ class UnCategorizedCollections extends StatelessWidget {
         padding: const EdgeInsets.all(0),
         side: BorderSide(
           width: 0.5,
-          color: Theme.of(context).iconTheme.color!.withOpacity(0.24),
+          color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.24),
         ),
       ),
       child: SizedBox(

--- a/mobile/apps/photos/lib/ui/components/notification_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/notification_widget.dart
@@ -60,7 +60,7 @@ class NotificationWidget extends StatelessWidget {
         subTextStyle = textTheme.miniMuted;
         strokeColorScheme = colorScheme;
         boxShadow = [
-          BoxShadow(color: Colors.black.withOpacity(0.25), blurRadius: 1),
+          BoxShadow(color: Colors.black.withValues(alpha: 0.25), blurRadius: 1),
         ];
         break;
       case NotificationType.goldenBanner:

--- a/mobile/apps/photos/lib/ui/home/grant_permissions_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/grant_permissions_widget.dart
@@ -44,7 +44,7 @@ class _GrantPermissionsWidgetState extends State<GrantPermissionsWidget> {
                     isLightMode
                         ? Image.asset(
                             'assets/loading_photos_background.png',
-                            color: Colors.white.withOpacity(0.4),
+                            color: Colors.white.withValues(alpha: 0.4),
                             colorBlendMode: BlendMode.modulate,
                           )
                         : Image.asset(

--- a/mobile/apps/photos/lib/ui/home/landing_page_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/landing_page_widget.dart
@@ -350,7 +350,7 @@ class FeatureItemWidget extends StatelessWidget {
               subText,
               textAlign: TextAlign.center,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
                 fontSize: 16,
               ),
             ),

--- a/mobile/apps/photos/lib/ui/home/loading_photos_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/loading_photos_widget.dart
@@ -124,12 +124,12 @@ class _LoadingPhotosWidgetState extends State<LoadingPhotosWidget> {
                     isLightMode
                         ? Image.asset(
                             'assets/loading_photos_background.png',
-                            color: Colors.white.withOpacity(0.5),
+                            color: Colors.white.withValues(alpha: 0.5),
                             colorBlendMode: BlendMode.modulate,
                           )
                         : Image.asset(
                             'assets/loading_photos_background_dark.png',
-                            color: Colors.white.withOpacity(0.25),
+                            color: Colors.white.withValues(alpha: 0.25),
                             colorBlendMode: BlendMode.modulate,
                           ),
                     Column(

--- a/mobile/apps/photos/lib/ui/home/memories/full_screen_memory.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/full_screen_memory.dart
@@ -345,7 +345,7 @@ class _FullScreenMemoryState extends State<FullScreenMemory> {
                                     currentIndex: value,
                                     selectedColor: Colors.white,
                                     unselectedColor:
-                                        Colors.white.withOpacity(0.4),
+                                        Colors.white.withValues(alpha: 0.4),
                                     duration: duration,
                                     animationController: (controller) {
                                       _progressAnimationController = controller;

--- a/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
@@ -115,7 +115,7 @@ class _MemoryCoverWidgetState extends State<MemoryCoverWidget> {
                           decoration: BoxDecoration(
                             gradient: LinearGradient(
                               colors: [
-                                Colors.black.withOpacity(0.5),
+                                Colors.black.withValues(alpha: 0.5),
                                 Colors.transparent,
                               ],
                               stops: const [0, 1],
@@ -171,7 +171,7 @@ class _MemoryCoverWidgetState extends State<MemoryCoverWidget> {
                         decoration: BoxDecoration(
                           gradient: LinearGradient(
                             colors: [
-                              Colors.black.withOpacity(0.5),
+                              Colors.black.withValues(alpha: 0.5),
                               Colors.transparent,
                             ],
                             stops: const [0, 1],

--- a/mobile/apps/photos/lib/ui/payment/subscription_plan_widget.dart
+++ b/mobile/apps/photos/lib/ui/payment/subscription_plan_widget.dart
@@ -60,7 +60,7 @@ class _SubscriptionPlanWidgetState extends State<SubscriptionPlanWidget> {
               : null,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.08),
+              color: Colors.black.withValues(alpha: 0.08),
               offset: const Offset(0, 4),
               blurRadius: 4,
             ),

--- a/mobile/apps/photos/lib/ui/settings/about_section_widget.dart
+++ b/mobile/apps/photos/lib/ui/settings/about_section_widget.dart
@@ -77,7 +77,7 @@ class AboutSectionWidget extends StatelessWidget {
                               updateService.getLatestVersionInfo(),
                             );
                           },
-                          barrierColor: Colors.black.withOpacity(0.85),
+                          barrierColor: Colors.black.withValues(alpha: 0.85),
                         );
                       } else {
                         showShortToast(

--- a/mobile/apps/photos/lib/ui/settings/account_section_widget.dart
+++ b/mobile/apps/photos/lib/ui/settings/account_section_widget.dart
@@ -71,7 +71,7 @@ class AccountSectionWidget extends StatelessWidget {
                 builder: (BuildContext context) {
                   return const ChangeEmailDialog();
                 },
-                barrierColor: Colors.black.withOpacity(0.85),
+                barrierColor: Colors.black.withValues(alpha: 0.85),
                 barrierDismissible: false,
               );
             }

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
@@ -272,7 +272,7 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
                   final elevation = lerpDouble(0, 8, t)!;
                   final themeColor = Theme.of(context).colorScheme.onSurface;
                   final color =
-                      Color.lerp(themeColor, themeColor.withOpacity(0.8), t);
+                      Color.lerp(themeColor, themeColor.withValues(alpha: 0.8), t);
                   return SizeFadeTransition(
                     sizeFraction: 0.7,
                     curve: Curves.easeInOut,
@@ -359,7 +359,7 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
                                 : Theme.of(context)
                                     .colorScheme
                                     .onSurface
-                                    .withOpacity(0.7),
+                                    .withValues(alpha: 0.7),
                           ),
                           overflow: TextOverflow.ellipsis,
                           maxLines: 2,

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_item_card.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_item_card.dart
@@ -77,7 +77,7 @@ class _BackupItemCardState extends State<BackupItemCard> {
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(4),
           border: Border.all(
-            color: colorScheme.fillFaint.withOpacity(0.08),
+            color: colorScheme.fillFaint.withValues(alpha: 0.08),
             width: 1,
           ),
         ),

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
@@ -138,8 +138,8 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
                       fontSize: 16,
                       height: 20 / 16,
                       color: Theme.of(context).brightness == Brightness.light
-                          ? const Color(0xFF000000).withOpacity(0.7)
-                          : const Color(0xFFFFFFFF).withOpacity(0.7),
+                          ? const Color(0xFF000000).withValues(alpha: 0.7)
+                          : const Color(0xFFFFFFFF).withValues(alpha: 0.7),
                     ),
                   ),
                   const SizedBox(height: 48),

--- a/mobile/apps/photos/lib/ui/settings/debug/memories_debug_section.dart
+++ b/mobile/apps/photos/lib/ui/settings/debug/memories_debug_section.dart
@@ -186,7 +186,7 @@ class MomentRecommendation extends StatelessWidget {
                   cornerSmoothing: _cornerSmoothing,
                 ),
                 child: Container(
-                  color: Colors.white.withOpacity(0.16),
+                  color: Colors.white.withValues(alpha: 0.16),
                   width: _width + _borderWidth * 2,
                   height: _height + _borderWidth * 2,
                 ),
@@ -195,7 +195,7 @@ class MomentRecommendation extends StatelessWidget {
                 decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 6.25,
                       offset: const Offset(-1.25, 2.5),
                     ),
@@ -232,9 +232,9 @@ class MomentRecommendation extends StatelessWidget {
                             begin: Alignment.topCenter,
                             end: Alignment.bottomCenter,
                             colors: [
-                              Colors.black.withOpacity(0),
-                              Colors.black.withOpacity(0),
-                              Colors.black.withOpacity(0.5),
+                              Colors.black.withValues(alpha: 0),
+                              Colors.black.withValues(alpha: 0),
+                              Colors.black.withValues(alpha: 0.5),
                             ],
                             stops: const [
                               0,

--- a/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_confirm_password.dart
+++ b/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_confirm_password.dart
@@ -117,10 +117,10 @@ class _LockScreenConfirmPasswordState extends State<LockScreenConfirmPassword> {
                         shape: BoxShape.circle,
                         gradient: LinearGradient(
                           colors: [
-                            Colors.grey.shade500.withOpacity(0.2),
-                            Colors.grey.shade50.withOpacity(0.1),
-                            Colors.grey.shade400.withOpacity(0.2),
-                            Colors.grey.shade300.withOpacity(0.4),
+                            Colors.grey.shade500.withValues(alpha: 0.2),
+                            Colors.grey.shade50.withValues(alpha: 0.1),
+                            Colors.grey.shade400.withValues(alpha: 0.2),
+                            Colors.grey.shade300.withValues(alpha: 0.4),
                           ],
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_confirm_pin.dart
+++ b/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_confirm_pin.dart
@@ -101,10 +101,10 @@ class _LockScreenConfirmPinState extends State<LockScreenConfirmPin> {
                     shape: BoxShape.circle,
                     gradient: LinearGradient(
                       colors: [
-                        Colors.grey.shade500.withOpacity(0.2),
-                        Colors.grey.shade50.withOpacity(0.1),
-                        Colors.grey.shade400.withOpacity(0.2),
-                        Colors.grey.shade300.withOpacity(0.4),
+                        Colors.grey.shade500.withValues(alpha: 0.2),
+                        Colors.grey.shade50.withValues(alpha: 0.1),
+                        Colors.grey.shade400.withValues(alpha: 0.2),
+                        Colors.grey.shade300.withValues(alpha: 0.4),
                       ],
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_password.dart
+++ b/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_password.dart
@@ -127,10 +127,10 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
                         shape: BoxShape.circle,
                         gradient: LinearGradient(
                           colors: [
-                            Colors.grey.shade500.withOpacity(0.2),
-                            Colors.grey.shade50.withOpacity(0.1),
-                            Colors.grey.shade400.withOpacity(0.2),
-                            Colors.grey.shade300.withOpacity(0.4),
+                            Colors.grey.shade500.withValues(alpha: 0.2),
+                            Colors.grey.shade50.withValues(alpha: 0.1),
+                            Colors.grey.shade400.withValues(alpha: 0.2),
+                            Colors.grey.shade300.withValues(alpha: 0.4),
                           ],
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_pin.dart
+++ b/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_pin.dart
@@ -178,10 +178,10 @@ class _LockScreenPinState extends State<LockScreenPin> {
                     shape: BoxShape.circle,
                     gradient: LinearGradient(
                       colors: [
-                        Colors.grey.shade500.withOpacity(0.2),
-                        Colors.grey.shade50.withOpacity(0.1),
-                        Colors.grey.shade400.withOpacity(0.2),
-                        Colors.grey.shade300.withOpacity(0.4),
+                        Colors.grey.shade500.withValues(alpha: 0.2),
+                        Colors.grey.shade50.withValues(alpha: 0.1),
+                        Colors.grey.shade400.withValues(alpha: 0.2),
+                        Colors.grey.shade300.withValues(alpha: 0.4),
                       ],
                       begin: Alignment.topCenter,
                       end: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/settings/widget_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/widget_settings_screen.dart
@@ -87,7 +87,10 @@ class WidgetSettingsScreen extends StatelessWidget {
                               ),
                               leadingIconWidget: SvgPicture.asset(
                                 "assets/icons/people-widget-icon.svg",
-                                color: colorScheme.textBase,
+                                colorFilter: ColorFilter.mode(
+                                  colorScheme.textBase,
+                                  BlendMode.srcIn,
+                                ),
                               ),
                               menuItemColor: colorScheme.fillFaint,
                               singleBorderRadius: 8,
@@ -101,7 +104,10 @@ class WidgetSettingsScreen extends StatelessWidget {
                               ),
                               leadingIconWidget: SvgPicture.asset(
                                 "assets/icons/albums-widget-icon.svg",
-                                color: colorScheme.textBase,
+                                colorFilter: ColorFilter.mode(
+                                  colorScheme.textBase,
+                                  BlendMode.srcIn,
+                                ),
                               ),
                               menuItemColor: colorScheme.fillFaint,
                               singleBorderRadius: 8,
@@ -115,7 +121,10 @@ class WidgetSettingsScreen extends StatelessWidget {
                               ),
                               leadingIconWidget: SvgPicture.asset(
                                 "assets/icons/memories-widget-icon.svg",
-                                color: colorScheme.textBase,
+                                colorFilter: ColorFilter.mode(
+                                  colorScheme.textBase,
+                                  BlendMode.srcIn,
+                                ),
                               ),
                               menuItemColor: colorScheme.fillFaint,
                               singleBorderRadius: 8,

--- a/mobile/apps/photos/lib/ui/settings/widgets/memories_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/memories_widget_settings.dart
@@ -156,7 +156,10 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
                           ),
                           leadingIconWidget: SvgPicture.asset(
                             "assets/icons/past-year-memory-icon.svg",
-                            color: colorScheme.textBase,
+                            colorFilter: ColorFilter.mode(
+                              colorScheme.textBase,
+                              BlendMode.srcIn,
+                            ),
                           ),
                           menuItemColor: colorScheme.fillFaint,
                           trailingWidget: ToggleSwitchWidget(
@@ -179,7 +182,10 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
                           ),
                           leadingIconWidget: SvgPicture.asset(
                             "assets/icons/memories-widget-icon.svg",
-                            color: colorScheme.textBase,
+                            colorFilter: ColorFilter.mode(
+                              colorScheme.textBase,
+                              BlendMode.srcIn,
+                            ),
                           ),
                           menuItemColor: colorScheme.fillFaint,
                           trailingWidget: ToggleSwitchWidget(
@@ -203,7 +209,10 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
                             ),
                             leadingIconWidget: SvgPicture.asset(
                               "assets/icons/smart-memory-icon.svg",
-                              color: colorScheme.textBase,
+                              colorFilter: ColorFilter.mode(
+                                colorScheme.textBase,
+                                BlendMode.srcIn,
+                              ),
                             ),
                             menuItemColor: colorScheme.fillFaint,
                             trailingWidget: ToggleSwitchWidget(

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -230,7 +230,7 @@ class _HomeWidgetState extends State<HomeWidget> {
                 updateService.getLatestVersionInfo(),
               );
             },
-            barrierColor: Colors.black.withOpacity(0.85),
+            barrierColor: Colors.black.withValues(alpha: 0.85),
           );
           updateService.resetUpdateAvailableShownTime();
         }

--- a/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
@@ -342,7 +342,7 @@ class _ButtonState extends State<Button> with TickerProviderStateMixin {
                   : widget.border,
               gradient: widget.gradient,
               color: _expanded!
-                  ? widget.color!.withOpacity(0)
+                  ? widget.color!.withValues(alpha: 0)
                   : widget.debug!
                       ? Colors.red
                       : widget.gradient != null

--- a/mobile/apps/photos/lib/ui/tabs/user_collections_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/user_collections_tab.dart
@@ -124,7 +124,7 @@ class _UserCollectionsTabState extends State<UserCollectionsTab>
                   .textTheme
                   .titleMedium!
                   .color!
-                  .withOpacity(0.5),
+                  .withValues(alpha: 0.5),
             );
 
     return Stack(

--- a/mobile/apps/photos/lib/ui/tools/deduplicate_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/deduplicate_page.dart
@@ -204,7 +204,7 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
         text,
         style: Theme.of(context).textTheme.titleMedium!.copyWith(
               fontSize: 14,
-              color: Theme.of(context).iconTheme.color!.withOpacity(0.7),
+              color: Theme.of(context).iconTheme.color!.withValues(alpha: 0.7),
             ),
       );
     }
@@ -303,7 +303,7 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
                     color: Theme.of(context)
                         .colorScheme
                         .inverseTextColor
-                        .withOpacity(0.7),
+                        .withValues(alpha: 0.7),
                     fontSize: 12,
                   ),
                 ),

--- a/mobile/apps/photos/lib/ui/tools/editor/export_video_result.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/export_video_result.dart
@@ -168,7 +168,7 @@ class FileDescription extends StatelessWidget {
       child: Container(
         width: MediaQuery.of(context).size.width - 60,
         padding: const EdgeInsets.all(10),
-        color: Colors.black.withOpacity(0.5),
+        color: Colors.black.withValues(alpha: 0.5),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: description.entries
@@ -184,7 +184,7 @@ class FileDescription extends StatelessWidget {
                         text: entry.value,
                         style: TextStyle(
                           fontSize: 10,
-                          color: Colors.white.withOpacity(0.8),
+                          color: Colors.white.withValues(alpha: 0.8),
                         ),
                       ),
                     ],

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/circular_icon_button.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/circular_icon_button.dart
@@ -39,7 +39,7 @@ class CircularIconButton extends StatelessWidget {
                     ? Theme.of(context)
                         .colorScheme
                         .imageEditorPrimaryColor
-                        .withOpacity(0.24)
+                        .withValues(alpha: 0.24)
                     : colorScheme.backgroundElevated2,
                 shape: BoxShape.circle,
                 border: Border.all(

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -349,7 +349,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
                               margin: const EdgeInsets.only(bottom: 24),
                               decoration: BoxDecoration(
                                 color: isHovered
-                                    ? colorScheme.warning400.withOpacity(0.8)
+                                    ? colorScheme.warning400.withValues(alpha: 0.8)
                                     : Colors.white,
                                 shape: BoxShape.circle,
                               ),
@@ -361,7 +361,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
                                     isHovered
                                         ? Colors.white
                                         : colorScheme.warning400
-                                            .withOpacity(0.8),
+                                            .withValues(alpha: 0.8),
                                     BlendMode.srcIn,
                                   ),
                                 ),

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_text_bar.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_text_bar.dart
@@ -232,10 +232,10 @@ class _BackgroundPickerWidget extends StatelessWidget {
         'backgroundColor': colorScheme.backgroundElevated2,
         'border': null,
         'textColor': Colors.black,
-        'selectedInnerBackgroundColor': Colors.black.withOpacity(0.11),
+        'selectedInnerBackgroundColor': Colors.black.withValues(alpha: 0.11),
         'innerBackgroundColor': isLightMode
-            ? Colors.black.withOpacity(0.11)
-            : Colors.white.withOpacity(0.11),
+            ? Colors.black.withValues(alpha: 0.11)
+            : Colors.white.withValues(alpha: 0.11),
       },
       LayerBackgroundMode.onlyColor: {
         'text': 'Aa',
@@ -246,7 +246,7 @@ class _BackgroundPickerWidget extends StatelessWidget {
             isLightMode ? null : Border.all(color: Colors.white, width: 2),
         'textColor': Colors.black,
         'selectedInnerBackgroundColor': Colors.white,
-        'innerBackgroundColor': Colors.white.withOpacity(0.6),
+        'innerBackgroundColor': Colors.white.withValues(alpha: 0.6),
       },
     };
 

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
@@ -302,11 +302,11 @@ class _CircularProgressWithValueState extends State<CircularProgressWithValue>
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               color: showValue || widget.isSelected
-                  ? progressColor.withOpacity(0.2)
+                  ? progressColor.withValues(alpha: 0.2)
                   : colorTheme.backgroundElevated2,
               border: Border.all(
                 color: widget.isSelected
-                    ? progressColor.withOpacity(0.4)
+                    ? progressColor.withValues(alpha: 0.4)
                     : colorTheme.backgroundElevated2,
                 width: 2,
               ),

--- a/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
@@ -80,7 +80,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
           lineColor: Theme.of(context)
               .colorScheme
               .videoPlayerBorderColor
-              .withOpacity(0.6),
+              .withValues(alpha: 0.6),
         ),
       );
 

--- a/mobile/apps/photos/lib/ui/tools/free_space_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/free_space_page.dart
@@ -56,7 +56,7 @@ class _FreeSpacePageState extends State<FreeSpacePage> {
     final informationTextStyle = TextStyle(
       fontSize: 14,
       height: 1.3,
-      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.8),
       fontWeight: FontWeight.w500,
     );
     final isLightMode = Theme.of(context).brightness == Brightness.light;
@@ -71,12 +71,12 @@ class _FreeSpacePageState extends State<FreeSpacePage> {
             isLightMode
                 ? Image.asset(
                     'assets/loading_photos_background.png',
-                    color: Colors.white.withOpacity(0.4),
+                    color: Colors.white.withValues(alpha: 0.4),
                     colorBlendMode: BlendMode.modulate,
                   )
                 : Image.asset(
                     'assets/loading_photos_background_dark.png',
-                    color: Colors.white.withOpacity(0.25),
+                    color: Colors.white.withValues(alpha: 0.25),
                   ),
             Padding(
               padding: const EdgeInsets.only(top: 16),

--- a/mobile/apps/photos/lib/ui/tools/lock_screen.dart
+++ b/mobile/apps/photos/lib/ui/tools/lock_screen.dart
@@ -103,10 +103,10 @@ class _LockScreenState extends State<LockScreen>
                           shape: BoxShape.circle,
                           gradient: LinearGradient(
                             colors: [
-                              Colors.grey.shade500.withOpacity(0.2),
-                              Colors.grey.shade50.withOpacity(0.1),
-                              Colors.grey.shade400.withOpacity(0.2),
-                              Colors.grey.shade300.withOpacity(0.4),
+                              Colors.grey.shade500.withValues(alpha: 0.2),
+                              Colors.grey.shade50.withValues(alpha: 0.1),
+                              Colors.grey.shade400.withValues(alpha: 0.2),
+                              Colors.grey.shade300.withValues(alpha: 0.4),
                             ],
                             begin: Alignment.topCenter,
                             end: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/viewer/actions/album_selection_overlay_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/album_selection_overlay_bar.dart
@@ -142,7 +142,7 @@ class _SelectAllAlbumsButtonState extends State<SelectAllAlbumsButton> {
             borderRadius: BorderRadius.circular(16),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.1),
+                color: Colors.black.withValues(alpha: 0.1),
                 blurRadius: 4,
                 offset: const Offset(0, -1),
               ),

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -256,7 +256,7 @@ class _SelectAllButtonState extends State<SelectAllButton> {
             borderRadius: BorderRadius.circular(16),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withOpacity(0.1),
+                color: Colors.black.withValues(alpha: 0.1),
                 blurRadius: 4,
                 offset: const Offset(0, -1),
               ),

--- a/mobile/apps/photos/lib/ui/viewer/actions/smart_albums_status_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/smart_albums_status_widget.dart
@@ -80,7 +80,7 @@ class _SmartAlbumsStatusWidgetState extends State<SmartAlbumsStatusWidget>
                 .copyWith(left: 14),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(8),
-              color: Colors.black.withOpacity(0.65),
+              color: Colors.black.withValues(alpha: 0.65),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,

--- a/mobile/apps/photos/lib/ui/viewer/file/exif_info_dialog.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/exif_info_dialog.dart
@@ -61,7 +61,7 @@ class ExifInfoDialog extends StatelessWidget {
           }
           return Container(
             padding: const EdgeInsets.all(2),
-            color: Colors.white.withOpacity(0.05),
+            color: Colors.white.withValues(alpha: 0.05),
             child: Center(
               child: Padding(
                 padding: const EdgeInsets.all(4),
@@ -76,7 +76,7 @@ class ExifInfoDialog extends StatelessWidget {
                     color: Theme.of(context)
                         .colorScheme
                         .onSurface
-                        .withOpacity(0.7),
+                        .withValues(alpha: 0.7),
                   ),
                 ),
               ),

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -115,8 +115,8 @@ class FileAppBarState extends State<FileAppBar> {
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
               colors: [
-                Colors.black.withOpacity(0.72),
-                Colors.black.withOpacity(0.6),
+                Colors.black.withValues(alpha: 0.72),
+                Colors.black.withValues(alpha: 0.6),
                 Colors.transparent,
               ],
               stops: const [0, 0.2, 1],

--- a/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
@@ -192,8 +192,8 @@ class FileBottomBarState extends State<FileBottomBar> {
                     end: Alignment.bottomCenter,
                     colors: [
                       Colors.transparent,
-                      Colors.black.withOpacity(0.6),
-                      Colors.black.withOpacity(0.72),
+                      Colors.black.withValues(alpha: 0.6),
+                      Colors.black.withValues(alpha: 0.72),
                     ],
                     stops: const [0, 0.8, 1],
                   ),

--- a/mobile/apps/photos/lib/ui/viewer/file/file_icons_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_icons_widget.dart
@@ -173,7 +173,7 @@ class VideoOverlayDuration extends StatelessWidget {
             padding: EdgeInsets.only(bottom: inset, right: inset),
             child: Container(
               decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.3),
+                color: Colors.black.withValues(alpha: 0.3),
                 borderRadius: iconFallback ? null : BorderRadius.circular(8.0),
                 shape: iconFallback ? BoxShape.circle : BoxShape.rectangle,
               ),
@@ -256,7 +256,7 @@ class FileOverlayText extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
-          colors: [Colors.black.withOpacity(0.33), Colors.transparent],
+          colors: [Colors.black.withValues(alpha: 0.33), Colors.transparent],
         ),
       ),
       alignment: Alignment.bottomCenter,

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/play_pause_button.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/play_pause_button.dart
@@ -53,7 +53,7 @@ class _PlayPauseButtonState extends State<PlayPauseButton> {
         width: 54,
         height: 54,
         decoration: BoxDecoration(
-          color: Colors.black.withOpacity(0.3),
+          color: Colors.black.withValues(alpha: 0.3),
           shape: BoxShape.circle,
           border: Border.all(
             color: strokeFaintDark,

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
@@ -130,7 +130,7 @@ class _VideoWidgetState extends State<VideoWidget> {
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(24),
-            color: Colors.black.withOpacity(0.3),
+            color: Colors.black.withValues(alpha: 0.3),
             border: Border.all(
               color: strokeFaintDark,
               width: 1,

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -240,7 +240,7 @@ class _PlayPauseButtonState extends State<PlayPauseButtonMediaKit> {
         width: 54,
         height: 54,
         decoration: BoxDecoration(
-          color: Colors.black.withOpacity(0.3),
+          color: Colors.black.withValues(alpha: 0.3),
           shape: BoxShape.circle,
           border: Border.all(
             color: strokeFaintDark,
@@ -299,7 +299,7 @@ class SeekBarAndDuration extends StatelessWidget {
           4,
         ),
         decoration: BoxDecoration(
-          color: Colors.black.withOpacity(0.3),
+          color: Colors.black.withValues(alpha: 0.3),
           borderRadius: const BorderRadius.all(
             Radius.circular(8),
           ),

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -642,7 +642,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(24),
-              color: Colors.black.withOpacity(0.3),
+              color: Colors.black.withValues(alpha: 0.3),
               border: Border.all(
                 color: strokeFaintDark,
                 width: 1,
@@ -793,7 +793,7 @@ class _SeekBarAndDuration extends StatelessWidget {
                   4,
                 ),
                 decoration: BoxDecoration(
-                  color: Colors.black.withOpacity(0.3),
+                  color: Colors.black.withValues(alpha: 0.3),
                   borderRadius: const BorderRadius.all(
                     Radius.circular(8),
                   ),
@@ -947,12 +947,12 @@ class _VideoDescriptionAndSwitchToMediaKitButton extends StatelessWidget {
                                 Icon(
                                   Icons.play_arrow_outlined,
                                   size: 24,
-                                  color: Colors.white.withOpacity(0.2),
+                                  color: Colors.white.withValues(alpha: 0.2),
                                 ),
                                 Icon(
                                   Icons.question_mark_rounded,
                                   size: 10,
-                                  color: Colors.white.withOpacity(0.2),
+                                  color: Colors.white.withValues(alpha: 0.2),
                                 ),
                               ],
                             ),

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -229,7 +229,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
                               showDetailsSheet(context, widget.photo);
                             },
                             child: Container(
-                              color: Colors.black.withOpacity(0.1),
+                              color: Colors.black.withValues(alpha: 0.1),
                               width: double.infinity,
                               child: Row(
                                 mainAxisAlignment: MainAxisAlignment.center,

--- a/mobile/apps/photos/lib/ui/viewer/file_details/location_tags_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/location_tags_widget.dart
@@ -287,7 +287,7 @@ class _InfoMapState extends State<InfoMap> {
                                 child: Container(
                                   color: getEnteColorScheme(context)
                                       .backgroundElevated
-                                      .withOpacity(0.5),
+                                      .withValues(alpha: 0.5),
                                 ),
                               ),
                               Container(

--- a/mobile/apps/photos/lib/ui/viewer/gallery/collect_photos_card_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/collect_photos_card_widget.dart
@@ -30,8 +30,8 @@ class _CollectPhotosCardWidgetState extends State<CollectPhotosCardWidget> {
             decoration: ShapeDecoration(
               gradient: LinearGradient(
                 colors: [
-                  colorTheme.primary700.withOpacity(0.9),
-                  colorTheme.backdropBase.withOpacity(0.6),
+                  colorTheme.primary700.withValues(alpha: 0.9),
+                  colorTheme.backdropBase.withValues(alpha: 0.6),
                   colorTheme.backdropBase,
                 ],
                 begin: Alignment.bottomLeft,
@@ -55,7 +55,7 @@ class _CollectPhotosCardWidgetState extends State<CollectPhotosCardWidget> {
                 color: colorTheme.backgroundElevated,
                 shadows: [
                   BoxShadow(
-                    color: colorTheme.textBase.withOpacity(0.1),
+                    color: colorTheme.textBase.withValues(alpha: 0.1),
                     blurRadius: 4.0,
                     offset: const Offset(0, 1),
                   ),
@@ -118,8 +118,8 @@ class _CollectPhotosCardWidgetState extends State<CollectPhotosCardWidget> {
                   const BorderRadius.only(bottomLeft: Radius.circular(10)),
               gradient: LinearGradient(
                 colors: [
-                  colorTheme.primary700.withOpacity(0.4),
-                  colorTheme.backgroundElevated.withOpacity(0.6),
+                  colorTheme.primary700.withValues(alpha: 0.4),
+                  colorTheme.backgroundElevated.withValues(alpha: 0.6),
                   colorTheme.backgroundElevated,
                 ],
                 begin: Alignment.bottomLeft,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/empty_state.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/empty_state.dart
@@ -19,7 +19,7 @@ class EmptyState extends StatelessWidget {
             color: Theme.of(context)
                 .colorScheme
                 .defaultTextColor
-                .withOpacity(0.35),
+                .withValues(alpha: 0.35),
           ),
         ),
       ),

--- a/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/custom_scroll_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/custom_scroll_bar.dart
@@ -279,7 +279,7 @@ class ScrollBarDivider extends StatelessWidget {
         // is affected.
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 3,
             offset: const Offset(0, 2),
           ),

--- a/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/scroll_bar_with_use_notifier.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/scroll_bar_with_use_notifier.dart
@@ -262,17 +262,17 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
     late Color idleColor;
     switch (brightness) {
       case Brightness.light:
-        dragColor = onSurface.withOpacity(0.6);
-        hoverColor = onSurface.withOpacity(0.5);
+        dragColor = onSurface.withValues(alpha: 0.6);
+        hoverColor = onSurface.withValues(alpha: 0.5);
         idleColor = _useAndroidScrollbar
-            ? Theme.of(context).highlightColor.withOpacity(1.0)
-            : onSurface.withOpacity(0.1);
+            ? Theme.of(context).highlightColor.withValues(alpha: 1.0)
+            : onSurface.withValues(alpha: 0.1);
       case Brightness.dark:
-        dragColor = onSurface.withOpacity(0.75);
-        hoverColor = onSurface.withOpacity(0.65);
+        dragColor = onSurface.withValues(alpha: 0.75);
+        hoverColor = onSurface.withValues(alpha: 0.65);
         idleColor = _useAndroidScrollbar
-            ? Theme.of(context).highlightColor.withOpacity(1.0)
-            : onSurface.withOpacity(0.3);
+            ? Theme.of(context).highlightColor.withValues(alpha: 1.0)
+            : onSurface.withValues(alpha: 0.3);
     }
 
     return WidgetStateProperty.resolveWith((Set<WidgetState> states) {
@@ -304,8 +304,8 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
       if (showScrollbar && _trackVisibility.resolve(states)) {
         return _scrollbarTheme.trackColor?.resolve(states) ??
             switch (brightness) {
-              Brightness.light => onSurface.withOpacity(0.03),
-              Brightness.dark => onSurface.withOpacity(0.05),
+              Brightness.light => onSurface.withValues(alpha: 0.03),
+              Brightness.dark => onSurface.withValues(alpha: 0.05),
             };
       }
       return const Color(0x00000000);
@@ -322,8 +322,8 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
       if (showScrollbar && _trackVisibility.resolve(states)) {
         return _scrollbarTheme.trackBorderColor?.resolve(states) ??
             switch (brightness) {
-              Brightness.light => onSurface.withOpacity(0.1),
-              Brightness.dark => onSurface.withOpacity(0.25),
+              Brightness.light => onSurface.withValues(alpha: 0.1),
+              Brightness.dark => onSurface.withValues(alpha: 0.25),
             };
       }
       return const Color(0x00000000);

--- a/mobile/apps/photos/lib/ui/viewer/hierarchicial_search/applied_filters_for_appbar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/hierarchicial_search/applied_filters_for_appbar.dart
@@ -111,7 +111,7 @@ class _AppliedFiltersForAppbarState extends State<AppliedFiltersForAppbar> {
             gradient: LinearGradient(
               colors: [
                 getEnteColorScheme(context).backdropBase,
-                getEnteColorScheme(context).backdropBase.withOpacity(0),
+                getEnteColorScheme(context).backdropBase.withValues(alpha: 0),
               ],
               begin: Alignment.centerLeft,
               end: Alignment.centerRight,

--- a/mobile/apps/photos/lib/ui/viewer/people/cluster_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/cluster_app_bar.dart
@@ -99,7 +99,7 @@ class _AppBarWidgetState extends State<ClusterAppBar> {
       ),
       actions: _getDefaultActions(context),
       scrolledUnderElevation: 4,
-      shadowColor: Colors.black.withOpacity(0.15),
+      shadowColor: Colors.black.withValues(alpha: 0.15),
       surfaceTintColor: Colors.transparent,
     );
   }

--- a/mobile/apps/photos/lib/ui/viewer/people/person_cluster_suggestion.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/person_cluster_suggestion.dart
@@ -503,7 +503,7 @@ class _PersonClustersState extends State<PersonReviewClusterSuggestion> {
                   ),
                   child: Container(
                     decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.7),
+                      color: Colors.black.withValues(alpha: 0.7),
                     ),
                     child: Center(
                       child: Text(

--- a/mobile/apps/photos/lib/ui/viewer/search/result/people_section_all_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/people_section_all_page.dart
@@ -217,7 +217,7 @@ class SelectablePersonSearchExample extends StatelessWidget {
                           ),
                           child: ColorFiltered(
                             colorFilter: ColorFilter.mode(
-                              Colors.black.withOpacity(
+                              Colors.black.withValues(alpha: 
                                 isSelected ? 0.4 : 0,
                               ),
                               BlendMode.darken,
@@ -596,7 +596,7 @@ class _PeopleSectionAllWidgetState extends State<PeopleSectionAllWidget> {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
               side: BorderSide(
-                color: Theme.of(context).colorScheme.outline.withOpacity(0.3),
+                color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
                 width: 1,
               ),
             ),

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
@@ -185,7 +185,7 @@ class LocationRecommendation extends StatelessWidget {
                   cornerSmoothing: cornerSmoothing,
                 ),
                 child: Container(
-                  color: Colors.white.withOpacity(0.1),
+                  color: Colors.white.withValues(alpha: 0.1),
                   width: width + outerStrokeWidth * 2,
                   height: height + outerStrokeWidth * 2,
                 ),
@@ -233,7 +233,7 @@ class LocationRecommendation extends StatelessWidget {
                                   : const NoThumbnailWidget(),
                             ),
                             Container(
-                              color: Colors.black.withOpacity(0.2),
+                              color: Colors.black.withValues(alpha: 0.2),
                             ),
                           ],
                         ),
@@ -257,7 +257,7 @@ class LocationRecommendation extends StatelessWidget {
                                       cornerSmoothing: cornerSmoothing,
                                     ),
                                     child: Container(
-                                      color: Colors.black.withOpacity(0.1),
+                                      color: Colors.black.withValues(alpha: 0.1),
                                       width: sideOfThumbnail +
                                           thumbnailBorderWidth * 2,
                                       height: sideOfThumbnail +
@@ -400,7 +400,7 @@ class GoToMapWithBG extends StatelessWidget {
                 cornerSmoothing: LocationRecommendation.cornerSmoothing,
               ),
               child: Container(
-                color: Colors.white.withOpacity(0.1),
+                color: Colors.white.withValues(alpha: 0.1),
                 width: LocationRecommendation.width +
                     LocationRecommendation.outerStrokeWidth * 2,
                 height: LocationRecommendation.height +
@@ -510,7 +510,7 @@ class LocationCTA extends StatelessWidget {
                 cornerSmoothing: LocationRecommendation.cornerSmoothing,
               ),
               child: Container(
-                color: Colors.white.withOpacity(0.1),
+                color: Colors.white.withValues(alpha: 0.1),
                 width: LocationRecommendation.width +
                     LocationRecommendation.outerStrokeWidth * 2,
                 height: LocationRecommendation.height +

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/magic_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/magic_section.dart
@@ -172,7 +172,7 @@ class MagicRecommendation extends StatelessWidget {
                 decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 6.25,
                       offset: const Offset(-1.25, 2.5),
                     ),
@@ -209,9 +209,9 @@ class MagicRecommendation extends StatelessWidget {
                             begin: Alignment.topCenter,
                             end: Alignment.bottomCenter,
                             colors: [
-                              Colors.black.withOpacity(0),
-                              Colors.black.withOpacity(0),
-                              Colors.black.withOpacity(0.5),
+                              Colors.black.withValues(alpha: 0),
+                              Colors.black.withValues(alpha: 0),
+                              Colors.black.withValues(alpha: 0.5),
                             ],
                             stops: const [
                               0,

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
@@ -286,7 +286,7 @@ class PersonSearchExample extends StatelessWidget {
                           ),
                           child: ColorFiltered(
                             colorFilter: ColorFilter.mode(
-                              Colors.black.withOpacity(
+                              Colors.black.withValues(alpha: 
                                 isSelected ? 0.4 : 0,
                               ),
                               BlendMode.darken,

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -605,7 +605,7 @@ Future<List<String>> deleteLocalFilesInBatches(
     builder: (context) {
       return dialog;
     },
-    barrierColor: Colors.black.withOpacity(0.85),
+    barrierColor: Colors.black.withValues(alpha: 0.85),
   );
   final batchSize = min(
     max(minimumBatchSize, (localIDs.length / minimumParts).round()),


### PR DESCRIPTION
## Description
- Remove references to the deprecated `withOpacity` function, instead preferring `withValues` with an `alpha` parameter as referenced in [the Flutter 3.27 migration guide](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity)
- Remove references to the deprecated `color.red` int (on a 0-255 scale), instead preferring `color.r` double (on a 0-1 scale), and updating logic to use the new scale as referenced in [the Flutter 3.27 migration guide](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#8-bit-unsigned-integer-constructors)
- Remove references to the deprecated `color` parameter within `flutter_svg`, instead preferring `colorFilter` as referenced in [the flutter_svg 2.0 migration guide](https://github.com/dnfield/flutter_svg/blob/master/vector_graphics.md)

## Tests
