### PR TITLE
[auth] hide auth directory on iOS

### DIFF
--- a/mobile/apps/auth/ios/Runner/Info.plist
+++ b/mobile/apps/auth/ios/Runner/Info.plist
@@ -80,9 +80,5 @@
 		</array>
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
-		<key>LSSupportsOpeningDocumentsInPlace</key>
-		<true/>
-		<key>UIFileSharingEnabled</key>
-		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
## Description

Fixes the issue on iOS where ente auth was visible as a directory in iOS.

## Tests

- [x] Tested on simulator
