### PR TITLE
Replace deprecated `mc config` with `mc alias set`

### DIFF
--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -58,7 +58,7 @@ services:
           sh -c '
           #!/bin/sh
 
-          while ! mc config host add h0 http://minio:3200 changeme changeme1234 2>/dev/null
+          while ! mc alias set h0 http://minio:3200 changeme changeme1234 2>/dev/null
           do
             echo "Waiting for minio..."
             sleep 0.5


### PR DESCRIPTION
## Description

Fix MinIO container hanging by replacing removed `mc config` with `mc alias set`.

```
minio-1     | MinIO Object Storage Server
minio-1     | Copyright: 2015-2025 MinIO, Inc.
minio-1     | License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
minio-1     | Version: RELEASE.2025-09-07T16-13-09Z (go1.24.6 linux/amd64)
minio-1     |
minio-1     | API: http://172.19.0.3:3200  http://127.0.0.1:3200
minio-1     | WebUI: http://172.19.0.3:3201 http://127.0.0.1:3201
minio-1     |
minio-1     | Docs: https://docs.min.io
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
minio-1 ->  |
minio-1 ->  | Waiting for minio...
```

Reference: [coollabsio/coolify#6438](https://github.com/coollabsio/coolify/issues/6438)