### PR TITLE
[mob][photos] bypass interaction check for manual stream requests

### DIFF
--- a/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
@@ -70,10 +70,14 @@ class ComputeController {
     _logger.info('init done ');
   }
 
-  bool requestCompute({bool ml = false, bool stream = false}) {
-    _logger.info("Requesting compute: ml: $ml, stream: $stream");
-    if (!_isDeviceHealthy || !_canRunGivenUserInteraction()) {
-      _logger.info("Device not healthy or user interacting, denying request.");
+  bool requestCompute({bool ml = false, bool stream = false, bool bypassInteractionCheck = false}) {
+    _logger.info("Requesting compute: ml: $ml, stream: $stream, bypassInteraction: $bypassInteractionCheck");
+    if (!_isDeviceHealthy) {
+      _logger.info("Device not healthy, denying request.");
+      return false;
+    }
+    if (!bypassInteractionCheck && !_canRunGivenUserInteraction()) {
+      _logger.info("User interacting, denying request.");
       return false;
     }
     bool result = false;


### PR DESCRIPTION
## Summary
Manual Create/Recreate Stream button presses now bypass user interaction timer for immediate processing while maintaining device health and ML priority checks.

## Tests
- [x] Manual Create Stream button bypasses interaction timer
- [x] Manual Recreate Stream button bypasses interaction timer  
- [x] Automatic streaming still respects interaction timer
- [x] Device health checks still enforced for manual requests
- [x] ML operations can still preempt manual streaming