### PR TITLE
[mob][photos] Remove feature flags from manage links widget

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -186,6 +186,7 @@
   "@allowAddingPhotos": {
     "description": "Switch button to enable uploading photos to a public link"
   },
+  "allowJoiningAlbum": "Allow joining album",
   "allowAddPhotosDescription": "Allow people with the link to also add photos to the shared album.",
   "passwordLock": "Password lock",
   "canNotOpenTitle": "Cannot open this album",

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: Remove feature flags from manage_links_widget (album layout, allow joining album, copy embed HTML)
 - Ashil: Use better copy on auto-add people selection page
 - Ashil: Add more logs to debug app stuck at splash screen issue
 - Prateek: Tag Sentry errors with execution_context for background vs foreground


### PR DESCRIPTION
## Summary
- Remove feature flags for album layout, allow joining album, and copy embed HTML features
- Make these features available to all users
- Move "Allow joining album" toggle below "Allow downloads"

## Test plan
- [ ] Verify album layout selector appears for all users
- [ ] Verify "Allow joining album" toggle appears below "Allow downloads"
- [ ] Verify "Copy embed HTML" option appears for all users
- [ ] Test all three features work correctly
- [ ] No regression in manage links functionality

Co-Authored-By: Claude <noreply@anthropic.com>