### PR TITLE
[server] Pass gin.Context directly instead of ctx.Request.Context()

### DIFF
--- a/server/pkg/api/public_comments.go
+++ b/server/pkg/api/public_comments.go
@@ -278,7 +278,7 @@ func (h *PublicCommentsHandler) Participants(c *gin.Context) {
 	}
 	collectionID := auth.MustGetPublicAccessContext(c).CollectionID
 	// ignore includeSharees flag for now
-	participants, err := h.CommentsCtrl.Participants(c.Request.Context(), collectionID)
+	participants, err := h.CommentsCtrl.Participants(c, collectionID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/api/social.go
+++ b/server/pkg/api/social.go
@@ -90,7 +90,7 @@ func (h *SocialHandler) Counts(c *gin.Context) {
 		handler.Error(c, ente.ErrAuthenticationRequired)
 		return
 	}
-	counts, err := h.Controller.CountActiveCollections(c.Request.Context(), userID)
+	counts, err := h.Controller.CountActiveCollections(c, userID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -105,7 +105,7 @@ func (h *SocialHandler) LatestUpdates(c *gin.Context) {
 		return
 	}
 	app := auth.GetApp(c)
-	updates, err := h.Controller.LatestUpdates(c.Request.Context(), userID, app)
+	updates, err := h.Controller.LatestUpdates(c, userID, app)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -135,4 +135,3 @@ func (h *SocialHandler) AnonProfiles(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"profiles": profiles})
 }
-

--- a/server/pkg/controller/appstore.go
+++ b/server/pkg/controller/appstore.go
@@ -124,7 +124,7 @@ func (c *AppStoreController) HandleNotification(ctx *gin.Context, notification a
 		return stacktrace.Propagate(err, "")
 	}
 
-	if err := c.validateSandboxRequest(ctx.Request.Context(), string(notification.Environment), subscription.UserID,
+	if err := c.validateSandboxRequest(ctx, string(notification.Environment), subscription.UserID,
 		fmt.Sprintf("notification (type: %s)", notification.NotificationType)); err != nil {
 		return err
 	}

--- a/server/pkg/controller/collections/share.go
+++ b/server/pkg/controller/collections/share.go
@@ -146,7 +146,7 @@ func (c *CollectionController) UnShare(ctx *gin.Context, cID int64, fromUserID i
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
-	if err := c.removeUserSocialActivity(ctx.Request.Context(), cID, toUserID); err != nil {
+	if err := c.removeUserSocialActivity(ctx, cID, toUserID); err != nil {
 		return nil, err
 	}
 	err = c.CastRepo.RevokeForGivenUserAndCollection(ctx, cID, toUserID)
@@ -185,7 +185,7 @@ func (c *CollectionController) Leave(ctx *gin.Context, cID int64) error {
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	if err := c.removeUserSocialActivity(ctx.Request.Context(), cID, userID); err != nil {
+	if err := c.removeUserSocialActivity(ctx, cID, userID); err != nil {
 		return err
 	}
 	return nil

--- a/server/pkg/controller/public/anon_identity.go
+++ b/server/pkg/controller/public/anon_identity.go
@@ -47,7 +47,7 @@ func (c *AnonIdentityController) Create(ctx *gin.Context, req CreateAnonIdentity
 		return AnonIdentityResponse{}, stacktrace.Propagate(err, "")
 	}
 	anonID := fmt.Sprintf("anon_%s", rawID)
-	if err := c.AnonUsersRepo.Insert(ctx.Request.Context(), socialentity.AnonUser{
+	if err := c.AnonUsersRepo.Insert(ctx, socialentity.AnonUser{
 		ID:           anonID,
 		CollectionID: req.CollectionID,
 		Cipher:       req.Cipher,

--- a/server/pkg/controller/public/comments.go
+++ b/server/pkg/controller/public/comments.go
@@ -75,7 +75,7 @@ func (c *CommentsController) CreateComment(ctx *gin.Context, collectionID int64,
 	if err != nil {
 		return "", err
 	}
-	if err := ensureAnonUserForCollection(ctx.Request.Context(), c.AnonUsersRepo, collectionID, actor); err != nil {
+	if err := ensureAnonUserForCollection(ctx, c.AnonUsersRepo, collectionID, actor); err != nil {
 		return "", err
 	}
 	createReq := socialcontroller.CreateCommentRequest{
@@ -108,7 +108,7 @@ func (c *CommentsController) UpdateComment(ctx *gin.Context, collectionID int64,
 	if err != nil {
 		return err
 	}
-	if err := ensureAnonUserForCollection(ctx.Request.Context(), c.AnonUsersRepo, collectionID, actor); err != nil {
+	if err := ensureAnonUserForCollection(ctx, c.AnonUsersRepo, collectionID, actor); err != nil {
 		return err
 	}
 	updateReq := socialcontroller.UpdateCommentRequest{
@@ -133,7 +133,7 @@ func (c *CommentsController) DeleteComment(ctx *gin.Context, collectionID int64,
 	if err != nil {
 		return err
 	}
-	if err := ensureAnonUserForCollection(ctx.Request.Context(), c.AnonUsersRepo, collectionID, actor); err != nil {
+	if err := ensureAnonUserForCollection(ctx, c.AnonUsersRepo, collectionID, actor); err != nil {
 		return err
 	}
 	return c.deleteCommentWithActor(ctx, commentID, actor, false)
@@ -192,7 +192,7 @@ func (c *CommentsController) ListAnonProfiles(ctx *gin.Context, collectionID int
 	if err := ensureCommentsFeatureEnabled(ctx); err != nil {
 		return nil, err
 	}
-	return c.AnonUsersRepo.ListByCollection(ctx.Request.Context(), collectionID)
+	return c.AnonUsersRepo.ListByCollection(ctx, collectionID)
 }
 
 func ensureCommentsFeatureEnabled(ctx *gin.Context) error {

--- a/server/pkg/controller/public/reactions.go
+++ b/server/pkg/controller/public/reactions.go
@@ -46,7 +46,7 @@ func (c *ReactionsController) UpsertReaction(ctx *gin.Context, collectionID int6
 	if err != nil {
 		return "", err
 	}
-	if err := ensureAnonUserForCollection(ctx.Request.Context(), c.AnonUsersRepo, collectionID, actor); err != nil {
+	if err := ensureAnonUserForCollection(ctx, c.AnonUsersRepo, collectionID, actor); err != nil {
 		return "", err
 	}
 	upsertReq := socialcontroller.UpsertReactionRequest{
@@ -70,7 +70,7 @@ func (c *ReactionsController) DeleteReaction(ctx *gin.Context, collectionID int6
 	if err != nil {
 		return err
 	}
-	if err := ensureAnonUserForCollection(ctx.Request.Context(), c.AnonUsersRepo, collectionID, actor); err != nil {
+	if err := ensureAnonUserForCollection(ctx, c.AnonUsersRepo, collectionID, actor); err != nil {
 		return err
 	}
 	deleteReq := socialcontroller.ReactionDeleteRequest{

--- a/server/pkg/controller/social/comments_controller.go
+++ b/server/pkg/controller/social/comments_controller.go
@@ -85,7 +85,7 @@ func (c *CommentsController) Create(ctx *gin.Context, req CreateCommentRequest) 
 
 	var parentComment *socialentity.Comment
 	if req.ParentCommentID != nil {
-		parentComment, err = c.Repo.GetByID(ctx.Request.Context(), *req.ParentCommentID)
+		parentComment, err = c.Repo.GetByID(ctx, *req.ParentCommentID)
 		if err != nil {
 			return "", stacktrace.Propagate(err, "")
 		}
@@ -119,7 +119,7 @@ func (c *CommentsController) Create(ctx *gin.Context, req CreateCommentRequest) 
 	if len(req.Nonce) > 0 {
 		comment.Nonce = req.Nonce
 	}
-	if err := c.Repo.Insert(ctx.Request.Context(), comment); err != nil {
+	if err := c.Repo.Insert(ctx, comment); err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}
 	return comment.ID, nil
@@ -139,7 +139,7 @@ func (c *CommentsController) Diff(ctx *gin.Context, req CommentDiffRequest) ([]s
 			return nil, false, stacktrace.Propagate(err, "")
 		}
 	}
-	return c.Repo.GetDiff(ctx.Request.Context(), req.CollectionID, req.Since, req.Limit, req.FileID)
+	return c.Repo.GetDiff(ctx, req.CollectionID, req.Since, req.Limit, req.FileID)
 }
 
 // UpdatePayload edits the encrypted payload of a comment.
@@ -148,7 +148,7 @@ func (c *CommentsController) UpdatePayload(ctx *gin.Context, req UpdateCommentRe
 		return ente.ErrBadRequest
 	}
 	userID, hasUserID := req.Actor.UserIDValue()
-	comment, err := c.Repo.GetByID(ctx.Request.Context(), req.CommentID)
+	comment, err := c.Repo.GetByID(ctx, req.CommentID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -162,13 +162,13 @@ func (c *CommentsController) UpdatePayload(ctx *gin.Context, req UpdateCommentRe
 	} else if !hasUserID || comment.UserID != userID {
 		return stacktrace.Propagate(ente.ErrPermissionDenied, "")
 	}
-	return c.Repo.UpdateCipher(ctx.Request.Context(), req.CommentID, req.Cipher, req.Nonce)
+	return c.Repo.UpdateCipher(ctx, req.CommentID, req.Cipher, req.Nonce)
 }
 
 // Delete removes a comment if the actor is allowed to do so.
 func (c *CommentsController) Delete(ctx *gin.Context, req DeleteCommentRequest) error {
 	userID, hasUserID := req.Actor.UserIDValue()
-	comment, err := c.Repo.GetByID(ctx.Request.Context(), req.CommentID)
+	comment, err := c.Repo.GetByID(ctx, req.CommentID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -205,7 +205,7 @@ func (c *CommentsController) Delete(ctx *gin.Context, req DeleteCommentRequest) 
 			}
 		}
 	}
-	return c.Repo.SoftDelete(ctx.Request.Context(), req.CommentID)
+	return c.Repo.SoftDelete(ctx, req.CommentID)
 }
 
 func validateReplyFileContext(parent *socialentity.Comment, requestedFileID *int64) error {

--- a/server/pkg/controller/social/controller.go
+++ b/server/pkg/controller/social/controller.go
@@ -69,11 +69,11 @@ func (c *Controller) UnifiedDiff(ctx *gin.Context, req UnifiedDiffRequest) ([]so
 			return nil, nil, false, false, stacktrace.Propagate(err, "")
 		}
 	}
-	comments, moreComments, err := c.CommentsRepo.GetDiff(ctx.Request.Context(), req.CollectionID, req.CommentsSince, req.Limit, req.FileID)
+	comments, moreComments, err := c.CommentsRepo.GetDiff(ctx, req.CollectionID, req.CommentsSince, req.Limit, req.FileID)
 	if err != nil {
 		return nil, nil, false, false, stacktrace.Propagate(err, "")
 	}
-	reactions, moreReactions, err := c.ReactionsRepo.GetDiff(ctx.Request.Context(), req.CollectionID, req.ReactionsSince, req.Limit, req.FileID, nil)
+	reactions, moreReactions, err := c.ReactionsRepo.GetDiff(ctx, req.CollectionID, req.ReactionsSince, req.Limit, req.FileID, nil)
 	if err != nil {
 		return nil, nil, false, false, stacktrace.Propagate(err, "")
 	}
@@ -243,6 +243,5 @@ func (c *Controller) ListAnonProfiles(ctx *gin.Context, req AnonProfilesRequest)
 			return nil, stacktrace.Propagate(err, "")
 		}
 	}
-	return c.AnonUsersRepo.ListByCollection(ctx.Request.Context(), req.CollectionID)
+	return c.AnonUsersRepo.ListByCollection(ctx, req.CollectionID)
 }
-

--- a/server/pkg/controller/social/reactions_controller.go
+++ b/server/pkg/controller/social/reactions_controller.go
@@ -78,7 +78,7 @@ func (c *ReactionsController) Upsert(ctx *gin.Context, req UpsertReactionRequest
 
 	var targetComment *socialentity.Comment
 	if req.CommentID != nil {
-		targetComment, err = c.CommentsRepo.GetByID(ctx.Request.Context(), *req.CommentID)
+		targetComment, err = c.CommentsRepo.GetByID(ctx, *req.CommentID)
 		if err != nil {
 			return "", stacktrace.Propagate(err, "")
 		}
@@ -112,7 +112,7 @@ func (c *ReactionsController) Upsert(ctx *gin.Context, req UpsertReactionRequest
 		// file_id to validate that the caller has consistent context.
 		reaction.FileID = nil
 	}
-	id, err := c.Repo.Upsert(ctx.Request.Context(), reaction)
+	id, err := c.Repo.Upsert(ctx, reaction)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}
@@ -133,13 +133,13 @@ func (c *ReactionsController) Diff(ctx *gin.Context, req ReactionDiffRequest) ([
 			return nil, false, stacktrace.Propagate(err, "")
 		}
 	}
-	return c.Repo.GetDiff(ctx.Request.Context(), req.CollectionID, req.Since, req.Limit, req.FileID, req.CommentID)
+	return c.Repo.GetDiff(ctx, req.CollectionID, req.Since, req.Limit, req.FileID, req.CommentID)
 }
 
 // Delete removes a reaction if the actor owns it.
 func (c *ReactionsController) Delete(ctx *gin.Context, req ReactionDeleteRequest) error {
 	userID, hasUserID := req.Actor.UserIDValue()
-	reaction, err := c.Repo.GetByID(ctx.Request.Context(), req.ReactionID)
+	reaction, err := c.Repo.GetByID(ctx, req.ReactionID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -168,7 +168,7 @@ func (c *ReactionsController) Delete(ctx *gin.Context, req ReactionDeleteRequest
 	if hasUserID {
 		repoUserID = userID
 	}
-	return c.Repo.SoftDeleteByID(ctx.Request.Context(), req.ReactionID, repoUserID, req.Actor.AnonUserID)
+	return c.Repo.SoftDeleteByID(ctx, req.ReactionID, repoUserID, req.Actor.AnonUserID)
 }
 
 func validateCommentReactionContext(comment *socialentity.Comment, requestedFileID *int64) error {

--- a/server/pkg/middleware/collection_link.go
+++ b/server/pkg/middleware/collection_link.go
@@ -298,7 +298,7 @@ func (m *CollectionLinkMiddleware) attachAnonIdentity(c *gin.Context, collection
 		return ente.ErrAuthenticationRequired
 	}
 	if m.AnonUsersRepo != nil {
-		anonUser, err := m.AnonUsersRepo.GetByID(c.Request.Context(), anonID)
+		anonUser, err := m.AnonUsersRepo.GetByID(c, anonID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ente.ErrAuthenticationRequired


### PR DESCRIPTION
## Summary
- Refactors controller and middleware code to pass `*gin.Context` directly instead of extracting `ctx.Request.Context()`
- Ensures consistent context handling across social, public, and collection controllers

