### PR TITLE
[Docs]Simplify public link sharing documentation

### DIFF
--- a/docs/docs/locker/getting-started/family-setup.md
+++ b/docs/docs/locker/getting-started/family-setup.md
@@ -149,8 +149,7 @@ All items in the collection will be shared with that person.
 ### Sharing individual items
 
 To share a single item (like a specific document), create a
-[public link](/locker/features/sharing/public-links) for that item. Public links
-can be password-protected and set to expire.
+[public link](/locker/features/sharing/public-links) for that item.
 
 ### Recommended sharing setup
 


### PR DESCRIPTION
## Description

Removed redundant information about password protection and expiration features from the public link sharing section in the family setup documentation. This sentence was duplicative as these features are already documented in detail on the dedicated public links feature page that is linked in the same paragraph.

## Tests

Documentation only - no tests required.

https://claude.ai/code/session_01Lj6YVZ9YSS4nvyti77AeZp