### PR TITLE
[auth] Add note search functionality to mobile and web apps

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1055,6 +1055,7 @@ class _HomePageState extends State<HomePage> {
       // is the account name.
       final List<Code> issuerMatch = [];
       final List<Code> accountMatch = [];
+      final List<Code> noteMatch = [];
 
       for (final Code codeState in _allCodes!) {
         if (codeState.hasError ||
@@ -1068,10 +1069,13 @@ class _HomePageState extends State<HomePage> {
           issuerMatch.add(codeState);
         } else if (codeState.account.toLowerCase().contains(val)) {
           accountMatch.add(codeState);
+        } else if (codeState.note.toLowerCase().contains(val)) {
+          noteMatch.add(codeState);
         }
       }
       _filteredCodes = issuerMatch;
       _filteredCodes.addAll(accountMatch);
+      _filteredCodes.addAll(noteMatch);
     } else if (_isTrashOpen) {
       _filteredCodes = _allCodes
               ?.where(

--- a/web/apps/auth/src/pages/auth.tsx
+++ b/web/apps/auth/src/pages/auth.tsx
@@ -67,7 +67,8 @@ const Page: React.FC = () => {
     const filteredCodes = codes.filter(
         (code) =>
             code.issuer.toLowerCase().includes(lcSearch) ||
-            code.account?.toLowerCase().includes(lcSearch),
+            code.account?.toLowerCase().includes(lcSearch) ||
+            code.codeDisplay?.note?.toLowerCase().includes(lcSearch),
     );
 
     if (!hasFetched) {

--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -69,11 +69,19 @@ export interface CodeDisplay {
      * Pinned codes show at the top of the list of codes.
      */
     pinned?: boolean;
+    /**
+     * User-provided note or description for this code.
+     *
+     * This is optional metadata that users can add to help remember details
+     * about the code (e.g., which account, recovery codes location, etc.).
+     */
+    note?: string;
 }
 
 const CodeDisplay = z.object({
     trashed: z.boolean().nullish().transform(nullToUndefined),
     pinned: z.boolean().nullish().transform(nullToUndefined),
+    note: z.string().nullish().transform(nullToUndefined),
 });
 
 /**


### PR DESCRIPTION
## Description

Users can now search for 2FA codes by the notes they've added to them. This makes it easier to find codes when you've added descriptive notes like backup code locations or account details.

## Tests

- [x] Tested on simulator
- [x] Tested on auth web