### PR TITLE
[auth] Show black color as default background color for privacy-screen

### DIFF
--- a/mobile/apps/auth/lib/utils/lock_screen_settings.dart
+++ b/mobile/apps/auth/lib/utils/lock_screen_settings.dart
@@ -93,7 +93,6 @@ class LockScreenSettings {
 
   Future<void> setHideAppContent(bool hideContent) async {
     if (PlatformUtil.isDesktop()) return;
-    final bool isLightMode = _preferences.getBool(kIsLightMode) ?? true;
     !hideContent
         ? PrivacyScreen.instance.disable()
         : await PrivacyScreen.instance.enable(
@@ -103,11 +102,8 @@ class LockScreenSettings {
             androidOptions: const PrivacyAndroidOptions(
               enableSecure: true,
             ),
-            backgroundColor:
-                isLightMode ? const Color(0xffffffff) : const Color(0xff000000),
-            blurEffect: isLightMode
-                ? PrivacyBlurEffect.extraLight
-                : PrivacyBlurEffect.extraLight,
+            backgroundColor: const Color(0xff000000),
+            blurEffect: PrivacyBlurEffect.extraLight,
           );
     await _preferences.setBool(keyHideAppContent, hideContent);
   }


### PR DESCRIPTION
## Description]
When switching between tabs on mobile, a white flash appear when lockscreen is enable.
This PR fixes that by setting the background color to black for both light and dark theme.