### PR TITLE
[server] Reduce frequency of device limit warning alerts

### DIFF
--- a/server/pkg/middleware/collection_link.go
+++ b/server/pkg/middleware/collection_link.go
@@ -162,10 +162,15 @@ func (m *CollectionLinkMiddleware) isDeviceLimitReached(ctx context.Context,
 	}
 
 	if count >= public2.DeviceLimitWarningThreshold {
-		if !array.Int64InList(sharedID, whitelistedCollectionShareIDs) {
+		alertStepSize := int64(200)
+		shouldAlert := count == public2.DeviceLimitWarningThreshold || 
+			(count > public2.DeviceLimitWarningThreshold && 
+			(count-public2.DeviceLimitWarningThreshold)%alertStepSize == 0)
+		
+		if shouldAlert && !array.Int64InList(sharedID, whitelistedCollectionShareIDs) {
 			m.DiscordController.NotifyPotentialAbuse(
-				fmt.Sprintf("Album exceeds warning threshold: {CollectionID: %d, ShareID: %d}",
-					collectionSummary.CollectionID, collectionSummary.ID))
+				fmt.Sprintf("Album exceeds warning threshold: {CollectionID: %d, ShareID: %d, DeviceCount: %d}",
+					collectionSummary.CollectionID, collectionSummary.ID, count))
 		}
 	}
 

--- a/server/pkg/middleware/file_link.go
+++ b/server/pkg/middleware/file_link.go
@@ -140,9 +140,16 @@ func (m *FileLinkMiddleware) isDeviceLimitReached(ctx context.Context,
 	}
 
 	if count >= publicCtrl.DeviceLimitWarningThreshold {
-		m.DiscordController.NotifyPotentialAbuse(
-			fmt.Sprintf("FileLink exceeds warning threshold: {FileID: %d, ShareID: %s}",
-				collectionSummary.FileID, collectionSummary.LinkID))
+		alertStepSize := int64(200)
+		shouldAlert := count == publicCtrl.DeviceLimitWarningThreshold || 
+			(count > publicCtrl.DeviceLimitWarningThreshold && 
+			(count-publicCtrl.DeviceLimitWarningThreshold)%alertStepSize == 0)
+		
+		if shouldAlert {
+			m.DiscordController.NotifyPotentialAbuse(
+				fmt.Sprintf("FileLink exceeds warning threshold: {FileID: %d, ShareID: %s, DeviceCount: %d}",
+					collectionSummary.FileID, collectionSummary.LinkID, count))
+		}
 	}
 
 	if deviceLimit > 0 && count >= deviceLimit {


### PR DESCRIPTION
## Description
Alert at step intervals (200 devices) instead of every access after threshold

## Tests
