### PR TITLE
[auth] Remove unused bloc dependencies from auth app

### DIFF
--- a/mobile/apps/auth/lib/bootstrap.dart
+++ b/mobile/apps/auth/lib/bootstrap.dart
@@ -3,22 +3,7 @@
 import "dart:async";
 import "dart:developer";
 
-import "package:bloc/bloc.dart";
 import "package:flutter/widgets.dart";
-
-class AppBlocObserver extends BlocObserver {
-  @override
-  void onChange(BlocBase bloc, Change change) {
-    super.onChange(bloc, change);
-    log("onChange(${bloc.runtimeType}, $change)");
-  }
-
-  @override
-  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
-    log("onError(${bloc.runtimeType}, $error, $stackTrace)");
-    super.onError(bloc, error, stackTrace);
-  }
-}
 
 Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
   FlutterError.onError = (details) {
@@ -27,7 +12,6 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
 
   await runZonedGuarded(
     () async {
-      Bloc.observer = AppBlocObserver();
       runApp(await builder());
     },
     (error, stackTrace) => log(error.toString(), stackTrace: stackTrace),

--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -113,14 +113,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
-  bloc:
-    dependency: "direct main"
-    description:
-      name: bloc
-      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -581,14 +573,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
-  flutter_bloc:
-    dependency: "direct main"
-    description:
-      name: flutter_bloc
-      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.1"
   flutter_context_menu:
     dependency: "direct main"
     description:
@@ -1166,14 +1150,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   nm:
     dependency: transitive
     description:
@@ -1366,14 +1342,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5"
   pub_semver:
     dependency: transitive
     description:

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   auto_size_text: ^3.0.0
   base32: ^2.1.3
   bip39: ^1.0.6
-  bloc: ^9.0.0
   clipboard: ^0.1.3
   collection: ^1.18.0
   confetti: ^0.8.0
@@ -62,7 +61,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_animate: ^4.1.0
-  flutter_bloc: ^9.1.1
   flutter_context_menu: ^0.2.0
   flutter_displaymode: ^0.6.0
   flutter_email_sender: ^7.0.0


### PR DESCRIPTION
## Description

- Remove unused bloc and flutter_bloc dependencies from the auth app
- Drop the now unused imports from bootstrap

## Tests

- [x] Tested on Mac, app performs like usual