### PR TITLE
[auth] Fix auth app to send correct client_pkg header

### DIFF
--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -280,6 +280,13 @@ class BaseConfiguration {
     return _preferences.getString(endPointKey) ?? endpoint;
   }
 
+  // isEnteProduction checks if the current endpoint is the default production
+  // endpoint. This is used to determine if the app is in production mode or
+  // not. The default production endpoint is set in the environment variable
+  bool isEnteProduction() {
+    return getHttpEndpoint() == kDefaultProductionEndpoint;
+  }
+
   Future<void> setHttpEndpoint(String endpoint) async {
     await _preferences.setString(endPointKey, endpoint);
     Bus.instance.fire(EndpointUpdatedEvent());


### PR DESCRIPTION
## Description

The auth app was sending incorrect client_pkg values on Windows/Linux platforms instead of "io.ente.auth".

Root Cause:
Before August 5, 2025, the auth app had its own PackageInfoUtil class that hardcoded "io.ente.auth" for desktop platforms. When the network code was refactored into the shared ente_network package (commit a7d0e2e), this logic was lost, causing desktop builds to send incorrect package names.

Platform-specific behaviors:
- Linux: PackageInfo returns "ente_auth" from pubspec.yaml name field (via version.json)
- Windows: PackageInfo returns "Ente Auth" from Runner.rc InternalName field
- Android: Returns "io.ente.auth" (or with .independent/.debug suffixes)
- iOS: Returns "io.ente.auth"
- macOS: Returns "io.ente.auth.mac"

Changes:
- Added platform-specific logic in Network.init() to normalize "ente_auth" and "Ente Auth" to "io.ente.auth" on Windows/Linux only
- Replicates the behavior from the old auth-specific PackageInfoUtil
- No changes needed in auth app or other apps
- Mobile platforms and macOS continue to work as expected

This ensures the server always receives "io.ente.auth" or acceptable variants, never "ente_auth" or "Ente Auth".

Resolves #7640

## Tests
