### PR TITLE
[auth] Fix Windows auth passkey focus handling

### DIFF
--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -555,7 +555,6 @@ class _CodeWidgetState extends State<CodeWidget> {
     }
     bool isAuthSuccessful = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, context.l10n.editCodeAuthMessage);
-    await PlatformUtil.refocusWindows();
     if (!isAuthSuccessful) {
       return;
     }
@@ -579,7 +578,6 @@ class _CodeWidgetState extends State<CodeWidget> {
     }
     bool isAuthSuccessful = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, context.l10n.showQRAuthMessage);
-    await PlatformUtil.refocusWindows();
     if (!isAuthSuccessful) {
       return;
     }
@@ -599,7 +597,6 @@ class _CodeWidgetState extends State<CodeWidget> {
     }
     bool isAuthSuccessful = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, context.l10n.authenticateGeneric);
-    await PlatformUtil.refocusWindows();
     if (!isAuthSuccessful) {
       return;
     }

--- a/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
@@ -13,7 +13,6 @@ import 'package:ente_auth/ui/home_page.dart';
 import 'package:ente_auth/ui/settings/common_settings.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_auth/utils/navigation_util.dart';
-import 'package:ente_auth/utils/platform_util.dart';
 import 'package:ente_crypto_dart/ente_crypto_dart.dart';
 import 'package:ente_lock_screen/local_authentication_service.dart';
 import 'package:flutter/material.dart';
@@ -49,7 +48,6 @@ class AccountSectionWidget extends StatelessWidget {
             context,
             l10n.authToChangeYourEmail,
           );
-          await PlatformUtil.refocusWindows();
           if (hasAuthenticated) {
             // ignore: unawaited_futures
             showDialog(

--- a/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
-import 'package:ente_auth/models/export/ente.dart'; 
+import 'package:ente_auth/models/export/ente.dart';
 import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
@@ -144,7 +144,6 @@ Future<void> _exportCodes(
   String exportFileName = 'ente-auth-codes-$formattedDate';
   final hasAuthenticated = await LocalAuthenticationService.instance
       .requestLocalAuthentication(context, context.l10n.authToExportCodes);
-  await PlatformUtil.refocusWindows();
   if (!hasAuthenticated) {
     return;
   }

--- a/mobile/apps/auth/lib/ui/settings/security_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/security_section_widget.dart
@@ -18,7 +18,6 @@ import 'package:ente_auth/ui/components/toggle_switch_widget.dart';
 import 'package:ente_auth/ui/settings/common_settings.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_auth/utils/navigation_util.dart';
-import 'package:ente_auth/utils/platform_util.dart';
 import 'package:ente_auth/utils/toast_util.dart';
 import 'package:ente_crypto_dart/ente_crypto_dart.dart';
 import 'package:ente_lock_screen/auth_util.dart';
@@ -86,7 +85,6 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
               );
               final isEmailMFAEnabled =
                   UserService.instance.hasEmailMFAEnabled();
-              await PlatformUtil.refocusWindows();
               if (hasAuthenticated) {
                 await updateEmailMFA(!isEmailMFAEnabled);
                 if (mounted) {
@@ -122,7 +120,6 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
               context,
               context.l10n.authToViewYourActiveSessions,
             );
-            await PlatformUtil.refocusWindows();
             if (hasAuthenticated) {
               // ignore: unawaited_futures
               Navigator.of(context).push(
@@ -204,8 +201,8 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
           await LocalAuthenticationService.instance.requestLocalAuthentication(
         context,
         context.l10n.authenticateGeneric,
+        refocusWindows: false,
       );
-      await PlatformUtil.refocusWindows();
       if (!hasAuthenticated) {
         return;
       }
@@ -225,7 +222,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
           CryptoUtil.bin2base64(encryptionResult.nonce!),
         );
       }
-      PasskeyService.instance.openPasskeyPage(buildContext).ignore();
+      await PasskeyService.instance.openPasskeyPage(buildContext);
     } catch (e, s) {
       _logger.severe("failed to open passkey page", e, s);
       await showGenericErrorDialog(

--- a/mobile/apps/auth/lib/ui/settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings_page.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
-import 'package:ente_auth/onboarding/view/onboarding_page.dart'; 
+import 'package:ente_auth/onboarding/view/onboarding_page.dart';
 import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/theme/colors.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
@@ -25,7 +25,6 @@ import 'package:ente_auth/ui/settings/theme_switch_widget.dart';
 import 'package:ente_auth/ui/settings/title_bar_widget.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_auth/utils/navigation_util.dart';
-import 'package:ente_auth/utils/platform_util.dart';
 import 'package:ente_lock_screen/local_authentication_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -118,7 +117,6 @@ class SettingsPage extends StatelessWidget {
                     context,
                     context.l10n.authToInitiateSignIn,
                   );
-                  await PlatformUtil.refocusWindows();
                   if (!hasAuthenticated) {
                     return;
                   }

--- a/mobile/apps/auth/lib/utils/platform_util.dart
+++ b/mobile/apps/auth/lib/utils/platform_util.dart
@@ -78,9 +78,9 @@ class PlatformUtil {
   // https://github.com/flutter/flutter/issues/122322
   static Future<void> refocusWindows() async {
     if (!Platform.isWindows) return;
-    await windowManager.blur();
-    await windowManager.focus();
     await windowManager.setAlwaysOnTop(true);
+    await windowManager.blur();
+    await windowManager.show();
     await windowManager.setAlwaysOnTop(false);
   }
 }

--- a/mobile/apps/locker/lib/ui/settings/account_section_widget.dart
+++ b/mobile/apps/locker/lib/ui/settings/account_section_widget.dart
@@ -11,7 +11,6 @@ import "package:ente_ui/components/menu_item_widget.dart";
 import "package:ente_ui/theme/ente_theme.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_utils/navigation_util.dart";
-import "package:ente_utils/platform_util.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:locker/l10n/l10n.dart";
@@ -51,7 +50,6 @@ class AccountSectionWidget extends StatelessWidget {
             context,
             l10n.authToChangeYourEmail,
           );
-          await PlatformUtil.refocusWindows();
           if (hasAuthenticated) {
             // ignore: unawaited_futures
             showDialog(

--- a/mobile/apps/locker/lib/ui/settings/security_section_widget.dart
+++ b/mobile/apps/locker/lib/ui/settings/security_section_widget.dart
@@ -17,7 +17,6 @@ import "package:ente_ui/theme/ente_theme.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:ente_utils/navigation_util.dart";
-import "package:ente_utils/platform_util.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:locker/l10n/l10n.dart";
@@ -159,8 +158,8 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
           await LocalAuthenticationService.instance.requestLocalAuthentication(
         context,
         context.l10n.authenticateGeneric,
+        refocusWindows: false,
       );
-      await PlatformUtil.refocusWindows();
       if (!hasAuthenticated) {
         return;
       }

--- a/mobile/packages/accounts/lib/pages/delete_account_page.dart
+++ b/mobile/packages/accounts/lib/pages/delete_account_page.dart
@@ -9,7 +9,6 @@ import 'package:ente_ui/components/buttons/gradient_button.dart';
 import 'package:ente_ui/components/dialogs.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_utils/email_util.dart';
-import 'package:ente_utils/platform_util.dart';
 import 'package:flutter/material.dart';
 
 class DeleteAccountPage extends StatelessWidget {
@@ -150,8 +149,6 @@ class DeleteAccountPage extends StatelessWidget {
       context,
       context.strings.initiateAccountDeleteTitle,
     );
-
-    await PlatformUtil.refocusWindows();
 
     if (hasAuthenticated) {
       final choice = await showChoiceDialogOld(

--- a/mobile/packages/lock_screen/lib/local_authentication_service.dart
+++ b/mobile/packages/lock_screen/lib/local_authentication_service.dart
@@ -7,6 +7,7 @@ import 'package:ente_lock_screen/ui/lock_screen_password.dart';
 import 'package:ente_lock_screen/ui/lock_screen_pin.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import 'package:ente_ui/utils/toast_util.dart';
+import 'package:ente_utils/platform_util.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -23,8 +24,9 @@ class LocalAuthenticationService {
 
   Future<bool> requestLocalAuthentication(
     BuildContext context,
-    String infoMessage,
-  ) async {
+    String infoMessage, {
+    bool refocusWindows = true,
+  }) async {
     if (kDebugMode) {
       // if last auth time is less than 60 seconds, don't ask for auth again
       if (lastAuthTime != 0 &&
@@ -43,6 +45,9 @@ class LocalAuthenticationService {
       AppLock.of(context)!.setEnabled(
         await LockScreenSettings.instance.shouldShowLockScreen(),
       );
+      if (refocusWindows) {
+        await PlatformUtil.refocusWindows();
+      }
       if (!result) {
         showToast(context, infoMessage);
         return false;

--- a/mobile/packages/utils/lib/platform_util.dart
+++ b/mobile/packages/utils/lib/platform_util.dart
@@ -62,9 +62,9 @@ class PlatformUtil {
   // https://github.com/flutter/flutter/issues/122322
   static Future<void> refocusWindows() async {
     if (!Platform.isWindows) return;
-    await windowManager.blur();
-    await windowManager.focus();
     await windowManager.setAlwaysOnTop(true);
+    await windowManager.blur();
+    await windowManager.show();
     await windowManager.setAlwaysOnTop(false);
   }
 }


### PR DESCRIPTION
## Description

Windows was refocusing on auth even after launching passkey page, making user think the page is not launched. This fixes that.

Also tries to update the combination for refocus based on https://github.com/flutter/flutter/issues/122322#issuecomment-2569059033

## Tests
