### PR TITLE
Added Light/Dark mode support for X logo

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/icons/x.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/x.svg
@@ -1,6 +1,6 @@
 <svg version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 49.8 45" style="enable-background:new 0 0 49.8 45;" xml:space="preserve">
  <style type="text/css">
-  .st0{fill:#FFFFFF;}
+  path { fill: black; } @media (prefers-color-scheme: dark) { path { fill: white; }}
  </style>
  <metadata>
   <sfw xmlns="ns_sfw;">


### PR DESCRIPTION
## Description

Fixes #
X logo (SVG) did not have automatic colour switching based on light/dark mode selected by the user. Added this to change which fixes #7324

## Tests
Here, you can see the logo automatically switching color from black to white depending on the mode user is in:
https://github.com/user-attachments/assets/a21eb6ea-c9f6-4ab1-bf58-9f238669a891


