### PR TITLE
[mob][photos] Fix search screen stuck at loading state when person has no associated files

### DIFF
--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -898,6 +898,7 @@ class SearchService {
         final files = personIdToFiles[personID]!;
         final PersonEntity p = personIdToPerson[personID]!;
         if (p.data.isIgnored) continue;
+        if (files.isEmpty) continue;
         facesResult.add(
           GenericSearchResult(
             ResultType.faces,


### PR DESCRIPTION
## Description

getAllFace() crashed with "Bad state: No element" when calling files.first on an empty list.

This occurs when a person has manually assigned face IDs but all those files have been deleted. The code at lines 863-876 creates an empty list entry in personIdToFiles for such persons, which then causes a crash at line 910 when accessing files.first.

Add an empty list guard to skip persons with no available files, consistent with the existing isIgnored check pattern.
