### PR TITLE
[docs] Document admin role, suggest deletion, and delete suggestions features

### DIFF
--- a/docs/docs/photos/faq/albums-and-organization.md
+++ b/docs/docs/photos/faq/albums-and-organization.md
@@ -392,12 +392,14 @@ If you want to delete a photo from Ente, you must do it manually within the Ente
 
 ### What happens to deleted photos in collaborative albums? {#collaborative-deletion}
 
-In collaborative albums:
+In collaborative albums, deletion permissions depend on your role:
 
+- **If you're a viewer**: You cannot delete any photos from the album.
 - **If you're a collaborator**: You can only delete photos that you uploaded. When you delete a photo you uploaded, it goes to your trash.
-- **If you're the album owner**: You can remove any photos from the album, but you can only permanently delete photos you own. Other collaborators' photos will be removed from the album but remain in their accounts.
+- **If you're an admin**: You can remove any photo from the album (including photos uploaded by others), but you can only permanently delete photos you own. Other participants' photos will be removed from the album but remain in their accounts. You can also [suggest deletion](/photos/faq/sharing-and-collaboration#suggest-deletion) for photos owned by others.
+- **If you're the album owner**: You have all admin permissions, plus you can manage link settings and delete the album.
 
-When a collaborator leaves or is removed from a shared album, any photos they uploaded are also removed from that album.
+When a participant leaves or is removed from a shared album, any photos they uploaded are also removed from that album.
 
 ### Can I recover photos after deleting my account? {#recover-after-account-deletion}
 
@@ -432,8 +434,10 @@ All selected photos will be moved to trash together.
 You may not be able to delete photos if:
 
 - They are owned by someone else who shared them with you
-- You don't have permission (you're a viewer, not a collaborator or owner)
+- You don't have permission (you're a viewer or collaborator trying to delete others' photos)
 - There's a sync issue - try refreshing or restarting the app
+
+If you're an admin or owner and want to remove photos that others uploaded, you can remove them from the album or use [suggest deletion](/photos/faq/sharing-and-collaboration#suggest-deletion).
 
 If you still can't delete photos you own, contact [support@ente.io](mailto:support@ente.io).
 

--- a/docs/docs/photos/faq/sharing-and-collaboration.md
+++ b/docs/docs/photos/faq/sharing-and-collaboration.md
@@ -17,7 +17,7 @@ Share directly with specific people who have Ente accounts:
 
 - Invite by email address
 - Recipients need an Ente account
-- Choose Viewer or Collaborator permissions
+- Choose Viewer, Collaborator, or Admin permissions
 - Each photo's storage counts towards whoever uploaded it
 - Perfect for ongoing collaboration with family and friends
 
@@ -126,7 +126,7 @@ Ente has shared albums but does not support sharing your entire library in one c
 1. Open the album you want to share
 2. Tap/click the Share icon
 3. Select "Share with Ente users" or enter email addresses
-4. Choose permissions (Viewer or Collaborator)
+4. Choose permissions (Viewer, Collaborator, or Admin)
 5. Send the invitation
 
 The recipient will receive a notification and can access the shared album from their Ente app. They must have an Ente account to receive shared albums.
@@ -151,23 +151,29 @@ Learn more: [Collaboration guide](/photos/features/sharing-and-collaboration/col
 
 Permissions depend on your role:
 
+**Viewers can:**
+
+- View all photos in the album
+- Download photos
+- Add photos to their own albums (creates a copy)
+
 **Collaborators can:**
 
+- Everything viewers can do, plus:
 - Add photos to the shared album
 - Delete photos they uploaded themselves
-- View all photos in the album
 
-**Collaborators cannot:**
+**Admins can:**
 
-- Delete photos uploaded by others
-- Delete the album itself
-- Change album settings or permissions
+- Everything collaborators can do, plus:
+- Remove any photo from the album (including photos uploaded by others)
+- Add or remove participants (as Admin, Collaborator, or Viewer)
+- Suggest deletion for photos owned by others
 
 **Album owner can:**
 
-- Remove any photos from the album
-- Only permanently delete photos they own
-- Remove or change permissions for collaborators
+- Everything admins can do, plus:
+- Manage link settings (passwords, expiry, device limits)
 - Delete the entire album
 
 ### What happens when I remove a collaborator from an album? {#remove-collaborator}
@@ -190,6 +196,114 @@ When a collaborator is removed from a shared album (or when they leave the album
 
 - Can be created on all platforms (mobile, web, desktop)
 - Anyone with the link can add photos via web browser
+
+### What can admins do in shared albums? {#admin-permissions}
+
+Admins have elevated permissions that help them manage shared albums:
+
+**Admins can:**
+
+- Everything collaborators can do (view, add photos)
+- Remove any photo from the album (including photos uploaded by others)
+- Add or remove participants (as Admin, Collaborator, or Viewer)
+- Suggest deletion for photos owned by others
+
+**Admins cannot:**
+
+- Manage link settings (passwords, expiry, device limits)
+- Delete the album itself
+- Permanently delete photos they don't own
+
+Admins are ideal for trusted participants who help curate and manage the album, such as family members or event co-organizers.
+
+Learn more: [Collaboration guide](/photos/features/sharing-and-collaboration/collaboration#permissions-explained)
+
+### How do I add someone as an admin? {#add-admin}
+
+1. Open the album you want to share
+2. Tap/click the Share icon
+3. Enter the person's email address
+4. Select "Admin" as the permission level
+5. Send the invitation
+
+You can also change an existing participant's role to Admin by opening the album's sharing settings and updating their permissions.
+
+### What's the difference between admin and collaborator? {#admin-vs-collaborator}
+
+| Permission | Collaborator | Admin |
+| --- | --- | --- |
+| View and download photos | ✓ | ✓ |
+| Add photos to album | ✓ | ✓ |
+| Remove own photos | ✓ | ✓ |
+| Remove any photo | ✗ | ✓ |
+| Manage participants | ✗ | ✓ |
+| Suggest deletion | ✗ | ✓ |
+| Manage link settings | ✗ | ✗ |
+
+Use **Collaborator** for participants who should only add and view photos. Use **Admin** for trusted participants who help manage the album.
+
+### Can admins manage link settings? {#admin-link-settings}
+
+No, only the album owner can manage link settings (passwords, expiry, device limits). Admins can manage participants and photos, but cannot change link settings or delete the album.
+
+### What is suggest deletion? {#suggest-deletion}
+
+Suggest deletion allows album owners and admins to suggest that other participants delete their photos from shared albums.
+
+**How it works:**
+
+1. Open a shared album where you are owner or admin
+2. Select photos owned by other participants
+3. Tap the suggest deletion action
+4. Confirm the suggestion
+
+**What happens:**
+
+- Photos are immediately removed from the album
+- Photo owners receive the suggestion in their Delete Suggestions queue
+- Photo owners can accept (delete) or reject (keep) each suggestion
+
+This is useful for curating shared albums after group trips or events by suggesting removal of blurry, duplicate, or unwanted shots.
+
+> **Note**: Suggest deletion is currently available on mobile apps only.
+
+Learn more: [Collaboration guide](/photos/features/sharing-and-collaboration/collaboration#suggest-deletion)
+
+### How do I suggest deleting photos in a shared album? {#use-suggest-deletion}
+
+**On mobile:**
+
+1. Open a shared album where you are owner or admin
+2. Select photos that belong to other participants
+3. Tap the suggest deletion action (flag icon)
+4. Confirm the suggestion
+
+The photos will be removed from the album immediately, and the photo owners will receive delete suggestions to review.
+
+> **Note**: Suggest deletion is currently available on mobile apps only.
+
+### How do I review delete suggestions? {#review-delete-suggestions}
+
+If album owners or admins suggest deleting your photos, you can review these suggestions:
+
+**On mobile:**
+
+Open `Settings > Backup > Free up space > Delete suggestions` to see photos suggested for deletion.
+
+For each suggestion, you can:
+
+- **Accept**: Move the photo to Trash (can be recovered within 30 days)
+- **Reject**: Keep the photo and dismiss the suggestion
+
+The photo was already removed from the shared album when the suggestion was made. Accepting deletes the photo from your account. Rejecting keeps it in your account (but not in the album).
+
+> **Note**: Delete suggestions is currently available on mobile apps only.
+
+Learn more: [Storage optimization guide](/photos/features/albums-and-organization/storage-optimization#delete-suggestions)
+
+### Is suggest deletion available on web? {#suggest-deletion-web}
+
+No, suggest deletion and reviewing delete suggestions are currently available on mobile apps (iOS and Android) only. We're working on adding this feature to web and desktop in the future.
 
 ### Why am I not getting notifications when photos are added to shared albums? {#shared-album-notifications}
 
@@ -391,14 +505,14 @@ Paid users can:
 
 ### Can I change permissions for collaborators after sharing? {#change-permissions}
 
-Yes, the album owner can change permissions at any time:
+Yes, the album owner or admins can change permissions at any time:
 
 1. Open the shared album
 2. Open sharing settings
-3. Find the collaborator
-4. Change their role from Collaborator to Viewer (or vice versa)
+3. Find the participant
+4. Change their role (Viewer, Collaborator, or Admin)
 
-Viewers can only view photos, while Collaborators can both view and add photos.
+Viewers can only view and download photos. Collaborators can also add photos. Admins can manage photos and participants.
 
 ### What happens to shared albums if I cancel my subscription? {#cancel-subscription-impact}
 

--- a/docs/docs/photos/features/albums-and-organization/deleting.md
+++ b/docs/docs/photos/features/albums-and-organization/deleting.md
@@ -170,22 +170,62 @@ Choose carefully based on whether you want to keep the photos or remove them ent
 
 ### Deleting from collaborative albums
 
-In collaborative albums, deletion permissions vary:
+In collaborative albums, deletion permissions vary by role:
+
+**If you're a viewer:**
+
+- You cannot delete any photos from the album
+- You can only view and download photos
 
 **If you're a collaborator:**
 
 - You can only delete photos that you uploaded
 - When you delete your photo, it goes to your trash
-- You cannot delete photos uploaded by other collaborators
+- You cannot delete photos uploaded by others
+
+**If you're an admin:**
+
+- You can remove any photo from the album (including photos uploaded by others)
+- You can only permanently delete photos you own
+- Other participants' photos will be removed from the album but remain in their accounts
+- You can suggest deletion for photos owned by others (see below)
 
 **If you're the album owner:**
 
-- You can remove any photos from the album
-- You can only permanently delete photos you own
-- Other collaborators' photos will be removed from the album but remain in their accounts
+- You have all admin permissions, plus:
+- You can manage link settings
+- You can delete the entire album
 
 **When someone leaves:**
-When a collaborator leaves or is removed from a shared album, any photos they uploaded are also removed from that album (but remain in their personal library).
+When a participant leaves or is removed from a shared album, any photos they uploaded are also removed from that album (but remain in their personal library).
+
+### Suggest deletion
+
+Album owners and admins can suggest that other participants delete their photos from shared albums. This helps curate shared albums while respecting photo ownership.
+
+**How suggest deletion works:**
+
+1. Open a shared album where you are owner or admin
+2. Select photos owned by other participants
+3. Tap the suggest deletion action
+4. Confirm the suggestion
+
+**What happens:**
+
+- Photos are immediately removed from the album
+- Photo owners receive the suggestion in their Delete Suggestions queue
+- Photo owners can review suggestions in `Settings > Backup > Free up space > Delete suggestions`
+- Photo owners can accept (delete) or reject (keep) each suggestion
+
+This is useful for:
+
+- Filtering blurry or duplicate photos after a group trip
+- Curating event albums by suggesting removal of low-quality shots
+- Helping participants identify photos they might want to delete
+
+> **Note**: Suggest deletion is currently available on mobile apps only.
+
+Learn more in the [collaboration guide](/photos/features/sharing-and-collaboration/collaboration#suggest-deletion).
 
 ### Shared photos
 
@@ -242,6 +282,8 @@ This prevents accidental deletion when reorganizing files on your computer. If y
 - [Can I delete photos that are shared with me?](/photos/faq/albums-and-organization#delete-shared-photos)
 - [Do deleted photos on my device also delete from Ente?](/photos/faq/albums-and-organization#device-deletion-sync)
 - [What happens to deleted photos in collaborative albums?](/photos/faq/albums-and-organization#collaborative-deletion)
+- [What is suggest deletion?](/photos/faq/sharing-and-collaboration#suggest-deletion)
+- [How do I review delete suggestions?](/photos/faq/sharing-and-collaboration#review-delete-suggestions)
 
 **Troubleshooting:**
 

--- a/docs/docs/photos/features/albums-and-organization/storage-optimization.md
+++ b/docs/docs/photos/features/albums-and-organization/storage-optimization.md
@@ -130,6 +130,45 @@ The similar images feature requires:
 
 Learn more about [Machine learning](/photos/features/search-and-discovery/machine-learning).
 
+## Delete suggestions
+
+If you participate in shared albums, album owners or admins may suggest that certain photos be deleted. These suggestions appear in your Delete Suggestions queue for you to review.
+
+### What are delete suggestions?
+
+When an album owner or admin wants to help curate a shared album, they can suggest that participants delete specific photos. This is common after group trips or events when someone helps filter out blurry, duplicate, or unwanted shots.
+
+When a suggestion is made:
+
+- The photo is removed from the shared album
+- You receive a delete suggestion to review
+- You decide whether to delete or keep the photo
+
+### Reviewing delete suggestions
+
+**On mobile:**
+
+Open `Settings > Backup > Free up space > Delete suggestions` to see photos that have been suggested for deletion.
+
+For each suggestion, you can:
+
+- **Accept**: Move the photo to Trash (can be recovered within 30 days)
+- **Reject**: Keep the photo and dismiss the suggestion
+
+### Why review suggestions?
+
+Accepting suggestions helps you:
+
+- Free up storage space
+- Remove photos you might have forgotten about
+- Keep your library clean based on feedback from album curators
+
+Rejecting suggestions keeps the photo in your account. The photo was already removed from the shared album when the suggestion was made.
+
+> **Note**: Delete suggestions is currently available on mobile apps only.
+
+Learn more about [suggest deletion](/photos/features/sharing-and-collaboration/collaboration#suggest-deletion) in the collaboration guide.
+
 ## Understanding storage in Ente
 
 **Cloud storage (your Ente quota):**
@@ -170,3 +209,4 @@ Learn more in [deletion feature guide](/photos/features/albums-and-organization/
 - [How can I remove duplicate photos?](/photos/faq/albums-and-organization#remove-duplicates)
 - [What's the difference between duplicates and similar images?](/photos/faq/albums-and-organization#duplicates-vs-similar)
 - [Does removing duplicates affect automatic duplicate detection?](/photos/faq/albums-and-organization#manual-vs-auto-dedup)
+- [How do I review delete suggestions?](/photos/faq/sharing-and-collaboration#review-delete-suggestions)

--- a/docs/docs/photos/features/sharing-and-collaboration/collaboration.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/collaboration.md
@@ -15,20 +15,20 @@ Collaborative albums allow multiple Ente users to contribute photos to the same 
 
 - **Album owner**: The person who created the album
 - **Participants**: Added by email address (must have Ente accounts)
-- **Permissions**: Owner can assign Viewer or Collaborator roles
+- **Permissions**: Owner can assign Viewer, Collaborator, or Admin roles
 - **Storage**: Each photo's storage counts towards whoever uploaded it
 
-### Adding collaborators
+### Adding participants
 
 1. Open the album you want to share
 2. Tap/click the Share icon
 3. Select "Share with Ente users" or enter email addresses
-4. Choose permissions (Viewer or Collaborator)
+4. Choose permissions (Viewer, Collaborator, or Admin)
 5. Send the invitation
 
 Recipients receive a notification and can access the shared album from their Ente app.
 
-Multiple albums can be selected (long press to select), and choosing Share > Add Collaborator will apply collaboration to all selected albums at once.
+Multiple albums can be selected (long press to select), and choosing Share will apply sharing to all selected albums at once.
 
 ### Permissions explained
 
@@ -45,14 +45,34 @@ Multiple albums can be selected (long press to select), and choosing Share > Add
 - Remove photos they uploaded
 - Comment and react (coming soon)
 
-**Album owners can:**
+**Admins can:**
 
 - Everything collaborators can do, plus:
-- Add or remove participants
-- Change permissions for existing participants
-- Remove any photo from the album
-- Delete photos they own
+- Remove any photo from the album (including photos uploaded by others)
+- Add or remove participants (as Admin, Collaborator, or Viewer)
+- Suggest deletion for photos owned by others
+
+**Admins cannot:**
+
+- Manage link settings (passwords, expiry, device limits)
+- Delete the album
+- Permanently delete photos they don't own
+
+**Album owners can:**
+
+- Everything admins can do, plus:
+- Manage link settings
 - Delete the entire album
+
+### When to use the Admin role
+
+Admins are ideal for trusted participants who help manage a shared album:
+
+- **Family albums**: Trusted family members who help curate and organize photos
+- **Group trip albums**: Someone who filters and removes duplicates or blurry photos after a trip
+- **Event albums**: A co-organizer who helps manage photos from weddings, parties, or gatherings
+
+Use Collaborator for participants who should only add and view photos without management responsibilities.
 
 ### Storage in collaborative albums
 
@@ -63,14 +83,37 @@ Storage is counted towards the person who uploaded each photo:
 - The album owner does not pay for photos uploaded by collaborators
 - Storage is only counted once, even if the photo appears in multiple albums
 
-### When collaborators leave
+### When participants leave
 
-When a collaborator is removed from a shared album (or when they leave voluntarily):
+When a participant is removed from a shared album (or when they leave voluntarily):
 
 - Any photos they uploaded will also be removed from the album
-- Those photos remain in the collaborator's own account
+- Those photos remain in the participant's own account
 - Photos uploaded by other participants remain in the album
-- The removed collaborator loses access to view the album
+- The removed participant loses access to view the album
+
+### Suggest deletion
+
+Album owners and admins can suggest that other participants delete their photos from shared albums. This is useful when curating a shared album after a group trip or event.
+
+**How it works:**
+
+1. Open a shared album where you are owner or admin
+2. Select photos owned by other participants
+3. Tap the suggest deletion action
+4. Confirm the suggestion
+
+**What happens:**
+
+- Photos are immediately removed from the album
+- Photo owners receive the suggestion in their Delete Suggestions queue
+- Photo owners can accept (delete) or reject (keep) each suggestion
+
+Photo owners can review delete suggestions in `Settings > Backup > Free up space > Delete suggestions`.
+
+Learn more in the [storage optimization guide](/photos/features/albums-and-organization/storage-optimization#delete-suggestions).
+
+> **Note**: Suggest deletion is currently available on mobile apps only.
 
 ### Platform availability
 
@@ -170,6 +213,9 @@ Currently, you cannot see who added which photos to a collect link. All collecte
 ## Related FAQs
 
 - [How do I share an album with other Ente users?](/photos/faq/sharing-and-collaboration#share-with-users)
+- [What can admins do in shared albums?](/photos/faq/sharing-and-collaboration#admin-permissions)
+- [What's the difference between admin and collaborator?](/photos/faq/sharing-and-collaboration#admin-vs-collaborator)
+- [What is suggest deletion?](/photos/faq/sharing-and-collaboration#suggest-deletion)
 - [Can people without Ente add photos to my album?](/photos/faq/sharing-and-collaboration#collect-without-account)
 - [Who pays for storage in collaborative albums?](/photos/faq/sharing-and-collaboration#collab-storage)
 - [Can collaborators delete photos?](/photos/faq/sharing-and-collaboration#collab-permissions)


### PR DESCRIPTION
## Summary

- Document the new Admin role for album sharing with permissions between Collaborator and Owner
- Document the Suggest Deletion feature for owners/admins to suggest photo deletions
- Document the Delete Suggestions review flow under Backup > Free up space

## Changes

### Features documented:
- **Admin role**: Elevated permissions to manage participants and remove any photo, but cannot manage link settings
- **Suggest deletion**: Owners/admins can suggest deletion of photos they don't own (mobile only)
- **Delete suggestions**: Photo owners can review suggestions under Settings > Backup > Free up space (mobile only)

### Files updated:
- `collaboration.md` - Admin permissions, use cases, suggest deletion section
- `deleting.md` - Role-based deletion permissions, suggest deletion feature
- `storage-optimization.md` - Delete suggestions review section
- `sharing-and-collaboration.md` (FAQ) - 9 new FAQs for admin and suggest deletion
- `albums-and-organization.md` (FAQ) - Updated collaborative deletion FAQ

## Test plan

- [ ] Verify docs build successfully with `yarn build`
- [ ] Review new sections render correctly
- [ ] Check all internal links work
- [ ] Verify FAQ anchor IDs are unique