### PR TITLE
[auth] Fix CodeWidget timer context race

### DIFF
--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -68,6 +68,8 @@ class _CodeWidgetState extends State<CodeWidget> {
   int _codeTimeStep = -1;
   int lastRefreshTime = 0;
   bool ignorePin = false;
+  // Cached localization string to avoid BuildContext access in async callbacks
+  String _errorText = 'Error';
 
   @override
   void initState() {
@@ -78,6 +80,7 @@ class _CodeWidgetState extends State<CodeWidget> {
     _everySecondTimer = Timer.periodic(const Duration(milliseconds: 500), (
       Timer t,
     ) {
+      if (!mounted) return;
       int newStep = 0;
       int epochSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       if (widget.code.type != Type.hotp) {
@@ -125,6 +128,8 @@ class _CodeWidgetState extends State<CodeWidget> {
       _isInitialized = true;
     }
     final l10n = context.l10n;
+    // Cache the localized error label for use in timer callbacks
+    _errorText = l10n.error;
 
     Widget getCardContents(AppLocalizations l10n, {required bool isSelected}) {
       final colorScheme = getEnteColorScheme(context);
@@ -1055,7 +1060,8 @@ class _CodeWidgetState extends State<CodeWidget> {
     try {
       return getOTP(widget.code);
     } catch (e) {
-      return context.l10n.error;
+      // Avoid accessing BuildContext from async timer callbacks
+      return _errorText;
     }
   }
 
@@ -1064,7 +1070,8 @@ class _CodeWidgetState extends State<CodeWidget> {
       assert(widget.code.type.isTOTPCompatible);
       return getNextTotp(widget.code);
     } catch (e) {
-      return context.l10n.error;
+      // Avoid accessing BuildContext from async timer callbacks
+      return _errorText;
     }
   }
 


### PR DESCRIPTION
## Description

Caches l10n.error, guards the timer with mounted, and routes _getCurrentOTP/ _getNextTotp through the cached string, eliminating the context-after-dispose crash.

## Tests
