### PR TITLE
[auth] Fix passkey loading dialog on android

### DIFF
--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -362,12 +362,20 @@ class UserService {
     try {
       final userPassword = _config.getVolatilePassword();
       await _saveConfiguration(response);
+      if (!context.mounted) {
+        await dialog.hide();
+        return;
+      }
+      final navigator = Navigator.of(context, rootNavigator: true);
       if (userPassword == null) {
         await dialog.hide();
+        if (!context.mounted) {
+          return;
+        }
         // ignore: unawaited_futures
-        Navigator.of(context).pushAndRemoveUntil(
+        navigator.pushAndRemoveUntil(
           MaterialPageRoute(
-            builder: (BuildContext context) {
+            builder: (BuildContext _) {
               return PasswordReentryPage(
                 _config,
                 _homePage,
@@ -376,6 +384,7 @@ class UserService {
           ),
           (route) => route.isFirst,
         );
+        return;
       } else {
         Widget page;
         if (_config.getEncryptedToken() != null) {
@@ -389,16 +398,20 @@ class UserService {
           throw Exception("unexpected response during passkey verification");
         }
         await dialog.hide();
+        if (!context.mounted) {
+          return;
+        }
 
         // ignore: unawaited_futures
-        Navigator.of(context).pushAndRemoveUntil(
+        navigator.pushAndRemoveUntil(
           MaterialPageRoute(
-            builder: (BuildContext context) {
+            builder: (BuildContext _) {
               return page;
             },
           ),
           (route) => route.isFirst,
         );
+        return;
       }
     } catch (e) {
       _logger.severe(e);


### PR DESCRIPTION
## Description

After passkey verification the spinner was not getting dismissed, this fixes that.

## Tests

- [x] Tested on android and verified before this and after this patch