### PR TITLE
[mob][photos] Add file type filter and lower threshold for large files section

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/gallery/large_files_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/large_files_page.dart
@@ -6,10 +6,12 @@ import 'package:photos/events/files_updated_event.dart';
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
+import "package:photos/models/file/file_type.dart";
 import 'package:photos/models/file_load_result.dart';
 import 'package:photos/models/gallery_type.dart';
 import 'package:photos/models/selected_files.dart';
 import "package:photos/services/search_service.dart";
+import "package:photos/theme/ente_theme.dart";
 import 'package:photos/ui/viewer/actions/file_selection_overlay_bar.dart';
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
 import 'package:photos/ui/viewer/gallery/gallery.dart';
@@ -18,12 +20,18 @@ import "package:photos/ui/viewer/gallery/state/gallery_boundaries_provider.dart"
 import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
+enum LargeFileFilter {
+  all,
+  photos,
+  videos,
+}
+
 class LargeFilesPagePage extends StatefulWidget {
   final String tagPrefix;
   final GalleryType appBarType;
   final GalleryType overlayType;
   final _selectedFiles = SelectedFiles();
-  static const int minLargeFileSize = 50 * 1024 * 1024;
+  static const int minLargeFileSize = 10 * 1024 * 1024;
 
   LargeFilesPagePage({
     this.tagPrefix = "Uncategorized_page",
@@ -37,9 +45,32 @@ class LargeFilesPagePage extends StatefulWidget {
 }
 
 class _LargeFilesPagePageState extends State<LargeFilesPagePage> {
+  LargeFileFilter _currentFilter = LargeFileFilter.all;
+
+  bool _matchesFilter(EnteFile file) {
+    switch (_currentFilter) {
+      case LargeFileFilter.all:
+        return true;
+      case LargeFileFilter.photos:
+        return file.fileType == FileType.image ||
+            file.fileType == FileType.livePhoto;
+      case LargeFileFilter.videos:
+        return file.fileType == FileType.video;
+    }
+  }
+
+  void _onFilterChanged(LargeFileFilter filter) {
+    if (_currentFilter != filter) {
+      setState(() {
+        _currentFilter = filter;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final gallery = Gallery(
+      key: ValueKey(_currentFilter),
       asyncLoader: (creationStartTime, creationEndTime, {limit, asc}) async {
         final List<EnteFile> allFiles =
             await SearchService.instance.getAllFilesForSearch();
@@ -50,7 +81,8 @@ class _LargeFilesPagePageState extends State<LargeFilesPagePage> {
           if (file.isOwner &&
               file.isUploaded &&
               file.fileSize != null &&
-              file.fileSize! > LargeFilesPagePage.minLargeFileSize) {
+              file.fileSize! > LargeFilesPagePage.minLargeFileSize &&
+              _matchesFilter(file)) {
             if (!alreadyTracked.contains(file.uploadedFileID!)) {
               filesWithSize.add(file);
               alreadyTracked.add(file.uploadedFileID!);
@@ -81,9 +113,12 @@ class _LargeFilesPagePageState extends State<LargeFilesPagePage> {
     return GalleryBoundariesProvider(
       child: GalleryFilesState(
         child: Scaffold(
-          appBar: const PreferredSize(
-            preferredSize: Size.fromHeight(50.0),
-            child: _LargeFilesAppBar(),
+          appBar: PreferredSize(
+            preferredSize: const Size.fromHeight(100.0),
+            child: _LargeFilesAppBar(
+              currentFilter: _currentFilter,
+              onFilterChanged: _onFilterChanged,
+            ),
           ),
           body: SelectionState(
             selectedFiles: widget._selectedFiles,
@@ -105,7 +140,13 @@ class _LargeFilesPagePageState extends State<LargeFilesPagePage> {
 }
 
 class _LargeFilesAppBar extends StatefulWidget {
-  const _LargeFilesAppBar();
+  final LargeFileFilter currentFilter;
+  final ValueChanged<LargeFileFilter> onFilterChanged;
+
+  const _LargeFilesAppBar({
+    required this.currentFilter,
+    required this.onFilterChanged,
+  });
 
   @override
   State<_LargeFilesAppBar> createState() => _LargeFilesAppBarState();
@@ -126,6 +167,97 @@ class _LargeFilesAppBarState extends State<_LargeFilesAppBar>
               Theme.of(context).textTheme.headlineSmall!.copyWith(fontSize: 16),
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(50.0),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, right: 16, bottom: 8),
+            child: Row(
+              children: [
+                _FilterChip(
+                  label: AppLocalizations.of(context).all,
+                  isSelected: widget.currentFilter == LargeFileFilter.all,
+                  onTap: () => widget.onFilterChanged(LargeFileFilter.all),
+                ),
+                const SizedBox(width: 8),
+                _FilterChip(
+                  label: AppLocalizations.of(context).photos,
+                  icon: Icons.image,
+                  isSelected: widget.currentFilter == LargeFileFilter.photos,
+                  onTap: () => widget.onFilterChanged(LargeFileFilter.photos),
+                ),
+                const SizedBox(width: 8),
+                _FilterChip(
+                  label: AppLocalizations.of(context).videos,
+                  icon: Icons.videocam,
+                  isSelected: widget.currentFilter == LargeFileFilter.videos,
+                  onTap: () => widget.onFilterChanged(LargeFileFilter.videos),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  final String label;
+  final IconData? icon;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
+    final textTheme = getEnteTextTheme(context);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 32,
+        decoration: BoxDecoration(
+          color: isSelected ? colorScheme.primary500 : colorScheme.fillFaint,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color:
+                isSelected ? colorScheme.primary500 : colorScheme.strokeFaint,
+            width: 0.5,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(
+                  icon,
+                  size: 16,
+                  color: isSelected
+                      ? colorScheme.backgroundBase
+                      : colorScheme.textBase,
+                ),
+                const SizedBox(width: 4),
+              ],
+              Text(
+                label,
+                style: textTheme.miniBold.copyWith(
+                  color: isSelected
+                      ? colorScheme.backgroundBase
+                      : colorScheme.textBase,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: Large files section: add type filter, lower threshold to 10MB [QOL]
 - Neeraj: Jump to date when clicking on album from file info [QOL]
 - Neeraj: Add camera make/model search and filter by model [feature](https://github.com/ente-io/ente/discussions/5588)
 - Neeraj: Fixed order for [pinned albums](https://github.com/ente-io/ente/discussions/5979)


### PR DESCRIPTION
## Summary
- Add filter chips (All/Photos/Videos) to large files page
- Lower large file threshold from 50MB to 10MB

## Test plan
- Navigate to Settings → Free Up Space → View Large Files
- Verify filter chips appear and toggle correctly
- Confirm files under 10MB no longer appear