### PR TITLE
[mob][locker] Set limit for self-hosted locker items to 1000

### DIFF
--- a/mobile/apps/locker/lib/services/files/upload/file_upload_service.dart
+++ b/mobile/apps/locker/lib/services/files/upload/file_upload_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
+import 'package:ente_accounts/models/user_details.dart';
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_crypto_api/ente_crypto_api.dart';
 import 'package:ente_events/event_bus.dart';
@@ -544,7 +545,7 @@ class FileUploader {
       if (userDetails == null) {
         return;
       }
-      final maxFileCount = userDetails.getLockerFileLimit();
+      final maxFileCount = _effectiveLockerFileLimit(userDetails);
       final currentFileCount =
           userDetails.isPartOfFamily() && userDetails.lockerFamilyUsage != null
               ? userDetails.lockerFamilyUsage!.familyFileCount
@@ -563,6 +564,14 @@ class FileUploader {
         _logger.severe('Error checking file count limit', e);
       }
     }
+  }
+
+  int _effectiveLockerFileLimit(UserDetails userDetails) {
+    final currentLimit = userDetails.getLockerFileLimit();
+    if (!Configuration.instance.isEnteProduction() && currentLimit < 1000) {
+      return 1000;
+    }
+    return currentLimit;
   }
 
   /*

--- a/mobile/apps/locker/lib/ui/components/usage_card_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/usage_card_widget.dart
@@ -5,6 +5,7 @@ import "package:ente_ui/theme/ente_theme.dart";
 import "package:flutter/material.dart";
 import "package:intl/intl.dart";
 import "package:locker/l10n/l10n.dart";
+import "package:locker/services/configuration.dart";
 import "package:locker/states/user_details_state.dart";
 
 class UsageCardWidget extends StatelessWidget {
@@ -99,9 +100,9 @@ class _UsageContent extends StatelessWidget {
     final textTheme = getEnteTextTheme(context);
     final colorScheme = getEnteColorScheme(context);
 
-    final maxFileCount =
-        userDetails?.getLockerFileLimit().clamp(1, double.maxFinite).toInt() ??
-            100;
+    final maxFileCount = _effectiveLockerFileLimit(
+      userDetails,
+    ).clamp(1, double.maxFinite).toInt();
     final userFileCount = userDetails?.fileCount ?? 0;
 
     final showFamilyBreakup = _shouldShowFamilyBreakup();
@@ -248,5 +249,13 @@ class _UsageContent extends StatelessWidget {
     if (userDetails == null) return false;
     if (!userDetails!.isPartOfFamily()) return false;
     return userDetails!.lockerFamilyUsage != null;
+  }
+
+  int _effectiveLockerFileLimit(UserDetails? userDetails) {
+    final currentLimit = userDetails?.getLockerFileLimit() ?? 100;
+    if (!Configuration.instance.isEnteProduction() && currentLimit < 1000) {
+      return 1000;
+    }
+    return currentLimit;
   }
 }


### PR DESCRIPTION
Set Locker item-limit display and client-side upload gating to use a 1000-item minimum on non-api.ente.io endpoints while preserving production behavior.