### PR TITLE
[destkop] Update typo in translation

### DIFF
--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -486,7 +486,7 @@
     "watch_folders": "Watch folders",
     "watched_folders": "Watched folders",
     "no_folders_added": "No folders added yet",
-    "watch_folders_hint_1": "The folders you add here will monitored to automatically",
+    "watch_folders_hint_1": "The folders you add here are monitored to automatically",
     "watch_folders_hint_2": "Upload new files to Ente",
     "watch_folders_hint_3": "Remove deleted files from Ente",
     "add_folder": "Add folder",


### PR DESCRIPTION
See: https://github.com/ente-io/ente/pull/5546#issuecomment-3268874821

Updated the strings in crowdin by `gh workflow run web-crowdin-push-both.yml`