### PR TITLE
[mob][photos] Fix storage viewer not refreshing after clearing cache

### DIFF
--- a/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
@@ -187,9 +187,7 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
                             },
                             itemCount: paths.length,
                           ),
-                          const SizedBox(
-                            height: 24,
-                          ),
+                          const SizedBox(height: 24),
                           MenuItemWidget(
                             leadingIcon: Icons.delete_sweep_outlined,
                             captionedTextWidget: CaptionedTextWidget(
@@ -202,9 +200,7 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
                             onTap: () async {
                               for (var pathItem in paths) {
                                 if (pathItem.allowCacheClear) {
-                                  await deleteDirectoryContents(
-                                    pathItem.path,
-                                  );
+                                  await deleteDirectoryContents(pathItem.path);
                                 }
                               }
                               if (!Platform.isAndroid) {
@@ -212,15 +208,17 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
                                   iosTempDirectoryPath,
                                 );
                               }
+                              // Small delay to allow file system to sync
+                              await Future.delayed(
+                                const Duration(milliseconds: 300),
+                              );
                               _refreshCounterKey++;
                               if (mounted) {
                                 setState(() => {});
                               }
                             },
                           ),
-                          const SizedBox(
-                            height: 24,
-                          ),
+                          const SizedBox(height: 24),
                         ],
                       ),
                     ],

--- a/mobile/apps/photos/lib/utils/standalone/directory_content.dart
+++ b/mobile/apps/photos/lib/utils/standalone/directory_content.dart
@@ -101,8 +101,9 @@ Future<DirectoryStat> getDirectoryStat(
         size += fileSize;
         fileNameToSize[entity.uri.pathSegments.last] = fileSize;
       } else if (entity is Directory) {
-        final DirectoryStat subDirStat =
-            await getDirectoryStat(Directory(entity.path));
+        final DirectoryStat subDirStat = await getDirectoryStat(
+          Directory(entity.path),
+        );
         subDirectories.add(subDirStat);
         size += subDirStat.size;
       }
@@ -121,7 +122,11 @@ Future<void> deleteDirectoryContents(String directoryPath) async {
 
   // Iterate through the list and delete each file or directory
   for (final fileOrDirectory in contents) {
-    await fileOrDirectory.delete();
+    if (fileOrDirectory is Directory) {
+      await fileOrDirectory.delete(recursive: true);
+    } else {
+      await fileOrDirectory.delete();
+    }
   }
 }
 

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: Fix storage viewer not refreshing after clearing cache
 - Neeraj: Remove feature flags from manage_links_widget (album layout, allow joining album, copy embed HTML)
 - Ashil: Use better copy on auto-add people selection page
 - Ashil: Add more logs to debug app stuck at splash screen issue


### PR DESCRIPTION
## Summary
- Store FutureBuilder future in state to enable proper rebuilds
- Add didUpdateWidget to detect key changes and refresh storage stats
- Add 300ms delay after cache deletion for file system sync
- Fix deleteDirectoryContents to recursively delete subdirectories

Co-Authored-By: Claude <noreply@anthropic.com>