### PR TITLE
[auth] Fix crash on window close on Windows

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -214,9 +214,10 @@ class _AppState extends State<App>
         if (Platform.isWindows) {
           final int hProcess = GetCurrentProcess();
           TerminateProcess(hProcess, 0);
+        } else {
+          windowManager.setPreventClose(false);
+          windowManager.destroy();
         }
-        windowManager.setPreventClose(false);
-        windowManager.destroy();
         break;
     }
   }
@@ -232,9 +233,10 @@ class _AppState extends State<App>
       if (Platform.isWindows) {
         final int hProcess = GetCurrentProcess();
         TerminateProcess(hProcess, 0);
+      } else {
+        windowManager.setPreventClose(false);
+        windowManager.destroy();
       }
-      windowManager.setPreventClose(false);
-      windowManager.destroy();
     }
   }
 }


### PR DESCRIPTION
## Description

closes #7419 and #7154

On Windows, closing the app window caused a crash. Explicitly terminating the process prevents this.

**Note:** This may be related to [flutter_inappwebview#2512](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2512), though the exact cause is unclear.

**Solution:** Call `TerminateProcess()` on the current process handle during app closure on Windows.

## Tests

Tested locally on Windows.