### PR TITLE
[mob] Pin flutter_secure_storage to 9.0.0

### DIFF
--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -727,10 +727,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -76,7 +76,13 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_native_splash: ^2.2.13
-  flutter_secure_storage: ^9.0.0
+  # Do not upgrade this package unless this issue is resolved:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870
+  # On v9.2.4, keys related to lockscreen persist even after reintsall. For context see:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870#issuecomment-2777447937
+  # Let's wait till the issue is resolved by the package maintainer.
+  # If not resolved and we need to upgrade, write a migration script.
+  flutter_secure_storage: 9.0.0
   flutter_speed_dial: ^7.0.0
   flutter_staggered_grid_view: ^0.7.0
   flutter_svg: ^2.0.16

--- a/mobile/packages/configuration/pubspec.lock
+++ b/mobile/packages/configuration/pubspec.lock
@@ -97,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   ente_base:
     dependency: "direct main"
     description:
@@ -184,10 +200,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -366,6 +382,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   package_info_plus:
     dependency: transitive
     description:

--- a/mobile/packages/configuration/pubspec.yaml
+++ b/mobile/packages/configuration/pubspec.yaml
@@ -20,7 +20,13 @@ dependencies:
     path: ../../packages/logging
   flutter:
     sdk: flutter
-  flutter_secure_storage: ^9.0.0
+  # Do not upgrade this package unless this issue is resolved:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870
+  # On v9.2.4, keys related to lockscreen persist even after reintsall. For context see:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870#issuecomment-2777447937
+  # Let's wait till the issue is resolved by the package maintainer.
+  # If not resolved and we need to upgrade, write a migration script.
+  flutter_secure_storage: 9.0.0
   path_provider: ^2.1.5
   shared_preferences: ^2.5.3
   tuple: ^2.0.2

--- a/mobile/packages/lock_screen/pubspec.lock
+++ b/mobile/packages/lock_screen/pubspec.lock
@@ -440,10 +440,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/mobile/packages/lock_screen/pubspec.yaml
+++ b/mobile/packages/lock_screen/pubspec.yaml
@@ -30,7 +30,13 @@ dependencies:
     git:
       url: https://github.com/eaceto/flutter_local_authentication
       ref: 1ac346a04592a05fd75acccf2e01fa3c7e955d96
-  flutter_secure_storage: ^9.0.0
+  # Do not upgrade this package unless this issue is resolved:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870
+  # On v9.2.4, keys related to lockscreen persist even after reintsall. For context see:
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/870#issuecomment-2777447937
+  # Let's wait till the issue is resolved by the package maintainer.
+  # If not resolved and we need to upgrade, write a migration script.
+  flutter_secure_storage: 9.0.0
   local_auth: ^2.3.0
   logging: ^1.1.1
   pinput: ^5.0.0


### PR DESCRIPTION
## Description

Pins flutter_secure_storage similar to photos app due to the reason added in the comment above it.

Affects Locker and Auth.

## Tests
