### PR TITLE
[mobile][auth] Fix keyboard not appearing on search bar auto-focus

### DIFF
--- a/mobile/apps/auth/lib/ui/custom_icon_page.dart
+++ b/mobile/apps/auth/lib/ui/custom_icon_page.dart
@@ -39,6 +39,15 @@ class _CustomIconPageState extends State<CustomIconPage> {
     _showSearchBox = _autoFocusSearch;
     searchBoxFocusNode = FocusNode();
     ServicesBinding.instance.keyboard.addHandler(_handleKeyEvent);
+
+    // Programmatically request focus after widget is built to ensure keyboard
+    // appears on all Android devices (autofocus alone is unreliable on some devices)
+    if (_autoFocusSearch) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        searchBoxFocusNode.requestFocus();
+      });
+    }
+
     super.initState();
   }
 

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -138,6 +138,14 @@ class _HomePageState extends State<HomePage> {
 
     searchBoxFocusNode = FocusNode();
     ServicesBinding.instance.keyboard.addHandler(_handleKeyEvent);
+
+    // Programmatically request focus after widget is built to ensure keyboard
+    // appears on all Android devices (autofocus alone is unreliable on some devices)
+    if (_autoFocusSearch) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        searchBoxFocusNode.requestFocus();
+      });
+    }
   }
 
   void _onAddTagPressed() {


### PR DESCRIPTION
On some Android devices (particularly Samsung keyboard), the TextField's autofocus property doesn't reliably trigger the soft keyboard to appear. This fix adds an explicit requestFocus() call after the widget tree is built, which reliably shows the keyboard on all devices.

Fixes #279

## Description

## Tests
