### PR TITLE
[mob][photos] Fix whitelisted exceptions being reported to Sentry

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -239,6 +239,15 @@ class SuperLogging {
             options.transport =
                 TunneledTransport(Uri.parse(appConfig.tunnel!), options);
           }
+          // Filter out errors that should not be sent to Sentry
+          options.beforeSend = (SentryEvent event, Hint hint) async {
+            // Check if the error should be skipped
+            final dynamic error = event.throwable;
+            if (error != null && _shouldSkipSentry(error)) {
+              return null; // Returning null drops the event
+            }
+            return event;
+          };
         },
         appRunner: () => appConfig!.body!(),
       );


### PR DESCRIPTION
## Description
Add beforeSend callback to filter out errors that should not be sent to Sentry. This prevents StorageLimitExceededError and other whitelisted errors from being reported when they're caught by SentryFlutter's automatic error handling.


## Tests
