### PR TITLE
[server] Include parentCommentUserID in comment API responses

### DIFF
--- a/server/ente/social/comment.go
+++ b/server/ente/social/comment.go
@@ -5,7 +5,8 @@ type Comment struct {
 	ID              string  `json:"id"`
 	CollectionID    int64   `json:"collectionID"`
 	FileID          *int64  `json:"fileID,omitempty"`
-	ParentCommentID *string `json:"parentCommentID,omitempty"`
+	ParentCommentID     *string `json:"parentCommentID,omitempty"`
+	ParentCommentUserID *int64  `json:"parentCommentUserID,omitempty"`
 	UserID          int64   `json:"userID"`
 	AnonUserID      *string `json:"anonUserID,omitempty"`
 	Cipher          string  `json:"cipher,omitempty"`


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                  
  - Add `parentCommentUserID` field to the `Comment` struct and API response                                                                                                                                  
  - Update `GetByID`, `GetDiff`, and `GetAlbumFeedComments` queries to LEFT JOIN the parent comment and select its `user_id`                                                                                  
                                                                                                                                                                                                              
  ## Motivation                                                                                                                                                                                               
  The mobile client expects `parentCommentUserID` in the comment JSON to distinguish "Replied to your comment" from "Replied to a comment". Without it, the field is always `null` and the notification copy  
  always falls through to the generic variant.                                                                                                                                                                
                                                                                                                                                                                                              
  ## Notes                                                                                                                                                                                                    
  - The LEFT JOIN is on `comments.id` (primary key), so cost is negligible on the already-paginated queries                                                                                                   
  - `parentCommentUserID` exposes the same `user_id` already visible on every comment — no new information leakage                                                                                            
  - Top-level comments produce NULL from the LEFT JOIN, omitted from JSON via `omitempty`                                                                                                                     
  - Deleted parent comments still have `user_id` in the DB, so the JOIN still returns the correct value  
