### PR TITLE
[mob][photos] trim-only fix iOS

### DIFF
--- a/mobile/packages/native_video_editor/ios/Classes/NativeVideoEditorPlugin.swift
+++ b/mobile/packages/native_video_editor/ios/Classes/NativeVideoEditorPlugin.swift
@@ -765,7 +765,7 @@ public class NativeVideoEditorPlugin: NSObject, FlutterPlugin {
         exportSession.shouldOptimizeForNetworkUse = true
 
         if !isReEncoded {
-            exportSession.timeRange = timeRange
+            exportSession.timeRange =  CMTimeRange(start: .zero, duration: composition.duration)
         }
 
         startProgressReporting()


### PR DESCRIPTION
## Description

Native video editor was fallbacking to ffmpeg when trim only or no-reencode case. This PR fixes that.

## Tests
