### PR TITLE
[server] Prevent adding/moving trashed or deleted files to collections

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -366,6 +366,7 @@ func main() {
 		CollectionLinkCtrl:    collectionLinkCtrl,
 		UserRepo:              userRepo,
 		FileRepo:              fileRepo,
+		TrashRepo:             trashRepo,
 		CastRepo:              &castDb,
 		BillingCtrl:           billingController,
 		QueueRepo:             queueRepo,

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -225,6 +225,12 @@ var ErrLinkEditNotAllowed = ApiError{
 	HttpStatusCode: http.StatusForbidden,
 }
 
+var ErrFileInTrash = ApiError{
+	Code:           FileInTrash,
+	Message:        "One or more files are in trash or have been deleted, please restore them first",
+	HttpStatusCode: http.StatusConflict,
+}
+
 var ErrLockerRegistrationDisabled = &ApiError{
 	Code:           LockerRegistrationDisabled,
 	Message:        "Locker is restricted to paid users currently",
@@ -284,6 +290,9 @@ const (
 
 	// FileLimitReached indicates the user hit the maximum number of files allowed
 	FileLimitReached ErrorCode = "FILE_LIMIT_REACHED"
+
+	// FileInTrash indicates files are present in trash and cannot be added to collection
+	FileInTrash ErrorCode = "FILE_IN_TRASH"
 
 	SessionExpired ErrorCode = "SESSION_EXPIRED"
 

--- a/server/pkg/controller/collections/collection.go
+++ b/server/pkg/controller/collections/collection.go
@@ -35,6 +35,7 @@ type CollectionController struct {
 	UserRepo              *repo.UserRepository
 	FileRepo              *repo.FileRepository
 	QueueRepo             *repo.QueueRepository
+	TrashRepo             *repo.TrashRepository
 	CastRepo              *cast.Repository
 	TaskRepo              *repo.TaskLockRepository
 	CollectionActionsRepo *repo.CollectionActionsRepository


### PR DESCRIPTION
## Summary
- Add validation in AddFiles and MoveFiles endpoints to check if files are in trash (non-restored) or permanently deleted before allowing the operation
- Returns HTTP 409 Conflict with error code `FILE_IN_TRASH` if any files are in trash or deleted state

## Changes
- Add `TrashRepo` to `CollectionController`
- Add `GetFilesInTrashOrDeleted` method to `TrashRepository` - returns files where `is_restored = FALSE` (covers both trashed and deleted)
- Add `ErrFileInTrash` error type
- Update `AddFiles` and `MoveFiles` to validate files are not in trash/deleted state

## Test plan
- [ ] Test adding files to a collection - should work for normal files
- [ ] Test adding trashed files to a collection - should return FILE_IN_TRASH error
- [ ] Test moving files between collections - should work for normal files
- [ ] Test moving trashed files between collections - should return FILE_IN_TRASH error