### PR TITLE
docs: Add details on enabling replication

### DIFF
--- a/docs/docs/self-hosting/administration/object-storage.md
+++ b/docs/docs/self-hosting/administration/object-storage.md
@@ -52,6 +52,13 @@ configuration body.
 Use the `s3.hot_storage.primary` option if you'd like to set one of the other
 pre-defined buckets as the primary bucket.
 
+To enable replication after configuring all 3 storage buckets, set `replication.enabled` to `true` in [museum.yaml](https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml):
+
+```yaml
+replication:
+    enabled: true
+```
+
 ### Bucket configuration
 
 The keys `b2-eu-cen` (primary storage), `wasabi-eu-central-2-v3` (secondary


### PR DESCRIPTION
## Description
This change was prompted by a support question in the self-hosted Discord channel[1], where users struggled to find this information. Previously, the details were only available in the installation guide, which users typically don't revisit when trying to enable features post-installation.

[1] https://discord.com/channels/948937918347608085/1414631496039403712
