### PR TITLE
[docs] command was commented out  

### DIFF
--- a/docs/docs/self-hosting/installation/post-install/index.md
+++ b/docs/docs/self-hosting/installation/post-install/index.md
@@ -45,8 +45,8 @@ If running Museum without Docker, the code should be visible in the terminal
     ```shell
     # Change the DB name and DB user name if you use different
     # values.
-
-    # If using Docker docker exec -it <postgres-ente-container-name> sh
+    # If using Docker
+    docker exec -it <postgres-ente-container-name> sh
     psql -U pguser -d ente_db
 
     # Or when using psql directly


### PR DESCRIPTION
## Description
Fixed typo as per https://ente.io/help/self-hosting/administration/users
## Tests
