### PR TITLE
[mob][auth] Fix notification permission dialog on startup

### DIFF
--- a/mobile/apps/auth/lib/services/notification_service.dart
+++ b/mobile/apps/auth/lib/services/notification_service.dart
@@ -23,17 +23,18 @@ class NotificationService {
     await _flutterLocalNotificationsPlugin.initialize(
       initializationSettings,
     );
-    final implementation =
-        _flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>();
-    if (implementation != null) {
-      await implementation.requestNotificationsPermission();
-    }
   }
 
   Future<void> showNotification(String title, String message) async {
     if (!Platform.isAndroid) {
       return;
+    }
+    final implementation =
+        _flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (implementation != null) {
+      final granted = await implementation.requestNotificationsPermission();
+      if (granted != true) return;
     }
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(


### PR DESCRIPTION
**Issue:** Notification permission dialog was appearing on splash screen during app startup.

**Fix:** Moved permission request from `init()` to `showNotification()` so it only triggers when an update notification is needed.