### PR TITLE
[mob][photos] Improve settings tap targets and destructive styling

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/account/account_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/account/account_settings_page.dart
@@ -119,6 +119,7 @@ class AccountSettingsPage extends StatelessWidget {
                       const SizedBox(height: 8),
                       MenuItemWidgetNew(
                         title: AppLocalizations.of(context).deleteAccount,
+                        titleColor: colorScheme.warning700,
                         leadingIconWidget: _buildIconWidget(
                           context,
                           HugeIcons.strokeRoundedDelete02,

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
@@ -193,27 +193,25 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
               ),
             ),
             if (_searchQuery.isNotEmpty)
-              GestureDetector(
-                onTap: _clearSearch,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Icon(
-                    Icons.cancel_rounded,
-                    size: 16,
-                    color: colorScheme.textMuted,
-                  ),
+              IconButton(
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+                padding: EdgeInsets.zero,
+                iconSize: 16,
+                onPressed: _clearSearch,
+                icon: Icon(
+                  Icons.cancel_rounded,
+                  color: colorScheme.textMuted,
                 ),
               )
             else
-              GestureDetector(
-                onTap: () => Navigator.of(context).pop(),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Icon(
-                    Icons.close_rounded,
-                    size: 16,
-                    color: colorScheme.textMuted,
-                  ),
+              IconButton(
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+                padding: EdgeInsets.zero,
+                iconSize: 16,
+                onPressed: () => Navigator.of(context).pop(),
+                icon: Icon(
+                  Icons.close_rounded,
+                  color: colorScheme.textMuted,
                 ),
               ),
           ],

--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -146,7 +146,7 @@ class _SettingsBody extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(8),
             child: Icon(
-              Icons.chevron_left,
+              Icons.keyboard_double_arrow_left,
               size: 24,
               color: colorScheme.textBase,
             ),
@@ -155,39 +155,37 @@ class _SettingsBody extends StatelessWidget {
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            GestureDetector(
-              onTap: () {
+            IconButton(
+              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              padding: const EdgeInsets.all(8),
+              iconSize: 20,
+              onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) => const SettingsSearchPage(),
                   ),
                 );
               },
-              child: Container(
-                padding: const EdgeInsets.all(8),
-                child: Icon(
-                  Icons.search_rounded,
-                  size: 20,
-                  color: colorScheme.textMuted,
-                ),
+              icon: Icon(
+                Icons.search_rounded,
+                color: colorScheme.textMuted,
               ),
             ),
             if (localSettings.enableDatabaseLogging)
-              GestureDetector(
-                onTap: () {
+              IconButton(
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+                padding: const EdgeInsets.all(8),
+                iconSize: 20,
+                onPressed: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
                       builder: (context) => const LogViewerPage(),
                     ),
                   );
                 },
-                child: Container(
-                  padding: const EdgeInsets.all(8),
-                  child: Icon(
-                    Icons.bug_report,
-                    size: 20,
-                    color: colorScheme.textMuted,
-                  ),
+                icon: Icon(
+                  Icons.bug_report,
+                  color: colorScheme.textMuted,
                 ),
               ),
           ],


### PR DESCRIPTION
## Description
- Increase tappable areas for settings header search and search page clear/close icons.
- Align settings back icon with the double-arrow design.
- Match delete account title color to the logout warning color.
