### PR TITLE
[web] Fix visual flash when selecting album from search results

### DIFF
--- a/web/apps/photos/src/components/Collections/AllAlbums.tsx
+++ b/web/apps/photos/src/components/Collections/AllAlbums.tsx
@@ -61,11 +61,9 @@ export const AllAlbums: React.FC<AllAlbums> = ({
     const fullScreen = useMediaQuery("(max-width: 428px)");
     const [searchTerm, setSearchTerm] = useState("");
 
-    useEffect(() => {
-        if (!open) {
-            setSearchTerm("");
-        }
-    }, [open]);
+    const handleExited = () => {
+        setSearchTerm("");
+    };
 
     const onCollectionClick = (collectionID: number) => {
         onSelectCollectionID(collectionID);
@@ -86,6 +84,7 @@ export const AllAlbums: React.FC<AllAlbums> = ({
         <AllAlbumsDialog
             {...{ open, onClose, fullScreen }}
             slots={{ transition: SlideUpTransition }}
+            slotProps={{ transition: { onExited: handleExited } }}
             fullWidth
         >
             <Title

--- a/web/packages/new/photos/components/CollectionSelector.tsx
+++ b/web/packages/new/photos/components/CollectionSelector.tsx
@@ -126,11 +126,9 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
         CollectionSummary[]
     >([]);
 
-    useEffect(() => {
-        if (!open) {
-            setSearchTerm("");
-        }
-    }, [open]);
+    const handleExited = () => {
+        setSearchTerm("");
+    };
 
     useEffect(() => {
         if (!attributes || !open) {
@@ -219,6 +217,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
                         "@media (min-width: 491px)": { height: "100%" },
                     },
                 },
+                transition: { onExited: handleExited },
             }}
         >
             <DialogTitle>


### PR DESCRIPTION
## Description

Deferred clearing album search terms until after dialog exit animation to fix flashing back to the full list on album selection.