### PR TITLE
[docs] Add more notes about pg configuration

### DIFF
--- a/docs/docs/self-hosting/installation/manual.md
+++ b/docs/docs/self-hosting/installation/manual.md
@@ -156,8 +156,6 @@ Values you used for `database name` and `username` correspond to the values you 
    you cloned the repository to `ente`:
 
    ```shell
-   # Change into the ente/server
-   cd ente/server
    # Generate secrets
    go run tools/gen-random-keys/main.go
    ```


### PR DESCRIPTION
## Description

PR adds info about needed configuration for PostgreSQL to run museum successfully

also, it removes duplicate `cd ente/server`