### PR TITLE
[locker] Add NSFaceIDUsageDescription to enable Face ID

### DIFF
--- a/mobile/apps/locker/ios/Runner/Info.plist
+++ b/mobile/apps/locker/ios/Runner/Info.plist
@@ -49,6 +49,8 @@
 		<false/>
 		<key>NSCameraUsageDescription</key>
 		<string>Please allow access to camera so that Ente can scan and backup your documents.</string>
+		<key>NSFaceIDUsageDescription</key>
+		<string>Please allow Ente Locker to lock itself with FaceID or TouchID</string>
 		<key>NSPhotoLibraryUsageDescription</key>
 		<string>Please allow access to your library so that Ente can encrypt and back up your documents.</string>
 		<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary
- Add missing `NSFaceIDUsageDescription` key to locker's Info.plist
- This key is required for iOS apps to use Face ID authentication
- Without it, iOS falls back to passcode-only authentication

## Root Cause
The locker app was asking for passcode instead of Face ID because the `NSFaceIDUsageDescription` key was missing from `ios/Runner/Info.plist`. Both the `auth` and `photos` apps have this key configured, but `locker` was missing it.

## Test Plan
- [ ] Build locker app on iOS
- [ ] Enable app lock in Settings > Security > App Lock
- [ ] Verify Face ID prompt appears instead of passcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)