### PR TITLE
[web] Safari 26 MOV workaround

### DIFF
--- a/web/packages/gallery/services/convert.ts
+++ b/web/packages/gallery/services/convert.ts
@@ -210,10 +210,7 @@ export const playableVideoURL = async (
                 const detected = await detectFileTypeInfo(
                     new File([videoBlob], videoFileName),
                 );
-                if (
-                    detected.mimeType &&
-                    detected.mimeType !== videoBlob.type
-                ) {
+                if (detected.mimeType && detected.mimeType !== videoBlob.type) {
                     typedBlob = new Blob([videoBlob], {
                         type: detected.mimeType,
                     });


### PR DESCRIPTION
gallery: Fix Safari MOV playback by setting blob MIME via extension (video/quicktime) with detect fallback in playableVideoURL; mitigates NotSupportedError on Safari 26.x

(attempted fix, needs testing)