### PR TITLE
[mob][photos] Fix gallery files exception during AnimatedCrossFade early build

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -257,7 +257,10 @@ class _SelectAllButtonState extends State<SelectAllButton> {
   @override
   Widget build(BuildContext context) {
     final selectionState = SelectionState.of(context);
-    final allGalleryFiles = GalleryFilesState.of(context).galleryFiles;
+    final allGalleryFiles = GalleryFilesState.of(context).galleryFilesOrNull;
+    if (allGalleryFiles == null) {
+      return const SizedBox.shrink();
+    }
     assert(
       selectionState != null,
       "SelectionState not found in context, SelectionState should be an ancestor of FileSelectionOverlayBar",

--- a/mobile/apps/photos/lib/ui/viewer/gallery/state/gallery_files_inherited_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/state/gallery_files_inherited_widget.dart
@@ -22,12 +22,13 @@ class GalleryFilesState extends InheritedWidget {
     _galleryFiles!.remove(file);
   }
 
+  List<EnteFile>? get galleryFilesOrNull => _galleryFiles;
+
   List<EnteFile> get galleryFiles {
-    if (_galleryFiles == null) {
-      throw Exception(
-        "Gallery files not set yet. Should be set in the gallery widget",
-      );
-    }
+    assert(
+      _galleryFiles != null,
+      "Gallery files not set yet. Should be set in the gallery widget",
+    );
     return _galleryFiles!;
   }
 


### PR DESCRIPTION
### Description

AnimatedCrossFade builds both children immediately, causing SelectAllButton to access gallery files before they're set. Replaced exception with assertion and add galleryFilesOrNull getter for safe null-checking.