### PR TITLE
[auth] Change backup sign-in dialog title to a Note

### DIFF
--- a/mobile/apps/auth/lib/l10n/arb/app_en.arb
+++ b/mobile/apps/auth/lib/l10n/arb/app_en.arb
@@ -303,6 +303,7 @@
   "checking": "Checking...",
   "youAreOnTheLatestVersion": "You are on the latest version",
   "warning": "Warning",
+  "note": "Note",
   "exportWarningDesc": "The exported file contains sensitive information. Please store this safely.",
   "iUnderStand": "I understand",
   "@iUnderStand": {

--- a/mobile/apps/auth/lib/ui/settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings_page.dart
@@ -96,7 +96,7 @@ class SettingsPage extends StatelessWidget {
           onTap: () async {
             ButtonResult? result = await showChoiceActionSheet(
               context,
-              title: context.l10n.warning,
+              title: context.l10n.note,
               body: context.l10n.sigInBackupReminder,
               secondButtonLabel: context.l10n.singIn,
               secondButtonAction: ButtonAction.second,


### PR DESCRIPTION
## Description

Update the dialog title when signing in from offline mode in the Auth app to use 'Note' instead of 'Warning' for a more appropriate tone.

## Tests
