### PR TITLE
[mob][photos] Refactor delete progress calculation in DeleteEmptyAlbums component

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/actions/delete_empty_albums.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/delete_empty_albums.dart
@@ -160,6 +160,9 @@ class _DeleteEmptyAlbumsState extends State<DeleteEmptyAlbums> {
         } catch (_) {
           failedCount++;
         }
+        if (!mounted || _isCancelled) {
+          return;
+        }
         final int current = i + 1;
         final String currentlyDeleting =
             current.toString().padLeft(totalDigits, '0');


### PR DESCRIPTION
## Description
Previously, the progress counter (currentlyDeleting) was updated before the asynchronous call to trashEmptyCollection finished. This allowed the UI to potentially update rapidly for multiple items before the background work was truly complete, causing visual inconsistencies and the appearance of 'glitching' numbers in the progress indicator (e.g., 0202→3623→0210).

Additionally, the progress update was originally inside the try block, meaning albums that failed to delete were not correctly counted in the UI's progress, preventing the counter from reaching the final totalCount.


## Issue
https://github.com/user-attachments/assets/a24cdbb5-3578-4f32-9f07-8ac1a6b1b072

