### PR TITLE
[mob][photos] Fix export logs button infinite loading 

### DIFF
--- a/mobile/apps/photos/lib/utils/email_util.dart
+++ b/mobile/apps/photos/lib/utils/email_util.dart
@@ -85,6 +85,7 @@ Future<void> sendLogs(
         buttonType: ButtonType.secondary,
         labelText: AppLocalizations.of(context).exportLogs,
         buttonAction: ButtonAction.third,
+        shouldSurfaceExecutionStates: false,
         onTap: () async {
           final zipFilePath = await getZippedLogsFile(context);
           await exportLogs(context, zipFilePath);


### PR DESCRIPTION
Disable button execution states for export logs button since iOS share sheet doesn't properly signal completion, causing the button to load indefinitely.