### PR TITLE
[mob][photos] Fix video rotation bounds calculation for metadata-rotated videos

### DIFF
--- a/mobile/packages/native_video_editor/ios/Classes/NativeVideoEditorPlugin.swift
+++ b/mobile/packages/native_video_editor/ios/Classes/NativeVideoEditorPlugin.swift
@@ -305,7 +305,8 @@ public class NativeVideoEditorPlugin: NSObject, FlutterPlugin {
         }
 
         // Use bounds testing to calculate the necessary translation to center the video
-        let testRect = CGRect(origin: .zero, size: orientedSize)
+        // Use naturalSize here because transform expects input in natural/file coordinate space
+        let testRect = CGRect(origin: .zero, size: naturalSize)
         let finalBounds = testRect.applying(transform)
 
         // Center the video in the renderSize
@@ -706,7 +707,8 @@ public class NativeVideoEditorPlugin: NSObject, FlutterPlugin {
             }
 
             // Use bounds testing to calculate the necessary translation to center the video
-            let testRect = CGRect(origin: .zero, size: orientedSize)
+            // Use naturalSize here because transform expects input in natural/file coordinate space
+            let testRect = CGRect(origin: .zero, size: naturalSize)
             let finalBounds = testRect.applying(transform)
 
             // Center the video in the renderSize


### PR DESCRIPTION
## Description

The rotation functions were using orientedSize (display coordinates) when creating test rectangles for bounds calculation, but the transform chain expects input in natural/file coordinate space. This caused incorrect bounds when rotating videos that have metadata rotation (e.g., videos recorded in portrait mode).

The fix changes the test rectangle to use naturalSize instead of orientedSize, ensuring the full transform chain (orientation + rotation) is applied correctly to calculate proper final bounds.

This fixes rotation and rotation+trim operations on metadata-rotated videos while maintaining correct behavior for normal videos and crop operations.

## Tests
