### PR TITLE
[server] Mask email domain in public collection participants

### DIFF
--- a/server/pkg/controller/public/comments.go
+++ b/server/pkg/controller/public/comments.go
@@ -178,7 +178,7 @@ func (c *CommentsController) Participants(ctx context.Context, collectionID int6
 		}
 		participants = append(participants, participant{
 			UserID:      id,
-			EmailMasked: emailUtil.GetMaskedEmail(user.Email),
+			EmailMasked: emailUtil.GetMaskedEmailForPublic(user.Email),
 		})
 	}
 	// Sort by userID for consistent ordering

--- a/server/pkg/utils/email/email.go
+++ b/server/pkg/utils/email/email.go
@@ -354,6 +354,43 @@ func GetMaskedEmail(email string) string {
 	}
 }
 
+// GetMaskedEmailForPublic masks an email for public display.
+// Format: first 2 chars of username + masked remainder + @ + first char of domain + masked middle + last char of domain
+func GetMaskedEmailForPublic(email string) string {
+	email = strings.TrimSpace(email)
+	at := strings.LastIndex(email, "@")
+	if at <= 0 || at == len(email)-1 {
+		return "[invalid_email]"
+	}
+	username := email[:at]
+	domain := email[at+1:]
+
+	maskedUsername := maskForPublicUsername(username)
+	maskedDomain := maskForPublicDomain(domain)
+
+	return maskedUsername + "@" + maskedDomain
+}
+
+// maskForPublicUsername masks a username keeping the first 2 runes visible.
+// Remaining runes are replaced with asterisks.
+func maskForPublicUsername(s string) string {
+	runes := []rune(s)
+	if len(runes) <= 2 {
+		return s
+	}
+	return string(runes[:2]) + strings.Repeat("*", len(runes)-2)
+}
+
+// maskForPublicDomain masks a domain showing first and last rune.
+// Middle runes are replaced with asterisks.
+func maskForPublicDomain(domain string) string {
+	runes := []rune(domain)
+	if len(runes) <= 2 {
+		return domain
+	}
+	return string(runes[0]) + strings.Repeat("*", len(runes)-2) + string(runes[len(runes)-1])
+}
+
 // GetMaskedEmailWithHint masks both the username and non-TLD domain segments while keeping helpful hints.
 func GetMaskedEmailWithHint(email string) string {
 	email = strings.TrimSpace(email)

--- a/server/pkg/utils/email/email_test.go
+++ b/server/pkg/utils/email/email_test.go
@@ -1,0 +1,98 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMaskedEmailForPublic(t *testing.T) {
+	tests := []struct {
+		name     string
+		email    string
+		expected string
+	}{
+		{
+			name:     "standard email",
+			email:    "john@example.io",
+			expected: "jo**@e********o",
+		},
+		{
+			name:     "gmail address",
+			email:    "john.doe@gmail.com",
+			expected: "jo******@g*******m",
+		},
+		{
+			name:     "short username 2 chars",
+			email:    "ab@example.com",
+			expected: "ab@e*********m",
+		},
+		{
+			name:     "short username 1 char",
+			email:    "a@example.com",
+			expected: "a@e*********m",
+		},
+		{
+			name:     "short domain 2 chars",
+			email:    "test@ab",
+			expected: "te**@ab",
+		},
+		{
+			name:     "short domain 1 char",
+			email:    "test@a",
+			expected: "te**@a",
+		},
+		{
+			name:     "email with spaces trimmed",
+			email:    "  user@domain.com  ",
+			expected: "us**@d********m",
+		},
+		{
+			name:     "invalid email no @",
+			email:    "invalidemail",
+			expected: "[invalid_email]",
+		},
+		{
+			name:     "invalid email @ at start",
+			email:    "@domain.com",
+			expected: "[invalid_email]",
+		},
+		{
+			name:     "invalid email @ at end",
+			email:    "user@",
+			expected: "[invalid_email]",
+		},
+		{
+			name:     "empty string",
+			email:    "",
+			expected: "[invalid_email]",
+		},
+		{
+			name:     "long username and domain",
+			email:    "verylongusername@verylongdomain.org",
+			expected: "ve**************@v****************g",
+		},
+		{
+			name:     "unicode username",
+			email:    "用户名@example.com",
+			expected: "用户*@e*********m",
+		},
+		{
+			name:     "unicode domain",
+			email:    "test@例え.jp",
+			expected: "te**@例***p",
+		},
+		{
+			name:     "mixed unicode",
+			email:    "日本語@ドメイン.jp",
+			expected: "日本*@ド*****p",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMaskedEmailForPublic(tt.email)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Previously, the public collection participants endpoint was exposing the full email domain (e.g., `******@gmail.com`)
- Now masks both username and domain: first 2 chars of username + `***` + `@` + first char of domain + `***` + last char
- Example: `john@gmail.com` → `jo**@g*******m`

## Changes
- Added `GetMaskedEmailForPublic` function in `pkg/utils/email/email.go`
- Updated `Participants` method in `pkg/controller/public/comments.go` to use the new masking
- Added tests for the new masking function