### PR TITLE
[locker] Bump build number to 86

### DIFF
--- a/mobile/apps/locker/pubspec.yaml
+++ b/mobile/apps/locker/pubspec.yaml
@@ -1,7 +1,7 @@
 name: locker
 description: "Ente Locker – Safe space for your important documents"
 publish_to: "none"
-version: 0.1.6+83
+version: 0.1.6+86
 environment:
   sdk: ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
## Summary
- Bump Locker build number from 83 to 86 (`version: 0.1.6+83` → `version: 0.1.6+86`)

## Test plan
- [ ] Verify build number is correct in app settings/about page after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>