### PR TITLE
remove revolt icons and reference in json

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -1523,10 +1523,6 @@
       ]
     },
     {
-      "title": "Revolt",
-      "hex": "858585"
-    },
-    {
       "title": "RippleMatch"
     },
     {


### PR DESCRIPTION
stoat chat [(link)](https://stoat.chat/updates/long-live-stoat), formerly revolt chat, recently completed their rebrand from revolt to stoat with new logos and everything. i noticed that the icons and references in the json file were added correctly, but revolt was not removed.

 closed because i forgot to change something, sorry.
