### PR TITLE
[mob][photos] fix unsupported locales in language selector

### DIFF
--- a/mobile/apps/photos/lib/app.dart
+++ b/mobile/apps/photos/lib/app.dart
@@ -142,7 +142,7 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
             debugShowCheckedModeBanner: false,
             builder: EasyLoading.init(),
             locale: locale,
-            supportedLocales: AppLocalizations.supportedLocales,
+            supportedLocales: appSupportedLocales,
             localeListResolutionCallback: localResolutionCallBack,
             localizationsDelegates: const [
               ...AppLocalizations.localizationsDelegates,
@@ -164,7 +164,7 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
           debugShowCheckedModeBanner: false,
           builder: EasyLoading.init(),
           locale: locale,
-          supportedLocales: AppLocalizations.supportedLocales,
+          supportedLocales: appSupportedLocales,
           localeListResolutionCallback: localResolutionCallBack,
           localizationsDelegates: const [
             ...AppLocalizations.localizationsDelegates,

--- a/mobile/apps/photos/lib/l10n/l10n.dart
+++ b/mobile/apps/photos/lib/l10n/l10n.dart
@@ -2,6 +2,29 @@ import "package:flutter/widgets.dart";
 import 'package:photos/generated/intl/app_localizations.dart';
 import "package:shared_preferences/shared_preferences.dart";
 
+// list of locales which are enabled for photos app.
+// Add more language to the list only when at least 90% of the strings are
+// translated in the corresponding language.
+const List<Locale> appSupportedLocales = <Locale>[
+  Locale('en'),
+  Locale('es'),
+  Locale('de'),
+  Locale('fr'),
+  Locale('it'),
+  Locale('ja'),
+  Locale("nl"),
+  Locale("no"),
+  Locale("pl"),
+  Locale("pt", "BR"),
+  Locale('pt', 'PT'),
+  Locale("ro"),
+  Locale("ru"),
+  Locale("tr"),
+  Locale("uk"),
+  Locale("vi"),
+  Locale("zh", "CN"),
+];
+
 extension AppLocalizationsX on BuildContext {
   AppLocalizations get l10n => AppLocalizations.of(this);
 }
@@ -12,12 +35,12 @@ Locale? autoDetectedLocale;
 Locale localResolutionCallBack(deviceLocales, supportedLocales) {
   _onDeviceLocales = deviceLocales;
   final Set<String> languageSupport = {};
-  for (Locale supportedLocale in AppLocalizations.supportedLocales) {
+  for (Locale supportedLocale in appSupportedLocales) {
     languageSupport.add(supportedLocale.languageCode);
   }
   for (Locale locale in deviceLocales) {
     // check if exact local is supported, if yes, return it
-    if (AppLocalizations.supportedLocales.contains(locale)) {
+    if (appSupportedLocales.contains(locale)) {
       autoDetectedLocale = locale;
       return locale;
     }
@@ -67,7 +90,7 @@ Future<Locale?> getLocale({
     } else {
       savedLocale = Locale(savedValue);
     }
-    if (AppLocalizations.supportedLocales.contains(savedLocale)) {
+    if (appSupportedLocales.contains(savedLocale)) {
       return savedLocale;
     }
   }
@@ -81,7 +104,7 @@ Future<Locale?> getLocale({
 }
 
 Future<void> setLocale(Locale locale) async {
-  if (!AppLocalizations.supportedLocales.contains(locale)) {
+  if (!appSupportedLocales.contains(locale)) {
     throw Exception('Locale $locale is not supported by the app');
   }
   final StringBuffer out = StringBuffer(locale.languageCode);

--- a/mobile/apps/photos/lib/ui/home/landing_page_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/landing_page_widget.dart
@@ -94,7 +94,7 @@ class _LandingPageWidgetState extends State<LandingPageWidget> {
                       routeToPage(
                         context,
                         LanguageSelectorPage(
-                          AppLocalizations.supportedLocales,
+                          appSupportedLocales,
                           (locale) async {
                             await setLocale(locale);
                             EnteApp.setLocale(context, locale);

--- a/mobile/apps/photos/lib/ui/settings/general_section_widget.dart
+++ b/mobile/apps/photos/lib/ui/settings/general_section_widget.dart
@@ -100,7 +100,7 @@ class GeneralSectionWidget extends StatelessWidget {
             await routeToPage(
               context,
               LanguageSelectorPage(
-                AppLocalizations.supportedLocales,
+                appSupportedLocales,
                 (locale) async {
                   await setLocale(locale);
                   EnteApp.setLocale(context, locale);

--- a/mobile/apps/photos/lib/ui/tools/app_lock.dart
+++ b/mobile/apps/photos/lib/ui/tools/app_lock.dart
@@ -114,7 +114,7 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
       darkTheme: widget.darkTheme,
       locale: widget.locale,
       debugShowCheckedModeBanner: false,
-      supportedLocales: AppLocalizations.supportedLocales,
+      supportedLocales: appSupportedLocales,
       localeListResolutionCallback: localResolutionCallBack,
       localizationsDelegates: const [
         ...AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Description
- Replaced AppLocalizations.supportedLocales with a curated list of properly translated locales
- Fixed issue where unsupported language codes (Bg, Be, Ca, Cs, etc.) were appearing without proper formatting
- Added custom appSupportedLocales list containing only languages with >90% translation coverage
- Updated all references throughout the Photos app (main app, language picker, settings, app lock)

## Tests
- Verify language selector only shows supported languages
- Confirm all displayed languages have proper names (not just language codes)
- Test language switching functionality works correctly
- Ensure app doesn't crash when selecting any available language
- Verify locale resolution works correctly for device locale