### PR TITLE
Remove unused feature flag getters for add to album and widget

### DIFF
--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -76,10 +76,6 @@ class FlagService {
 
   String get embedUrl => flags.embedUrl;
 
-  bool get addToAlbumFeature => internalUser;
-
-  bool get widgetSharedAlbums => internalUser;
-
   bool get useNativeVideoEditor => true;
 
   bool get enableOnlyBackupFuturePhotos =>


### PR DESCRIPTION
## Description

Removed two unused feature flag getters from the `FlagService` class:
- `addToAlbumFeature` - was always returning `internalUser` value
- `widgetSharedAlbums` - was always returning `internalUser` value

These getters are no longer referenced in the codebase and can be safely removed to reduce technical debt and improve code maintainability.

## Tests

No tests required - this is a cleanup of unused code with no functional impact.

https://claude.ai/code/session_01F4NNEuPAx2gkiB5J2GbAoz