### PR TITLE
[mob][photos] Fix settings menu tap responsiveness

### DIFF
--- a/mobile/apps/photos/lib/ui/components/menu_item_widget/menu_item_widget_new.dart
+++ b/mobile/apps/photos/lib/ui/components/menu_item_widget/menu_item_widget_new.dart
@@ -191,6 +191,8 @@ class _MenuItemWidgetNewState extends State<MenuItemWidgetNew> {
         executionStateNotifier.value == ExecutionState.successful) {
       return;
     }
+    final shouldSurfaceExecutionStates =
+        widget.surfaceExecutionStates || widget.alwaysShowSuccessState;
     _debouncer.run(
       () => Future(() {
         executionStateNotifier.value = ExecutionState.inProgress;
@@ -215,7 +217,7 @@ class _MenuItemWidgetNewState extends State<MenuItemWidgetNew> {
       return;
     }
     if (executionStateNotifier.value == ExecutionState.inProgress) {
-      if (widget.showOnlyLoadingState) {
+      if (widget.showOnlyLoadingState || !shouldSurfaceExecutionStates) {
         executionStateNotifier.value = ExecutionState.idle;
       } else {
         executionStateNotifier.value = ExecutionState.successful;


### PR DESCRIPTION
## Description
- Avoid lingering success state when execution states are not displayed, so menu items remain tappable on return to settings.
