### PR TITLE
[mob][photos] Fix panorama metadata detection trigger in detail view

### DIFF
--- a/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
+++ b/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
@@ -144,7 +144,7 @@ Future<void> showSingleFileDeleteSheet(
 }
 
 Future<void> showDetailsSheet(BuildContext context, EnteFile file) async {
-  if (file.isUploaded && file.isPanorama() == null) {
+  if (file.canEditMetaInfo && file.isPanorama() == null) {
     guardedCheckPanorama(file).ignore();
   }
   Bus.instance.fire(

--- a/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
@@ -120,7 +120,9 @@ class FileBottomBarState extends State<FileBottomBar> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.file.canBePanorama() && widget.file.isPanorama() == null) {
+    if (widget.file.canEditMetaInfo &&
+        widget.file.canBePanorama() &&
+        widget.file.isPanorama() == null) {
       if (lastFileGenID != widget.file.generatedID) {
         lastFileGenID = widget.file.generatedID;
         guardedCheckPanorama(widget.file).ignore();

--- a/mobile/apps/photos/lib/utils/panorama_util.dart
+++ b/mobile/apps/photos/lib/utils/panorama_util.dart
@@ -42,7 +42,7 @@ bool checkPanoramaFromXMP(Map<String, dynamic> xmpData) {
 
 // guardedCheckPanorama() method is used to check if the file is a panorama image.
 Future<void> guardedCheckPanorama(EnteFile file) async {
-  if (file.isPanorama() != null) {
+  if (!file.canEditMetaInfo || file.isPanorama() != null) {
     return;
   }
   _logger.info(


### PR DESCRIPTION
## Summary
- call `guardedCheckPanorama` from the details sheet only for uploaded files with editable metadata and unknown panorama state
- gate `FileBottomBar` panorama checks to `file.canEditMetaInfo` to avoid expensive XMP/EXIF work for shared non-owned files
- add a defensive early return in `guardedCheckPanorama` when metadata cannot be edited
- fix `FileBottomBar` panorama trigger so it runs once per file change instead of never firing
- add the missing `file_props` extension import and valid logger usage in `panorama_util.dart`

## Test Plan
- [x] `dart format lib/ui/actions/file/file_actions.dart lib/ui/viewer/file/file_bottom_bar.dart lib/utils/panorama_util.dart`
- [x] `flutter analyze lib/ui/actions/file/file_actions.dart lib/ui/viewer/file/file_bottom_bar.dart lib/utils/panorama_util.dart`
