### PR TITLE
[mob][auth] Fix logging file path issue on Windows

### DIFF
--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -16,6 +16,7 @@ import 'package:ente_events/models/signed_in_event.dart';
 import 'package:ente_events/models/signed_out_event.dart';
 import 'package:ente_logging/logging.dart';
 import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -58,7 +59,8 @@ class BaseConfiguration {
   Future<void> init(List<EnteBaseDatabase> dbs) async {
     _databases = dbs;
     _documentsDirectory = (await getApplicationDocumentsDirectory()).path;
-    _tempDocumentsDirPath = "${(await getTemporaryDirectory()).path}/temp/";
+    _tempDocumentsDirPath =
+        "${p.join((await getTemporaryDirectory()).path, "temp")}${p.separator}";
     _preferences = await SharedPreferences.getInstance();
     _secureStorage = const FlutterSecureStorage(
       iOptions: IOSOptions(
@@ -451,7 +453,8 @@ class BaseConfiguration {
     }
     tempDirectory.createSync(recursive: true);
 
-    _cacheDirectory = "$_documentsDirectory/cache/";
+    _cacheDirectory =
+        "${p.join(p.dirname(_tempDocumentsDirPath), "cache")}${p.separator}";
     if (!io.Directory(_cacheDirectory).existsSync()) {
       io.Directory(_cacheDirectory).createSync(recursive: true);
     }

--- a/mobile/packages/configuration/pubspec.yaml
+++ b/mobile/packages/configuration/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   # Let's wait till the issue is resolved by the package maintainer.
   # If not resolved and we need to upgrade, write a migration script.
   flutter_secure_storage: 9.0.0
+  path: ^1.9.0
   path_provider: ^2.1.5
   shared_preferences: ^2.5.3
   tuple: ^2.0.2

--- a/mobile/packages/logging/lib/super_logging.dart
+++ b/mobile/packages/logging/lib/super_logging.dart
@@ -352,7 +352,7 @@ class SuperLogging {
     // choose [logDir]
     if (dirPath == null || dirPath.isEmpty) {
       final root = await getExternalStorageDirectory();
-      dirPath = '${root!.path}/logs';
+      dirPath = join(root!.path, 'logs');
     }
 
     // create [logDir]
@@ -392,7 +392,7 @@ class SuperLogging {
       }
     }
 
-    logFile = File("$dirPath/${config.dateFmt!.format(DateTime.now())}.txt");
+    logFile = File(join(dirPath, "${config.dateFmt!.format(DateTime.now())}.txt"));
   }
 
   /// Current app version, obtained from package_info plugin.


### PR DESCRIPTION
Use platform-aware path joining (path package) instead of hardcoded forward slashes when constructing file paths. This fixes a PathNotFoundException on Windows where paths like
'D:\name\Documents/cache/' would fail to be created.

Fixes #8347 #7999
 
## Description

## Tests
