### PR TITLE
[auth] Update sign-in backup warning message

### DIFF
--- a/mobile/apps/auth/lib/l10n/arb/app_en.arb
+++ b/mobile/apps/auth/lib/l10n/arb/app_en.arb
@@ -369,7 +369,7 @@
   "useOffline": "Use without backups",
   "signInToBackup": "Sign in to backup your codes",
   "singIn": "Sign in",
-  "sigInBackupReminder": "Please export your codes to ensure that you have a backup you can restore from.",
+  "sigInBackupReminder": "Ente will automatically backup codes after sign-in.\n\nWe still recommend exporting codes as an extra backup.",
   "offlineModeWarning": "You have chosen to proceed without backups. Please take manual backups to make sure your codes are safe.",
   "showLargeIcons": "Show large icons",
   "compactMode": "Compact mode",


### PR DESCRIPTION
## Description

Update the exit warning on mobile auth sign-in to emphasize automatic backup while still recommending manual export as an extra precaution.

## Tests
