### PR TITLE
[mob] Add flutter_rust_bridge codegen to melos bootstrap

### DIFF
--- a/mobile/apps/auth/README.md
+++ b/mobile/apps/auth/README.md
@@ -49,7 +49,7 @@ or managing your secrets, please use our mobile or desktop app.
 2. Pull in all submodules with `git submodule update --init --recursive`
 
 3. Install dependencies using one of these methods:
-   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies and generate Rust bindings for shared packages.
+   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies.
    - **Using Flutter directly:** Run `flutter pub get` in `packages/strings` and this folder
 
 4. For Android, [setup your

--- a/mobile/apps/locker/README.md
+++ b/mobile/apps/locker/README.md
@@ -10,7 +10,7 @@ important documents in the cloud with secure sharing capabilities.
 2. Pull in all submodules with `git submodule update --init --recursive`
 
 3. Install dependencies using one of these methods:
-   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies and generate Rust bindings for shared packages.
+   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies.
    - **Using Flutter directly:** Run `flutter pub get` in `packages/strings` and this folder
 
 4. For Android, [setup your

--- a/mobile/apps/photos/README.md
+++ b/mobile/apps/photos/README.md
@@ -53,7 +53,7 @@ You can alternatively install the build from PlayStore or F-Droid.
 3. Enable repo git hooks `git config core.hooksPath hooks`
 
 4. Install dependencies using one of these methods:
-   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap && melos run codegen:rust`. This will install dependencies, generate localization files, and automatically generate Rust bindings.
+   - **Using Melos (recommended):** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos run codegen:rust`. This will install dependencies and generate Rust bindings.
    - **Using Flutter directly:** Run `flutter pub get`, then install [Flutter Rust Bridge](https://cjycode.com/flutter_rust_bridge/) with `cargo install flutter_rust_bridge_codegen` and run `flutter_rust_bridge_codegen generate` in both this folder and in `mobile/packages/rust`.
 
 5. On Android:

--- a/mobile/melos.yaml
+++ b/mobile/melos.yaml
@@ -26,25 +26,25 @@ scripts:
 
       # Generate Rust bindings for packages/rust
       echo "Generating flutter_rust_bridge bindings for packages/rust..."
-      (cd packages/rust && flutter_rust_bridge_codegen generate)
+      (cd packages/rust && flutter pub get && flutter_rust_bridge_codegen generate)
 
       # Generate Rust bindings for apps/photos
       echo "Generating flutter_rust_bridge bindings for apps/photos..."
-      (cd apps/photos && flutter_rust_bridge_codegen generate)
+      (cd apps/photos && flutter pub get && flutter_rust_bridge_codegen generate)
     description: Generate Rust bindings for all packages using flutter_rust_bridge.
 
   codegen:rust:packages:
     run: |
       cargo install flutter_rust_bridge_codegen 2>/dev/null || true
       echo "Generating flutter_rust_bridge bindings for packages/rust..."
-      (cd packages/rust && flutter_rust_bridge_codegen generate)
+      (cd packages/rust && flutter pub get && flutter_rust_bridge_codegen generate)
     description: Generate Rust bindings for packages/rust only.
 
   codegen:rust:photos:
     run: |
       cargo install flutter_rust_bridge_codegen 2>/dev/null || true
       echo "Generating flutter_rust_bridge bindings for apps/photos..."
-      (cd apps/photos && flutter_rust_bridge_codegen generate)
+      (cd apps/photos && flutter pub get && flutter_rust_bridge_codegen generate)
     description: Generate Rust bindings for apps/photos only.
 
   # --- GLOBAL COMMANDS (run on all apps & packages) ---


### PR DESCRIPTION
## Description

`melos run codegen:rust` instead of `flutter_rust_bridge_codegen generate` in rust and photos folder. Can run this command anywhere in mobile/ directory or sub-directories

## Tests

- [x] Tested melos bootstrap does same thing as previous
- [x] Tested `melos run codegen:rust` regenerates rust files only