### PR TITLE
[mob][photos] Fix backup dialog recursion for only new backup

### DIFF
--- a/mobile/apps/photos/lib/ui/common/backup_flow_helper.dart
+++ b/mobile/apps/photos/lib/ui/common/backup_flow_helper.dart
@@ -55,12 +55,17 @@ Future<void> handleLimitedOrFolderBackupFlow(
 Future<bool?> handleFolderSelectionBackupFlow(
   BuildContext context, {
   bool isFirstBackup = false,
+  bool fromOnlyNewPhotosToggle = false,
 }) async {
   if (_shouldRunFirstImportFlow()) {
     return _handleFirstImportFlow(context);
   }
 
-  return _navigateToFolderSelection(context, isFirstBackup: isFirstBackup);
+  return _navigateToFolderSelection(
+    context,
+    isFirstBackup: isFirstBackup,
+    fromOnlyNewPhotosToggle: fromOnlyNewPhotosToggle,
+  );
 }
 
 bool _shouldRunFirstImportFlow() =>
@@ -99,10 +104,14 @@ bool _hasMinimalPermission(PermissionState state) =>
 Future<bool?> _navigateToFolderSelection(
   BuildContext context, {
   required bool isFirstBackup,
+  bool fromOnlyNewPhotosToggle = false,
 }) =>
     routeToPage<bool>(
       context,
-      BackupFolderSelectionPage(isFirstBackup: isFirstBackup),
+      BackupFolderSelectionPage(
+        isFirstBackup: isFirstBackup,
+        fromOnlyNewPhotosToggle: fromOnlyNewPhotosToggle,
+      ),
     );
 
 Future<void> _showPermissionDeniedDialog(BuildContext context) =>

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
@@ -27,9 +27,15 @@ class BackupFolderSelectionPage extends StatefulWidget {
   final bool isFirstBackup;
   final bool isOnboarding;
 
+  /// When true, skip the "only new backup" warning dialog.
+  /// This is used when coming from the "backup only new photos" toggle
+  /// to prevent recursive navigation back to backup settings.
+  final bool fromOnlyNewPhotosToggle;
+
   const BackupFolderSelectionPage({
     required this.isFirstBackup,
     this.isOnboarding = false,
+    this.fromOnlyNewPhotosToggle = false,
     super.key,
   });
 
@@ -249,8 +255,10 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
         await backupPreferenceService.setOnboardingPermissionSkipped(false);
       }
 
+      // Skip the warning dialog if we came from the "backup only new photos"
+      // toggle to avoid recursive navigation back to backup settings.
       final onlyNewSinceEpoch = backupPreferenceService.onlyNewSinceEpoch;
-      if (onlyNewSinceEpoch != null) {
+      if (onlyNewSinceEpoch != null && !widget.fromOnlyNewPhotosToggle) {
         final shouldContinue =
             await _showOnlyNewBackupWarning(onlyNewSinceEpoch);
 

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
@@ -327,7 +327,10 @@ class BackupSettingsScreen extends StatelessWidget {
     }
 
     if (result.action == ButtonAction.first) {
-      final bool? selected = await handleFolderSelectionBackupFlow(context);
+      final bool? selected = await handleFolderSelectionBackupFlow(
+        context,
+        fromOnlyNewPhotosToggle: true,
+      );
       if (selected != true) {
         return false;
       }


### PR DESCRIPTION
## Description

When user enables "backup only new photos" toggle and selects folders from the resulting dialog, the folder selection page would show a warning dialog with "Update settings" button that navigates back to backup settings, creating a confusing recursive navigation loop.

This fix adds a fromOnlyNewPhotosToggle flag that is passed through the navigation flow. When this flag is true, the warning dialog is skipped since the user is explicitly setting up their backup preferences through the toggle.

## Tests
