### PR TITLE
[mob][photos] Remove shareImageAndUrl

### DIFF
--- a/mobile/apps/photos/lib/utils/share_util.dart
+++ b/mobile/apps/photos/lib/utils/share_util.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import "dart:io";
-import "dart:typed_data";
 
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
@@ -240,28 +239,6 @@ void shareSelected(
     context,
     selectedFiles.toList(),
     shareButtonKey: shareButtonKey,
-  );
-}
-
-Future<void> shareImageAndUrl(
-  Uint8List imageBytes,
-  String url, {
-  BuildContext? context,
-  GlobalKey? key,
-}) async {
-  final sharePosOrigin = _sharePosOrigin(context, key);
-  await SharePlus.instance.share(
-    ShareParams(
-      files: [
-        XFile.fromData(
-          imageBytes,
-          name: 'placeholder_image.png',
-          mimeType: 'image/png',
-        ),
-      ],
-      text: url,
-      sharePositionOrigin: sharePosOrigin,
-    ),
   );
 }
 


### PR DESCRIPTION
## Description

- Replace shareImageAndUrl with shareText in _sendLink method
- Remove unused _createPlaceholder method
- Remove unused imports (screenshot, LinkPlaceholder, typed_data)
- Remove unused screenshotController and placeholderBytes variables


## Tests
