### PR TITLE
[auth] Improve auth code export with type tracking and timestamps

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
@@ -106,7 +106,7 @@ Future<void> _requestForEncryptionPassword(
             ),
           );
           // get json value of data
-          await _exportCodes(context, jsonEncode(data.toJson()), "txt");
+          await _exportCodes(context, jsonEncode(data.toJson()), "encrypted", "json");
         } catch (e) {
           showToast(context, "Error while exporting codes.");
         }
@@ -128,10 +128,10 @@ Future<void> _showExportWarningDialog(BuildContext context, String type) async {
   if (result?.action == ButtonAction.first) {
     if (type == "html") {
       final data = await generateHtml(context);
-      await _exportCodes(context, data, type);
+      await _exportCodes(context, data, "plainhtml", type);
     } else {
       final data = await _getAuthDataForExport();
-      await _exportCodes(context, data, type);
+      await _exportCodes(context, data, "plaintext", type);
     }
   }
 }
@@ -139,11 +139,12 @@ Future<void> _showExportWarningDialog(BuildContext context, String type) async {
 Future<void> _exportCodes(
   BuildContext context,
   String fileContent,
+  String exportType,
   String extension,
 ) async {
   DateTime now = DateTime.now().toUtc();
-  String formattedDate = DateFormat('yyyy-MM-dd').format(now);
-  String exportFileName = 'ente-auth-codes-$formattedDate';
+  String formattedDate = DateFormat('yyyyMMdd-HHmmss').format(now);
+  String exportFileName = 'ente-auth-codes-$exportType-$formattedDate';
   final hasAuthenticated = await LocalAuthenticationService.instance
       .requestLocalAuthentication(context, context.l10n.authToExportCodes);
   if (!hasAuthenticated) {


### PR DESCRIPTION
## Description

Enhanced the export functionality for authentication codes to better track export types and improve file naming:

- Added `exportType` parameter to `_exportCodes()` function to distinguish between different export formats (encrypted, plaintext, plainhtml)
- Updated export file naming to include the export type for better organization and clarity
- Changed timestamp format from `yyyy-MM-dd` to `yyyyMMdd-HHmmss` 
- Updated all call sites to pass the appropriate export type:
  - Encrypted JSON exports now labeled as "encrypted"
  - Plain HTML exports labeled as "plainhtml"
  - Plain text exports labeled as "plaintext"

Example filename changes:
- Before: `ente-auth-codes-2024-01-15.json`
- After: `ente-auth-codes-encrypted-20240115-143022.json`
