### PR TITLE
[workflow] Fix Windows build by installing Inno Setup properly

### DIFF
--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -168,12 +168,15 @@ jobs:
                   flutter config --enable-windows-desktop
                   # dart pub global activate flutter_distributor
                   dart pub global activate --source git https://github.com/ente-io/flutter_distributor_fork --git-ref develop --git-path packages/flutter_distributor
-                  make innoinstall
+                  choco install innosetup -y
                   flutter_distributor package --platform=windows --targets=exe --skip-clean
+                  shopt -s globstar
                   mv dist/**/*-windows-setup.exe artifacts/ente-${{ github.ref_name }}-installer.exe
+              shell: bash
 
             - name: Retain Windows EXE and DLLs
               run: cp -r build/windows/x64/runner/Release ente-${{ github.ref_name }}-windows
+              shell: bash
 
             - name: Sign files with Trusted Signing
               uses: azure/trusted-signing-action@v0
@@ -194,9 +197,11 @@ jobs:
 
             - name: Zip Windows EXE and DLLs
               run: tar.exe -a -c -f artifacts/ente-${{ github.ref_name }}-windows.zip ente-${{ github.ref_name }}-windows
+              shell: bash
 
             - name: Generate checksums
               run: sha256sum artifacts/ente-* > artifacts/sha256sum-windows
+              shell: bash
 
             - name: Create a draft GitHub release
               uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Description

Replaced the non-existent 'make innoinstall' command with the proper Chocolatey installation command 'choco install innosetup -y'.

The issue occurred because:
1. There was no Makefile with an 'innoinstall' target
2. Inno Setup is not pre-installed on Windows Server 2025 (windows-latest)
3. When shell was set to bash for glob pattern support, the make command failed with "No rule to make target 'innoinstall'"

This fix ensures Inno Setup is properly installed before flutter_distributor attempts to create the Windows installer package.

Also added 'shell: bash' to all Windows build steps to ensure consistent glob pattern handling for file operations (mv, cp, tar, sha256sum).

Fixes: make: *** No rule to make target 'innoinstall'. Stop.

## Tests
