### PR TITLE
Add cache clearing guidance to troubleshooting FAQ

### DIFF
--- a/docs/docs/photos/faq/troubleshooting.md
+++ b/docs/docs/photos/faq/troubleshooting.md
@@ -505,7 +505,7 @@ This deletes temporary files such as thumbnails and preloaded images that can be
 **Automatic cache cleanup:**
 
 - Ente clears upload-related temporary files every 6 hours.
-- If the cache still hasn't cleared after that window, force-close (kill) and reopen Ente Photos to trigger the manual cleanup.
+- If the cache still hasn't cleared after 6 hours, force-close (kill) and reopen Ente Photos to trigger the manual cleanup.
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary
- add troubleshooting guidance for manually clearing the Ente Photos cache
- document the automatic cache cleanup cadence and manual trigger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69086b3aab648331969733b4c6c709a1