### PR TITLE
[mob] Fix like button color in comment actions popup

### DIFF
--- a/mobile/apps/photos/lib/ui/social/widgets/comment_actions_popup.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/comment_actions_popup.dart
@@ -41,7 +41,7 @@ class CommentActionsPopup extends StatelessWidget {
           children: [
             _ActionItem(
               icon: isLiked ? EnteIcons.likeFilled : EnteIcons.likeStroke,
-              iconColor: isLiked ? const Color(0xFFE25454) : null,
+              iconColor: isLiked ? const Color(0xFF08C225) : null,
               label: l10n.like,
               onTap: onLikeTap,
               textStyle: textTheme.mini.copyWith(


### PR DESCRIPTION
Change the liked state color from red (0xFFE25454) to green (0xFF08C225)
to match the green color used elsewhere in the comments screen.

https://claude.ai/code/session_015Ev3EhfUNHUj1WSjw5dYen