### PR TITLE
Handle empty collection sync on first load

### DIFF
--- a/mobile/apps/locker/lib/main.dart
+++ b/mobile/apps/locker/lib/main.dart
@@ -176,7 +176,7 @@ Future<void> _init(bool bool, {String? via}) async {
     );
     await LockScreenSettings.instance.init(Configuration.instance);
     await CollectionApiClient.instance.init();
-    await CollectionService.instance.init();
+    await CollectionService.instance.init(preferences);
     await FavoritesService.instance.init();
     await LinksClient.instance.init();
     await LinksService.instance.init();

--- a/mobile/apps/locker/lib/services/collections/collections_service.dart
+++ b/mobile/apps/locker/lib/services/collections/collections_service.dart
@@ -26,6 +26,7 @@ import 'package:locker/services/trash/models/trash_item_request.dart';
 import "package:locker/services/trash/trash_service.dart";
 import "package:locker/utils/crypto_helper.dart";
 import 'package:logging/logging.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class CollectionService {
   static final CollectionService instance =
@@ -52,11 +53,15 @@ class CollectionService {
 
   final _collectionIDToCollections = <int, Collection>{};
 
+  static const String _firstSyncCompletedPrefKey = 'first_sync_completed';
+  late SharedPreferences _prefs;
+
   CollectionService._privateConstructor();
 
-  Future<void> init() async {
+  Future<void> init(SharedPreferences preferences) async {
     _db = LockerDB.instance;
     _apiClient = CollectionApiClient.instance;
+    _prefs = preferences;
 
     Bus.instance.on<SignedInEvent>().listen((event) async {
       _logger.info("User signed in, starting initial sync.");
@@ -69,20 +74,20 @@ class CollectionService {
   }
 
   Future<void> sync() async {
-    final syncTime = _db.getSyncTime();
+    final previousSyncTime = _db.getSyncTime();
+    final shouldCheckFirstSyncCompletion = previousSyncTime == 0;
+
     final updatedCollections =
-        await CollectionApiClient.instance.getCollections(syncTime);
+        await CollectionApiClient.instance.getCollections(previousSyncTime);
     if (updatedCollections.isEmpty) {
-      _logger.info("No collections to sync.");
-      // On the first sync for empty accounts, persist a minimal sync time so
-      // hasCompletedFirstSync() returns true and the UI can transition from
-      // the loading spinner to the empty state. A value of 1 means "synced,
-      // found nothing" — subsequent getCollections(1) still returns all real
-      // collections since their updationTime will always be > 1.
-      if (syncTime == 0) {
-        await _db.setSyncTime(1);
-        Bus.instance.fire(CollectionsUpdatedEvent('first_sync_empty'));
+      if (shouldCheckFirstSyncCompletion) {
+        final didMarkFirstSync = await _setFirstSyncCompleted();
+        if (didMarkFirstSync) {
+          Bus.instance
+              .fire(CollectionsUpdatedEvent('first_sync_complete_empty'));
+        }
       }
+      _logger.info("No collections to sync.");
       return;
     }
     await _db.updateCollections(updatedCollections);
@@ -91,6 +96,9 @@ class CollectionService {
       _collectionIDToCollections[collection.id] = collection;
     }
     await _db.setSyncTime(updatedCollections.last.updationTime);
+    if (shouldCheckFirstSyncCompletion) {
+      await _setFirstSyncCompleted();
+    }
 
     final List<Future> fileFutures = [];
     for (final collection in updatedCollections) {
@@ -130,8 +138,25 @@ class CollectionService {
   }
 
   bool hasCompletedFirstSync() {
-    return Configuration.instance.hasConfiguredAccount() &&
-        _db.getSyncTime() > 0;
+    if (!Configuration.instance.hasConfiguredAccount()) {
+      return false;
+    }
+    if (_db.getSyncTime() > 0) {
+      return true;
+    }
+    return _hasCompletedFirstSyncInPrefs();
+  }
+
+  Future<bool> _setFirstSyncCompleted() async {
+    if (_hasCompletedFirstSyncInPrefs()) {
+      return false;
+    }
+    await _prefs.setBool(_firstSyncCompletedPrefKey, true);
+    return true;
+  }
+
+  bool _hasCompletedFirstSyncInPrefs() {
+    return _prefs.getBool(_firstSyncCompletedPrefKey) ?? false;
   }
 
   Future<Collection> createCollection(


### PR DESCRIPTION
## Description


**Changes:**
- Added `_hasAttemptedFirstSync` flag to track whether a sync has been attempted
- When the first sync returns no collections, fire a `CollectionsUpdatedEvent` to allow the UI to transition from loading spinner to empty state
- Updated `hasCompletedFirstSync()` to return `true` if either sync data exists OR a sync has been attempted, ensuring the loading state is properly exited for empty accounts
- Set the flag to `true` after any sync attempt (whether collections were found or not)

**Why:** Previously, empty accounts would remain in a loading state indefinitely because `hasCompletedFirstSync()` only checked if `_db.getSyncTime() > 0`. For accounts with no collections, this condition would never be met, leaving the UI stuck on the loading spinner.
