### PR TITLE
[docs] Restore favicon

### DIFF
--- a/docs/docs/.vitepress/config.ts
+++ b/docs/docs/.vitepress/config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
     base: "/help/", // Serve under /help path
     title: "Ente Help",
     description: "Documentation and help for Ente's products",
-    head: [["link", { rel: "icon", type: "image/png", href: "/help/favicon.png" }]],
+    head: [
+        ["link", { rel: "icon", type: "image/png", href: "/help/favicon.png" }],
+    ],
     cleanUrls: true,
     ignoreDeadLinks: "localhostLinks",
     themeConfig: {


### PR DESCRIPTION
I assumed it'd fallback to the top level .ico, but that also has a png.
