### PR TITLE
Fix: Prevent redirect to ente.io for self-hosted instances

### DIFF
--- a/web/apps/embed/src/pages/index.tsx
+++ b/web/apps/embed/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
     type PublicAlbumsCredentials,
 } from "ente-base/http";
 import log from "ente-base/log";
+import { isCustomAlbumsAppOrigin } from "ente-base/origins";
 import { downloadManager } from "ente-gallery/services/download";
 import { extractCollectionKeyFromShareURL } from "ente-gallery/services/share";
 import { sortFiles } from "ente-gallery/utils/file";
@@ -130,8 +131,11 @@ export default function EmbedGallery() {
                 const t = currentURL.searchParams.get("t");
                 const ck = await extractCollectionKeyFromShareURL(currentURL);
                 if (!t && !ck) {
-                    window.location.href = "https://ente.io";
-                    redirectingToWebsite = true;
+                    // Only redirect to ente.io if this is NOT a custom/self-hosted instance
+                    if (!isCustomAlbumsAppOrigin) {
+                        window.location.href = "https://ente.io";
+                        redirectingToWebsite = true;
+                    }
                 }
                 if (!t || !ck) {
                     return;

--- a/web/apps/photos/src/pages/shared-albums.tsx
+++ b/web/apps/photos/src/pages/shared-albums.tsx
@@ -4,6 +4,7 @@ import AddPhotoAlternateOutlinedIcon from "@mui/icons-material/AddPhotoAlternate
 import CloseIcon from "@mui/icons-material/Close";
 import DownloadIcon from "@mui/icons-material/Download";
 import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
+
 import {
     Box,
     Button,
@@ -55,7 +56,7 @@ import {
     type PublicAlbumsCredentials,
 } from "ente-base/http";
 import log from "ente-base/log";
-import { albumsAppOrigin, shouldOnlyServeAlbumsApp } from "ente-base/origins";
+import { albumsAppOrigin, shouldOnlyServeAlbumsApp, isCustomAlbumsAppOrigin } from "ente-base/origins";
 import { FullScreenDropZone } from "ente-gallery/components/FullScreenDropZone";
 import {
     useSaveGroups,
@@ -205,8 +206,11 @@ export default function PublicCollectionGallery() {
                 const t = currentURL.searchParams.get("t");
                 const ck = await extractCollectionKeyFromShareURL(currentURL);
                 if (!t && !ck) {
-                    window.location.href = "https://ente.io";
-                    redirectingToWebsite = true;
+                    // Only redirect to ente.io if this is NOT a custom/self-hosted instance
+                    if (!isCustomAlbumsAppOrigin) {
+                        window.location.href = "https://ente.io";
+                        redirectingToWebsite = true;
+                    }
                 }
                 if (!t || !ck) {
                     return;
@@ -442,18 +446,18 @@ export default function PublicCollectionGallery() {
         () =>
             publicCollection && publicFiles
                 ? {
-                      component: (
-                          <FileListHeader
-                              {...{
-                                  publicCollection,
-                                  publicFiles,
-                                  downloadEnabled,
-                                  onAddSaveGroup,
-                              }}
-                          />
-                      ),
-                      height: fileListHeaderHeight,
-                  }
+                    component: (
+                        <FileListHeader
+                            {...{
+                                publicCollection,
+                                publicFiles,
+                                downloadEnabled,
+                                onAddSaveGroup,
+                            }}
+                        />
+                    ),
+                    height: fileListHeaderHeight,
+                }
                 : undefined,
         [onAddSaveGroup, publicCollection, publicFiles, downloadEnabled],
     );


### PR DESCRIPTION
### Fix: Prevent redirect to ente.io for self-hosted albums and embed instances

 ### Problem
When self-hosting ente and accessing the albums web app root endpoint without URL parameters, users were redirected to `https://ente.io` with no indication of why. This caused confusion for self-hosted users who expected to stay on their own instance.

### Technical Details
The issue occurred when both the `t` (token) and `ck` (collection key) URL parameters were missing:
- `t` parameter: Contains the access token for the shared album
- `ck` parameter: Contains the collection key extracted from the share URL

When neither parameter was present, the code would unconditionally redirect to `https://ente.io`, regardless of whether this was a self-hosted instance or the official ente.io deployment.

### Root Cause

The problematic code existed in two locations:

In `web/apps/photos/src/pages/shared-albums.tsx` (line ~208):
```typescript
if (!t && !ck) {
    window.location.href = "https://ente.io";  // ❌ Always redirects
    redirectingToWebsite = true;
}

In web/apps/embed/src/pages/index.tsx (line ~133):


if (!t && !ck) {
    window.location.href = "https://ente.io";  // ❌ Same issue in embed app
    redirectingToWebsite = true;
}

##Solution
Added conditional logic using the existing isCustomAlbumsAppOrigin utility function to detect self-hosted instances:

Changes made to both files:

if (!t && !ck) {
    // Only redirect to ente.io if this is NOT a custom/self-hosted instance
    if (!isCustomAlbumsAppOrigin) {
        window.location.href = "https://ente.io";
        redirectingToWebsite = true;
    }
}

Import added to both files:
import { isCustomAlbumsAppOrigin } from "ente-base/origins";


### Before (Problem)
<img width="580" height="34" alt="Screenshot 2025-10-07 at 5 21 09 PM" src="https://github.com/user-attachments/assets/94eb9d1d-e415-4064-af17-fe913dcb61c6" />
User visits their self hosted instance (http://localhost:3003/shared-albums)

<img width="1512" height="982" alt="Screenshot 2025-10-07 at 3 15 50 PM" src="https://github.com/user-attachments/assets/47537068-fa68-4ff3-9c61-a6eca089845e" />
User gets redirected to ente.io even though they are self hosted.

### After (Fixed)
<img width="1512" height="982" alt="Screenshot 2025-10-07 at 3 25 23 PM" src="https://github.com/user-attachments/assets/541d5d39-b256-43d1-aa25-27a631ed5cd8" />
The screenshot shows the fix working correctly:
URL: http://localhost:3003/shared-albums (stays on localhost)
Content: "404 - Not found" (expected behavior without valid t and ck parameters)
Key point: No redirect to ente.io occurred - the self-hosted instance stays on its own domain
This demonstrates that self-hosted ente instances now behave as expected, staying on their own domain instead of redirecting users to the official ente.io site.


### Tests Performed
Official ente.io behavior (no custom endpoint)

URL: http://localhost:3003/shared-albums (without NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT)
Expected: Redirect to ente.io
Result: ✅ Redirects to ente.io (unchanged behavior)
Self-hosted instance without parameters

URL: http://localhost:3003/shared-albums (with NEXT_PUBLIC_ENTE_ALBUMS_ENDPOINT set)
Expected: Stay on localhost
Result: ✅ Stays on localhost, shows "404 - Not found" (expected without valid tokens)
Self-hosted instance with parameters

URL: http://localhost:3003/shared-albums?t=test&ck=test
Expected: Attempt to load album
Result: ✅ Stays on localhost, shows appropriate error/loading
Embed app without parameters

URL: http://localhost:3003/embed
Expected: Stay on localhost
Result: ✅ Stays on localhost (no redirect to ente.io)
TypeScript compilation

Command: yarn workspace photos tsc && yarn workspace embed tsc
Result: ✅ No compilation errors