### PR TITLE
[mob][photos] Set default crop selection to "Free" in video editor

### DIFF
--- a/mobile/apps/photos/lib/ui/tools/editor/video_crop_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/video_crop_page.dart
@@ -32,7 +32,7 @@ class _VideoCropPageState extends State<VideoCropPage> {
   void _initializeSelectedValue() {
     final currentRatio = widget.controller.preferredCropAspectRatio;
     if (currentRatio == null) {
-      _selectedCropValue = null;
+      _selectedCropValue = CropValue.free;
       return;
     }
 


### PR DESCRIPTION
## Description

When opening the crop page in the video editor with no previous crop selection, the UI now defaults to selecting "Free" instead of showing no selection. This provides better UX by clearly indicating the current freeform crop mode.

## Tests
