### PR TITLE
[mob][photos] Enable select all date checkbox in shared album

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/gallery/collection_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/collection_page.dart
@@ -96,7 +96,7 @@ class CollectionPage extends StatelessWidget {
       albumName: c.collection.displayName,
       sortAsyncFn: () => c.collection.pubMagicMetadata.asc ?? false,
       addHeaderOrFooterEmptyState: false,
-      showSelectAll: galleryType != GalleryType.sharedCollection,
+      showSelectAll: true,
       emptyState: galleryType == GalleryType.ownedCollection
           ? EmptyAlbumState(
               c.collection,


### PR DESCRIPTION
## Description

Fixes issue where shared albums lacked select all functionality in date headers.

## Tests

- [x] Tested