### PR TITLE
Quickstart wget

### DIFF
--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -84,7 +84,7 @@ services:
       interval: 60s
       timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 120s
 
   # Resolve "localhost:3200" in the museum container to the minio container.
   socat:


### PR DESCRIPTION
## Description
Replaced the healthcheck's use of `curl` with `wget` in `quickstart.sh` as `curl` does not exist in the image, causing a permanently unhealthy container state. This problem and solution are documented in these locations:

https://www.answeroverflow.com/m/1435181757451472927
https://ente.io/help/self-hosting/guides/windows#docker-composeyaml

Another improvement described in these sources is also added: increasing the `start_period` to 120 seconds to allow extra time for first time bootstrapping.

This resolves https://github.com/ente-io/ente/issues/6991. 

## Tests
- The removed `curl` command would cause healthcheck to constantly fail and result in an unhealthy state.
- Testing the removed `curl` command in `docker exec` would report that `curl` does not exist.
- The added `wget` command works fine in `docker exec` and leaves Docker reporting a healthy instead of unhealthy state.