### PR TITLE
[mob][photos] Fix skip permission clearing logic

### DIFF
--- a/mobile/apps/photos/lib/services/backup_preference_service.dart
+++ b/mobile/apps/photos/lib/services/backup_preference_service.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:photos/db/device_files_db.dart';
 import 'package:photos/db/files_db.dart';
 import 'package:photos/models/device_collection.dart';
+import 'package:photos/services/sync/local_sync_service.dart';
 import 'package:photos/services/sync/remote_sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -121,7 +122,10 @@ class BackupPreferenceService {
       await _setAllFoldersShouldBackup(true);
       await setSelectAllFoldersForBackup(true);
       await setHasSelectedAnyBackupFolder(true);
-      if (hasSkippedOnboardingPermission) {
+      // Only clear skip flag if first import is done (folders loaded),
+      // ensuring user can see gallery properly after skip is cleared
+      if (hasSkippedOnboardingPermission &&
+          LocalSyncService.instance.hasCompletedFirstImport()) {
         await setOnboardingPermissionSkipped(false);
       }
       _logger.info('Auto-selected all folders for backup');

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -129,9 +129,6 @@ class LocalSyncService {
       }
       if (!hasCompletedFirstImport()) {
         await _prefs.setBool(kHasCompletedFirstImportKey, true);
-        if (backupPreferenceService.hasSkippedOnboardingPermission) {
-          await backupPreferenceService.setOnboardingPermissionSkipped(false);
-        }
         await _refreshDeviceFolderCountAndCover(isFirstSync: true);
         _logger.info("first gallery import finished");
         Bus.instance

--- a/mobile/apps/photos/lib/ui/home/grant_permissions_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/grant_permissions_widget.dart
@@ -235,7 +235,6 @@ class _GrantPermissionsWidgetState extends State<GrantPermissionsWidget> {
   }) async {
     _logger.info("Permission granted " + state.toString());
     await permissionService.onUpdatePermission(state);
-    await backupPreferenceService.setOnboardingPermissionSkipped(false);
     if (shouldMarkLimitedFolders && state == PermissionState.limited) {
       // when limited permission is granted, by default mark all folders for
       // backup

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_folder_selection_page.dart
@@ -205,8 +205,16 @@ class _BackupFolderSelectionPageState extends State<BackupFolderSelectionPage> {
                       ? GestureDetector(
                           key: const ValueKey("skipBackupButton"),
                           behavior: HitTestBehavior.opaque,
-                          onTap: () {
-                            Navigator.of(context).pop(false);
+                          onTap: () async {
+                            // Clear skip flag - user made explicit choice to skip
+                            if (backupPreferenceService
+                                .hasSkippedOnboardingPermission) {
+                              await backupPreferenceService
+                                  .setOnboardingPermissionSkipped(false);
+                            }
+                            if (context.mounted) {
+                              Navigator.of(context).pop(false);
+                            }
                           },
                           child: Padding(
                             padding: const EdgeInsets.only(bottom: 8),

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/generated/l10n.dart';
 import 'package:photos/l10n/l10n.dart';
 import 'package:photos/service_locator.dart';
+import 'package:photos/services/sync/local_sync_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
 import 'package:photos/services/wake_lock_service.dart';
 import 'package:photos/theme/ente_theme.dart';
@@ -235,7 +236,10 @@ class BackupSettingsScreen extends StatelessWidget {
             _onlyNewToggleDebouncer.run(() async {
               await SyncService.instance.sync();
             });
-            if (backupPreferenceService.hasSkippedOnboardingPermission) {
+            // Only clear skip flag if first import is done (folders loaded),
+            // ensuring user can see gallery properly after skip is cleared
+            if (backupPreferenceService.hasSkippedOnboardingPermission &&
+                LocalSyncService.instance.hasCompletedFirstImport()) {
               await backupPreferenceService.setOnboardingPermissionSkipped(
                 false,
               );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/device_folder_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/device_folder_page.dart
@@ -12,6 +12,7 @@ import 'package:photos/models/device_collection.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
+import 'package:photos/service_locator.dart';
 import 'package:photos/services/ignored_files_service.dart';
 import 'package:photos/services/sync/remote_sync_service.dart';
 import 'package:photos/theme/ente_theme.dart';
@@ -145,6 +146,13 @@ class _BackupHeaderWidgetState extends State<BackupHeaderWidget> {
                           .updateDeviceFolderSyncStatus(
                         {widget.deviceCollection.id: !shouldBackup.value},
                       );
+                      // Clear skip flag only when enabling backup (not disabling)
+                      if (!shouldBackup.value &&
+                          backupPreferenceService
+                              .hasSkippedOnboardingPermission) {
+                        await backupPreferenceService
+                            .setOnboardingPermissionSkipped(false);
+                      }
                       if (mounted) {
                         setState(() {
                           shouldBackup.value = !shouldBackup.value;


### PR DESCRIPTION
## Description
 
 Only reset skipped permissions when either first import is completed or user has made a manual selection.

## Tests
