### PR TITLE
[auth] Add icon for Adobe

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -34,6 +34,9 @@
       "slug": "addy_io"
     },
     {
+      "title": "Adobe"
+    },
+    {
       "title": "Airtable"
     },
     {

--- a/mobile/apps/auth/assets/custom-icons/icons/adobe.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/adobe.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" viewBox="0 10.22 16.86 14.94">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #eb1000;
+      }
+    </style>
+  </defs>
+  <path class="cls-1" d="M6.27,10.22h4.39l6.2,14.94h-4.64l-3.92-9.92-2.59,6.51h3.08l1.23,3.41H0l6.27-14.94"/>
+</svg>


### PR DESCRIPTION
## Description
Add SVG icon for Adobe: https://www.adobe.com

Source: https://dashboardicons.com/icons/adobe (Apache-2.0 licensed).

## Checklist
- SVG is optimized and under 20KB
- Filename is lowercase
- Added entry to custom-icons.json

## Tests
N/A