### PR TITLE
Update link for video streaming FAQ section to target #video-streaming

### DIFF
--- a/docs/docs/photos/faq/video-streaming.md
+++ b/docs/docs/photos/faq/video-streaming.md
@@ -11,7 +11,7 @@ The content from **Video Streaming FAQ** has been reorganized. You can find it i
 ## Video Streaming
 
 - [Video streaming feature guide](/photos/features/utilities/video-streaming) - Complete guide to streaming videos in-app
-- [Video streaming FAQ](/photos/faq/advanced-features) - How it works, enabling/disabling, compatibility
+- [Video streaming FAQ](/photos/faq/advanced-features#video-streaming) - How it works, enabling/disabling, compatibility
 
 ## Troubleshooting
 


### PR DESCRIPTION
I was a bit confused when I went to the video streaming FAQ section and was looking at CLI documentation on mobile. It's easier to see on desktop that I just needed to scroll down, but this change goes straight to the video streaming section of the advanced docs.
