### PR TITLE
[auth] add error handling to icon utils & icon picker

### DIFF
--- a/mobile/apps/auth/lib/ui/custom_icon_page.dart
+++ b/mobile/apps/auth/lib/ui/custom_icon_page.dart
@@ -5,7 +5,6 @@ import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/utils/icon_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:logging/logging.dart';
 
 class CustomIconPage extends StatefulWidget {
   final Map<String, AllIconData> allIcons;
@@ -179,35 +178,22 @@ class _CustomIconPageState extends State<CustomIconPage> {
                       String? color = iconData.color;
                       String? slug = iconData.slug;
                       Widget iconWidget;
-                      try {
-                        if (iconType == IconType.simpleIcon) {
-                          final simpleIconPath = normalizeSimpleIconName(title);
-                          iconWidget = IconUtils.instance.getSVGIcon(
-                            "assets/simple-icons/icons/$simpleIconPath.svg",
-                            title,
-                            color,
-                            40,
-                            context,
-                          );
-                        } else {
-                          iconWidget = IconUtils.instance.getSVGIcon(
-                            "assets/custom-icons/icons/${slug ?? title}.svg",
-                            title,
-                            color,
-                            40,
-                            context,
-                          );
-                        }
-                      } catch (e, s) {
-                        Logger("CustomIconPage").warning(
-                          "Failed to render icon '$title'",
-                          e,
-                          s,
-                        );
-                        iconWidget = IconUtils.instance.getIcon(
-                          context,
+                      if (iconType == IconType.simpleIcon) {
+                        final simpleIconPath = normalizeSimpleIconName(title);
+                        iconWidget = IconUtils.instance.getSVGIcon(
+                          "assets/simple-icons/icons/$simpleIconPath.svg",
                           title,
-                          width: 40,
+                          color,
+                          40,
+                          context,
+                        );
+                      } else {
+                        iconWidget = IconUtils.instance.getSVGIcon(
+                          "assets/custom-icons/icons/${slug ?? title}.svg",
+                          title,
+                          color,
+                          40,
+                          context,
                         );
                       }
 


### PR DESCRIPTION
## Description

Wrap IconUtils method with try-catch

Also fixes the same issue in Custom icon picker

Resolves #7878 #7979 #7943 #7941 

## Tests

- [x] Verified in both home and icon picker page after this patch