### PR TITLE
[mob][photos] Fix iOS rotated crop bounds for some videos

### DIFF
--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -73,7 +73,7 @@ class FlagService {
 
   bool get widgetSharedAlbums => internalUser;
 
-  bool get useNativeVideoEditor => internalUser && Platform.isAndroid;
+  bool get useNativeVideoEditor => internalUser;
 
   bool hasSyncedAccountFlags() {
     return _prefs.containsKey("remote_flags");


### PR DESCRIPTION
## Description

iOS native_video_editor was not giving accurate crop bounds for some type of videos, this fixes that and also enables that for iOS by default for internal users.

## Tests

- [x] Test crop
- [x] Test crop + rotate