### PR TITLE
Add comprehensive SEO improvements to help documentation

### DIFF
--- a/docs/docs/.vitepress/config.ts
+++ b/docs/docs/.vitepress/config.ts
@@ -11,6 +11,68 @@ export default defineConfig({
     ],
     cleanUrls: true,
     ignoreDeadLinks: "localhostLinks",
+    sitemap: {
+        hostname: "https://ente.io/help",
+    },
+    transformPageData(pageData) {
+        // Add canonical URL to all pages
+        const canonicalUrl = `https://ente.io/help/${pageData.relativePath}`
+            .replace(/index\.md$/, "")
+            .replace(/\.md$/, "");
+        pageData.frontmatter.canonicalUrl = canonicalUrl;
+    },
+    async transformHead({ pageData }) {
+        const head: any[] = [];
+        const canonicalUrl = pageData.frontmatter.canonicalUrl || `https://ente.io/help/`;
+        const title = pageData.frontmatter.title || pageData.title || "Ente Help";
+        const description = pageData.frontmatter.description || "Documentation and help for Ente's products";
+        const ogImage = "https://ente.io/help/og-image.png"; // You can customize this per page if needed
+
+        // Canonical URL
+        head.push(["link", { rel: "canonical", href: canonicalUrl }]);
+
+        // Open Graph tags
+        head.push(["meta", { property: "og:type", content: "website" }]);
+        head.push(["meta", { property: "og:title", content: title }]);
+        head.push(["meta", { property: "og:description", content: description }]);
+        head.push(["meta", { property: "og:url", content: canonicalUrl }]);
+        head.push(["meta", { property: "og:image", content: ogImage }]);
+        head.push(["meta", { property: "og:site_name", content: "Ente Help" }]);
+
+        // Twitter Card tags
+        head.push(["meta", { name: "twitter:card", content: "summary_large_image" }]);
+        head.push(["meta", { name: "twitter:site", content: "@enteio" }]);
+        head.push(["meta", { name: "twitter:title", content: title }]);
+        head.push(["meta", { name: "twitter:description", content: description }]);
+        head.push(["meta", { name: "twitter:image", content: ogImage }]);
+
+        // Meta description
+        head.push(["meta", { name: "description", content: description }]);
+
+        // Add FAQ Schema markup for FAQ pages
+        if (pageData.relativePath.includes("/faq/") && pageData.relativePath !== "photos/faq/index.md") {
+            const faqSchema = await generateFAQSchema(pageData);
+            if (faqSchema) {
+                head.push([
+                    "script",
+                    { type: "application/ld+json" },
+                    JSON.stringify(faqSchema),
+                ]);
+            }
+        }
+
+        // Add BreadcrumbList schema for better navigation
+        const breadcrumbSchema = generateBreadcrumbSchema(pageData);
+        if (breadcrumbSchema) {
+            head.push([
+                "script",
+                { type: "application/ld+json" },
+                JSON.stringify(breadcrumbSchema),
+            ]);
+        }
+
+        return head;
+    },
     themeConfig: {
         // We use the default theme (with some CSS color overrides). This
         // themeConfig block can be used to further customize the default theme.
@@ -39,3 +101,102 @@ export default defineConfig({
         ],
     },
 });
+
+// Generate FAQ Schema for FAQ pages
+async function generateFAQSchema(pageData: any) {
+    try {
+        const { readFile } = await import("fs/promises");
+        const { join } = await import("path");
+
+        // Read the actual markdown file
+        const filePath = join(process.cwd(), "docs", pageData.relativePath);
+        const content = await readFile(filePath, "utf-8");
+
+        const questions: any[] = [];
+
+        // Match headings with IDs (format: ### Question {#id})
+        // Updated regex to better match the content structure
+        const questionRegex = /###\s+(.+?)\s+\{#[^}]+\}\s*\n+([\s\S]*?)(?=\n###\s|\n##\s|$)/g;
+        let match;
+
+        while ((match = questionRegex.exec(content)) !== null) {
+            const question = match[1].trim();
+            let answer = match[2]
+                .trim()
+                // Remove markdown formatting
+                .replace(/\*\*([^*]+)\*\*/g, "$1") // Bold
+                .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Links
+                .replace(/`([^`]+)`/g, "$1") // Inline code
+                .replace(/^[-*]\s+/gm, "") // List items
+                .replace(/\n+/g, " ") // Newlines to spaces
+                .replace(/\s+/g, " ") // Multiple spaces to single
+                .trim();
+
+            // Limit answer length but try to end at a sentence
+            if (answer.length > 500) {
+                answer = answer.substring(0, 500);
+                const lastPeriod = answer.lastIndexOf(".");
+                if (lastPeriod > 300) {
+                    answer = answer.substring(0, lastPeriod + 1);
+                }
+            }
+
+            if (question && answer && answer.length > 20) {
+                questions.push({
+                    "@type": "Question",
+                    "name": question,
+                    "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": answer,
+                    },
+                });
+            }
+        }
+
+        if (questions.length === 0) {
+            return null;
+        }
+
+        return {
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": questions,
+        };
+    } catch (error) {
+        console.error(`Error generating FAQ schema for ${pageData.relativePath}:`, error);
+        return null;
+    }
+}
+
+// Generate Breadcrumb Schema
+function generateBreadcrumbSchema(pageData: any) {
+    const path = pageData.relativePath.replace(/\.md$/, "").replace(/\/index$/, "");
+    if (!path || path === "index") return null;
+
+    const parts = path.split("/").filter(Boolean);
+    const items = [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://ente.io/help/",
+        },
+    ];
+
+    let currentPath = "https://ente.io/help";
+    parts.forEach((part, index) => {
+        currentPath += `/${part}`;
+        items.push({
+            "@type": "ListItem",
+            "position": index + 2,
+            "name": part.charAt(0).toUpperCase() + part.slice(1).replace(/-/g, " "),
+            "item": currentPath,
+        });
+    });
+
+    return {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": items,
+    };
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     },
     "devDependencies": {
         "prettier": "^3.6.2",
+        "sitemap": "^8.0.2",
         "vitepress": "^1.6.4"
     },
     "packageManager": "yarn@1.22.22"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -521,6 +521,25 @@
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
   integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
+"@types/node@*":
+  version "24.9.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.9.2.tgz#90ded2422dbfcafcf72080f28975adc21366148d"
+  integrity sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==
+  dependencies:
+    undici-types "~7.16.0"
+
+"@types/node@^17.0.5":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/sax@^1.2.1":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.7.tgz#ba5fe7df9aa9c89b6dff7688a19023dd2963091d"
+  integrity sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -697,6 +716,11 @@ algoliasearch@^5.14.2:
     "@algolia/requester-browser-xhr" "5.18.0"
     "@algolia/requester-fetch" "5.18.0"
     "@algolia/requester-node-http" "5.18.0"
+
+arg@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 birpc@^2.3.0:
   version "2.6.1"
@@ -1025,6 +1049,11 @@ rollup@^4.20.0:
     "@rollup/rollup-win32-x64-msvc" "4.29.1"
     fsevents "~2.3.2"
 
+sax@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 shiki@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-2.5.0.tgz#09d01ebf3b0b06580431ce3ddc023320442cf223"
@@ -1038,6 +1067,16 @@ shiki@^2.1.0:
     "@shikijs/types" "2.5.0"
     "@shikijs/vscode-textmate" "^10.0.2"
     "@types/hast" "^3.0.4"
+
+sitemap@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-8.0.2.tgz#27bddb5fc2c61a1cf8f0194674cd89d762c9f5ae"
+  integrity sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==
+  dependencies:
+    "@types/node" "^17.0.5"
+    "@types/sax" "^1.2.1"
+    arg "^5.0.0"
+    sax "^1.4.1"
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -1078,6 +1117,11 @@ trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unist-util-is@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
 Implement SEO enhancements for ente.io/help to improve discoverability
  in search engines and LLM-based chat products (ChatGPT, Perplexity, etc.)

  ### Key Changes:

  **Meta Tags & Social Sharing:**
  - Add Open Graph tags for rich social media previews
  - Add Twitter Card metadata for better Twitter/X sharing
  - Add meta descriptions automatically from frontmatter
  - Generate canonical URLs for all pages to prevent duplicate content

  **Structured Data (Schema.org):**
  - Implement FAQPage schema with automatic Q&A extraction from markdown
  - Add BreadcrumbList schema for improved navigation hierarchy
  - Parse FAQ markdown format (### Question {#id}) and clean formatting
  - Include error handling for graceful schema generation failures

  **Search Engine Optimization:**
  - Enable built-in VitePress sitemap generation (140+ pages)
  - Configure hostname as https://ente.io/help for proper indexing
  - Auto-generate canonical URLs using transformPageData hook

  **Technical Implementation:**
  - Add transformHead hook for dynamic meta tag injection
  - Create generateFAQSchema() helper with markdown parsing
  - Create generateBreadcrumbSchema() helper for navigation
  - Add sitemap dependency (v8.0.2) for future enhancements

## Description

## Tests
