### PR TITLE
Revert "[auth] Add smaller Activision icon"

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -30,10 +30,6 @@
       ]
     },
     {
-      "title": "Activision",
-      "hex": "000000"
-    },
-    {
       "title": "Addy.io",
       "slug": "addy_io"
     },

--- a/mobile/apps/auth/assets/custom-icons/icons/activision.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/activision.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.079999923706055 20.530000686645508">
-  <path fill-rule="evenodd" d="m4.71 17.93-.83 2.6H0L7.04 0l7.04 20.52h-3.9l-.81-2.6Zm2.33-7.32L5.9 14.17h2.26z"></path>
-</svg>


### PR DESCRIPTION
Reverts ente-io/ente#6950

I rushed a bit, sorry. The PR wasn't meant to be merged yet (if ever) and it won't work right now anyway. It was meant to create conversation on the topic and then possibly merged and there may be concerns to this as a company may not want their logo/wordmark altered but I'm not well versed in this topic (idk maybe I'm overthinking this).

Discussion: #6951