### PR TITLE
[auth] fix linux tray manager compilation

### DIFF
--- a/mobile/apps/auth/linux/CMakeLists.txt
+++ b/mobile/apps/auth/linux/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  # FIXME: workaround for tray_manager deprecation issue:
+  target_compile_options(${TARGET} PRIVATE -Wno-error=deprecated-declarations) # Allow deprecated warnings
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
## Description

Auth doesn't compiles on newer linux due to this:
https://github.com/leanflutter/tray_manager/issues/67#issuecomment-2737796286

This is a temporary fix.

## Tests
