### PR TITLE
[server] Add required Date: header to emails

### DIFF
--- a/server/pkg/utils/email/email.go
+++ b/server/pkg/utils/email/email.go
@@ -15,6 +15,7 @@ import (
 	"net/smtp"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/ente-io/museum/ente"
 	"github.com/ente-io/stacktrace"
@@ -146,7 +147,8 @@ func sendViaSMTP(toEmails []string, fromName string, fromEmail string, subject s
 		emailAddresses += sanitizeHeaderValue(addr)
 	}
 
-	header := "From: " + cleanFromName + " <" + cleanFromEmail + ">\n" +
+	header :=  "Date: " + time.Now().Format(time.RFC1123Z) + "\n" +
+		"From: " + cleanFromName + " <" + cleanFromEmail + ">\n" +
 		"To: " + emailAddresses + "\n" +
 		"Subject: " + cleanSubject + "\n" +
 		"MIME-Version: 1.0\n" +


### PR DESCRIPTION
The `Date:` email header is actually required.

Emails without the `Date:` header may be considered malformed by some content scanners and not get delivered.

This adds a `Date:` header in the correct format to emails.

[RFC 5322 S3.6](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6)