### PR TITLE
fix: correct Play Store link for Ente Locker

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ you can store up to 1000 items. Learn more at
 <div align="center">
 
 [<img height="40" src=".github/assets/app-store-badge.svg">](https://apps.apple.com/us/app/ente-locker/id6747611956)
-[<img height="40" src=".github/assets/play-store-badge.png">](https://apps.apple.com/us/app/ente-locker/id6747611956)
+[<img height="40" src=".github/assets/play-store-badge.png">](https://play.google.com/store/apps/details?id=io.ente.locker)
 
 </div>
 


### PR DESCRIPTION
## Summary

This PR fixes an incorrect link in the README for Ente Locker.

## Problem

The Play Store badge for Ente Locker was incorrectly linking to the Apple App Store URL:
```
https://apps.apple.com/us/app/ente-locker/id6747611956
```

## Solution

Updated the Play Store badge to point to the correct Google Play Store listing:
```
https://play.google.com/store/apps/details?id=io.ente.locker
```

## Changes

- Fixed the Play Store link in the Ente Locker section of README.md

## Testing

Verified the link format matches the standard Play Store URL pattern used elsewhere in the README.