### PR TITLE
[auth] remove safearea from body of local backup settings

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/local_backup_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/local_backup_settings_page.dart
@@ -203,7 +203,7 @@ class _LocalBackupVariantShell extends StatelessWidget {
                         SliverList(
                           delegate: SliverChildBuilderDelegate(
                             (context, index) {
-                              return SafeArea(bottom: false, child: body);
+                              return body;
                             },
                             childCount: 1,
                           ),


### PR DESCRIPTION
## Description

SafeArea caused unnecessary space over the local backup settings area on mobile.

## Tests
