### PR TITLE
[docs] Add FAQ for content blockers blocking videos

### DIFF
--- a/docs/docs/auth/troubleshooting/windows-login.md
+++ b/docs/docs/auth/troubleshooting/windows-login.md
@@ -16,7 +16,6 @@ To update the Trusted Root Certificates on Windows, you can use the `certutil`
 command. Here are the steps to do so:
 
 1. **Open Command Prompt as Administrator**:
-
     - Press `Windows + X` and select `Command Prompt (Admin)` or
       `Windows PowerShell (Admin)`.
 

--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -427,7 +427,6 @@ This ensures smooth operation and prevents conflicts.
 Yes! On desktop, you have two options:
 
 1. **Watch folders**: Automatically sync specific folders (recommended for ongoing backup)
-
     - Continuous monitoring and automatic uploads
     - See watch folders section above
 

--- a/docs/docs/photos/faq/storage-and-plans.md
+++ b/docs/docs/photos/faq/storage-and-plans.md
@@ -429,7 +429,6 @@ When your subscription expires, you enter a **30-day grace period** before your 
 **To avoid losing your data:**
 
 1. **Renew your subscription** before the grace period ends:
-
     - All your data will be immediately accessible again
     - Uploads will resume automatically
     - No data loss

--- a/docs/docs/photos/faq/troubleshooting.md
+++ b/docs/docs/photos/faq/troubleshooting.md
@@ -159,12 +159,10 @@ The desktop/web app tries to detect if a particular file is a video or image. If
 **On Android:**
 
 1. **Disable battery optimization for Ente:**
-
     - Open device `Settings > Apps > Ente > Battery`
     - Select "Unrestricted" or "Don't optimize"
 
 2. **Check storage permissions:**
-
     - Open device `Settings > Apps > Ente > Permissions`
     - Ensure "Photos and videos" or "Files and media" is allowed
 
@@ -175,7 +173,6 @@ The desktop/web app tries to detect if a particular file is a video or image. If
 **On iOS:**
 
 1. **Check Background App Refresh:**
-
     - Open device `Settings > Ente > Background App Refresh`
     - Ensure it's enabled
 
@@ -243,12 +240,10 @@ Ente will automatically skip files that have already been uploaded, so you can d
 If watch folders aren't uploading new files automatically:
 
 1. **Check the watch folders list:**
-
     - Click "Watch folders" in the sidebar
     - Verify the correct folders are being watched
 
 2. **Check upload status:**
-
     - Look for the sync status indicator in the bottom right
     - Expand it to see any errors
 
@@ -418,7 +413,6 @@ Mobile browsers cannot handle the computationally intensive password derivation 
 **Solutions:**
 
 1. **Use the native mobile app instead** (recommended):
-
     - Install Ente Photos from the [App Store (iOS)](https://apps.apple.com/app/id1542026904) or [Play Store (Android)](https://play.google.com/store/apps/details?id=io.ente.photos)
     - Mobile apps are optimized for phones and tablets
     - Full feature support including machine learning
@@ -448,6 +442,16 @@ Click on each section to see the specific files and error messages.
 
 **On mobile:**
 Open `Settings > Backup` to see the backup status and any errors.
+
+### Why aren't videos playing on web? {#content-blocker-videos}
+
+If videos aren't playing on web.ente.io, browser content blockers or ad blockers may be blocking video playback.
+
+**Solution:**
+
+Disable your content blocker or add `web.ente.io` to your allowlist. Wait 15-20 seconds for changes to take effect before trying again.
+
+**Known issue with AdGuard:** AdGuard's basic filter blocks videos in Ente when using AdGuard Mini on Safari. This has been [reported to AdGuard filter developers](https://github.com/AdguardTeam/AdguardFilters/issues/216424).
 
 ## Performance Issues
 

--- a/docs/docs/self-hosting/administration/users.md
+++ b/docs/docs/self-hosting/administration/users.md
@@ -37,7 +37,6 @@ can achieve this the following steps:
 
 3.  Edit `internal.admins` or `internal.admin` (if you wish to whitelist only
     single user) in `museum.yaml` to add the user ID you wish to whitelist.
-
     - For multiple admins:
 
     ```yaml

--- a/docs/docs/self-hosting/installation/post-install/index.md
+++ b/docs/docs/self-hosting/installation/post-install/index.md
@@ -61,7 +61,6 @@ If running Museum without Docker, the code should be visible in the terminal
 
 3.  Edit `internal.admins` or `internal.admin` (if you wish to whitelist only
     single user) in `museum.yaml` to add the user ID you wish to whitelist.
-
     - For multiple admins:
 
     ```yaml


### PR DESCRIPTION
## Description

Adds FAQ entry explaining that content blockers (especially AdGuard) can prevent video playback on web.ente.io.

Also includes prettier formatting cleanup across documentation files.