### PR TITLE
Add Parallels custom icon

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -1237,6 +1237,12 @@
       "slug": "parqet"
     },
     {
+      "title": "Parallels",
+      "slug": "parallels",
+      "hex": "#E61E25",
+      "altNames": ["Parallels Desktop", "Parallels VM"]
+    },
+    {
       "title": "Parsec"
     },
     {

--- a/mobile/apps/auth/assets/custom-icons/icons/parallels.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/parallels.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="20" y="10" width="10" height="80" rx="5" fill="#E61E25"/>
+  <rect x="50" y="10" width="10" height="80" rx="5" fill="#E61E25"/>
+</svg>


### PR DESCRIPTION
## Description
This PR adds a custom icon for Parallels.

- Added `parallels.svg` under `mobile/apps/auth/assets/custom-icons/icons/`
- Updated `custom-icons.json` with:
  - title: "Parallels"
  - slug: "parallels"
  - hex: #E61E25
  - altNames: ["Parallels Desktop", "Parallels VM"]

The icon is optimized (well under 50KB) and uses the official Parallels red (#E61E25).

