### PR TITLE
[auth] Fix text direction for code display in compact mode

### DIFF
--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -420,6 +420,7 @@ class _CodeWidgetState extends State<CodeWidget> {
                                   fontSize: widget.isCompactMode ? 12 : 18,
                                   color: Colors.grey,
                                 ),
+                                textDirection: TextDirection.ltr,
                               ),
                             );
                           },


### PR DESCRIPTION
## Description
Fixes : https://github.com/ente-io/ente/issues/9039

Added explicit left-to-right text direction to the code display widget in compact mode. 
The change adds `textDirection: TextDirection.ltr` to the Text widget that displays the code and the next code, ensuring the text is always rendered left-to-right regardless of the device's locale settings.
