### PR TITLE
[cli] resolve path to absolute path (fixes #3770)

### DIFF
--- a/cli/internal/promt.go
+++ b/cli/internal/promt.go
@@ -4,13 +4,15 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/ente-io/cli/internal/api"
-	"golang.org/x/term"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/ente-io/cli/internal/api"
+	"golang.org/x/term"
 )
 
 func GetSensitiveField(label string) (string, error) {
@@ -225,12 +227,24 @@ func ValidateDirForWrite(dir string) (bool, error) {
 }
 
 func ResolvePath(path string) (string, error) {
-	if path[:2] != "~/" {
-		return path, nil
+	// Expand home directory if path starts with ~
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if len(path) == 1 {
+			path = home
+		} else if strings.HasPrefix(path, "~/") {
+			path = filepath.Join(home, path[2:])
+		}
 	}
-	home, err := os.UserHomeDir()
+
+	// Convert to absolute path
+	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
-	return home + path[1:], nil
+
+	return absPath, nil
 }

--- a/cli/internal/promt_test.go
+++ b/cli/internal/promt_test.go
@@ -1,0 +1,126 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	// Get current working directory for testing relative paths
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	// Get home directory for testing ~ expansion
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Failed to get home directory: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "current directory dot",
+			input:       ".",
+			expected:    cwd,
+			expectError: false,
+		},
+		{
+			name:        "tilde only",
+			input:       "~",
+			expected:    home,
+			expectError: false,
+		},
+		{
+			name:        "tilde with slash",
+			input:       "~/",
+			expected:    home,
+			expectError: false,
+		},
+		{
+			name:        "tilde with subdirectory",
+			input:       "~/Documents",
+			expected:    filepath.Join(home, "Documents"),
+			expectError: false,
+		},
+		{
+			name:        "tilde with nested path",
+			input:       "~/Documents/test/file.txt",
+			expected:    filepath.Join(home, "Documents", "test", "file.txt"),
+			expectError: false,
+		},
+		{
+			name:        "relative path",
+			input:       "test/dir",
+			expected:    filepath.Join(cwd, "test", "dir"),
+			expectError: false,
+		},
+		{
+			name:        "parent directory",
+			input:       "..",
+			expected:    filepath.Dir(cwd),
+			expectError: false,
+		},
+		{
+			name:        "parent with subdirectory",
+			input:       "../sibling",
+			expected:    filepath.Join(filepath.Dir(cwd), "sibling"),
+			expectError: false,
+		},
+		{
+			name:        "cleaned path",
+			input:       "/tmp/../test",
+			expected:    "/test",
+			expectError: false,
+		},
+		{
+			name:        "absolute path unchanged",
+			input:       "/tmp/test",
+			expected:    "/tmp/test",
+			expectError: false,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expected:    cwd,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolvePath(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Clean both paths for comparison to handle path separator differences
+			expectedClean := filepath.Clean(tt.expected)
+			resultClean := filepath.Clean(result)
+
+			if resultClean != expectedClean {
+				t.Errorf("Expected %q, got %q", expectedClean, resultClean)
+			}
+
+			// Verify the result is an absolute path
+			if !filepath.IsAbs(result) {
+				t.Errorf("Result %q is not an absolute path", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This fixes #3770 and always resolves the export dir to an absolute path.
This ensures a more consistent behavior.

## Tests

added unit tests
