### PR TITLE
[docs] Move 'Share albums' to free plan allowed features

### DIFF
--- a/docs/docs/photos/faq/storage-and-plans.md
+++ b/docs/docs/photos/faq/storage-and-plans.md
@@ -102,7 +102,7 @@ Yes, we offer 10 GB of storage for free, forever.
 
 On the free plan, you cannot:
 
-- Share albums or create public links
+- Create public links
 - Set up family plans
 
 All other features work on the free plan, including:
@@ -111,6 +111,7 @@ All other features work on the free plan, including:
 - End-to-end encryption
 - Map view
 - Machine learning (face recognition, magic search)
+- Share albums
 - Background sync
 - Receiving shared albums from others
 


### PR DESCRIPTION
## Description

Share albums is supported on the free plan, so moved it from the "cannot" list to the "can" list in the free plan limitations documentation.
