### PR TITLE
docs: Clarify which creds to unhide album

### DIFF
--- a/docs/docs/photos/features/hide.md
+++ b/docs/docs/photos/features/hide.md
@@ -41,13 +41,13 @@ memories sections.
 - Go to Albums tab
 - Scroll down to bottom
 - Click on _Hidden_ button
-- Authenticate in app
+- Authenticate in app with your device passcode
 
 #### Web / Desktop
 
 - Click on the topleft hamburger menu
 - Click on _Hidden_
-- Authenticate in app
+- Authenticate in app with your Ente password
 
 ### Unhide album
 


### PR DESCRIPTION
## Description

After accessing the hidden album on my Android using my device's passcode, I was confused with which creds to use on the desktop as I assumed they would be the same -- but they're clearly not.

Small update to the docs to clarify which password to use to access hidden album on desktop.