### PR TITLE
[auth] Fix flutter run by restoring MAIN/LAUNCHER intent-filter

### DIFF
--- a/mobile/apps/auth/android/app/src/main/AndroidManifest.xml
+++ b/mobile/apps/auth/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="io.ente.auth">
     <application android:name="${applicationName}"
                  android:label="Ente Auth"
                  android:icon="@mipmap/launcher_icon"
@@ -15,6 +16,11 @@
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
                   android:hardwareAccelerated="true"
                   android:windowSoftInputMode="adjustResize">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
## Problem
After the icon picker feature was added in f8953b66a1, `flutter run` started failing with "package identifier or launch activity not found" error.

## Root Cause
When the icon picker was implemented, two critical elements were removed from AndroidManifest.xml:
1. The `package` attribute in the manifest root element
2. The MAIN/LAUNCHER intent-filter from MainActivity (moved only to activity-aliases)

While activity-aliases work fine for installed apps, Flutter's development tooling specifically looks for the MAIN/LAUNCHER intent-filter in the main activity, not in aliases.

## Solution
Restore both missing elements to match the photos app implementation:
- Add `package="io.ente.auth"` to the manifest root
- Add MAIN/LAUNCHER intent-filter back to MainActivity (while keeping the activity-aliases for dynamic icon switching)

This brings the auth app's AndroidManifest.xml in line with the photos app, which correctly implements the same icon picker feature.

## Testing
- [x] Verified `flutter run` now works without specifying flavor
- [x] Confirmed app builds and runs successfully on Android device
- [x] Icon picker functionality remains intact (activity-aliases still present)
- [x] Matches the implementation pattern used in the photos app

## References
- Regression introduced in: f8953b66a1
- Photos app (correct implementation): mobile/apps/photos/android/app/src/main/AndroidManifest.xml