### PR TITLE
[mob][photos] Pre-cache thumbnails fetched from LRU cache to Flutter's ImageCache for faster rendering

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -432,11 +432,6 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   }
 
   void _cacheAndRender(ImageProvider<Object> imageProvider) {
-    if (imageCache.currentSizeBytes > 256 * 1024 * 1024) {
-      _logger.info("Clearing image cache");
-      imageCache.clear();
-      imageCache.clearLiveImages();
-    }
     precacheImage(imageProvider, context).then((value) {
       if (mounted) {
         setState(() {

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -245,12 +245,12 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       final cachedSmallThumbnail =
           ThumbnailInMemoryLruCache.get(widget.file, thumbnailSmallSize);
       if (cachedSmallThumbnail != null) {
-        _imageProvider = Image.memory(
+        final imageProvider = Image.memory(
           cachedSmallThumbnail,
           cacheHeight: optimizedImageHeight,
           cacheWidth: optimizedImageWidth,
         ).image;
-        _hasLoadedThumbnail = true;
+        _cacheAndRender(imageProvider);
       } else {
         if (widget.diskLoadDeferDuration != null) {
           Future.delayed(widget.diskLoadDeferDuration!, () {
@@ -383,12 +383,12 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       _isLoadingRemoteThumbnail = true;
       final cachedThumbnail = ThumbnailInMemoryLruCache.get(widget.file);
       if (cachedThumbnail != null) {
-        _imageProvider = Image.memory(
+        final imageProvider = Image.memory(
           cachedThumbnail,
           cacheHeight: optimizedImageHeight,
           cacheWidth: optimizedImageWidth,
         ).image;
-        _hasLoadedThumbnail = true;
+        _cacheAndRender(imageProvider);
         return;
       }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -432,14 +432,14 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   }
 
   void _cacheAndRender(ImageProvider<Object> imageProvider) {
-    precacheImage(imageProvider, context).then((value) {
-      if (mounted) {
-        setState(() {
-          _imageProvider = imageProvider;
-          _hasLoadedThumbnail = true;
-        });
-      }
-    });
+    if (mounted) {
+      setState(() {
+        _imageProvider = imageProvider;
+        _hasLoadedThumbnail = true;
+      });
+    }
+
+    precacheImage(imageProvider, context);
   }
 
   void _reset() {

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -251,16 +251,16 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
           cacheWidth: optimizedImageWidth,
         ).image;
         _cacheAndRender(imageProvider);
+        return;
+      }
+      if (widget.diskLoadDeferDuration != null) {
+        Future.delayed(widget.diskLoadDeferDuration!, () {
+          if (mounted) {
+            _getThumbnailFromDisk();
+          }
+        });
       } else {
-        if (widget.diskLoadDeferDuration != null) {
-          Future.delayed(widget.diskLoadDeferDuration!, () {
-            if (mounted) {
-              _getThumbnailFromDisk();
-            }
-          });
-        } else {
-          _getThumbnailFromDisk();
-        }
+        _getThumbnailFromDisk();
       }
     }
   }


### PR DESCRIPTION
## Description

In Gallery, even if thumbnails are stored in LRU cache, there was a delay in rendering thumbnails when scrolling fast enough. Pre-caching these thumbnails to flutter's `ImageCache` right before they're rendered has made the rendering fast enough for seamless UX.

#### Before:

https://github.com/user-attachments/assets/c47958fb-fbda-4e1f-9ce7-26b51ca87938

#### After:

https://github.com/user-attachments/assets/cbaf4427-f52f-4544-a0c2-820eb2b43953


