### PR TITLE
[mobile][photos] Reorganize settings page groups and update search suggestions

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
@@ -236,27 +236,32 @@ class SettingsSearchRegistry {
     final hasLoggedIn = Configuration.instance.isLoggedIn();
 
     return [
-      // App Icon suggestion
+      // Gallery suggestion
       SettingsSearchSuggestion(
-        title: l10n.appIcon,
-        onTap: () => onNavigate((_) => const AppearanceSettingsPage()),
+        title: l10n.gallery,
+        onTap: () => onNavigate(
+          (_) => const GallerySettingsScreen(
+            fromGalleryLayoutSettingsCTA: false,
+          ),
+        ),
       ),
       // App lock suggestion
       SettingsSearchSuggestion(
         title: l10n.appLock,
         onTap: () => onNavigate((_) => const SecuritySettingsPage()),
       ),
-      // Remove duplicates suggestion
+      // Free up device space suggestion
       if (hasLoggedIn)
         SettingsSearchSuggestion(
-          title: l10n.removeDuplicates,
+          title: l10n.freeUpDeviceSpace,
           onTap: () => onNavigate((_) => const FreeUpSpaceOptionsScreen()),
         ),
-      // Help suggestion
-      SettingsSearchSuggestion(
-        title: l10n.help,
-        onTap: () => onNavigate((_) => const HelpSupportPage()),
-      ),
+      // Backup settings suggestion
+      if (hasLoggedIn)
+        SettingsSearchSuggestion(
+          title: l10n.backupSettings,
+          onTap: () => onNavigate((_) => const BackupSettingsPage()),
+        ),
     ];
   }
 }

--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -334,6 +334,72 @@ class _SettingsBody extends StatelessWidget {
           },
         ),
         MenuItemWidgetNew(
+          title: AppLocalizations.of(context).familyPlans,
+          borderRadius: 0,
+          leadingIconWidget: _buildIconWidget(
+            HugeIcons.strokeRoundedUserMultiple,
+            colorScheme,
+          ),
+          trailingIcon: Icons.chevron_right_outlined,
+          trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
+          onTap: () async {
+            final userDetails =
+                await UserService.instance.getUserDetailsV2(memoryCount: false);
+            await billingService.launchFamilyPortal(context, userDetails);
+          },
+        ),
+        MenuItemWidgetNew(
+          title: AppLocalizations.of(context).referrals,
+          borderRadius: 0,
+          leadingIconWidget: _buildIconWidget(
+            HugeIcons.strokeRoundedTicketStar,
+            colorScheme,
+          ),
+          trailingIcon: Icons.chevron_right_outlined,
+          trailingIconIsMuted: true,
+          onTap: () async {
+            await routeToPage(context, const ReferralScreen());
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFeaturesAndPlansCard(
+    BuildContext context,
+    EnteColorScheme colorScheme,
+  ) {
+    return SettingsGroupedCard(
+      children: [
+        MenuItemWidgetNew(
+          title: AppLocalizations.of(context).freeUpSpace,
+          borderRadius: 0,
+          leadingIconWidget: _buildIconWidget(
+            HugeIcons.strokeRoundedRocket01,
+            colorScheme,
+          ),
+          trailingIcon: Icons.chevron_right_outlined,
+          trailingIconIsMuted: true,
+          showOnlyLoadingState: true,
+          onTap: () async {
+            await routeToPage(context, const FreeUpSpaceOptionsScreen());
+          },
+        ),
+        MenuItemWidgetNew(
+          title: AppLocalizations.of(context).machineLearning,
+          borderRadius: 0,
+          leadingIconWidget: _buildIconWidget(
+            HugeIcons.strokeRoundedMagicWand01,
+            colorScheme,
+          ),
+          trailingIcon: Icons.chevron_right_outlined,
+          trailingIconIsMuted: true,
+          onTap: () async {
+            await routeToPage(context, const MachineLearningSettingsPage());
+          },
+        ),
+        MenuItemWidgetNew(
           title: AppLocalizations.of(context).memories,
           borderRadius: 0,
           leadingIconWidget: _buildIconWidget(
@@ -372,29 +438,6 @@ class _SettingsBody extends StatelessWidget {
             await routeToPage(context, const WidgetSettingsScreen());
           },
         ),
-      ],
-    );
-  }
-
-  Widget _buildFeaturesAndPlansCard(
-    BuildContext context,
-    EnteColorScheme colorScheme,
-  ) {
-    return SettingsGroupedCard(
-      children: [
-        MenuItemWidgetNew(
-          title: AppLocalizations.of(context).machineLearning,
-          borderRadius: 0,
-          leadingIconWidget: _buildIconWidget(
-            HugeIcons.strokeRoundedMagicWand01,
-            colorScheme,
-          ),
-          trailingIcon: Icons.chevron_right_outlined,
-          trailingIconIsMuted: true,
-          onTap: () async {
-            await routeToPage(context, const MachineLearningSettingsPage());
-          },
-        ),
         MenuItemWidgetNew(
           title: AppLocalizations.of(context).videoStreaming,
           borderRadius: 0,
@@ -406,49 +449,6 @@ class _SettingsBody extends StatelessWidget {
           trailingIconIsMuted: true,
           onTap: () async {
             await routeToPage(context, const VideoStreamingSettingsPage());
-          },
-        ),
-        MenuItemWidgetNew(
-          title: AppLocalizations.of(context).freeUpSpace,
-          borderRadius: 0,
-          leadingIconWidget: _buildIconWidget(
-            HugeIcons.strokeRoundedRocket01,
-            colorScheme,
-          ),
-          trailingIcon: Icons.chevron_right_outlined,
-          trailingIconIsMuted: true,
-          showOnlyLoadingState: true,
-          onTap: () async {
-            await routeToPage(context, const FreeUpSpaceOptionsScreen());
-          },
-        ),
-        MenuItemWidgetNew(
-          title: AppLocalizations.of(context).referrals,
-          borderRadius: 0,
-          leadingIconWidget: _buildIconWidget(
-            HugeIcons.strokeRoundedTicketStar,
-            colorScheme,
-          ),
-          trailingIcon: Icons.chevron_right_outlined,
-          trailingIconIsMuted: true,
-          onTap: () async {
-            await routeToPage(context, const ReferralScreen());
-          },
-        ),
-        MenuItemWidgetNew(
-          title: AppLocalizations.of(context).familyPlans,
-          borderRadius: 0,
-          leadingIconWidget: _buildIconWidget(
-            HugeIcons.strokeRoundedUserMultiple,
-            colorScheme,
-          ),
-          trailingIcon: Icons.chevron_right_outlined,
-          trailingIconIsMuted: true,
-          showOnlyLoadingState: true,
-          onTap: () async {
-            final userDetails =
-                await UserService.instance.getUserDetailsV2(memoryCount: false);
-            await billingService.launchFamilyPortal(context, userDetails);
           },
         ),
         MenuItemWidgetNew(


### PR DESCRIPTION
## Summary
- Reorganize settings menu items into two groups:
  - Group 1: Legacy, Family Plans, Referral
  - Group 2: Free up space, Machine learning, Memories, Notifications, Widgets, Streamable Videos, Maps
- Update default search suggestions to: Gallery, App lock, Free up device space, Backup settings

## Test plan
- [ ] Open Settings page and verify the grouping is correct
- [ ] Open Settings search and verify the default suggestions appear correctly
- [ ] Tap each suggestion to verify navigation works