### PR TITLE
[locker] Disable Android auto backup

### DIFF
--- a/mobile/apps/locker/android/app/src/main/AndroidManifest.xml
+++ b/mobile/apps/locker/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
         android:label="Ente Locker"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity


### PR DESCRIPTION
Disable Android auto backup to fix BAD_DECRYPT error on fresh install.

When backup data is restored, encrypted keystore data cannot be decrypted with the new keystore key.