### PR TITLE
[server] Block file link sharing for free users

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -369,6 +369,7 @@ func main() {
 		FileController: fileController,
 		FileLinkRepo:   fileLinkRepo,
 		FileRepo:       fileRepo,
+		BillingCtrl:    billingController,
 		JwtSecret:      jwtSecretBytes,
 	}
 


### PR DESCRIPTION
## Summary
- Add subscription check to `/files/share-url` endpoint (used by Locker for single file sharing)
- Free users now receive `ErrSharingDisabledForFreeAccounts` error when attempting to create or update file share links
- Aligns file link sharing restrictions with existing collection link sharing behavior

## Context
Collection sharing already blocks free users via `HasActiveSelfOrFamilySubscription` check in `pkg/controller/collections/share.go`. However, the file link sharing endpoint (only used by Locker app) was missing this check.

