### PR TITLE
[mob][photos] Add layout options for public links

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -198,6 +198,9 @@
   "@noDeviceLimit": {
     "description": "Text to indicate that there is limit on number of devices"
   },
+  "layoutGrouped": "Grouped",
+  "layoutContinuous": "Continuous",
+  "layoutTrip": "Trip",
   "linkExpiry": "Link expiry",
   "linkExpired": "Expired",
   "linkEnabled": "Enabled",

--- a/mobile/apps/photos/lib/models/metadata/collection_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/collection_magic.dart
@@ -66,12 +66,18 @@ class CollectionPubMagicMetadata {
   // cover photo id for the collection
   int? coverID;
 
-  CollectionPubMagicMetadata({this.asc, this.coverID});
+  // layout for public link sharing (grouped, continuous, trip)
+  String? layout;
+
+  CollectionPubMagicMetadata({this.asc, this.coverID, this.layout});
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> result = {"asc": asc ?? false};
     if (coverID != null) {
       result["coverID"] = coverID!;
+    }
+    if (layout != null) {
+      result["layout"] = layout!;
     }
     return result;
   }
@@ -87,6 +93,7 @@ class CollectionPubMagicMetadata {
     return CollectionPubMagicMetadata(
       asc: map["asc"] as bool?,
       coverID: map["coverID"],
+      layout: map["layout"] as String? ?? "grouped",
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/sharing/manage_links_widget.dart
+++ b/mobile/apps/photos/lib/ui/sharing/manage_links_widget.dart
@@ -19,6 +19,7 @@ import 'package:photos/ui/components/menu_section_description_widget.dart';
 import "package:photos/ui/components/toggle_switch_widget.dart";
 import 'package:photos/ui/notification/toast.dart';
 import 'package:photos/ui/sharing/pickers/device_limit_picker_page.dart';
+import 'package:photos/ui/sharing/pickers/layout_picker_page.dart';
 import 'package:photos/ui/sharing/pickers/link_expiry_picker_page.dart';
 import 'package:photos/ui/sharing/qr_code_dialog_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
@@ -43,6 +44,19 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
   @override
   void initState() {
     super.initState();
+  }
+
+  String _getLayoutDisplayName(String layout, BuildContext context) {
+    switch (layout.toLowerCase()) {
+      case 'grouped':
+        return AppLocalizations.of(context).layoutGrouped;
+      case 'continuous':
+        return AppLocalizations.of(context).layoutContinuous;
+      case 'trip':
+        return AppLocalizations.of(context).layoutTrip;
+      default:
+        return AppLocalizations.of(context).layoutGrouped;
+    }
   }
 
   @override
@@ -74,6 +88,29 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  MenuItemWidget(
+                    alignCaptionedTextToLeft: true,
+                    captionedTextWidget: CaptionedTextWidget(
+                      title: AppLocalizations.of(context).layout,
+                      subTitle: _getLayoutDisplayName(
+                        widget.collection!.pubMagicMetadata.layout ?? "grouped",
+                        context,
+                      ),
+                    ),
+                    trailingIcon: Icons.chevron_right,
+                    menuItemColor: enteColorScheme.fillFaint,
+                    surfaceExecutionStates: false,
+                    onTap: () async {
+                      // ignore: unawaited_futures
+                      routeToPage(
+                        context,
+                        LayoutPickerPage(widget.collection!),
+                      ).then((value) {
+                        setState(() {});
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 24),
                   MenuItemWidget(
                     key: ValueKey("Allow collect $isCollectEnabled"),
                     captionedTextWidget: CaptionedTextWidget(

--- a/mobile/apps/photos/lib/ui/sharing/pickers/layout_picker_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/pickers/layout_picker_page.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import "package:photos/generated/l10n.dart";
+import 'package:photos/models/collection/collection.dart';
+import 'package:photos/services/collections_service.dart';
+import 'package:photos/theme/ente_theme.dart';
+import 'package:photos/ui/components/captioned_text_widget.dart';
+import 'package:photos/ui/components/divider_widget.dart';
+import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
+import 'package:photos/ui/components/title_bar_title_widget.dart';
+import 'package:photos/ui/components/title_bar_widget.dart';
+import 'package:photos/utils/dialog_util.dart';
+import 'package:photos/utils/separators_util.dart';
+import 'package:tuple/tuple.dart';
+
+class LayoutPickerPage extends StatelessWidget {
+  final Collection collection;
+  const LayoutPickerPage(this.collection, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        primary: false,
+        slivers: <Widget>[
+          TitleBarWidget(
+            flexibleSpaceTitle: TitleBarTitleWidget(
+              title: AppLocalizations.of(context).layout,
+            ),
+          ),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 20,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ClipRRect(
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(8)),
+                        child: ItemsWidget(collection),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              childCount: 1,
+            ),
+          ),
+          const SliverPadding(padding: EdgeInsets.symmetric(vertical: 12)),
+        ],
+      ),
+    );
+  }
+}
+
+class ItemsWidget extends StatefulWidget {
+  final Collection collection;
+  const ItemsWidget(this.collection, {super.key});
+
+  @override
+  State<ItemsWidget> createState() => _ItemsWidgetState();
+}
+
+class _ItemsWidgetState extends State<ItemsWidget> {
+  late final List<Tuple2<String, String>> _layoutOptions = [
+    Tuple2(AppLocalizations.of(context).layoutGrouped, "grouped"),
+    Tuple2(AppLocalizations.of(context).layoutContinuous, "continuous"),
+    Tuple2(AppLocalizations.of(context).layoutTrip, "trip"),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> items = [];
+    for (Tuple2<String, String> layoutOption in _layoutOptions) {
+      items.add(
+        _menuItemForPicker(context, layoutOption),
+      );
+    }
+    items = addSeparators(
+      items,
+      DividerWidget(
+        dividerType: DividerType.menuNoIcon,
+        bgColor: getEnteColorScheme(context).fillFaint,
+      ),
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: items,
+    );
+  }
+
+  Widget _menuItemForPicker(
+    BuildContext context,
+    Tuple2<String, String> layoutOption,
+  ) {
+    return MenuItemWidget(
+      menuItemColor: getEnteColorScheme(context).fillFaint,
+      captionedTextWidget: CaptionedTextWidget(
+        title: layoutOption.item1,
+      ),
+      alignCaptionedTextToLeft: true,
+      isTopBorderRadiusRemoved: true,
+      isBottomBorderRadiusRemoved: true,
+      alwaysShowSuccessState: true,
+      surfaceExecutionStates: true,
+      onTap: () async {
+        await updateLayout(layoutOption.item2, context);
+      },
+    );
+  }
+
+  Future<void> updateLayout(String newLayout, BuildContext context) async {
+    await _updateLayoutSettings(
+      context,
+      {'layout': newLayout},
+    );
+  }
+
+  Future<void> _updateLayoutSettings(
+    BuildContext context,
+    Map<String, dynamic> prop,
+  ) async {
+    try {
+      await CollectionsService.instance
+          .updatePublicMagicMetadata(widget.collection, prop);
+    } catch (e) {
+      await showGenericErrorDialog(context: context, error: e);
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add layout selection functionality to public link management, allowing users to choose between "grouped", "continuous", and "trip" layout options. The layout selector is positioned in the manage link interface. Layout preferences are stored in the collection's public magic metadata with "grouped" as the default option.