### PR TITLE
[workflow] Fix flutter_distributor not found on Windows

### DIFF
--- a/.github/workflows/auth-beta-release.yml
+++ b/.github/workflows/auth-beta-release.yml
@@ -275,6 +275,7 @@ jobs:
                   # dart pub global activate flutter_distributor
                   dart pub global activate --source git https://github.com/ente-io/flutter_distributor_fork --git-ref develop --git-path packages/flutter_distributor
                   choco install innosetup -y
+                  export PATH="$PATH:$LOCALAPPDATA/Pub/Cache/bin"
                   flutter_distributor package --platform=windows --targets=exe --skip-clean
                   shopt -s globstar
                   mv dist/**/*-windows-setup.exe artifacts/ente-auth-v${{ env.VERSION_NAME }}-beta-installer.exe

--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -201,6 +201,7 @@ jobs:
                   # dart pub global activate flutter_distributor
                   dart pub global activate --source git https://github.com/ente-io/flutter_distributor_fork --git-ref develop --git-path packages/flutter_distributor
                   choco install innosetup -y
+                  export PATH="$PATH:$LOCALAPPDATA/Pub/Cache/bin"
                   flutter_distributor package --platform=windows --targets=exe --skip-clean
                   shopt -s globstar
                   mv dist/**/*-windows-setup.exe artifacts/ente-${{ github.ref_name }}-installer.exe

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ente_auth
 description: ente two-factor authenticator
-version: 4.4.7+449
+version: 4.4.8+449
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Description

Add explicit PATH export for dart pub global packages on Windows in both auth-beta-release and auth-release workflows. Also bump auth version to 4.4.8+449.

## Tests
