### PR TITLE
[mob][photos] Enable shared albums in move-to-album flow for all users

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -382,6 +382,8 @@
   "subscribeToChangeLinkSetting": "You need a paid subscription to change this link setting.",
   "subscribe": "Subscribe",
   "canOnlyRemoveFilesOwnedByYou": "Can only remove files owned by you",
+  "cannotMoveToSharedAlbums": "Can't move to shared albums",
+  "cannotMoveToSharedAlbumsMessage": "Items can only be added to shared albums, not moved. Would you like to add instead?",
   "deleteSharedAlbum": "Delete shared album?",
   "deleteAlbum": "Delete album",
   "deleteAlbumDialog": "Also delete the photos (and videos) present in this album from <bold>all</bold> other albums they are part of?",

--- a/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
@@ -240,9 +240,8 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
     // Show dialog asking if user wants to add instead of move
     final result = await showChoiceActionSheet(
       context,
-      title: "Can't move to shared albums",
-      body:
-          "Items can only be added to shared albums, not moved. Would you like to add instead?\n\n(i) This option is shown for internal users only",
+      title: AppLocalizations.of(context).cannotMoveToSharedAlbums,
+      body: AppLocalizations.of(context).cannotMoveToSharedAlbumsMessage,
       icon: Icons.info_outline,
       firstButtonLabel: AppLocalizations.of(context).add,
       secondButtonLabel: AppLocalizations.of(context).cancel,

--- a/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
+++ b/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
@@ -355,10 +355,9 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
                 collections.removeWhere((c) => recentIds.contains(c.id));
               }
 
-              // Get shared collections for move action (internal users only)
+              // Get shared collections for move action
               List<Collection> sharedCollections = [];
-              if (widget.actionType == CollectionActionType.moveFiles &&
-                  flagService.showSharedAlbumsInMoveSheet) {
+              if (widget.actionType == CollectionActionType.moveFiles) {
                 sharedCollections = _getSharedCollections();
                 // Filter shared collections by search query
                 if (_searchQuery.isNotEmpty) {

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -96,8 +96,6 @@ class FlagService {
 
   bool get enableShareePin => true;
 
-  bool get showSharedAlbumsInMoveSheet => internalUser;
-
   bool get isSocialEnabled =>
       internalUser || _isServerFlagEnabled(_commentsFlag);
 

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -25,7 +25,7 @@
 - Laurens: Small improvements to rituals
 - Ashil: QOL: Fix jank on file info sheet
 - Ashil: QOL: Show large thumbnail for unsupported image formats in file viewer
-- Neeraj: (i) Surface shared albums in add/move-to-album flows with owner avatar
+- Neeraj: Surface shared albums in add/move-to-album flows with owner avatar
 - Neeraj: QOL: Priority debouncer for recent local photos (< 7 days) to reduce home gallery delay
 - Neeraj: QOL: Collage creator: swap photos via long-press select + tap to replace
 - Prateek: (i) Always enable video streaming


### PR DESCRIPTION
## Summary
- Remove the `showSharedAlbumsInMoveSheet` internal-only feature flag
- Shared albums now appear in the move-to-album sheet for all users
- Localize the "Can't move to shared albums" dialog strings
- Remove the "(i) This option is shown for internal users only" subtext