### PR TITLE
[server] Retain deleted token rows for 13 months

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1068,7 +1068,7 @@ func setupAndStartCrons(userAuthRepo *repo.UserAuthRepository, collectionLinkRep
 	embeddingCtrl *embeddingCtrl.Controller,
 	healthCheckHandler *api.HealthCheckHandler,
 	castDb castRepo.Repository) {
-	const deletedTokenRetentionDays = 390 // 13 months using a fixed-day approximation
+	const deletedTokenRetentionDays = 397 // 13 months using a fixed-day approximation
 
 	shouldSkipCron := viper.GetBool("jobs.cron.skip")
 	if shouldSkipCron {


### PR DESCRIPTION
## Summary
- change deleted-token cleanup retention from 30 days to a fixed 390-day window (13 months)
- introduce a deletedTokenRetentionDays constant in cron setup for clarity

## Testing
- go test ./cmd/museum
