### PR TITLE
[mob][locker] Show syncing state in home empty banner

### DIFF
--- a/mobile/apps/locker/lib/ui/components/home_empty_state_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/home_empty_state_widget.dart
@@ -6,18 +6,12 @@ import 'package:locker/l10n/l10n.dart';
 class HomeEmptyStateWidget extends StatelessWidget {
   const HomeEmptyStateWidget({
     super.key,
-    this.isSyncing = false,
   });
-
-  final bool isSyncing;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
     final textTheme = getEnteTextTheme(context);
-    final title =
-        isSyncing ? context.l10n.syncing : context.l10n.homeLockerEmptyTitle;
-    final subtitle = isSyncing ? null : context.l10n.homeLockerEmptySubtitle;
     return DottedBorder(
       options: RoundedRectDottedBorderOptions(
         strokeWidth: 1,
@@ -39,34 +33,24 @@ class HomeEmptyStateWidget extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            isSyncing
-                ? SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 3,
-                      color: colorScheme.primary700,
-                    ),
-                  )
-                : Image.asset(
-                    'assets/upload_file.png',
-                  ),
+            Image.asset(
+              'assets/upload_file.png',
+            ),
             const SizedBox(height: 12),
             Text(
-              title,
+              context.l10n.homeLockerEmptyTitle,
               style: textTheme.h3Bold.copyWith(
                 color: colorScheme.textBase,
               ),
             ),
-            if (subtitle != null) const SizedBox(height: 8),
-            if (subtitle != null)
-              Text(
-                subtitle,
-                style: textTheme.small.copyWith(
-                  color: colorScheme.primary700,
-                  decoration: TextDecoration.none,
-                ),
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.homeLockerEmptySubtitle,
+              style: textTheme.small.copyWith(
+                color: colorScheme.primary700,
+                decoration: TextDecoration.none,
               ),
+            ),
           ],
         ),
       ),

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -748,10 +748,10 @@ class _HomePageState extends UploaderPageState<HomePage>
       );
     }
     if (_displayedCollections.isEmpty) {
-      return Center(
+      return const Center(
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: HomeEmptyStateWidget(isSyncing: _isSyncingWithServer),
+          padding: EdgeInsets.all(16.0),
+          child: HomeEmptyStateWidget(),
         ),
       );
     }
@@ -761,10 +761,10 @@ class _HomePageState extends UploaderPageState<HomePage>
         final scrollBottomPadding = MediaQuery.of(context).padding.bottom + 120;
 
         return _recentFiles.isEmpty
-            ? Center(
+            ? const Center(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: HomeEmptyStateWidget(isSyncing: _isSyncingWithServer),
+                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                  child: HomeEmptyStateWidget(),
                 ),
               )
             : SingleChildScrollView(


### PR DESCRIPTION
## Summary
- show a syncing empty-state on Home while first sync is still in progress
- reuse existing first-sync/loading signal so users do not see a misleading "Your Locker is empty" right after update
- add a circular progress indicator in the home empty-state banner during syncing

## Why
After the locker DB/encryption refactor (#9134), local base state can temporarily appear empty until sync finishes. This change prevents panic by showing explicit syncing UX.


