### PR TITLE
[mob][photos] Fix issue with flipped thumbnails

### DIFF
--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -274,11 +274,11 @@ class UserService {
       }
     } catch (e) {
       // Determine if we should silently ignore the error and proceed with logout
-      final bool silentlyIgnoreError = 
+      final bool silentlyIgnoreError =
           // Token is already invalid (401 response)
           (e is DioException && e.response?.statusCode == 401) ||
-          // Custom endpoints where server might be non-existent or unavailable
-          !_config.isEnteProduction();
+              // Custom endpoints where server might be non-existent or unavailable
+              !_config.isEnteProduction();
 
       if (silentlyIgnoreError) {
         if (!_config.isEnteProduction()) {
@@ -288,9 +288,9 @@ class UserService {
         } else {
           _logger.info("Token already invalid, proceeding with local logout");
         }
-        
+
         await Configuration.instance.logout();
-        
+
         // Navigate to first route if context is still mounted
         if (context.mounted) {
           Navigator.of(context).popUntil((route) => route.isFirst);

--- a/mobile/apps/photos/lib/ui/collections/album/row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/row_item.dart
@@ -117,17 +117,20 @@ class AlbumRowItemWidget extends StatelessWidget {
                               return Hero(
                                 tag: heroTag,
                                 transitionOnUserGestures: true,
-                                child: isSelected
-                                    ? ColorFiltered(
-                                        colorFilter: ColorFilter.mode(
-                                          Colors.black.withValues(
+                                child: Stack(
+                                  fit: StackFit.expand,
+                                  children: [
+                                    thumbnailWidget,
+                                    if (isSelected)
+                                      Container(
+                                        decoration: BoxDecoration(
+                                          color: Colors.black.withValues(
                                             alpha: 0.4,
                                           ),
-                                          BlendMode.darken,
                                         ),
-                                        child: thumbnailWidget,
-                                      )
-                                    : thumbnailWidget,
+                                      ),
+                                  ],
+                                ),
                               );
                             } else {
                               return Container(

--- a/mobile/apps/photos/lib/ui/components/buttons/chip_button_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/buttons/chip_button_widget.dart
@@ -8,7 +8,7 @@ class ChipButtonWidget extends StatelessWidget {
   final double iconSize;
   final VoidCallback? onTap;
   final bool noChips;
-  
+
   const ChipButtonWidget(
     this.label, {
     this.leadingIcon,

--- a/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
@@ -92,121 +92,68 @@ class _MemoryCoverWidgetState extends State<MemoryCoverWidget> {
           ),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(5),
-            child: isSeen
-                ? ColorFiltered(
-                    colorFilter: const ColorFilter.mode(
-                      Color(0xFFBFBFBF),
-                      BlendMode.hue,
+            child: Container(
+              foregroundDecoration: isSeen
+                  ? const BoxDecoration(
+                      color: Color(0xFFBFBFBF),
+                      backgroundBlendMode: BlendMode.saturation,
+                    )
+                  : null,
+              child: Stack(
+                fit: StackFit.expand,
+                alignment: Alignment.bottomCenter,
+                children: [
+                  Hero(
+                    tag: "memories" + memory.file.tag,
+                    child: ThumbnailWidget(
+                      memory.file,
+                      shouldShowArchiveStatus: false,
+                      shouldShowSyncStatus: false,
+                      key: Key("memories" + memory.file.tag),
                     ),
-                    child: Stack(
-                      fit: StackFit.expand,
-                      alignment: Alignment.bottomCenter,
-                      children: [
-                        Hero(
-                          tag: "memories" + memory.file.tag,
-                          child: ThumbnailWidget(
-                            memory.file,
-                            shouldShowArchiveStatus: false,
-                            shouldShowSyncStatus: false,
-                            key: Key("memories" + memory.file.tag),
-                          ),
-                        ),
-                        Container(
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              colors: [
-                                Colors.black.withValues(alpha: 0.5),
-                                Colors.transparent,
-                              ],
-                              stops: const [0, 1],
-                              begin: Alignment.bottomCenter,
-                              end: Alignment.topCenter,
-                            ),
-                          ),
-                        ),
-                        Positioned(
-                          bottom: 8,
-                          child: SizedBox(
-                            width: widget.width,
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8.0,
-                              ),
-                              child: Hero(
-                                tag: title,
-                                child: Center(
-                                  child: Text(
-                                    title,
-                                    style: getEnteTextTheme(context)
-                                        .miniBold
-                                        .copyWith(
-                                          color: isSeen
-                                              ? textFaintDark
-                                              : Colors.white,
-                                        ),
-                                    textAlign: TextAlign.left,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  )
-                : Stack(
-                    fit: StackFit.expand,
-                    alignment: Alignment.bottomCenter,
-                    children: [
-                      Hero(
-                        tag: "memories" + memory.file.tag,
-                        child: ThumbnailWidget(
-                          memory.file,
-                          shouldShowArchiveStatus: false,
-                          shouldShowSyncStatus: false,
-                          key: Key("memories" + memory.file.tag),
-                        ),
-                      ),
-                      Container(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            colors: [
-                              Colors.black.withValues(alpha: 0.5),
-                              Colors.transparent,
-                            ],
-                            stops: const [0, 1],
-                            begin: Alignment.bottomCenter,
-                            end: Alignment.topCenter,
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        bottom: 8,
-                        child: SizedBox(
-                          width: widget.width,
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8.0,
-                            ),
-                            child: Hero(
-                              tag: title,
-                              child: Center(
-                                child: Text(
-                                  title,
-                                  style: getEnteTextTheme(context)
-                                      .miniBold
-                                      .copyWith(
-                                        color: Colors.white,
-                                      ),
-                                  textAlign: TextAlign.left,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
                   ),
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: [
+                          Colors.black.withValues(alpha: 0.5),
+                          Colors.transparent,
+                        ],
+                        stops: const [0, 1],
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 8,
+                    child: SizedBox(
+                      width: widget.width,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8.0,
+                        ),
+                        child: Hero(
+                          tag: title,
+                          child: Center(
+                            child: Text(
+                              title,
+                              style: getEnteTextTheme(context)
+                                  .miniBold
+                                  .copyWith(
+                                    color:
+                                        isSeen ? textFaintDark : Colors.white,
+                                  ),
+                              textAlign: TextAlign.left,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/mobile/apps/photos/lib/ui/sharing/share_collection_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/share_collection_page.dart
@@ -225,23 +225,23 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
             MenuItemWidget(
               captionedTextWidget: CaptionedTextWidget(
                 title: AppLocalizations.of(context).sendQrCode,
-                  makeTextBold: true,
-                ),
-                leadingIcon: Icons.qr_code_outlined,
-                menuItemColor: getEnteColorScheme(context).fillFaint,
-                onTap: () async {
-                  await showDialog<void>(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return QrCodeDialogWidget(
-                        collection: widget.collection,
-                      );
-                    },
-                  );
-                },
-                isTopBorderRadiusRemoved: true,
-                isBottomBorderRadiusRemoved: true,
+                makeTextBold: true,
               ),
+              leadingIcon: Icons.qr_code_outlined,
+              menuItemColor: getEnteColorScheme(context).fillFaint,
+              onTap: () async {
+                await showDialog<void>(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return QrCodeDialogWidget(
+                      collection: widget.collection,
+                    );
+                  },
+                );
+              },
+              isTopBorderRadiusRemoved: true,
+              isBottomBorderRadiusRemoved: true,
+            ),
           ],
         );
       }

--- a/mobile/apps/photos/lib/ui/tools/similar_images_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/similar_images_page.dart
@@ -828,31 +828,28 @@ class _SimilarImagesPageState extends State<SimilarImagesPage>
                       tag: "similar_images_" + file.tag,
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8),
-                        child: isSelected
-                            ? ColorFiltered(
-                                colorFilter: ColorFilter.mode(
-                                  Colors.black.withAlpha((0.4 * 255).toInt()),
-                                  BlendMode.darken,
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            ThumbnailWidget(
+                              file,
+                              diskLoadDeferDuration:
+                                  galleryThumbnailDiskLoadDeferDuration,
+                              serverLoadDeferDuration:
+                                  galleryThumbnailServerLoadDeferDuration,
+                              shouldShowLivePhotoOverlay: true,
+                              key: Key("similar_images_" + file.tag),
+                            ),
+                            if (isSelected)
+                              Container(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(8),
+                                  color: Colors.black
+                                      .withAlpha((0.4 * 255).toInt()),
                                 ),
-                                child: ThumbnailWidget(
-                                  file,
-                                  diskLoadDeferDuration:
-                                      galleryThumbnailDiskLoadDeferDuration,
-                                  serverLoadDeferDuration:
-                                      galleryThumbnailServerLoadDeferDuration,
-                                  shouldShowLivePhotoOverlay: true,
-                                  key: Key("similar_images_" + file.tag),
-                                ),
-                              )
-                            : ThumbnailWidget(
-                                file,
-                                diskLoadDeferDuration:
-                                    galleryThumbnailDiskLoadDeferDuration,
-                                serverLoadDeferDuration:
-                                    galleryThumbnailServerLoadDeferDuration,
-                                shouldShowLivePhotoOverlay: true,
-                                key: Key("similar_images_" + file.tag),
                               ),
+                          ],
+                        ),
                       ),
                     ),
                     Positioned(

--- a/mobile/apps/photos/lib/ui/viewer/search/result/people_section_all_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/people_section_all_page.dart
@@ -215,14 +215,17 @@ class SelectablePersonSearchExample extends StatelessWidget {
                                       : BorderRadius.circular(81),
                             ),
                           ),
-                          child: ColorFiltered(
-                            colorFilter: ColorFilter.mode(
-                              Colors.black.withValues(
-                                alpha: isSelected ? 0.4 : 0,
-                              ),
-                              BlendMode.darken,
-                            ),
-                            child: child,
+                          child: Stack(
+                            fit: StackFit.expand,
+                            children: [
+                              child,
+                              if (isSelected)
+                                Container(
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.4),
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
                       );

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
@@ -284,14 +284,17 @@ class PersonSearchExample extends StatelessWidget {
                                       : BorderRadius.circular(81),
                             ),
                           ),
-                          child: ColorFiltered(
-                            colorFilter: ColorFilter.mode(
-                              Colors.black.withValues(
-                                alpha: isSelected ? 0.4 : 0,
-                              ),
-                              BlendMode.darken,
-                            ),
-                            child: child,
+                          child: Stack(
+                            fit: StackFit.expand,
+                            children: [
+                              child,
+                              if (isSelected)
+                                Container(
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.4),
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
                       );

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Laurens: Fix flipped thumbnails issue by removing use of ColorFiltered widget
 - Ashil: Downgrade flutter secure storage back to version used before v1.2.4 release
 - Neeraj: Fix sorting for large files viewer
 - Anand: Option to change public album layout


### PR DESCRIPTION
## Description

Use of the `ColorFiltered` flutter widget appears to give issues for HEIC files viewed on Android, where their meta data seems to make the widget flip the child. In this case, it means image thumbnails were getting flipped on selection. Fixed the issue by no longer using the `ColorFiltered` widget and instead relying on a simple combo of Stack and Container with background color. 

## Tests

Tested in debug mode on my pixel phone, for all UI changes involved. 