### PR TITLE
[auth] Remove hex from some multi-color icons

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -17,8 +17,7 @@
         "uidai",
         "UIDAI",
         "Unique Identification Authority of India"
-      ],
-      "hex": "FBB401"
+      ]
     },
     {
       "title": "Accredible",
@@ -57,8 +56,7 @@
     },
     {
       "title": "Amtrak",
-      "slug": "amtrak",
-      "hex": "003A5D"
+      "slug": "amtrak"
     },
     {
       "title": "Animal Crossing",
@@ -321,8 +319,7 @@
     },
     {
       "title": "Caltrain",
-      "slug": "caltrain",
-      "hex": "E31837"
+      "slug": "caltrain"
     },
     {
       "title": "Canva"
@@ -387,8 +384,7 @@
         "ClipperCard",
         "clipper-card",
         "Clipper Card"
-      ],
-      "hex": "006298"
+      ]
     },
     {
       "title": "CloudAMQP"
@@ -433,8 +429,7 @@
     },
     {
       "title": "Coolify",
-      "slug": "coolify",
-      "hex": "8C52FF"
+      "slug": "coolify"
     },
     {
       "title": "Crowdpear"
@@ -547,8 +542,7 @@
       "altNames": [
         "Domino's",
         "Domino's Pizza"
-      ],
-      "hex": "0B648F"
+      ]
     },
     {
       "title": "Doppler"
@@ -571,8 +565,7 @@
         "Dunkin'",
         "Dunkin",
         "Dunkin Donuts"
-      ],
-      "hex": "C63663"
+      ]
     },
     {
       "title": "eBay"
@@ -638,8 +631,7 @@
     },
     {
       "title": "Experian",
-      "slug": "experian",
-      "hex": "AF1685"
+      "slug": "experian"
     },
     {
       "title": "Fanatical",
@@ -763,8 +755,7 @@
       "altNames": [
         "green man gaming",
         "gmg"
-      ],
-      "hex": "00E205"
+      ]
     },
     {
       "title": "Guideline"
@@ -891,8 +882,7 @@
     },
     {
       "title": "Kayak",
-      "slug": "kayak",
-      "hex": "FF6900"
+      "slug": "kayak"
     },
     {
       "title": "Keygen",
@@ -1193,8 +1183,7 @@
       "slug": "njtransit",
       "altNames": [
         "NJ Transit"
-      ],
-      "hex": "1A2B57"
+      ]
     },
     {
       "title": "nordvpn",
@@ -1299,8 +1288,7 @@
       "slug": "pcpartpicker",
       "altNames": [
         "PC Part Picker"
-      ],
-      "hex": "EDA920"
+      ]
     },
     {
       "title": "Peerberry"
@@ -1510,8 +1498,7 @@
       "altNames": [
         "onlinesbi",
         "State Bank of India"
-      ],
-      "hex": "12A8E0"
+      ]
     },
     {
       "title": "SEI",
@@ -1612,8 +1599,7 @@
     },
     {
       "title": "Supercell",
-      "slug": "supercell",
-      "hex": "000000"
+      "slug": "supercell"
     },
     {
       "title": "Surfshark"
@@ -1696,8 +1682,7 @@
       "altNames": [
         "StoryGraph",
         "TheStoryGraph"
-      ],
-      "hex": "15919B"
+      ]
     },
     {
       "title": "tianyiyun",
@@ -1872,8 +1857,7 @@
         "Washington Metro",
         "DC Metro",
         "Washington Metropolitan Area Transit Authority"
-      ],
-      "hex": "2D2D2D"
+      ]
     },
     {
       "title": "Wolvesville"


### PR DESCRIPTION
This PR removes the hex value from some multi-color icons that were added in #6694.  Removing the hex will fix broken icons like this:
<img width="270" height="284" alt="image" src="https://github.com/user-attachments/assets/8603ce89-b47d-4b4b-a809-5d67b7b30c6a" />
<img width="229" height="262" alt="image" src="https://github.com/user-attachments/assets/c38a8bce-57c5-4607-ac7b-47c677ea3871" />
<img width="334" height="293" alt="image" src="https://github.com/user-attachments/assets/fe1f95e5-66b6-49ce-9458-5fe17c98e0fa" />
<img width="302" height="269" alt="image" src="https://github.com/user-attachments/assets/4c7f59d8-534a-47e2-95bc-b6f70a1f2921" />
