### PR TITLE
[auth] Fix temp folder creation on Windows

### DIFF
--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -58,7 +58,7 @@ class BaseConfiguration {
   Future<void> init(List<EnteBaseDatabase> dbs) async {
     _databases = dbs;
     _documentsDirectory = (await getApplicationDocumentsDirectory()).path;
-    _tempDocumentsDirPath = "$_documentsDirectory/temp/";
+    _tempDocumentsDirPath = "${(await getTemporaryDirectory()).path}/temp/";
     _preferences = await SharedPreferences.getInstance();
     _secureStorage = const FlutterSecureStorage(
       iOptions: IOSOptions(


### PR DESCRIPTION
## Description

Changed temporary folder location from Documents/temp/ to the system temporary directory using getTemporaryDirectory(). This ensures temp files are stored in the appropriate OS-specific location (e.g., %TEMP% on Windows) instead of cluttering the user's Documents folder.

The existing auto-cleanup logic (deletes temp files older than 1 day) remains unchanged and will work with the new location.

## Tests
