### PR TITLE
[locker] Handle errors in resetSecureStorage method

### DIFF
--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -85,12 +85,18 @@ class BaseConfiguration {
   }
 
   Future<void> resetSecureStorage() async {
-    // Delete all keys except preserved ones
-    final allKeys = await _secureStorage.readAll();
-    for (final key in allKeys.keys) {
-      if (!preservedKeys.contains(key)) {
-        await _secureStorage.delete(key: key);
+    try {
+      // Delete all keys except preserved ones
+      final allKeys = await _secureStorage.readAll();
+      for (final key in allKeys.keys) {
+        if (!preservedKeys.contains(key)) {
+          await _secureStorage.delete(key: key);
+        }
       }
+    } catch (e) {
+      // On error, clear all keys
+      _logger.warning('Error resetting secure storage: $e');
+      await _secureStorage.deleteAll();
     }
   }
 


### PR DESCRIPTION
## Description
The issue is in the resetSecureStorage() method. It's trying to call readAll(), which causes the BadPaddingException.

`PlatformException(Exception encountered, readAll, javax.crypto.BadPaddingException: error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT`