### PR TITLE
[auth] Fix custom order button to open rearrange screen on first tap

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -485,8 +485,7 @@ class _HomePageState extends State<HomePage> {
                 currentKey: PreferenceService.instance.codeSortKey(),
                 onSelected: (newOrder) async {
                   await PreferenceService.instance.setCodeSortKey(newOrder);
-                  if (newOrder == CodeSortKey.manual &&
-                      newOrder == _codeSortKey) {
+                  if (newOrder == CodeSortKey.manual) {
                     await navigateToReorderPage(_allCodes!);
                   }
                   setState(() {


### PR DESCRIPTION
## Description

Previously, tapping "Custom order" from a different sort order would only switch to custom order but not open the rearrange screen. Users had to tap the sort button again and click "edit" beside Custom order to access it.

Fixed by removing the condition that checked if the current sort was already manual, so now selecting custom order immediately opens the rearrange screen.

## Tests

- [x] Tested on iOS sim