### PR TITLE
[mob][photos] Show shared albums in widget selection screen

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
@@ -159,8 +159,8 @@ class _AlbumsWidgetSettingsState extends State<AlbumsWidgetSettings> {
               )
             else
               FutureBuilder<List<Collection>>(
-                future:
-                    CollectionsService.instance.getCollectionForOnEnteSection(),
+                future: CollectionsService.instance
+                    .getCollectionForWidgetSelection(),
                 builder: (context, snapshot) {
                   if (snapshot.hasData) {
                     final data = snapshot.data!;

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -68,6 +68,8 @@ class FlagService {
 
   bool get addToAlbumFeature => internalUser;
 
+  bool get widgetSharedAlbums => internalUser;
+
   bool hasSyncedAccountFlags() {
     return _prefs.containsKey("remote_flags");
   }

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: (i) Show shared albums in widget selection screen
 - Neeraj: (i) Add to album option in file overflow menu and file details [#3291](https://github.com/ente-io/ente/discussions/3291)
 - Neeraj: (i) Add collection-level guest view option in album overflow menu
 - Neeraj: Fix IDN domain display in public URLs [#7079](https://github.com/ente-io/ente/issues/7079)


### PR DESCRIPTION
## Summary
- Added support for showing shared albums in the widget selection screen
- Internal users can now select albums shared with them for home screen widgets  
- Added feature flag `widgetSharedAlbums` to control this functionality (enabled for internal users only)

## Implementation
- Created new `getCollectionForWidgetSelection()` method that includes shared albums when feature flag is enabled
- Updated widget settings UI to use the new method
- Existing UI automatically displays owner avatars for shared albums

## Testing
- Feature is behind internal user flag
- Project builds and analyzes without errors
- No changes to iOS/Android widget display code required

Co-Authored-By: Claude <noreply@anthropic.com>