### PR TITLE
[server] Add optional TLS/SSL encryption for SMTP

### DIFF
--- a/cli/cmd/admin.go
+++ b/cli/cmd/admin.go
@@ -142,6 +142,22 @@ var _updateFreeUserStorage = &cobra.Command{
 	},
 }
 
+var _sendMail = &cobra.Command{
+	Use:   "send-mail <to-email> <from-email> <from-name>",
+	Args:  cobra.ExactArgs(3),
+	Short: "Sends a test mail via the admin api",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		recoverWithLog()
+		var flags = &model.AdminActionForUser{}
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Name == "admin-user" {
+				flags.AdminEmail = f.Value.String()
+			}
+		})
+		return ctrl.SendTestMail(context.Background(), *flags, args[0], args[1], args[2])
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(_adminCmd)
 	_ = _userDetailsCmd.MarkFlagRequired("admin-user")
@@ -159,5 +175,6 @@ func init() {
 	_updateFreeUserStorage.Flags().StringP("user", "u", "", "The email of the user to update subscription for. (required)")
 	// add a flag with no value --no-limit
 	_updateFreeUserStorage.Flags().String("no-limit", "True", "When true, sets 100TB as storage limit, and expiry to current date + 100 years")
-	_adminCmd.AddCommand(_userDetailsCmd, _disable2faCmd, _disablePasskeyCmd, _updateFreeUserStorage, _listUsers, _deleteUser)
+	_sendMail.Flags().StringP("admin-user", "a", "", "The email of the admin user. ")
+	_adminCmd.AddCommand(_userDetailsCmd, _disable2faCmd, _disablePasskeyCmd, _updateFreeUserStorage, _listUsers, _deleteUser, _sendMail)
 }

--- a/cli/internal/api/admin.go
+++ b/cli/internal/api/admin.go
@@ -139,5 +139,28 @@ func (c *Client) UpdateFreePlanSub(ctx context.Context, userDetails *models.User
 		}
 	}
 	return nil
+}
 
+func (c *Client) SendTestMail(ctx context.Context, toEmail, fromEmail, fromName string) error {
+	body := map[string]interface{}{
+		"to":        []string{toEmail},
+		"fromName":  fromName,
+		"fromEmail": fromEmail,
+		"subject":   "Test mail from Ente",
+		"body":      "This is a test mail from Ente",
+	}
+	r, err := c.restClient.R().
+		SetContext(ctx).
+		SetBody(body).
+		Post("/admin/mail")
+	if err != nil {
+		return err
+	}
+	if r.IsError() {
+		return &ApiError{
+			StatusCode: r.StatusCode(),
+			Message:    r.String(),
+		}
+	}
+	return nil
 }

--- a/cli/pkg/admin_actions.go
+++ b/cli/pkg/admin_actions.go
@@ -156,6 +156,23 @@ func (c *ClICtrl) UpdateFreeStorage(ctx context.Context, params model.AdminActio
 	return nil
 }
 
+func (c *ClICtrl) SendTestMail(ctx context.Context, params model.AdminActionForUser, to, from, fromName string) error {
+	accountCtx, err := c.buildAdminContext(ctx, params.AdminEmail)
+	if err != nil {
+		return err
+	}
+	err = c.Client.SendTestMail(accountCtx, to, from, fromName)
+	if err != nil {
+		if apiErr, ok := err.(*api.ApiError); ok && apiErr.StatusCode == 400 && strings.Contains(apiErr.Message, "Token is too old") {
+			fmt.Printf("Error: old admin token, please re-authenticate using `ente account add` \n")
+			return nil
+		}
+		return err
+	}
+	fmt.Printf("Successfully sent test email to %s\n", to)
+	return nil
+}
+
 func (c *ClICtrl) buildAdminContext(ctx context.Context, adminEmail string) (context.Context, error) {
 	accounts, err := c.GetAccounts(ctx)
 	if err != nil {

--- a/docs/docs/self-hosting/installation/config.md
+++ b/docs/docs/self-hosting/installation/config.md
@@ -171,16 +171,19 @@ smtp:
     email:
     # Optional name for sender
     sender-name:
+    # Optional encryption
+    encryption:
 ```
 
 | Variable           | Description                  | Default |
-| ------------------ | ---------------------------- | ------- |
+|--------------------|------------------------------| ------- |
 | `smtp.host`        | SMTP server host             |         |
 | `smtp.port`        | SMTP server port             |         |
 | `smtp.username`    | SMTP auth username           |         |
 | `smtp.password`    | SMTP auth password           |         |
 | `smtp.email`       | Sender email address         |         |
 | `smtp.sender-name` | Custom name for email sender |         |
+| `smtp.encryption`  | Encryption method (tls, ssl) |         |
 | `transmail.key`    | Zeptomail API key            |         |
 
 ### WebAuthn Passkey Support

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -248,6 +248,8 @@ smtp:
     # Optional override for the sender name in the emails. If specified, it will
     # be used for all emails sent by the instance (default is email specific).
     sender-name:
+    # Optional encryption method. If tls or ssl is chosen, encryption is enabled.
+    encryption:
 
 # Zoho Zeptomail config (optional)
 #


### PR DESCRIPTION
## Description

Implement TLS/SSL encryption for sending emails via SMTP. When an SMTP provider explicitly requires TLS/SSL communication the current implementation runs in a timeout and fails. A new configuration parameter for smtp was added to enable TLS/SSL communication.

This would solve #5958 

## Tests

I built a local docker image of my branch. The email provider I was using is mailbox.org and using the tls configuration. Registering a new user then resulted in a sent email containing the verification code.

I did not test a setup without TLS/SSL.
