### PR TITLE
[ente] Add CLAUDE.local.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # macOS
 .DS_Store
+
+# Ignore CLAUDE.local.md files anywhere in the repository
+**/CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .DS_Store
 
 # Ignore CLAUDE.local.md files anywhere in the repository
-**/CLAUDE.local.md
+CLAUDE.local.md


### PR DESCRIPTION
## Description

- Added pattern to ignore CLAUDE.local.md files anywhere in the repository
- Uses `**/CLAUDE.local.md` pattern to match files in root and all subdirectories

## Tests

- [x] Created CLAUDE.local.md in root directory
- [x] Created CLAUDE.local.md in mobile/ subdirectory
- [x] Verified both files are properly ignored by git status