### PR TITLE
Remove changesNotSentForReview from Play Store upload action

### DIFF
--- a/.github/workflows/mobile-daily-internal.yml
+++ b/.github/workflows/mobile-daily-internal.yml
@@ -158,7 +158,6 @@ jobs:
                   track: internal
                   whatsNewDirectory: mobile/apps/photos/whatsnew
                   mappingFile: mobile/apps/photos/build/app/outputs/mapping/playstoreRelease/mapping.txt
-                  changesNotSentForReview: true
 
             - name: Notify Discord
               uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
The Google Play API rejects the changesNotSentForReview parameter when
the app is configured to send changes for review automatically, causing
the "Upload AAB to PlayStore" step to fail with:
"Changes are sent for review automatically. The query parameter
changesNotSentForReview must not be set."

https://claude.ai/code/session_017ZyqysFxAG21zM1xG82yWu