### PR TITLE
[auth] password re-entry fails

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
@@ -80,7 +80,7 @@ Future<void> _decryptExportData(
           enteAuthExport.kdfParams.memLimit,
           enteAuthExport.kdfParams.opsLimit,
         );
-        Uint8List? decryptedContent;
+        late final Uint8List decryptedContent;
         try {
           decryptedContent = await CryptoUtil.decryptData(
             CryptoUtil.base642bin(enteAuthExport.encryptedData),
@@ -94,7 +94,7 @@ Future<void> _decryptExportData(
           await progressDialog.hide();
           return;
         }
-        String content = utf8.decode(decryptedContent!);
+        String content = utf8.decode(decryptedContent);
         List<String> splitCodes = content.split("\n");
         final parsedCodes = [];
         for (final code in splitCodes) {

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -56,7 +56,6 @@ dependencies:
   expansion_tile_card: ^3.0.0
   ffi: ^2.1.0
   figma_squircle: ^0.6.3
-  launcher_icon_switcher: ^0.0.2
   file_picker: ^10.3.2
   file_saver: ^0.3.1
   fixnum: ^1.1.0
@@ -101,6 +100,7 @@ dependencies:
   intl: ^0.20.2
   io: ^1.0.4
   json_annotation: ^4.5.0
+  launcher_icon_switcher: ^0.0.2
   local_auth: ^2.3.0
   local_auth_android: ^1.0.37
   local_auth_darwin: ^1.2.2


### PR DESCRIPTION
## Description

In Auth, Encrypted Ente export failed to import the codes if first password was wrong.

This was because of the recursive call that creates a new dialog and dismisses it immediately.

## Tests

- [x] Tested on emulator