### PR TITLE
[mobile][photos] Remove webview redirect for trip layout public links

### DIFF
--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -53,7 +53,6 @@ import "package:photos/states/user_details_state.dart";
 import "package:photos/theme/colors.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/collections/collection_action_sheet.dart";
-import "package:photos/ui/common/web_page.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
 import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/extents_page_view.dart";
@@ -356,19 +355,6 @@ class _HomeWidgetState extends State<HomeWidget> {
       // Check for action=join parameter to show join dialog
       final shouldShowJoinDialog = uri.queryParameters['action'] == 'join' &&
           Configuration.instance.isLoggedIn();
-
-      // Check for trip layout and show in webview
-      if (collection.pubMagicMetadata.layout == "trip") {
-        await routeToPage(
-          context,
-          WebPage(
-            collection.displayName,
-            uri.toString(),
-            canOpenInBrowser: true,
-          ),
-        );
-        return;
-      }
 
       final dialog = createProgressDialog(context, "Loading...");
       final publicUrl = collection.publicURLs[0];


### PR DESCRIPTION
## Description

- Trip layout public links' web views via deep links don't fully work (the sign-up, join album, add photos buttons).
- Removing web views for trip layout albums.
- Proper fix would be implementing trip layout for shared albums, not just public albums.
