### PR TITLE
[server] Fix CreateMetaFile returning wrong collectionID in response

### DIFF
--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -188,7 +188,7 @@ func (repo *FileRepository) CreateMetaFile(
 		EncryptedKey:       metaFile.EncryptedKey,
 		KeyDecryptionNonce: metaFile.KeyDecryptionNonce,
 		Info:               info,
-		CollectionID:       collectionOwnerID,
+		CollectionID:       metaFile.CollectionID,
 	}
 	return &file, stacktrace.Propagate(err, "")
 }


### PR DESCRIPTION
## Description

The CreateMetaFile method was incorrectly using collectionOwnerID (which is the userID) instead of metaFile.CollectionID when constructing the response. This caused the API to return the ownerID value in the collectionID field of the response, even though the database was correctly storing the actual collectionID.


