### PR TITLE
[mob][photos] Remove feature flags for admin role and suggest deletion

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1518,6 +1518,30 @@
     },
     "description": "Number of collaborators that were successfully added to an album."
   },
+  "adminsSuccessfullyAdded": "{count, plural, =0 {No admins were added} =1 {1 admin successfully added} other {{count} admins successfully added}}",
+  "@adminsSuccessfullyAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    },
+    "description": "Number of admins that were successfully added to an album."
+  },
+  "addAdmins": "{count, plural, =0 {Add admin} =1 {Add admin} other {Add admins}}",
+  "@addAdmins": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    },
+    "description": "Button text to add admins"
+  },
+  "adminsCanManagePhotosAndParticipants": "Admins can manage photos & participants.",
+  "suggestDeletion": "Suggest deletion",
+  "suggestDeletionDescription": "Selected photos will be removed from this album. Photo owners will also get a suggestion to review and delete the photos.",
+  "deleteSuggestionSent": "Delete suggestion sent",
   "accountIsAlreadyConfigured": "Account is already configured.",
   "sessionIdMismatch": "Session ID mismatch",
   "@sessionIdMismatch": {

--- a/mobile/apps/photos/lib/ui/sharing/add_participant_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/add_participant_page.dart
@@ -148,9 +148,9 @@ class _AddParticipantPage extends State<AddParticipantPage> {
                                 widget.actionTypesToShow.contains(
                                   ActionTypesToShow.addAdmin,
                                 )
-                                    ? const MenuSectionDescriptionWidget(
-                                        content:
-                                            '(i) Admins can manage photos & participants.',
+                                    ? MenuSectionDescriptionWidget(
+                                        content: AppLocalizations.of(context)
+                                            .adminsCanManagePhotosAndParticipants,
                                       )
                                     : const SizedBox.shrink(),
                               ],
@@ -345,7 +345,8 @@ class _AddParticipantPage extends State<AddParticipantPage> {
               ? ButtonType.primary
               : ButtonType.neutral,
           buttonSize: ButtonSize.large,
-          labelText: _adminActionLabel(_selectedEmails.length),
+          labelText: AppLocalizations.of(context)
+              .addAdmins(count: _selectedEmails.length),
           isDisabled: _selectedEmails.isEmpty,
           onTap: () async {
             final results = <bool>[];
@@ -365,7 +366,11 @@ class _AddParticipantPage extends State<AddParticipantPage> {
             }
 
             final successful = results.where((e) => e).length;
-            showToast(context, _adminSuccessMessage(successful));
+            showToast(
+              context,
+              AppLocalizations.of(context)
+                  .adminsSuccessfullyAdded(count: successful),
+            );
 
             if (!results.any((e) => e == false) && mounted) {
               Navigator.of(context).pop(true);
@@ -527,22 +532,7 @@ class _AddParticipantPage extends State<AddParticipantPage> {
       case ActionTypesToShow.addCollaborator:
         return AppLocalizations.of(context).addCollaborator;
       case ActionTypesToShow.addAdmin:
-        return _adminTitle();
+        return AppLocalizations.of(context).addAdmin;
     }
   }
-
-  String _adminActionLabel(int count) =>
-      count == 1 ? "(i) Add admin" : "(i) Add admins";
-
-  String _adminSuccessMessage(int count) {
-    if (count == 0) {
-      return "(i) No admins were added";
-    }
-    if (count == 1) {
-      return "(i) 1 admin successfully added";
-    }
-    return "(i) $count admins successfully added";
-  }
-
-  String _adminTitle() => "(i) Add admin";
 }

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -79,11 +79,6 @@ class _FileSelectionActionsWidgetState
   late FilesSplit split;
   late CollectionActions collectionActions;
   late bool isCollectionOwner;
-  static const String _suggestDeleteLabel = "(i) Suggest deletion";
-  static const String _suggestDeleteDialogTitle = "(i) Suggest deletion";
-  static const String _suggestDeleteDialogBody =
-      "(i) Selected photos will be removed from this album. Photo owners will also get a suggestion to review and delete the photos";
-  static const String _suggestDeleteSentMessage = "(i) Delete suggestion sent.";
   // _cachedCollectionForSharedLink is primarily used to avoid creating duplicate
   // links if user keeps on creating Create link button after selecting
   // few files. This link is reset on any selection changed;
@@ -160,11 +155,11 @@ class _FileSelectionActionsWidgetState
     final bool isCollectionOwnerOrAdmin = widget.collection != null &&
         (widget.collection!.isOwner(currentUserID) ||
             widget.collection!.isAdmin(currentUserID));
-    final bool canSuggestDeleteAction = flagService.enableDeleteSuggestion &&
+    final bool canSuggestDeleteAction =
         (widget.type == GalleryType.sharedCollection ||
-            widget.type == GalleryType.ownedCollection) &&
-        isCollectionOwnerOrAdmin &&
-        split.ownedByOtherUsers.isNotEmpty;
+                widget.type == GalleryType.ownedCollection) &&
+            isCollectionOwnerOrAdmin &&
+            split.ownedByOtherUsers.isNotEmpty;
 
     //To animate adding and removing of [SelectedActionButton], add all items
     //and set [shouldShow] to false for items that should not be shown and true
@@ -333,7 +328,7 @@ class _FileSelectionActionsWidgetState
         items.add(
           SelectionActionButton(
             icon: Icons.flag_outlined,
-            labelText: _suggestDeleteLabel,
+            labelText: AppLocalizations.of(context).suggestDeletion,
             onTap: _onSuggestDelete,
           ),
         );
@@ -670,14 +665,15 @@ class _FileSelectionActionsWidgetState
     if (filesToSuggest.isEmpty) {
       return;
     }
+    final l10n = AppLocalizations.of(context);
     final actionResult = await showActionSheet(
       context: context,
-      title: _suggestDeleteDialogTitle,
-      body: _suggestDeleteDialogBody,
+      title: l10n.suggestDeletion,
+      body: l10n.suggestDeletionDescription,
       actionSheetType: ActionSheetType.defaultActionSheet,
       buttons: [
         ButtonWidget(
-          labelText: _suggestDeleteLabel,
+          labelText: l10n.suggestDeletion,
           buttonType: ButtonType.neutral,
           buttonSize: ButtonSize.large,
           shouldStickToDarkTheme: true,
@@ -690,12 +686,12 @@ class _FileSelectionActionsWidgetState
             );
             showShortToast(
               context,
-              _suggestDeleteSentMessage,
+              l10n.deleteSuggestionSent,
             );
           },
         ),
         ButtonWidget(
-          labelText: AppLocalizations.of(context).cancel,
+          labelText: l10n.cancel,
           buttonType: ButtonType.secondary,
           buttonSize: ButtonSize.large,
           buttonAction: ButtonAction.second,

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -48,9 +48,6 @@ class FlagService {
     return (flags.internalUser || kDebugMode) && !isDisabled;
   }
 
-  bool get enableAdminRole => internalUser;
-  bool get enableDeleteSuggestion => internalUser;
-
   bool get betaUser => flags.betaUser;
 
   bool get internalOrBetaUser => internalUser || betaUser;
@@ -95,7 +92,6 @@ class FlagService {
   bool get manualTagFileToPerson => hasGrantedMLConsent;
 
   bool get enableShareePin => true;
-
 
   Future<void> tryRefreshFlags() async {
     try {

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: Admin Role + Suggest Delete feature
 - Neeraj: Large files section: add type filter, lower threshold to 10MB [QOL]
 - Neeraj: Jump to date when clicking on album from file info [QOL]
 - Neeraj: Add camera make/model search and filter by model [feature](https://github.com/ente-io/ente/discussions/5588)
@@ -6,4 +7,3 @@
 - Prateek: (i) Stop streaming if not 75% processed for upload and thermal change
 - Prateek(i): Stop streaming immediately on log-out
 - Prateek: (i) Add "Start with latest backups"  (last 7 days onwards)
-- Neeraj: (i) Admin Role + Suggest Delete feature


### PR DESCRIPTION
## Summary
- Remove internal-only feature flags for admin role and suggest deletion features
- Both features are now available to all users
- Move hardcoded strings to localization

## Test plan
- [ ] Test adding admin to a shared album
- [ ] Test suggest deletion action on photos owned by others in album