### PR TITLE
[mob][photos] bypass size/duration limits for manual video stream requests

### DIFF
--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -299,7 +299,7 @@ class VideoPreviewService {
         "Starting video preview generation for ${enteFile.displayName}",
       );
       // elimination case for <=10 MB with H.264
-      var (props, result, file) = await _checkFileForPreviewCreation(enteFile);
+      var (props, result, file) = await _checkFileForPreviewCreation(enteFile, isManual);
       if (result) {
         removeFile = true;
         return;
@@ -922,8 +922,9 @@ class VideoPreviewService {
   }
 
   Future<(FFProbeProps?, bool, File?)> _checkFileForPreviewCreation(
-    EnteFile enteFile,
-  ) async {
+    EnteFile enteFile, [
+    bool isManual = false,
+  ]) async {
     if ((enteFile.pubMagicMetadata?.sv ?? 0) == 1) {
       _logger.info("Skip Preview due to sv=1 for  ${enteFile.displayName}");
       return (null, true, null);
@@ -936,7 +937,7 @@ class VideoPreviewService {
     }
     final int size = enteFile.fileSize!;
     final int duration = enteFile.duration!;
-    if (size >= 500 * 1024 * 1024 || duration > 60) {
+    if (!isManual && (size >= 500 * 1024 * 1024 || duration > 60)) {
       _logger.info("Skip Preview due to size: $size or duration: $duration");
       return (null, true, null);
     }

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -299,7 +299,8 @@ class VideoPreviewService {
         "Starting video preview generation for ${enteFile.displayName}",
       );
       // elimination case for <=10 MB with H.264
-      var (props, result, file) = await _checkFileForPreviewCreation(enteFile, isManual);
+      var (props, result, file) =
+          await _checkFileForPreviewCreation(enteFile, isManual);
       if (result) {
         removeFile = true;
         return;
@@ -929,21 +930,28 @@ class VideoPreviewService {
       _logger.info("Skip Preview due to sv=1 for  ${enteFile.displayName}");
       return (null, true, null);
     }
-    if (enteFile.fileSize == null || enteFile.duration == null) {
-      _logger.warning(
-        "Skip Preview due to misisng size/duration for ${enteFile.displayName}",
-      );
-      return (null, true, null);
-    }
-    final int size = enteFile.fileSize!;
-    final int duration = enteFile.duration!;
-    if (!isManual && (size >= 500 * 1024 * 1024 || duration > 60)) {
-      _logger.info("Skip Preview due to size: $size or duration: $duration");
-      return (null, true, null);
+    if (!isManual) {
+      if (enteFile.fileSize == null || enteFile.duration == null) {
+        _logger.warning(
+          "Skip Preview due to misisng size/duration for ${enteFile.displayName}",
+        );
+        return (null, true, null);
+      }
+      final int size = enteFile.fileSize!;
+      final int duration = enteFile.duration!;
+      if (size >= 500 * 1024 * 1024 || duration > 60) {
+        _logger.info("Skip Preview due to size: $size or duration: $duration");
+        return (null, true, null);
+      }
     }
     FFProbeProps? props;
     File? file;
     bool skipFile = false;
+    if (enteFile.fileSize == null && isManual) {
+      return (props, skipFile, file);
+    }
+
+    final size = enteFile.fileSize ?? 0;
     try {
       final isFileUnder10MB = size <= 10 * 1024 * 1024;
       if (isFileUnder10MB) {

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -497,6 +497,7 @@ class FileAppBarState extends State<FileAppBar> {
     final userId = Configuration.instance.getUserID();
     return widget.file.fileType == FileType.video &&
         widget.file.isUploaded &&
+        widget.file.fileSize != null &&
         (widget.file.pubMagicMetadata?.sv ?? 0) != 1 &&
         widget.file.ownerID == userId;
   }


### PR DESCRIPTION
## Summary
- Modified `_checkFileForPreviewCreation` method to accept `isManual` parameter
- Bypass 500MB file size and 60 second duration limits when user manually triggers video stream processing
- Maintains size/duration restrictions for automatic streaming to preserve device performance

## Test plan
- [x] Manual Create/Recreate Stream button bypasses 500MB and 60 second limits
- [x] Automatic streaming still respects size and duration restrictions
- [x] Files larger than 500MB or longer than 60 seconds can be manually processed