### PR TITLE
[mob][photos] Fix incorrect file deletion from db when widget unmounts during thumbnail loading

### DIFF
--- a/mobile/apps/photos/lib/core/exceptions.dart
+++ b/mobile/apps/photos/lib/core/exceptions.dart
@@ -1,0 +1,13 @@
+/// Common runtime exceptions that can occur during normal app operation.
+/// These are recoverable conditions that should be caught and handled.
+
+class WidgetUnmountedException implements Exception {
+  final String? message;
+  
+  WidgetUnmountedException([this.message]);
+
+  @override
+  String toString() => message != null 
+      ? 'WidgetUnmountedException: $message' 
+      : 'WidgetUnmountedException';
+}


### PR DESCRIPTION
## Description

Previously, when _loadWithRetry returned null due to widget unmounting, the code incorrectly assumed the local file was deleted and would remove database reference of the file and which would trigger re-upload of the file. 

