### PR TITLE
[workflow] Fix Windows installer path resolution for nightly

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -171,9 +171,11 @@ jobs:
                   make innoinstall
                   flutter_distributor package --platform=windows --targets=exe --skip-clean
                   mv dist/**/*-windows-setup.exe artifacts/ente-${{ github.ref_name }}-installer.exe
+              shell: bash
 
             - name: Retain Windows EXE and DLLs
               run: cp -r build/windows/x64/runner/Release ente-${{ github.ref_name }}-windows
+              shell: bash
 
             - name: Sign files with Trusted Signing
               uses: azure/trusted-signing-action@v0
@@ -194,9 +196,11 @@ jobs:
 
             - name: Zip Windows EXE and DLLs
               run: tar.exe -a -c -f artifacts/ente-${{ github.ref_name }}-windows.zip ente-${{ github.ref_name }}-windows
+              shell: bash
 
             - name: Generate checksums
               run: sha256sum artifacts/ente-* > artifacts/sha256sum-windows
+              shell: bash
 
             - name: Create a draft GitHub release
               uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Description

The Windows build steps were using PowerShell by default, which doesn't handle glob patterns (like dist/**/*-windows-setup.exe) the same way as bash. This caused the mv and cp commands to fail silently, leaving the installer file unmoved and causing the signing step to fail with "File not found" errors.

This was particularly noticeable with nightly builds but could affect any build where the file pattern matching is critical.

Fixed by explicitly specifying shell: bash for the following steps:
- Build Windows installer
- Retain Windows EXE and DLLs
- Zip Windows EXE and DLLs
- Generate checksums

This ensures consistent glob pattern handling across all platforms.

Fixes: SignTool Error: File not found: D:\a\ente\ente/mobile/apps/auth/artifacts/ente-auth-v4.4.5-nightly-installer.exe

## Tests
