### PR TITLE
[locker] Refactor theme handling in Locker to fix DynamicFAB style

### DIFF
--- a/mobile/apps/locker/lib/app.dart
+++ b/mobile/apps/locker/lib/app.dart
@@ -7,8 +7,7 @@ import 'package:ente_events/event_bus.dart';
 import 'package:ente_events/models/signed_in_event.dart';
 import 'package:ente_events/models/signed_out_event.dart';
 import 'package:ente_strings/l10n/strings_localizations.dart';
-import 'package:ente_ui/theme/colors.dart';
-import 'package:ente_ui/theme/ente_theme_data.dart';
+import "package:ente_ui/theme/ente_theme_data.dart";
 import 'package:ente_ui/utils/window_listener_service.dart';
 import 'package:flutter/foundation.dart';
 import "package:flutter/material.dart";
@@ -87,37 +86,14 @@ class _AppState extends State<App>
 
   @override
   Widget build(BuildContext context) {
-    final schemes = ColorSchemeBuilder.fromCustomColors(
-      primary700: const Color(0xFF1565C0), // Dark blue
-      primary500: const Color(0xFF2196F3), // Material blue
-      primary400: const Color(0xFF42A5F5), // Light blue
-      primary300: const Color(0xFF90CAF9), // Very light blue
-      iconButtonColor: const Color(0xFF1976D2), // Custom icon color
-      gradientButtonBgColors: const [
-        Color(0xFF1565C0),
-        Color(0xFF2196F3),
-        Color(0xFF42A5F5),
-      ],
-    );
-
-    final lightTheme = createAppThemeData(
-      brightness: Brightness.light,
-      colorScheme: schemes.light,
-    );
-
-    final darkTheme = createAppThemeData(
-      brightness: Brightness.dark,
-      colorScheme: schemes.dark,
-    );
-
     Widget buildApp() {
       if (Platform.isAndroid ||
           Platform.isWindows ||
           Platform.isLinux ||
           kDebugMode) {
         return AdaptiveTheme(
-          light: lightTheme,
-          dark: darkTheme,
+          light: lightThemeData,
+          dark: darkThemeData,
           initial: AdaptiveThemeMode.system,
           builder: (lightTheme, dartTheme) => MaterialApp(
             title: "ente",
@@ -142,8 +118,8 @@ class _AppState extends State<App>
         return MaterialApp(
           title: "ente",
           themeMode: ThemeMode.system,
-          theme: lightTheme,
-          darkTheme: darkTheme,
+          theme: lightThemeData,
+          darkTheme: darkThemeData,
           debugShowCheckedModeBanner: false,
           locale: locale,
           supportedLocales: appSupportedLocales,

--- a/mobile/apps/locker/lib/main.dart
+++ b/mobile/apps/locker/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:ente_lock_screen/ui/lock_screen.dart';
 import 'package:ente_logging/logging.dart';
 import 'package:ente_network/network.dart';
 import "package:ente_strings/l10n/strings_localizations.dart";
+import "package:ente_ui/theme/ente_theme_data.dart";
 import "package:ente_ui/theme/theme_config.dart";
 import 'package:ente_ui/utils/window_listener_service.dart';
 import 'package:ente_utils/platform_util.dart';
@@ -103,6 +104,8 @@ Future<void> _runInForeground() async {
         lockScreen: LockScreen(Configuration.instance),
         enabled: await LockScreenSettings.instance.shouldShowLockScreen(),
         locale: locale,
+        lightTheme: lightThemeData,
+        darkTheme: darkThemeData,
         savedThemeMode: savedThemeMode,
         supportedLocales: appSupportedLocales,
         localizationsDelegates: const [


### PR DESCRIPTION
## Description
DynamicFAB theme was not getting applied from the commons package. This PR fix that issue.

## Tests

**Before**

<img width="300" height="750" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-30 at 15 53 26" src="https://github.com/user-attachments/assets/17dfc778-b652-4e10-ad8f-3c8aed2656f6" />


**After**

<img width="300" height="750" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-30 at 15 52 58" src="https://github.com/user-attachments/assets/9e0c2feb-8204-4875-9bad-f9d4eaab8f36" />

