### PR TITLE
Show/hide window when tray icon is clicked

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -680,6 +680,15 @@ const setupTrayItem = (mainWindow: BrowserWindow) => {
     const tray = new Tray(trayIcon);
     tray.setToolTip("Ente Photos");
     tray.setContextMenu(createTrayContextMenu(mainWindow));
+    if (process.platform === "linux") {
+        tray.on("click", () => {
+            if (mainWindow.isFocused()) {
+                mainWindow.hide();
+            } else {
+                mainWindow.show();
+            }
+        });
+    }
 };
 
 /**


### PR DESCRIPTION
## Description	

Right now, clicking the tray icon (at least on Linux) does nothing. This is contrary to platform expectations: clicking the tray icon should usually do something.

The most useful action to take is probably to open the app (or close it if it's already open), and that's what this PR does.

Specifically, this opens the window if it's not "visible", else closes it. On my system, this produces the following behaviours:

- if Ente is focused, clicking the icon hides it
- if Ente is not focused but it's visible on another monitor, the icon hides it
- if Ente is not the visible window in a tab, the icon focuses the existing window
- if Ente is on another workspace, the icon hides it (that seems suboptimal...)
- if Ente is hidden, the icon opens a new Ente window

I'm open to suggestions on the exact behaviours here (e.g. it would seem reasonable to only close the app if it's _focused_, not just if it's visible), but there's such a variety of behaviours in existing apps that I don't think there's necessarily a single correct set of behaviours to aim for.

This resolves https://github.com/ente-io/ente/discussions/6777.

## Tests

I've manually tested this on Linux. I'd appreciate testers on Windows and/or macOS.