### PR TITLE
[mobile][photos] Improve location display in file info

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file_details/location_tags_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/location_tags_widget.dart
@@ -109,19 +109,19 @@ class _LocationTagsWidgetState extends State<LocationTagsWidget> {
     if (locationTags.isEmpty) {
       if (mounted) {
         setState(() {
-          title = AppLocalizations.of(context).addLocation;
-          leadingIcon = Icons.add_location_alt_outlined;
-          hasChipButtons = false;
-          onTap = () => showAddLocationSheet(
-                context,
-                widget.file.location!,
-              );
+          title = AppLocalizations.of(context).location;
+          leadingIcon = Icons.pin_drop_outlined;
+          hasChipButtons = true;
+          onTap = null;
         });
       }
       return [
-        Text(
-          AppLocalizations.of(context).groupNearbyPhotos,
-          style: getEnteTextTheme(context).miniBoldMuted,
+        ChipButtonWidget(
+          AppLocalizations.of(context).addLocation,
+          onTap: () => showAddLocationSheet(
+            context,
+            widget.file.location!,
+          ),
         ),
       ];
     } else {

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: Simplify location display in file info - show "Location" title with "Add location" chip
 - Neeraj: (i) Add collection-level guest view option in album overflow menu
 - Neeraj: Fix IDN domain display in public URLs [#7079](https://github.com/ente-io/ente/issues/7079)
 - Neeraj: (i) Add allow joining album option in manage links


### PR DESCRIPTION
## Summary
- Simplified location display in file details widget for better UX consistency
- Changed title to always show "Location" instead of "Add location"
- Replaced text subtitle with actionable chip button

## Changes
- Title now consistently shows "Location" with pin drop icon
- Removed "Group nearby photos" subtitle text
- Added "Add location" chip button when no location tags exist
- Maintained existing + icon chip for adding additional location tags

Co-Authored-By: Claude <noreply@anthropic.com>