### PR TITLE
[mob][photos] Improve settings search results

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_item.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_item.dart
@@ -33,27 +33,83 @@ class SettingsSearchItem {
     this.keywords = const [],
   });
 
+  SettingsSearchMatchType matchType(String query) {
+    final normalizedQuery = query.toLowerCase().trim();
+    if (normalizedQuery.isEmpty) return SettingsSearchMatchType.none;
+
+    final normalizedTitle = title.toLowerCase();
+    if (normalizedTitle.startsWith(normalizedQuery)) {
+      return SettingsSearchMatchType.titlePrefix;
+    }
+    if (normalizedTitle.contains(normalizedQuery)) {
+      return SettingsSearchMatchType.title;
+    }
+    final normalizedSubtitle = subtitle?.toLowerCase();
+    if (normalizedSubtitle?.startsWith(normalizedQuery) ?? false) {
+      return SettingsSearchMatchType.subtitlePrefix;
+    }
+    if (normalizedSubtitle?.contains(normalizedQuery) ?? false) {
+      return SettingsSearchMatchType.subtitle;
+    }
+    final normalizedSectionPath = sectionPath.toLowerCase();
+    if (normalizedSectionPath.startsWith(normalizedQuery)) {
+      return SettingsSearchMatchType.sectionPathPrefix;
+    }
+    if (normalizedSectionPath.contains(normalizedQuery)) {
+      return SettingsSearchMatchType.sectionPath;
+    }
+    for (final keyword in keywords) {
+      final normalizedKeyword = keyword.toLowerCase();
+      if (normalizedKeyword.startsWith(normalizedQuery)) {
+        return SettingsSearchMatchType.keywordPrefix;
+      }
+      if (normalizedKeyword.contains(normalizedQuery)) {
+        return SettingsSearchMatchType.keyword;
+      }
+    }
+
+    return SettingsSearchMatchType.none;
+  }
+
   /// Check if this item matches the search query
   bool matchesQuery(String query) {
     final normalizedQuery = query.toLowerCase().trim();
     if (normalizedQuery.isEmpty) return false;
 
-    // Check title
+    return matchType(normalizedQuery) != SettingsSearchMatchType.none;
+  }
+
+  bool matchesLabel(String query) {
+    final normalizedQuery = query.toLowerCase().trim();
+    if (normalizedQuery.isEmpty) return false;
+
     if (title.toLowerCase().contains(normalizedQuery)) return true;
-
-    // Check subtitle
     if (subtitle?.toLowerCase().contains(normalizedQuery) ?? false) return true;
-
-    // Check section path
     if (sectionPath.toLowerCase().contains(normalizedQuery)) return true;
+    return false;
+  }
 
-    // Check keywords
+  bool matchesKeyword(String query) {
+    final normalizedQuery = query.toLowerCase().trim();
+    if (normalizedQuery.isEmpty) return false;
+
     for (final keyword in keywords) {
       if (keyword.toLowerCase().contains(normalizedQuery)) return true;
     }
-
     return false;
   }
+}
+
+enum SettingsSearchMatchType {
+  titlePrefix,
+  title,
+  subtitlePrefix,
+  subtitle,
+  sectionPathPrefix,
+  sectionPath,
+  keywordPrefix,
+  keyword,
+  none,
 }
 
 /// Represents a quick suggestion shown when search is empty

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
@@ -20,7 +20,7 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
   final FocusNode _searchFocusNode = FocusNode();
   String _searchQuery = "";
   List<SettingsSearchItem>? _allItems;
-  List<SettingsSearchItem> _filteredItems = [];
+  List<_SearchResultEntry> _filteredItems = [];
 
   @override
   void initState() {
@@ -50,8 +50,70 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
       if (query.isEmpty || _allItems == null) {
         _filteredItems = [];
       } else {
-        _filteredItems =
-            _allItems!.where((item) => item.matchesQuery(query)).toList();
+        final l10n = AppLocalizations.of(context);
+        final sectionOrder = <String, int>{};
+        for (var i = 0; i < _allItems!.length; i++) {
+          final item = _allItems![i];
+          final sectionKey = _sectionKey(item.sectionPath);
+          sectionOrder.putIfAbsent(sectionKey, () => i);
+        }
+
+        final freeUpSpacePriority = <String, int>{
+          l10n.deleteSuggestions: 0,
+          l10n.freeUpDeviceSpace: 1,
+        };
+
+        final entries = <_SearchResultEntry>[];
+        for (var i = 0; i < _allItems!.length; i++) {
+          final item = _allItems![i];
+          final matchType = item.matchType(query);
+          if (matchType == SettingsSearchMatchType.none) {
+            continue;
+          }
+          final sectionKey = _sectionKey(item.sectionPath);
+          final intraSectionOrder =
+              sectionKey == l10n.freeUpSpace && freeUpSpacePriority.isNotEmpty
+                  ? (freeUpSpacePriority[item.title] ?? 100 + i)
+                  : i;
+          entries.add(
+            _SearchResultEntry(
+              item: item,
+              matchType: matchType,
+              sectionKey: sectionKey,
+              sectionOrder: sectionOrder[sectionKey] ?? i,
+              itemOrder: i,
+              intraSectionOrder: intraSectionOrder,
+            ),
+          );
+        }
+
+        final hasSubPageMatch = <String, bool>{};
+        for (final entry in entries) {
+          if (entry.item.isSubPage) {
+            hasSubPageMatch[entry.sectionKey] = true;
+          }
+        }
+
+        final filteredEntries = entries
+            .where(
+              (entry) => !(hasSubPageMatch[entry.sectionKey] ?? false) ||
+                  entry.item.isSubPage,
+            )
+            .toList();
+
+        filteredEntries.sort((a, b) {
+          final matchPriority = _matchPriority(a.matchType)
+              .compareTo(_matchPriority(b.matchType));
+          if (matchPriority != 0) return matchPriority;
+          final sectionPriority = a.sectionOrder.compareTo(b.sectionOrder);
+          if (sectionPriority != 0) return sectionPriority;
+          final intraSection =
+              a.intraSectionOrder.compareTo(b.intraSectionOrder);
+          if (intraSection != 0) return intraSection;
+          return a.itemOrder.compareTo(b.itemOrder);
+        });
+
+        _filteredItems = filteredEntries;
       }
     });
   }
@@ -241,14 +303,55 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
       );
     }
 
+    final rows = _buildResultRows(colorScheme, textTheme);
     return ListView.builder(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      itemCount: _filteredItems.length,
+      itemCount: rows.length,
       itemBuilder: (context, index) {
-        final item = _filteredItems[index];
-        return _buildSearchResultItem(item, colorScheme, textTheme);
+        return rows[index];
       },
     );
+  }
+
+  List<Widget> _buildResultRows(
+    EnteColorScheme colorScheme,
+    EnteTextTheme textTheme,
+  ) {
+    final sectionCounts = <String, int>{};
+    for (final entry in _filteredItems) {
+      sectionCounts.update(
+        entry.sectionKey,
+        (value) => value + 1,
+        ifAbsent: () => 1,
+      );
+    }
+
+    final rows = <Widget>[];
+    String? currentSectionKey;
+    for (final entry in _filteredItems) {
+      final shouldShowHeader =
+          sectionCounts[entry.sectionKey] != null &&
+              sectionCounts[entry.sectionKey]! >= 2;
+      if (shouldShowHeader && currentSectionKey != entry.sectionKey) {
+        currentSectionKey = entry.sectionKey;
+        rows.add(
+          Padding(
+            padding: const EdgeInsets.only(top: 12, bottom: 8),
+            child: Text(
+              entry.sectionKey,
+              style: textTheme.mini.copyWith(
+                color: colorScheme.textMuted,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        );
+      }
+      rows.add(
+        _buildSearchResultItem(entry.item, colorScheme, textTheme),
+      );
+    }
+    return rows;
   }
 
   Widget _buildSearchResultItem(
@@ -285,7 +388,7 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
                       color: colorScheme.textBase,
                     ),
                   ),
-                  if (item.isSubPage) ...[
+                  if (item.sectionPath != item.title) ...[
                     const SizedBox(height: 2),
                     Text(
                       item.sectionPath,
@@ -307,4 +410,50 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
       ),
     );
   }
+
+  String _sectionKey(String sectionPath) {
+    final parts = sectionPath.split(" > ");
+    return parts.isNotEmpty ? parts.first : sectionPath;
+  }
+
+  int _matchPriority(SettingsSearchMatchType matchType) {
+    switch (matchType) {
+      case SettingsSearchMatchType.titlePrefix:
+        return 0;
+      case SettingsSearchMatchType.title:
+        return 1;
+      case SettingsSearchMatchType.subtitlePrefix:
+        return 2;
+      case SettingsSearchMatchType.subtitle:
+        return 3;
+      case SettingsSearchMatchType.sectionPathPrefix:
+        return 4;
+      case SettingsSearchMatchType.sectionPath:
+        return 5;
+      case SettingsSearchMatchType.keywordPrefix:
+        return 6;
+      case SettingsSearchMatchType.keyword:
+        return 7;
+      case SettingsSearchMatchType.none:
+        return 8;
+    }
+  }
+}
+
+class _SearchResultEntry {
+  final SettingsSearchItem item;
+  final SettingsSearchMatchType matchType;
+  final String sectionKey;
+  final int sectionOrder;
+  final int itemOrder;
+  final int intraSectionOrder;
+
+  _SearchResultEntry({
+    required this.item,
+    required this.matchType,
+    required this.sectionKey,
+    required this.sectionOrder,
+    required this.itemOrder,
+    required this.intraSectionOrder,
+  });
 }

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
@@ -1,17 +1,26 @@
+import "dart:io";
+
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:photos/core/configuration.dart";
 import "package:photos/generated/l10n.dart";
+import "package:photos/l10n/l10n.dart";
+import "package:photos/service_locator.dart";
 import "package:photos/ui/settings/about/about_us_page.dart";
 import "package:photos/ui/settings/account/account_settings_page.dart";
 import "package:photos/ui/settings/appearance/appearance_settings_page.dart";
 import "package:photos/ui/settings/backup/backup_settings_page.dart";
 import "package:photos/ui/settings/backup/free_space_options.dart";
 import "package:photos/ui/settings/gallery_settings_screen.dart";
+import "package:photos/ui/settings/memories_settings_screen.dart";
 import "package:photos/ui/settings/ml/machine_learning_settings_page.dart";
+import "package:photos/ui/settings/notification_settings_screen.dart";
 import "package:photos/ui/settings/search/settings_search_item.dart";
 import "package:photos/ui/settings/security/security_settings_page.dart";
+import "package:photos/ui/settings/streaming/video_streaming_settings_page.dart";
 import "package:photos/ui/settings/support/help_support_page.dart";
+import "package:photos/ui/settings/widget_settings_screen.dart";
 
 /// Registry that provides all searchable settings items
 class SettingsSearchRegistry {
@@ -31,6 +40,63 @@ class SettingsSearchRegistry {
           keywords: ["email", "password", "delete", "subscription"],
         ),
       );
+
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.manageSubscription,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedCreditCard,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["subscription", "plan", "billing", "payment"],
+        ),
+        SettingsSearchItem(
+          title: l10n.changeEmail,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedMail01,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["email", "mail", "address"],
+        ),
+        SettingsSearchItem(
+          title: l10n.changePassword,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedLockPassword,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["password", "passphrase", "credentials"],
+        ),
+        SettingsSearchItem(
+          title: l10n.recoveryKey,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedKey01,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["recovery", "key", "backup key"],
+        ),
+        SettingsSearchItem(
+          title: l10n.exportYourData,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedDownload04,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["export", "download", "data"],
+        ),
+        SettingsSearchItem(
+          title: l10n.deleteAccount,
+          subtitle: l10n.account,
+          sectionPath: l10n.account,
+          icon: HugeIcons.strokeRoundedDelete02,
+          routeBuilder: (_) => const AccountSettingsPage(),
+          isSubPage: true,
+          keywords: ["delete", "remove", "close account", "close"],
+        ),
+      ]);
     }
 
     // Backup settings
@@ -44,6 +110,84 @@ class SettingsSearchRegistry {
           keywords: ["sync", "upload", "photos", "videos"],
         ),
       );
+
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.backedUpFolders,
+          subtitle: l10n.backup,
+          sectionPath: l10n.backup,
+          icon: HugeIcons.strokeRoundedFolder01,
+          routeBuilder: (_) => const BackupSettingsPage(),
+          isSubPage: true,
+          keywords: ["folders", "albums", "camera", "backup folders"],
+        ),
+        SettingsSearchItem(
+          title: l10n.backupStatus,
+          subtitle: l10n.backup,
+          sectionPath: l10n.backup,
+          icon: HugeIcons.strokeRoundedCloudSavingDone01,
+          routeBuilder: (_) => const BackupSettingsPage(),
+          isSubPage: true,
+          keywords: ["status", "progress", "queue", "sync status"],
+        ),
+        SettingsSearchItem(
+          title: l10n.backupSettings,
+          subtitle: l10n.backup,
+          sectionPath: l10n.backup,
+          icon: HugeIcons.strokeRoundedSettings01,
+          routeBuilder: (_) => const BackupSettingsPage(),
+          isSubPage: true,
+          keywords: ["mobile data", "videos", "only new", "resumable"],
+        ),
+        SettingsSearchItem(
+          title: l10n.backupOverMobileData,
+          subtitle: l10n.backupSettings,
+          sectionPath: "${l10n.backup} > ${l10n.backupSettings}",
+          icon: HugeIcons.strokeRoundedSettings01,
+          routeBuilder: (_) => const BackupSettingsPage(),
+          isSubPage: true,
+          keywords: ["mobile data", "cellular", "network"],
+        ),
+        SettingsSearchItem(
+          title: l10n.backupVideos,
+          subtitle: l10n.backupSettings,
+          sectionPath: "${l10n.backup} > ${l10n.backupSettings}",
+          icon: HugeIcons.strokeRoundedVideoCameraAi,
+          routeBuilder: (_) => const BackupSettingsPage(),
+          isSubPage: true,
+          keywords: ["videos", "movies", "backup video"],
+        ),
+        if (flagService.enableOnlyBackupFuturePhotos)
+          SettingsSearchItem(
+            title: l10n.backupOnlyNewPhotos,
+            subtitle: l10n.backupSettings,
+            sectionPath: "${l10n.backup} > ${l10n.backupSettings}",
+            icon: HugeIcons.strokeRoundedSettings01,
+            routeBuilder: (_) => const BackupSettingsPage(),
+            isSubPage: true,
+            keywords: ["only new", "new photos", "since now"],
+          ),
+        if (flagService.enableMobMultiPart)
+          SettingsSearchItem(
+            title: l10n.resumableUploads,
+            subtitle: l10n.backupSettings,
+            sectionPath: "${l10n.backup} > ${l10n.backupSettings}",
+            icon: HugeIcons.strokeRoundedCloudUpload,
+            routeBuilder: (_) => const BackupSettingsPage(),
+            isSubPage: true,
+            keywords: ["resumable", "multipart", "uploads"],
+          ),
+        if (Platform.isIOS)
+          SettingsSearchItem(
+            title: l10n.disableAutoLock,
+            subtitle: l10n.backupSettings,
+            sectionPath: "${l10n.backup} > ${l10n.backupSettings}",
+            icon: HugeIcons.strokeRoundedSquareLock02,
+            routeBuilder: (_) => const BackupSettingsPage(),
+            isSubPage: true,
+            keywords: ["auto lock", "screen", "awake"],
+          ),
+      ]);
     }
 
     // Security settings
@@ -59,6 +203,7 @@ class SettingsSearchRegistry {
           "biometric",
           "fingerprint",
           "face id",
+          "app lock",
           "2fa",
           "two factor",
           "authentication",
@@ -66,6 +211,57 @@ class SettingsSearchRegistry {
         ],
       ),
     );
+
+    items.addAll([
+      if (Configuration.instance.hasConfiguredAccount())
+        SettingsSearchItem(
+          title: l10n.twofactor,
+          subtitle: l10n.security,
+          sectionPath: l10n.security,
+          icon: HugeIcons.strokeRoundedSmartPhone01,
+          routeBuilder: (_) => const SecuritySettingsPage(),
+          isSubPage: true,
+          keywords: ["2fa", "two factor", "authenticator", "otp"],
+        ),
+      if (Configuration.instance.hasConfiguredAccount())
+        SettingsSearchItem(
+          title: l10n.emailVerificationToggle,
+          subtitle: l10n.security,
+          sectionPath: l10n.security,
+          icon: HugeIcons.strokeRoundedMailSecure01,
+          routeBuilder: (_) => const SecuritySettingsPage(),
+          isSubPage: true,
+          keywords: ["email", "verification", "mfa"],
+        ),
+      if (Configuration.instance.hasConfiguredAccount())
+        SettingsSearchItem(
+          title: context.l10n.passkey,
+          subtitle: l10n.security,
+          sectionPath: l10n.security,
+          icon: HugeIcons.strokeRoundedFingerAccess,
+          routeBuilder: (_) => const SecuritySettingsPage(),
+          isSubPage: true,
+          keywords: ["passkey", "webauthn", "biometric"],
+        ),
+      SettingsSearchItem(
+        title: l10n.appLock,
+        subtitle: l10n.security,
+        sectionPath: l10n.security,
+        icon: HugeIcons.strokeRoundedSquareLock02,
+        routeBuilder: (_) => const SecuritySettingsPage(),
+        isSubPage: true,
+        keywords: ["lock", "pin", "biometric", "face id", "fingerprint"],
+      ),
+      SettingsSearchItem(
+        title: l10n.activeSessions,
+        subtitle: l10n.security,
+        sectionPath: l10n.security,
+        icon: HugeIcons.strokeRoundedComputerPhoneSync,
+        routeBuilder: (_) => const SecuritySettingsPage(),
+        isSubPage: true,
+        keywords: ["sessions", "devices", "logins"],
+      ),
+    ]);
 
     // Appearance settings
     items.add(
@@ -77,6 +273,41 @@ class SettingsSearchRegistry {
         keywords: ["theme", "dark mode", "light mode", "app icon"],
       ),
     );
+
+    if (Platform.isAndroid || kDebugMode) {
+      items.add(
+        SettingsSearchItem(
+          title: l10n.theme,
+          subtitle: l10n.appearance,
+          sectionPath: l10n.appearance,
+          icon: HugeIcons.strokeRoundedMoon02,
+          routeBuilder: (_) => const AppearanceSettingsPage(),
+          isSubPage: true,
+          keywords: ["theme", "dark mode", "light mode", "system"],
+        ),
+      );
+    }
+
+    items.addAll([
+      SettingsSearchItem(
+        title: l10n.appIcon,
+        subtitle: l10n.appearance,
+        sectionPath: l10n.appearance,
+        icon: HugeIcons.strokeRoundedImage02,
+        routeBuilder: (_) => const AppearanceSettingsPage(),
+        isSubPage: true,
+        keywords: ["icon", "app icon"],
+      ),
+      SettingsSearchItem(
+        title: l10n.language,
+        subtitle: l10n.appearance,
+        sectionPath: l10n.appearance,
+        icon: HugeIcons.strokeRoundedTranslation,
+        routeBuilder: (_) => const AppearanceSettingsPage(),
+        isSubPage: true,
+        keywords: ["language", "locale", "translation"],
+      ),
+    ]);
 
     // Gallery settings (under Appearance)
     items.add(
@@ -123,6 +354,20 @@ class SettingsSearchRegistry {
       ),
     );
 
+    items.add(
+      SettingsSearchItem(
+        title: l10n.hideSharedItemsFromHomeGallery,
+        subtitle: l10n.gallery,
+        sectionPath: "${l10n.appearance} > ${l10n.gallery}",
+        icon: HugeIcons.strokeRoundedImage01,
+        routeBuilder: (_) => const GallerySettingsScreen(
+          fromGalleryLayoutSettingsCTA: false,
+        ),
+        isSubPage: true,
+        keywords: ["shared", "hide", "home gallery"],
+      ),
+    );
+
     // Machine Learning settings
     if (hasLoggedIn) {
       items.add(
@@ -142,6 +387,142 @@ class SettingsSearchRegistry {
           ],
         ),
       );
+
+      items.add(
+        SettingsSearchItem(
+          title: l10n.localIndexing,
+          subtitle: l10n.machineLearning,
+          sectionPath: l10n.machineLearning,
+          icon: HugeIcons.strokeRoundedDatabase01,
+          routeBuilder: (_) => const MachineLearningSettingsPage(),
+          isSubPage: true,
+          keywords: ["indexing", "local", "on-device"],
+        ),
+      );
+    }
+
+    if (hasLoggedIn) {
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.memories,
+          sectionPath: l10n.memories,
+          icon: HugeIcons.strokeRoundedSparkles,
+          routeBuilder: (_) => const MemoriesSettingsScreen(),
+          keywords: ["flashback", "reminder", "highlights"],
+        ),
+        SettingsSearchItem(
+          title: l10n.showMemories,
+          subtitle: l10n.memories,
+          sectionPath: l10n.memories,
+          icon: HugeIcons.strokeRoundedSparkles,
+          routeBuilder: (_) => const MemoriesSettingsScreen(),
+          isSubPage: true,
+          keywords: ["show", "memories", "highlights"],
+        ),
+        if (memoriesCacheService.curatedMemoriesOption)
+          SettingsSearchItem(
+            title: l10n.curatedMemories,
+            subtitle: l10n.memories,
+            sectionPath: l10n.memories,
+            icon: HugeIcons.strokeRoundedSparkles,
+            routeBuilder: (_) => const MemoriesSettingsScreen(),
+            isSubPage: true,
+            keywords: ["curated", "smart", "memories"],
+          ),
+      ]);
+
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.notifications,
+          sectionPath: l10n.notifications,
+          icon: HugeIcons.strokeRoundedNotification01,
+          routeBuilder: (_) => const NotificationSettingsScreen(),
+          keywords: ["alerts", "push", "reminders"],
+        ),
+        SettingsSearchItem(
+          title: l10n.sharedPhotoNotifications,
+          subtitle: l10n.notifications,
+          sectionPath: l10n.notifications,
+          icon: HugeIcons.strokeRoundedNotification01,
+          routeBuilder: (_) => const NotificationSettingsScreen(),
+          isSubPage: true,
+          keywords: ["shared", "notifications", "shares"],
+        ),
+        SettingsSearchItem(
+          title: l10n.onThisDayMemories,
+          subtitle: l10n.notifications,
+          sectionPath: l10n.notifications,
+          icon: HugeIcons.strokeRoundedNotification01,
+          routeBuilder: (_) => const NotificationSettingsScreen(),
+          isSubPage: true,
+          keywords: ["on this day", "memories", "reminders"],
+        ),
+        SettingsSearchItem(
+          title: l10n.birthdays,
+          subtitle: l10n.notifications,
+          sectionPath: l10n.notifications,
+          icon: HugeIcons.strokeRoundedNotification01,
+          routeBuilder: (_) => const NotificationSettingsScreen(),
+          isSubPage: true,
+          keywords: ["birthday", "birthdays", "reminders"],
+        ),
+      ]);
+
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.widgets,
+          sectionPath: l10n.widgets,
+          icon: HugeIcons.strokeRoundedAlignBoxBottomRight,
+          routeBuilder: (_) => const WidgetSettingsScreen(),
+          keywords: ["home screen", "homescreen"],
+        ),
+        SettingsSearchItem(
+          title: l10n.people,
+          subtitle: l10n.widgets,
+          sectionPath: l10n.widgets,
+          icon: HugeIcons.strokeRoundedUserMultiple,
+          routeBuilder: (_) => const WidgetSettingsScreen(),
+          isSubPage: true,
+          keywords: ["people", "faces", "widget"],
+        ),
+        SettingsSearchItem(
+          title: l10n.albums,
+          subtitle: l10n.widgets,
+          sectionPath: l10n.widgets,
+          icon: HugeIcons.strokeRoundedFolder01,
+          routeBuilder: (_) => const WidgetSettingsScreen(),
+          isSubPage: true,
+          keywords: ["albums", "collections", "widget"],
+        ),
+        SettingsSearchItem(
+          title: l10n.memories,
+          subtitle: l10n.widgets,
+          sectionPath: l10n.widgets,
+          icon: HugeIcons.strokeRoundedSparkles,
+          routeBuilder: (_) => const WidgetSettingsScreen(),
+          isSubPage: true,
+          keywords: ["memories", "widget"],
+        ),
+      ]);
+
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.videoStreaming,
+          sectionPath: l10n.videoStreaming,
+          icon: HugeIcons.strokeRoundedVideoCameraAi,
+          routeBuilder: (_) => const VideoStreamingSettingsPage(),
+          keywords: ["stream", "playback", "video"],
+        ),
+        SettingsSearchItem(
+          title: l10n.enabled,
+          subtitle: l10n.videoStreaming,
+          sectionPath: l10n.videoStreaming,
+          icon: HugeIcons.strokeRoundedVideoCameraAi,
+          routeBuilder: (_) => const VideoStreamingSettingsPage(),
+          isSubPage: true,
+          keywords: ["enable", "streaming"],
+        ),
+      ]);
     }
 
     // Free up space
@@ -163,8 +544,16 @@ class SettingsSearchRegistry {
         ),
       );
 
-      // Remove duplicates (under Free up space)
-      items.add(
+      items.addAll([
+        SettingsSearchItem(
+          title: l10n.freeUpDeviceSpace,
+          subtitle: l10n.freeUpSpace,
+          sectionPath: l10n.freeUpSpace,
+          icon: HugeIcons.strokeRoundedRocket01,
+          routeBuilder: (_) => const FreeUpSpaceOptionsScreen(),
+          isSubPage: true,
+          keywords: ["device space", "storage", "delete"],
+        ),
         SettingsSearchItem(
           title: l10n.removeDuplicates,
           subtitle: l10n.freeUpSpace,
@@ -181,25 +570,49 @@ class SettingsSearchRegistry {
             "copies",
           ],
         ),
-      );
-
-      // Similar images (under Free up space)
-      items.add(
+        if (flagService.enableVectorDb)
+          SettingsSearchItem(
+            title: l10n.similarImages,
+            subtitle: l10n.freeUpSpace,
+            sectionPath: l10n.freeUpSpace,
+            icon: HugeIcons.strokeRoundedRocket01,
+            routeBuilder: (_) => const FreeUpSpaceOptionsScreen(),
+            isSubPage: true,
+            keywords: [
+              "similar",
+              "alike",
+              "resembling",
+              "cleanup",
+            ],
+          ),
         SettingsSearchItem(
-          title: l10n.similarImages,
+          title: l10n.viewLargeFiles,
           subtitle: l10n.freeUpSpace,
           sectionPath: l10n.freeUpSpace,
-          icon: HugeIcons.strokeRoundedRocket01,
+          icon: HugeIcons.strokeRoundedFile01,
           routeBuilder: (_) => const FreeUpSpaceOptionsScreen(),
           isSubPage: true,
-          keywords: [
-            "similar",
-            "alike",
-            "resembling",
-            "cleanup",
-          ],
+          keywords: ["large files", "big", "size", "storage"],
         ),
-      );
+        SettingsSearchItem(
+          title: l10n.deleteSuggestions,
+          subtitle: l10n.freeUpSpace,
+          sectionPath: l10n.freeUpSpace,
+          icon: HugeIcons.strokeRoundedDelete02,
+          routeBuilder: (_) => const FreeUpSpaceOptionsScreen(),
+          isSubPage: true,
+          keywords: ["delete", "suggestions", "cleanup"],
+        ),
+        SettingsSearchItem(
+          title: l10n.manageDeviceStorage,
+          subtitle: l10n.freeUpSpace,
+          sectionPath: l10n.freeUpSpace,
+          icon: HugeIcons.strokeRoundedSettings01,
+          routeBuilder: (_) => const FreeUpSpaceOptionsScreen(),
+          isSubPage: true,
+          keywords: ["storage", "device", "cache"],
+        ),
+      ]);
     }
 
     // Help & Support
@@ -213,6 +626,54 @@ class SettingsSearchRegistry {
       ),
     );
 
+    items.addAll([
+      SettingsSearchItem(
+        title: l10n.help,
+        subtitle: l10n.support,
+        sectionPath: l10n.support,
+        icon: HugeIcons.strokeRoundedHelpCircle,
+        routeBuilder: (_) => const HelpSupportPage(),
+        isSubPage: true,
+        keywords: ["help", "faq", "guide"],
+      ),
+      SettingsSearchItem(
+        title: l10n.reportABug,
+        subtitle: l10n.support,
+        sectionPath: l10n.support,
+        icon: HugeIcons.strokeRoundedBug02,
+        routeBuilder: (_) => const HelpSupportPage(),
+        isSubPage: true,
+        keywords: ["bug", "issue", "crash"],
+      ),
+      SettingsSearchItem(
+        title: l10n.contactSupport,
+        subtitle: l10n.support,
+        sectionPath: l10n.support,
+        icon: HugeIcons.strokeRoundedMail01,
+        routeBuilder: (_) => const HelpSupportPage(),
+        isSubPage: true,
+        keywords: ["contact", "support", "email"],
+      ),
+      SettingsSearchItem(
+        title: l10n.suggestFeatures,
+        subtitle: l10n.support,
+        sectionPath: l10n.support,
+        icon: HugeIcons.strokeRoundedIdea01,
+        routeBuilder: (_) => const HelpSupportPage(),
+        isSubPage: true,
+        keywords: ["suggest", "feature request", "feedback"],
+      ),
+      SettingsSearchItem(
+        title: l10n.crashReporting,
+        subtitle: l10n.support,
+        sectionPath: l10n.support,
+        icon: HugeIcons.strokeRoundedAlert02,
+        routeBuilder: (_) => const HelpSupportPage(),
+        isSubPage: true,
+        keywords: ["crash", "reporting", "diagnostics"],
+      ),
+    ]);
+
     // About
     items.add(
       SettingsSearchItem(
@@ -223,6 +684,55 @@ class SettingsSearchRegistry {
         keywords: ["version", "privacy", "terms", "license"],
       ),
     );
+
+    items.addAll([
+      SettingsSearchItem(
+        title: l10n.weAreOpenSource,
+        subtitle: l10n.about,
+        sectionPath: l10n.about,
+        icon: HugeIcons.strokeRoundedGithub,
+        routeBuilder: (_) => const AboutUsPage(),
+        isSubPage: true,
+        keywords: ["open source", "github", "code"],
+      ),
+      SettingsSearchItem(
+        title: l10n.blog,
+        subtitle: l10n.about,
+        sectionPath: l10n.about,
+        icon: HugeIcons.strokeRoundedPencilEdit01,
+        routeBuilder: (_) => const AboutUsPage(),
+        isSubPage: true,
+        keywords: ["blog", "news", "updates"],
+      ),
+      SettingsSearchItem(
+        title: l10n.privacy,
+        subtitle: l10n.about,
+        sectionPath: l10n.about,
+        icon: HugeIcons.strokeRoundedShield01,
+        routeBuilder: (_) => const AboutUsPage(),
+        isSubPage: true,
+        keywords: ["privacy", "policy"],
+      ),
+      SettingsSearchItem(
+        title: l10n.termsOfServicesTitle,
+        subtitle: l10n.about,
+        sectionPath: l10n.about,
+        icon: HugeIcons.strokeRoundedFile01,
+        routeBuilder: (_) => const AboutUsPage(),
+        isSubPage: true,
+        keywords: ["terms", "tos", "service"],
+      ),
+      if (updateService.isIndependent())
+        SettingsSearchItem(
+          title: l10n.checkForUpdates,
+          subtitle: l10n.about,
+          sectionPath: l10n.about,
+          icon: HugeIcons.strokeRoundedDownload04,
+          routeBuilder: (_) => const AboutUsPage(),
+          isSubPage: true,
+          keywords: ["updates", "version", "check"],
+        ),
+    ]);
 
     return items;
   }


### PR DESCRIPTION
## Description
- Expand settings search coverage across settings pages and sub-items
- Improve search ordering with prefix-first ranking and section grouping
- Hide redundant parent rows when sub-items match and show clearer breadcrumbs
