### PR TITLE
Fix ToggleSwitchWidget not syncing with parent state

### DIFF
--- a/mobile/apps/photos/lib/ui/components/toggle_switch_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/toggle_switch_widget.dart
@@ -33,6 +33,17 @@ class _ToggleSwitchWidgetState extends State<ToggleSwitchWidget> {
   }
 
   @override
+  void didUpdateWidget(covariant ToggleSwitchWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newValue = widget.value.call();
+    if (toggleValue != newValue) {
+      setState(() {
+        toggleValue = newValue;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final enteColorScheme = Theme.of(context).colorScheme.enteTheme.colorScheme;
     final Widget stateIcon = _stateIcon(enteColorScheme);

--- a/mobile/packages/ui/lib/components/toggle_switch_widget.dart
+++ b/mobile/packages/ui/lib/components/toggle_switch_widget.dart
@@ -35,6 +35,17 @@ class _ToggleSwitchWidgetState extends State<ToggleSwitchWidget> {
   }
 
   @override
+  void didUpdateWidget(covariant ToggleSwitchWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newValue = widget.value.call();
+    if (toggleValue != newValue) {
+      setState(() {
+        toggleValue = newValue;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final enteColorScheme = getEnteColorScheme(context);
     final Widget stateIcon = _stateIcon(enteColorScheme);


### PR DESCRIPTION
## Summary
- Add `didUpdateWidget()` override to sync toggle value when parent rebuilds
- Fixes issue where toggle UI showed stale state when parent's state changed asynchronously

## Test plan
- Open Settings > App Lock
- Toggle app lock on/off
- Verify toggle state reflects actual setting after async initialization