### PR TITLE
[mob] Log dio response body

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -48,14 +48,19 @@ extension SuperLogRecord on LogRecord {
 
     if (error != null) {
       if (error is DioException) {
-        final String? id = (error as DioException)
-            .requestOptions
-            .headers['x-request-id'] as String?;
+        final e = error as DioException;
+        final String? id = e.requestOptions.headers['x-request-id'] as String?;
         if (id != null) {
-          msg += "\n⤷ id: $id";
+          msg += "\n⤷ id: $id ";
         }
+        if (e.response?.data != null) {
+          msg += "\n⤷ type: ${e.type}\n⤷ error: ${e.response?.data}";
+        } else {
+          msg += "\n⤷ type: ${e.type}\n⤷ error: $error";
+        }
+      } else {
+        msg += "\n⤷ type: ${error.runtimeType}\n⤷ error: $error";
       }
-      msg += "\n⤷ type: ${error.runtimeType}\n⤷ error: $error";
     }
     if (stackTrace != null) {
       msg += "\n⤷ trace: $stackTrace";


### PR DESCRIPTION
## Description
Previously, for non-ok response, generic content was being logged instead of actual response body
## Tests

Before
```
I/flutter (11903): ⤷ type: DioException
I/flutter (11903): ⤷ error: DioException [bad response]: This exception was thrown because the response has a status code of 400 and RequestOptions.validateStatus was configured to throw for this status code.
I/flutter (11903): The status code of 400 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"
I/flutter (11903): Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
I/flutter (11903): In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.
```

After:

```
I/flutter (13833): ⤷ type: DioExceptionType.badResponse
I/flutter (13833): ⤷ error: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
I/flutter (13833): <Error>
I/flutter (13833):     <Code>BadDigest</Code>
I/flutter (13833):     <Message>Checksum did not match data received</Message>
I/flutter (13833): </Error>
```