### PR TITLE
fix(icon-update): fix icon not updating on changing issuer

### DIFF
--- a/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
+++ b/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
@@ -433,11 +433,10 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
               CodeDisplay(tags: selectedTags);
       display.note = notes;
       if (widget.code != null) {
-        if (widget.code!.issuer != issuer) {
-          display.iconID = issuer.toLowerCase();
-        }
         if (widget.code!.display.iconID != _customIconID.toLowerCase()) {
           display.iconID = _customIconID.toLowerCase();
+        } else if (widget.code!.issuer != issuer) {
+          display.iconID = issuer.toLowerCase();
         }
       }
 


### PR DESCRIPTION
* fix icon not updating on changing issuer

there were two contradicting if conditions
issue link : https://github.com/ente-io/ente/issues/8561

before issuer XYZ
<img width="1344" height="2992" alt="Screenshot_1767604691" src="https://github.com/user-attachments/assets/1a218398-f610-47ef-84d9-3cd8483e8df0" />
renamed to google
<img width="1344" height="2992" alt="Screenshot_1767604820" src="https://github.com/user-attachments/assets/1cad4b76-276b-4abb-a740-afa1b8040ec7" />
