### PR TITLE
[server] Add album-level comments/reactions controls on server

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -271,13 +271,15 @@ func main() {
 	reactionsRepo := &socialrepo.ReactionsRepository{DB: db}
 	anonUsersRepo := &socialrepo.AnonUsersRepository{DB: db}
 	commentsController := &socialcontroller.CommentsController{
-		Repo:       commentsRepo,
-		AccessCtrl: accessCtrl,
+		Repo:           commentsRepo,
+		CollectionRepo: collectionRepo,
+		AccessCtrl:     accessCtrl,
 	}
 	reactionsController := &socialcontroller.ReactionsController{
-		Repo:         reactionsRepo,
-		CommentsRepo: commentsRepo,
-		AccessCtrl:   accessCtrl,
+		Repo:           reactionsRepo,
+		CommentsRepo:   commentsRepo,
+		CollectionRepo: collectionRepo,
+		AccessCtrl:     accessCtrl,
 	}
 	socialController := &socialcontroller.Controller{
 		CommentsRepo:   commentsRepo,
@@ -666,6 +668,7 @@ func main() {
 	privateAPI.POST("/collections/join-link", collectionHandler.JoinLink)
 	privateAPI.POST("/collections/share-url", collectionHandler.ShareURL)
 	privateAPI.PUT("/collections/share-url", collectionHandler.UpdateShareURL)
+	privateAPI.PUT("/collections/comment-and-reactions", collectionHandler.UpdateCommentAndReactions)
 	privateAPI.DELETE("/collections/share-url/:collectionID", collectionHandler.UnShareURL)
 	privateAPI.POST("/collections/unshare", collectionHandler.UnShare)
 	privateAPI.POST("/collections/leave/:collectionID", collectionHandler.Leave)

--- a/server/ente/collection.go
+++ b/server/ente/collection.go
@@ -29,7 +29,8 @@ type Collection struct {
 	PublicMagicMetadata *MagicMetadata       `json:"pubMagicMetadata,omitempty"`
 	// SharedMagicMetadata keeps the metadata of the sharees to store settings like
 	// if the collection should be shown on timeline or not
-	SharedMagicMetadata *MagicMetadata `json:"sharedMagicMetadata,omitempty"`
+	SharedMagicMetadata        *MagicMetadata `json:"sharedMagicMetadata,omitempty"`
+	EnableCommentAndReactions bool           `json:"enableCommentAndReactions"`
 }
 
 // AllowSharing indicates if this particular collection type can be shared
@@ -147,6 +148,11 @@ type RenameRequest struct {
 	CollectionID        int64  `json:"collectionID" binding:"required"`
 	EncryptedName       string `json:"encryptedName" binding:"required"`
 	NameDecryptionNonce string `json:"nameDecryptionNonce" binding:"required"`
+}
+
+type UpdateCommentAndReactionsRequest struct {
+	CollectionID               int64 `json:"collectionID" binding:"required"`
+	EnableCommentAndReactions bool  `json:"enableCommentAndReactions"`
 }
 
 // UpdateCollectionMagicMetadata payload for updating magic metadata for single file

--- a/server/migrations/115_collection_enable_comment_and_reactions.down.sql
+++ b/server/migrations/115_collection_enable_comment_and_reactions.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collections
+    DROP COLUMN IF EXISTS enable_comment_and_reactions;

--- a/server/migrations/115_collection_enable_comment_and_reactions.up.sql
+++ b/server/migrations/115_collection_enable_comment_and_reactions.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collections
+    ADD COLUMN IF NOT EXISTS enable_comment_and_reactions BOOLEAN;

--- a/server/pkg/api/collection.go
+++ b/server/pkg/api/collection.go
@@ -181,6 +181,19 @@ func (h *CollectionHandler) UpdateShareURL(c *gin.Context) {
 	})
 }
 
+func (h *CollectionHandler) UpdateCommentAndReactions(c *gin.Context) {
+	var req ente.UpdateCommentAndReactionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	if err := h.Controller.UpdateCommentAndReactions(c, auth.GetUserID(c.Request.Header), req); err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{})
+}
+
 // UnShareURL disable all shared urls for the given collectionID
 func (h *CollectionHandler) UnShareURL(c *gin.Context) {
 	cID, err := strconv.ParseInt(c.Param("collectionID"), 10, 64)

--- a/server/pkg/controller/collections/collection.go
+++ b/server/pkg/controller/collections/collection.go
@@ -53,6 +53,7 @@ func (c *CollectionController) Create(collection ente.Collection, ownerID int64)
 	app := collection.App
 	collection.Owner.ID = ownerID
 	collection.UpdationTime = time.Microseconds()
+	collection.EnableCommentAndReactions = true
 	// [20th Dec 2022] Patch on server side untill majority of the existing mobile clients upgrade to a version higher > 0.7.0
 	// https://github.com/ente-io/photos-app/pull/725
 	if collection.Type == "CollectionType.album" {
@@ -189,6 +190,16 @@ func (c *CollectionController) Rename(userID int64, cID int64, encryptedName str
 		return stacktrace.Propagate(err, "")
 	}
 	return nil
+}
+
+func (c *CollectionController) UpdateCommentAndReactions(ctx *gin.Context, userID int64, req ente.UpdateCommentAndReactionsRequest) error {
+	if err := c.verifyOwnership(req.CollectionID, userID); err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	return stacktrace.Propagate(
+		c.CollectionRepo.UpdateCommentAndReactionsSetting(ctx, req.CollectionID, req.EnableCommentAndReactions, time.Microseconds()),
+		"",
+	)
 }
 
 // UpdateMagicMetadata updates the magic metadata for given collection


### PR DESCRIPTION
## Summary

  Implements **server-side only** support for album-level comments/reactions control for shared albums.

  This adds an album setting backed by `collections.enable_comment_and_reactions` with effective semantics:
  - `NULL` => enabled
  - `TRUE` => enabled
  - `FALSE` => disabled

  Public-link-level `enableComment` remains unchanged as a field name and is now constrained by album-level setting.

  ## What changed

  - Added migration:
    - `115_collection_enable_comment_and_reactions`
    - Adds nullable `collections.enable_comment_and_reactions` (no default).
  - Added collection response field:
    - `enableCommentAndReactions` (always returned as effective boolean via `COALESCE(..., TRUE)` behavior).
  - Added owner-only endpoint:
    - `PUT /collections/comment-and-reactions`
    - Payload: `collectionID`, `enableCommentAndReactions` (bool).
  - Added enforcement:
    - If album-level setting is `false`, block comment create/update.
    - If album-level setting is `false`, block reaction upsert.
    - If album-level setting is `false`, public-link `enableComment` cannot be enabled.
    - When album-level setting is set to `false`, active public links are forced to `enable_comment = false`.
  - Public token read behavior updated:
    - Effective comment permission is now:
      `public_link_enable_comment AND COALESCE(collection.enable_comment_and_reactions, TRUE)`.

  ## Backward compatibility

  - Create flow remains compatible with older clients:
    - DB default stays `NULL`
    - `NULL` is treated as enabled, so clients do not see false by default.