### PR TITLE
[server] Join public albums on web

### DIFF
--- a/server/config/example.env
+++ b/server/config/example.env
@@ -27,3 +27,4 @@ MINIO_ROOT_PASSWORD=<secret>
 # Replace the below endpoints to the correct subdomains of your choice.
 ENTE_API_ORIGIN=http://localhost:8080
 ENTE_ALBUMS_ORIGIN=https://localhost:3002
+ENTE_PHOTOS_ORIGIN=http://localhost:3000

--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -108,6 +108,7 @@ services:
     environment:
       ENTE_API_ORIGIN: http://localhost:8080
       ENTE_ALBUMS_ORIGIN: https://localhost:3002
+      ENTE_PHOTOS_ORIGIN: http://localhost:3000
 
   postgres:
     image: postgres:15


### PR DESCRIPTION
Add ENTE_PHOTOS_ORIGIN env variable to quickstart.sh and example.env. This is used by the web app to redirect users back to the photos app after authentication when joining public albums.