### PR TITLE
[auth] Fix auth data key persistence on cold start

### DIFF
--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -32,12 +32,21 @@ class Configuration extends BaseConfiguration {
     );
     sqfliteFfiInit();
     await _initOfflineAccount();
+    await _initOnlineAccount();
   }
 
   Future<void> _initOfflineAccount() async {
     _offlineAuthKey = await _secureStorage.read(
       key: offlineAuthSecretKey,
     );
+  }
+
+  Future<void> _initOnlineAccount() async {
+    if (hasConfiguredAccount()) {
+      _authSecretKey = await _secureStorage.read(
+        key: authSecretKeyKey,
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
## Description
- Ensure the auth data key is persisted when the app cold starts

## Tests
- [x] Tested on Mac