### PR TITLE
[locker] Fix authentication not popping up on android

### DIFF
--- a/mobile/apps/locker/android/app/src/main/AndroidManifest.xml
+++ b/mobile/apps/locker/android/app/src/main/AndroidManifest.xml
@@ -54,4 +54,5 @@
             <data android:mimeType="text/plain"/>
         </intent>
     </queries>
+    <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
 </manifest>

--- a/mobile/apps/locker/android/app/src/main/kotlin/io/ente/locker/MainActivity.kt
+++ b/mobile/apps/locker/android/app/src/main/kotlin/io/ente/locker/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.ente.locker
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity()
+class MainActivity: FlutterFragmentActivity() {
+}

--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -502,5 +502,7 @@
   },
   "leaveCollection": "Leave collection",
   "filesAddedByYouWillBeRemovedFromTheCollection": "Files added by you will be removed from the collection",
-  "leaveSharedCollection": "Leave shared collection?"
+  "leaveSharedCollection": "Leave shared collection?",
+  "noSystemLockFound": "No system lock found",
+  "toEnableAppLockPleaseSetupDevicePasscodeOrScreen": "To enable app lock, please setup device passcode or screen lock in your system settings."
 }

--- a/mobile/apps/locker/lib/l10n/app_localizations.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations.dart
@@ -1575,6 +1575,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Leave shared collection?'**
   String get leaveSharedCollection;
+
+  /// No description provided for @noSystemLockFound.
+  ///
+  /// In en, this message translates to:
+  /// **'No system lock found'**
+  String get noSystemLockFound;
+
+  /// No description provided for @toEnableAppLockPleaseSetupDevicePasscodeOrScreen.
+  ///
+  /// In en, this message translates to:
+  /// **'To enable app lock, please setup device passcode or screen lock in your system settings.'**
+  String get toEnableAppLockPleaseSetupDevicePasscodeOrScreen;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/apps/locker/lib/l10n/app_localizations_en.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations_en.dart
@@ -896,4 +896,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get leaveSharedCollection => 'Leave shared collection?';
+
+  @override
+  String get noSystemLockFound => 'No system lock found';
+
+  @override
+  String get toEnableAppLockPleaseSetupDevicePasscodeOrScreen =>
+      'To enable app lock, please setup device passcode or screen lock in your system settings.';
 }

--- a/mobile/apps/locker/lib/ui/settings/security_section_widget.dart
+++ b/mobile/apps/locker/lib/ui/settings/security_section_widget.dart
@@ -13,7 +13,7 @@ import "package:ente_lock_screen/ui/lock_screen_options.dart";
 import "package:ente_ui/components/captioned_text_widget.dart";
 import "package:ente_ui/components/menu_item_widget.dart";
 import "package:ente_ui/components/toggle_switch_widget.dart";
-import "package:ente_ui/theme/ente_theme.dart";
+import "package:ente_ui/theme/ente_theme.dart"; 
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:ente_utils/navigation_util.dart";
@@ -122,7 +122,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
         trailingIcon: Icons.chevron_right_outlined,
         trailingIconIsMuted: true,
         onTap: () async {
-          if (await LockScreenSettings.instance.shouldShowLockScreen()) {
+          if (await LockScreenSettings.instance.isDeviceSupported()) {
             final bool result = await requestAuthentication(
               context,
               context.l10n.authToChangeLockscreenSetting,
@@ -137,19 +137,17 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
               );
             }
           } else {
-            await Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (BuildContext context) {
-                  return const LockScreenOptions();
-                },
-              ),
+            await showErrorDialog(
+              context,
+              context.l10n.noSystemLockFound,
+              context.l10n.toEnableAppLockPleaseSetupDevicePasscodeOrScreen,
             );
           }
         },
       ),
       sectionOptionSpacing,
     ]);
-    
+
     return Column(
       children: children,
     );

--- a/mobile/packages/lock_screen/lib/lock_screen_settings.dart
+++ b/mobile/packages/lock_screen/lib/lock_screen_settings.dart
@@ -9,6 +9,7 @@ import "package:ente_events/models/signed_out_event.dart";
 import "package:ente_utils/platform_util.dart";
 import "package:flutter/material.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
+import "package:local_auth/local_auth.dart";
 import "package:privacy_screen/privacy_screen.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
@@ -245,5 +246,9 @@ class LockScreenSettings {
       await _secureStorage.delete(key: pin);
       await _secureStorage.delete(key: saltKey);
     }
+  }
+
+  Future<bool> isDeviceSupported() async{
+    return await LocalAuthentication().isDeviceSupported();
   }
 }


### PR DESCRIPTION
## Description
Authentication service was not working on android as  `local_auth` requires the use of a `FragmentActivity` instead of an `Activity` in `MainActivity.kt` 

Also updated `AndroidManifest.xml` file to include the USE_BIOMETRIC permissions:
