### PR TITLE
feat: Improve search keyboard navigation and shortcuts

### DIFF
--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -40,6 +40,7 @@ class CodeWidget extends StatefulWidget {
   final bool isReordering;
   final bool enableDesktopContextActions;
   final List<Code> Function()? selectedCodesBuilder;
+  final FocusNode? focusNode;
 
   const CodeWidget(
     this.code, {
@@ -49,6 +50,7 @@ class CodeWidget extends StatefulWidget {
     this.isReordering = false,
     this.enableDesktopContextActions = false,
     this.selectedCodesBuilder,
+    this.focusNode,
   });
 
   @override
@@ -252,6 +254,7 @@ class _CodeWidgetState extends State<CodeWidget> {
                   child: Material(
                     color: Colors.transparent,
                     child: InkWell(
+                      focusNode: widget.focusNode,
                       customBorder: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(10),
                       ),

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -104,6 +104,7 @@ class _HomePageState extends State<HomePage> {
 
   late CodeSortKey _codeSortKey;
   final Set<LogicalKeyboardKey> _pressedKeys = <LogicalKeyboardKey>{};
+  final FocusNode _firstItemFocusNode = FocusNode();
 
   @override
   void initState() {
@@ -1023,7 +1024,7 @@ class _HomePageState extends State<HomePage> {
               _pressedKeys.contains(LogicalKeyboardKey.control) ||
               _pressedKeys.contains(LogicalKeyboardKey.controlRight));
 
-      if (isMetaKeyPressed && event.logicalKey == LogicalKeyboardKey.keyF) {
+      if ((isMetaKeyPressed && event.logicalKey == LogicalKeyboardKey.keyF) || event.logicalKey == LogicalKeyboardKey.slash) {
         setState(() {
           _showSearchBox = true;
           searchBoxFocusNode.requestFocus();
@@ -1152,6 +1153,7 @@ class _HomePageState extends State<HomePage> {
     _textController.removeListener(_applyFilteringAndRefresh);
     ServicesBinding.instance.keyboard.removeHandler(_handleKeyEvent);
     searchBoxFocusNode.dispose();
+    _firstItemFocusNode.dispose();
 
     super.dispose();
   }
@@ -1396,6 +1398,12 @@ class _HomePageState extends State<HomePage> {
               onChanged: (val) {
                 _searchText = val;
                 _applyFilteringAndRefresh();
+              },
+              onSubmitted: (_) {
+                if (_filteredCodes.isNotEmpty) {
+                  // Move focus to the first item in the grid
+                  _firstItemFocusNode.requestFocus();
+                }
               },
               decoration: InputDecoration(
                 hintText: l10n.searchHint,
@@ -1785,6 +1793,7 @@ class _HomePageState extends State<HomePage> {
                             enableDesktopContextActions:
                                 PlatformUtil.isDesktop(),
                             selectedCodesBuilder: _selectedCodesForContextMenu,
+                            focusNode: index == 0 ? _firstItemFocusNode : null,
                           );
                         }),
                         itemCount: _filteredCodes.length,


### PR DESCRIPTION
## Description

   * Add '/' as a keyboard shortcut to open the search bar.
   * Move focus to the first search result when pressing Enter in the search field. This prevents users having to press Tab multiple times to directly to go to the search results

This will work well with [my other PR](https://github.com/ente-io/ente/pull/8296) for using `C` and `N` for copying codes

## Screengrab

https://github.com/user-attachments/assets/272b5a81-a432-4b0f-a3ed-11825534dd79


