### PR TITLE
[server] Add support for updating recovery notice period

### DIFF
--- a/server/ente/emergency.go
+++ b/server/ente/emergency.go
@@ -11,9 +11,10 @@ type AddContact struct {
 }
 
 type UpdateContact struct {
-	UserID             int64        `json:"userID" binding:"required"`
-	EmergencyContactID int64        `json:"emergencyContactID" binding:"required"`
-	State              ContactState `json:"state" binding:"required"`
+	UserID               int64        `json:"userID" binding:"required"`
+	EmergencyContactID   int64        `json:"emergencyContactID" binding:"required"`
+	State                ContactState `json:"state"`
+	RecoveryNoticeInDays *int         `json:"recoveryNoticeInDays"`
 }
 
 type ContactIdentifier struct {


### PR DESCRIPTION
Extends the existing `/emergency-contacts/update` endpoint to support updating the recovery notice period.

## Changes
- Add optional `recoveryNoticeInDays` field to `UpdateContact` request
- Add `UpdateNoticePeriod` repository method
- Allow state-only, notice-only, or both updates in a single request
- Only account owner can update the recovery notice period