### PR TITLE
Fix sitemap URLs to include /help prefix

### DIFF
--- a/docs/docs/.vitepress/config.ts
+++ b/docs/docs/.vitepress/config.ts
@@ -12,7 +12,24 @@ export default defineConfig({
     cleanUrls: true,
     ignoreDeadLinks: "localhostLinks",
     sitemap: {
-        hostname: "https://ente.io/help",
+        hostname: "https://ente.io/help/",
+        transformItems: (items) => {
+            // Remove trailing slashes for consistency (cleanUrls is enabled)
+            // and deduplicate URLs
+            const seen = new Set();
+            return items
+                .map((item) => ({
+                    ...item,
+                    url: item.url.replace(/\/$/, ''),
+                }))
+                .filter((item) => {
+                    if (seen.has(item.url)) {
+                        return false;
+                    }
+                    seen.add(item.url);
+                    return true;
+                });
+        },
     },
     transformPageData(pageData) {
         // Add canonical URL to all pages


### PR DESCRIPTION
 Update VitePress sitemap configuration to correctly include the base path prefix in all generated URLs by adding trailing slash to hostname and implementing transformItems for URL normalization

## Description

## Tests
