### PR TITLE
[web] Make thumbSize optional in FileInfo schema

### DIFF
--- a/web/packages/media/file.ts
+++ b/web/packages/media/file.ts
@@ -214,13 +214,15 @@ export interface FileInfo {
     fileSize?: number;
     /**
      * The size of the thumbnail associated with the file (in bytes).
+     *
+     * This will not be present for files that don't have thumbnails (an old Locker issue)
      */
-    thumbSize: number;
+    thumbSize?: number;
 }
 
 export const RemoteFileInfo = z.looseObject({
     fileSize: z.number().nullish().transform(nullToUndefined),
-    thumbSize: z.number(),
+    thumbSize: z.number().nullish().transform(nullToUndefined),
 });
 
 const RemoteFileMetadata = z.object({


### PR DESCRIPTION
Handle files that don't have thumbnails (from an old Locker issue). Solves this error where diff sync was failing:

```
[2025-12-04T22:51:15+05:30] [rndr] [error] Remote pull failed: ZodError: [
  {
    "expected": "number",
    "code": "invalid_type",
    "path": [
      "diff",
      591,
      "info",
      "thumbSize"
    ],
    "message": "Invalid input: expected number, received undefined"
  }
]
```
