### PR TITLE
Fix URL in Ente CLI error message for keyring issue

### DIFF
--- a/cli/pkg/secrets/secret.go
+++ b/cli/pkg/secrets/secret.go
@@ -38,7 +38,7 @@ func GetOrCreateClISecret() []byte {
 				return GetSecretFromSecretText(fmt.Sprintf("%s.secret.txt", constants.CliDataPath))
 			} else {
 				log.Fatal(fmt.Errorf(`error getting password from keyring: %w
-          Refer to https://ente.io/help/self-hosting/troubleshooting/keyring
+          Refer to https://ente.io/help/self-hosting/troubleshooting/cli
           `, err))
 			}
 		}


### PR DESCRIPTION
It seems the information to resolve the keyring error when using Ente CLI has moved to  https://ente.io/help/self-hosting/troubleshooting/cli

These docs might also help to resolve issue #7493.
## Description

## Tests
