### PR TITLE
[mob][photos] Run vectorDB migration is memory safe way

### DIFF
--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -1292,8 +1292,11 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
     int processedCount = 0;
     int weirdCount = 0;
     int whileCount = 0;
+    const String migrationKey = "clip_vector_db_migration_in_progress";
     final stopwatch = Stopwatch()..start();
     try {
+      // Make sure no other heavy compute is running
+      computeController.blockCompute(blocker: migrationKey);
       while (true) {
         whileCount++;
         _logger.info("$whileCount st round of while loop");
@@ -1363,6 +1366,8 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
       rethrow;
     } finally {
       stopwatch.stop();
+      // Make sure compute can run again
+      computeController.unblockCompute(blocker: migrationKey);
     }
   }
 

--- a/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
@@ -32,6 +32,8 @@ class ComputeController {
   bool _isDeviceHealthy = true;
   bool _isUserInteracting = true;
   bool _canRunCompute = false;
+
+  /// If true, user interaction is ignored and compute tasks can run regardless of user activity.
   bool interactionOverride = false;
   late Timer _userInteractionTimer;
 

--- a/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
@@ -35,6 +35,11 @@ class ComputeController {
 
   /// If true, user interaction is ignored and compute tasks can run regardless of user activity.
   bool interactionOverride = false;
+
+  /// If true, compute tasks are paused regardless of device health or user activity.
+  bool get computeBlocked => _computeBlocks.isNotEmpty;
+  final Set<String> _computeBlocks = {};
+
   late Timer _userInteractionTimer;
 
   ComputeRunState _currentRunState = ComputeRunState.idle;
@@ -89,6 +94,10 @@ class ComputeController {
       _logger.info("User interacting, denying request.");
       return false;
     }
+    if (computeBlocked) {
+      _logger.info("Compute is blocked by: $_computeBlocks, denying request.");
+      return false;
+    }
     bool result = false;
     if (ml) {
       result = _requestML();
@@ -121,7 +130,8 @@ class ComputeController {
   }
 
   bool _requestStream([bool bypassMLWaiting = false]) {
-    if (_currentRunState == ComputeRunState.idle && (bypassMLWaiting || !_waitingToRunML)) {
+    if (_currentRunState == ComputeRunState.idle &&
+        (bypassMLWaiting || !_waitingToRunML)) {
       _logger.info("Stream request granted");
       _currentRunState = ComputeRunState.generatingStream;
       return true;
@@ -168,12 +178,25 @@ class ComputeController {
     _fireControlEvent();
   }
 
+  void blockCompute({required String blocker}) {
+    _computeBlocks.add(blocker);
+    _logger.info("Forcing to pauze compute due to: $blocker");
+    _fireControlEvent();
+  }
+
+  void unblockCompute({required String blocker}) {
+    _computeBlocks.remove(blocker);
+    _logger.info("removed blocker: $blocker, now blocked: $computeBlocked");
+    _fireControlEvent();
+  }
+
   void _fireControlEvent() {
-    final shouldRunCompute = _isDeviceHealthy && _canRunGivenUserInteraction();
+    final shouldRunCompute =
+        _isDeviceHealthy && _canRunGivenUserInteraction() && !computeBlocked;
     if (shouldRunCompute != _canRunCompute) {
       _canRunCompute = shouldRunCompute;
       _logger.info(
-        "Firing event: $shouldRunCompute      (device health: $_isDeviceHealthy, user interaction: $_isUserInteracting, mlInteractionOverride: $interactionOverride)",
+        "Firing event: $shouldRunCompute      (device health: $_isDeviceHealthy, user interaction: $_isUserInteracting, mlInteractionOverride: $interactionOverride, blockers: $_computeBlocks)",
       );
       Bus.instance.fire(ComputeControlEvent(shouldRunCompute));
     }


### PR DESCRIPTION
## Description

- Add ability to block computeController temporarily
- Block computeController when vectorDB migration is running
