### PR TITLE
[mob][photos] improve logout handling

### DIFF
--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -457,85 +457,85 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/workmanager/ios"
 
 SPEC CHECKSUMS:
-  app_links: f3e17e4ee5e357b39d8b95290a9b2c299fca71c6
-  battery_info: b6c551049266af31556b93c9d9b9452cfec0219f
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  cupertino_http: 947a233f40cfea55167a49f2facc18434ea117ba
-  dart_ui_isolate: d5bcda83ca4b04f129d70eb90110b7a567aece14
-  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
-  emoji_picker_flutter: fe2e6151c5b548e975d546e6eeb567daf0962a58
+  app_links: 76b66b60cc809390ca1ad69bfd66b998d2387ac7
+  battery_info: 83f3aae7be2fccefab1d2bf06b8aa96f11c8bcdd
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
+  dart_ui_isolate: 46f6714abe6891313267153ef6f9748d8ecfcab1
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  emoji_picker_flutter: ed468d9746c21711e66b2788880519a9de5de211
   ffmpeg_kit_custom: 682b4f2f1ff1f8abae5a92f6c3540f2441d5be99
-  ffmpeg_kit_flutter: 9dce4803991478c78c6fb9f972703301101095fe
-  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
+  ffmpeg_kit_flutter: 915b345acc97d4142e8a9a8549d177ff10f043f5
+  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
-  firebase_core: cf4d42a8ac915e51c0c2dc103442f3036d941a2d
-  firebase_messaging: fee490327c1aae28a0da1e65fca856547deca493
+  firebase_core: ece862f94b2bc72ee0edbeec7ab5c7cb09fe1ab5
+  firebase_messaging: e1a5fae495603115be1d0183bc849da748734e2b
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_email_sender: e03bdda7637bcd3539bfe718fddd980e9508efaa
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  flutter_sodium: a00383520fc689c688b66fd3092984174712493e
-  flutter_timezone: ac3da59ac941ff1c98a2e1f0293420e020120282
-  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
+  flutter_email_sender: aa1e9772696691d02cd91fea829856c11efb8e58
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  flutter_sodium: 7e4621538491834eba53bd524547854bcbbd6987
+  flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
+  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  home_widget: 0434835a4c9a75704264feff6be17ea40e0f0d57
-  in_app_purchase_storekit: a1ce04056e23eecc666b086040239da7619cd783
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  launcher_icon_switcher: 8e0ad2131a20c51c1dd939896ee32e70cd845b37
+  home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
+  in_app_purchase_storekit: d1a48cb0f8b29dbf5f85f782f5dd79b21b90a5e6
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  launcher_icon_switcher: 84c218d233505aa7d8655d8fa61a3ba802c022da
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  local_auth_ios: 5046a18c018dd973247a0564496c8898dbb5adf9
+  local_auth_ios: f7a1841beef3151d140a967c2e46f30637cdf451
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  maps_launcher: 2e5b6a2d664ec6c27f82ffa81b74228d770ab203
-  media_extension: 6618f07abd762cdbfaadf1b0c56a287e820f0c84
-  media_kit_libs_ios_video: a5fe24bc7875ccd6378a0978c13185e1344651c1
-  media_kit_video: 5da63f157170e5bf303bf85453b7ef6971218a2e
-  motion_sensors: 03f55b7c637a7e365a0b5f9697a449f9059d5d91
-  motionphoto: 8b65ce50c7d7ff3c767534fc3768b2eed9ac24e4
-  move_to_background: cd3091014529ec7829e342ad2d75c0a11f4378a5
+  maps_launcher: edf829809ba9e894d70e569bab11c16352dedb45
+  media_extension: 671e2567880d96c95c65c9a82ccceed8f2e309fd
+  media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
+  media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474
+  motion_sensors: 741e702c17467b9569a92165dda8d4d88c6167f1
+  motionphoto: 23e2aeb5c6380112f69468d71f970fa7438e5ed1
+  move_to_background: 7e3467dd2a1d1013e98c9c1cb93fd53cd7ef9d84
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  native_video_player: 29ab24a926804ac8c4a57eb6d744c7d927c2bc3e
-  objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
-  onnxruntime: e7c2ae44385191eaad5ae64c935a72debaddc997
+  native_video_player: 6809dec117e8997161dbfb42a6f90d6df71a504d
+  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
+  onnxruntime: f9b296392c96c42882be020a59dbeac6310d81b2
   onnxruntime-c: a909204639a1f035f575127ac406f781ac797c9c
   onnxruntime-objc: b6fab0f1787aa6f7190c2013f03037df4718bd8b
-  open_mail_app: 70273c53f768beefdafbe310c3d9086e4da3cb02
+  open_mail_app: 7314a609e88eed22d53671279e189af7a0ab0f11
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  photo_manager: 81954a1bf804b6e882d0453b3b6bc7fad7b47d3d
-  privacy_screen: 1a131c052ceb3c3659934b003b0d397c2381a24e
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  photo_manager: 1d80ae07a89a67dfbcae95953a1e5a24af7c3e62
+  privacy_screen: 3159a541f5d3a31bea916cfd4e58f9dc722b3fd4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
-  rive_common: 4743dbfd2911c99066547a3c6454681e0fa907df
-  rust_lib_photos: 8813b31af48ff02ca75520cbc81a363a13d51a84
+  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
+  rive_common: dd421daaf9ae69f0125aa761dd96abd278399952
+  rust_lib_photos: 04d3901908d2972192944083310b65abf410774c
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
-  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sentry_flutter: 27892878729f42701297c628eb90e7c6529f3684
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   sqlite3: 1d85290c3321153511f6e900ede7a1608718bbd5
-  sqlite3_flutter_libs: 2c48c4ee7217fd653251975e43412250d5bcbbe2
-  system_info_plus: 5393c8da281d899950d751713575fbf91c7709aa
-  thermal: a9261044101ae8f532fa29cab4e8270b51b3f55c
-  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  vibration: 7d883d141656a1c1a6d8d238616b2042a51a1241
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
-  video_thumbnail: c4e2a3c539e247d4de13cd545344fd2d26ffafd1
-  volume_controller: 2e3de73d6e7e81a0067310d17fb70f2f86d71ac7
-  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
-  workmanager: 05afacf221f5086e18450250dce57f59bb23e6b0
+  sqlite3_flutter_libs: e7fc8c9ea2200ff3271f08f127842131746b70e2
+  system_info_plus: 555ce7047fbbf29154726db942ae785c29211740
+  thermal: d4c48be750d1ddbab36b0e2dcb2471531bc8df41
+  ua_client_hints: 92fe0d139619b73ec9fcb46cc7e079a26178f586
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  vibration: 8e2f50fc35bb736f9eecb7dd9f7047fbb6a6e888
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
+  video_thumbnail: b637e0ad5f588ca9945f6e2c927f73a69a661140
+  volume_controller: 3657a1f65bedb98fa41ff7dc5793537919f31b12
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
+  workmanager: b89e4e4445d8b57ee2fdbf1c3925696ebe5b8990
 
 PODFILE CHECKSUM: cce2cd3351d3488dca65b151118552b680e23635
 

--- a/mobile/apps/photos/lib/core/cache/image_cache.dart
+++ b/mobile/apps/photos/lib/core/cache/image_cache.dart
@@ -12,4 +12,8 @@ class FileLruCache {
   static void put(String key, File value) {
     _map.put(key, value);
   }
+
+  static void clearAll() {
+    _map.clear();
+  }
 }

--- a/mobile/apps/photos/lib/core/cache/lru_map.dart
+++ b/mobile/apps/photos/lib/core/cache/lru_map.dart
@@ -32,4 +32,8 @@ class LRUMap<K, V> {
   void remove(K key) {
     _map.remove(key);
   }
+
+  void clear() {
+    _map.clear();
+  }
 }

--- a/mobile/apps/photos/lib/core/cache/thumbnail_in_memory_cache.dart
+++ b/mobile/apps/photos/lib/core/cache/thumbnail_in_memory_cache.dart
@@ -36,4 +36,8 @@ class ThumbnailInMemoryLruCache {
       enteFile.cacheKey() + "_" + thumbnailSmallSize.toString(),
     );
   }
+
+  static void clearAll() {
+    _map.clear();
+  }
 }

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -262,17 +262,6 @@ class Configuration {
     } else {
       await _preferences.setBool("auto_logout", true);
     }
-
-    // Clear temporary directories
-    try {
-      final tempDir = Directory(_tempDocumentsDirPath);
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-        await tempDir.create(recursive: true);
-      }
-    } catch (e) {
-      _logger.warning("Failed to clear temp directory", e);
-    }
   }
 
   bool showAutoLogoutDialog() {

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -8,6 +8,9 @@ import "package:flutter/services.dart";
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:photos/core/cache/image_cache.dart';
+import 'package:photos/core/cache/thumbnail_in_memory_cache.dart';
+import 'package:photos/core/cache/video_cache_manager.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/error-reporting/super_logging.dart';
 import 'package:photos/core/event_bus.dart';
@@ -23,6 +26,7 @@ import 'package:photos/events/user_logged_out_event.dart';
 import 'package:photos/models/api/user/key_attributes.dart';
 import 'package:photos/models/api/user/key_gen_result.dart';
 import 'package:photos/models/api/user/private_key_attributes.dart';
+import 'package:photos/service_locator.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/favorites_service.dart';
 import "package:photos/services/home_widget_service.dart";
@@ -188,21 +192,55 @@ class Configuration {
         }
       }
     }
+
+    // Clear preferences and secure storage
     await _preferences.clear();
     await _secureStorage.deleteAll();
     _key = null;
     _cachedToken = null;
     _secretKey = null;
+    _volatilePassword = null;
+
+    // Clear all database tables
     await FilesDB.instance.clearTable();
     await CollectionsDB.instance.clearTable();
     await MemoriesDB.instance.clearTable();
     await MLDataDB.instance.clearTable();
-    await SimilarImagesService.instance.clearCache();
-
     await UploadLocksDB.instance.clearTable();
-    await IgnoredFilesService.instance.reset();
     await TrashDB.instance.clearTable();
+
+    // Clear all in-memory caches
+    ThumbnailInMemoryLruCache.clearAll();
+    FileLruCache.clearAll();
+
+    // Clear video cache
+    try {
+      await VideoCacheManager.instance.emptyCache();
+    } catch (e) {
+      _logger.warning("Failed to clear video cache", e);
+    }
+
+    // Clear all service caches
+    await SimilarImagesService.instance.clearCache();
+    await IgnoredFilesService.instance.reset();
     unawaited(HomeWidgetService.instance.clearWidget(autoLogout));
+
+    // Clear additional caches (safe to call even if not initialized)
+    try {
+      await magicCacheService.clearMagicCache();
+    } catch (e) {
+      _logger.info("MagicCacheService not initialized or failed to clear", e);
+    }
+
+    try {
+      await memoriesCacheService.clearMemoriesCache();
+    } catch (e) {
+      _logger.info(
+        "MemoriesCacheService not initialized or failed to clear",
+        e,
+      );
+    }
+
     if (!autoLogout) {
       // Following services won't be initialized if it's the case of autoLogout
       FileUploader.instance.clearCachedUploadURLs();
@@ -210,9 +248,30 @@ class Configuration {
       FavoritesService.instance.clearCache();
       SearchService.instance.clearCache();
       PersonService.instance.clearCache();
+      try {
+        smartAlbumsService.clearCache();
+      } catch (e) {
+        _logger.info("SmartAlbumsService not initialized", e);
+      }
+      try {
+        billingService.clearCache();
+      } catch (e) {
+        _logger.info("BillingService not initialized", e);
+      }
       Bus.instance.fire(UserLoggedOutEvent());
     } else {
       await _preferences.setBool("auto_logout", true);
+    }
+
+    // Clear temporary directories
+    try {
+      final tempDir = Directory(_tempDocumentsDirPath);
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+        await tempDir.create(recursive: true);
+      }
+    } catch (e) {
+      _logger.warning("Failed to clear temp directory", e);
     }
   }
 
@@ -245,13 +304,17 @@ class Configuration {
     final loginKey = await CryptoUtil.deriveLoginKey(derivedKeyResult.key);
 
     // Encrypt the key with this derived key
-    final encryptedKeyData =
-        CryptoUtil.encryptSync(masterKey, derivedKeyResult.key);
+    final encryptedKeyData = CryptoUtil.encryptSync(
+      masterKey,
+      derivedKeyResult.key,
+    );
 
     // Generate a public-private keypair and encrypt the latter
     final keyPair = await CryptoUtil.generateKeyPair();
-    final encryptedSecretKeyData =
-        CryptoUtil.encryptSync(keyPair.sk, masterKey);
+    final encryptedSecretKeyData = CryptoUtil.encryptSync(
+      keyPair.sk,
+      masterKey,
+    );
 
     final attributes = KeyAttributes(
       CryptoUtil.bin2base64(kekSalt),
@@ -291,8 +354,10 @@ class Configuration {
     final loginKey = await CryptoUtil.deriveLoginKey(derivedKeyResult.key);
 
     // Encrypt the key with this derived key
-    final encryptedKeyData =
-        CryptoUtil.encryptSync(masterKey!, derivedKeyResult.key);
+    final encryptedKeyData = CryptoUtil.encryptSync(
+      masterKey!,
+      derivedKeyResult.key,
+    );
 
     final existingAttributes = getKeyAttributes();
 
@@ -353,9 +418,7 @@ class Configuration {
       CryptoUtil.base642bin(attributes.publicKey),
       secretKey,
     );
-    await setToken(
-      CryptoUtil.bin2base64(token, urlSafe: true),
-    );
+    await setToken(CryptoUtil.bin2base64(token, urlSafe: true));
     return keyEncryptionKey;
   }
 
@@ -371,14 +434,18 @@ class Configuration {
     final encryptedRecoveryKey = CryptoUtil.encryptSync(recoveryKey, masterKey);
 
     return existingAttributes!.copyWith(
-      masterKeyEncryptedWithRecoveryKey:
-          CryptoUtil.bin2base64(encryptedMasterKey.encryptedData!),
-      masterKeyDecryptionNonce:
-          CryptoUtil.bin2base64(encryptedMasterKey.nonce!),
-      recoveryKeyEncryptedWithMasterKey:
-          CryptoUtil.bin2base64(encryptedRecoveryKey.encryptedData!),
-      recoveryKeyDecryptionNonce:
-          CryptoUtil.bin2base64(encryptedRecoveryKey.nonce!),
+      masterKeyEncryptedWithRecoveryKey: CryptoUtil.bin2base64(
+        encryptedMasterKey.encryptedData!,
+      ),
+      masterKeyDecryptionNonce: CryptoUtil.bin2base64(
+        encryptedMasterKey.nonce!,
+      ),
+      recoveryKeyEncryptedWithMasterKey: CryptoUtil.bin2base64(
+        encryptedRecoveryKey.encryptedData!,
+      ),
+      recoveryKeyDecryptionNonce: CryptoUtil.bin2base64(
+        encryptedRecoveryKey.nonce!,
+      ),
     );
   }
 
@@ -503,14 +570,9 @@ class Configuration {
     _key = key;
     if (key == null) {
       // Used to clear key from secure storage
-      await _secureStorage.delete(
-        key: keyKey,
-      );
+      await _secureStorage.delete(key: keyKey);
     } else {
-      await _secureStorage.write(
-        key: keyKey,
-        value: key,
-      );
+      await _secureStorage.write(key: keyKey, value: key);
     }
   }
 
@@ -518,14 +580,9 @@ class Configuration {
     _secretKey = secretKey;
     if (secretKey == null) {
       // Used to clear secret key from secure storage
-      await _secureStorage.delete(
-        key: secretKeyKey,
-      );
+      await _secureStorage.delete(key: secretKeyKey);
     } else {
-      await _secureStorage.write(
-        key: secretKeyKey,
-        value: secretKey,
-      );
+      await _secureStorage.write(key: secretKeyKey, value: secretKey);
     }
   }
 
@@ -649,18 +706,9 @@ class Configuration {
     final hasMigratedSecureStorage =
         _preferences.getBool(hasMigratedSecureStorageKey) ?? false;
     if (!hasMigratedSecureStorage && _key != null && _secretKey != null) {
-      await _secureStorage.write(
-        key: keyKey,
-        value: _key,
-      );
-      await _secureStorage.write(
-        key: secretKeyKey,
-        value: _secretKey,
-      );
-      await _preferences.setBool(
-        hasMigratedSecureStorageKey,
-        true,
-      );
+      await _secureStorage.write(key: keyKey, value: _key);
+      await _secureStorage.write(key: secretKeyKey, value: _secretKey);
+      await _preferences.setBool(hasMigratedSecureStorageKey, true);
     }
   }
 

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,5 @@
+- Prateek: Fix logout failure for custom endpoints when server is unreachable
+- Prateek: Ensure comprehensive cache clearing on logout
 - Neeraj: Simplify location display in file info - show "Location" title with "Add location" chip
 - Laurens: Fix edge case bug in similar images cache when user hasn't indexed ML yet
 - Neeraj: (i) Show shared albums in widget selection screen


### PR DESCRIPTION
Description:
- Allow logout to proceed locally when server call fails with custom endpoints
- Add comprehensive cache clearing on logout (in-memory, service, and video caches)
- Clear volatile password and temporary directories during logout
- Preserve strict error handling for production endpoints

Tests:
- [x] Test logout with production endpoint shows error if server fails
- [x] Test logout with custom endpoint proceeds even if server is unreachable
- [x] Verify all caches are cleared after logout
- [x] Check temporary directories are cleaned up
- [x] Ensure no user data remains in memory after logout