### PR TITLE
[mob][photos] Fix auto-add people deselection

### DIFF
--- a/mobile/apps/photos/lib/services/smart_albums_service.dart
+++ b/mobile/apps/photos/lib/services/smart_albums_service.dart
@@ -221,21 +221,13 @@ class SmartAlbumsService {
   Future<void> saveConfig(SmartAlbumConfig config) async {
     final userId = Configuration.instance.getUserID()!;
 
-    if (config.personIDs.isNotEmpty) {
-      await _addOrUpdateEntity(
-        EntityType.smartAlbum,
-        config.toJson(),
-        collectionId: config.collectionId,
-        addWithCustomID: config.id == null,
-        userId: userId,
-      );
-    } else {
-      // Delete the config when no people are selected
-      await _deleteEntry(
-        userId: userId,
-        collectionId: config.collectionId,
-      );
-    }
+    await _addOrUpdateEntity(
+      EntityType.smartAlbum,
+      config.toJson(),
+      collectionId: config.collectionId,
+      addWithCustomID: config.id == null,
+      userId: userId,
+    );
   }
 
   Future<SmartAlbumConfig?> getConfig(int collectionId) async {


### PR DESCRIPTION
## Description

When deselecting all people from an album's auto-add feature, the UI would continue to show people as selected even after saving. This was caused by the saveConfig method only updating the database when personIDs was non-empty, leaving the old config with selections intact.

Now it always syncs even when no selection is present.

## Tests

- [x] Test on device