### PR TITLE
[workflow] fix linux workflow space issue for auth-release

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -48,6 +48,38 @@ jobs:
               with:
                   submodules: recursive
 
+            - name: Free up disk space
+              run: |
+                  echo "Initial disk usage:"
+                  df -h /
+                  # Get available space in KB
+                  INITIAL=$(df / | awk 'NR==2 {print $4}')
+
+                  echo -e "\n=== Removing .NET SDK (~20-25GB) ==="
+                  BEFORE=$(df / | awk 'NR==2 {print $4}')
+                  START=$(date +%s)
+                  sudo rm -rf /usr/share/dotnet
+                  END=$(date +%s)
+                  AFTER=$(df / | awk 'NR==2 {print $4}')
+                  FREED=$(( (AFTER - BEFORE) / 1048576 ))  # Convert KB to GB
+                  echo "Time: $((END-START))s | Freed: ${FREED}GB"
+
+                  echo -e "\n=== Removing cached tools (~5-10GB) ==="
+                  BEFORE=$(df / | awk 'NR==2 {print $4}')
+                  START=$(date +%s)
+                  sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+                  END=$(date +%s)
+                  AFTER=$(df / | awk 'NR==2 {print $4}')
+                  FREED=$(( (AFTER - BEFORE) / 1048576 ))
+                  echo "Time: $((END-START))s | Freed: ${FREED}GB"
+
+                  echo -e "\n=== Final Summary ==="
+                  FINAL=$(df / | awk 'NR==2 {print $4}')
+                  TOTAL_FREED=$(( (FINAL - INITIAL) / 1048576 ))
+                  echo "Total space freed: ${TOTAL_FREED}GB"
+                  echo "Final disk usage:"
+                  df -h /
+
             - name: Setup JDK 17
               uses: actions/setup-java@v1
               with:


### PR DESCRIPTION
## Description

Added disk cleanup step to auth-release.yml to free up space before building. This matches the approach used in mobile-daily-internal.yml.

The cleanup removes:
- .NET SDK (~20-25GB) - not required for Flutter Linux builds
- Cached tools (~5-10GB) - not essential for Flutter development

All essential Flutter Linux build dependencies are explicitly installed in subsequent steps, so this cleanup is safe.

## Tests

Used same cleanup process as daily workflow code so it should work.