### PR TITLE
pin to specific release of debian to avoid collation mismatch

### DIFF
--- a/server/config/compose.yaml
+++ b/server/config/compose.yaml
@@ -21,7 +21,7 @@ services:
     command: "TCP-LISTEN:3200,fork,reuseaddr TCP:minio:3200"
 
   postgres:
-    image: postgres:15
+    image: postgres:15-trixie
     env_file:
       - .env
     # Wait for postgres to accept connections before starting museum.


### PR DESCRIPTION
## Description

this pins the postgres container to a specific version of debian to prevent issues with updated glibc in newer deb release

https://github.com/docker-library/postgres/issues/1356

## Tests
