### PR TITLE
fix: dynamically position text detection button to avoid layout overl…

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/text_detection_overlay_button.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/text_detection_overlay_button.dart
@@ -193,15 +193,15 @@ class _TextDetectionOverlayButtonState
           final textPainter = TextPainter(
             text: TextSpan(
               text: caption.trim(),
-              style: getEnteTextTheme(context).small,
+              style: getEnteTextTheme(context).mini,
             ),
             textDirection: TextDirection.ltr,
             textScaler: MediaQuery.textScalerOf(context),
             maxLines: 3,
           );
 
-          // 2. Measure against the available screen width (assuming ~16px padding on each side)
-          final double maxWidth = MediaQuery.sizeOf(context).width - 32.0;
+          // 2. Measure against the available screen width
+          final double maxWidth = MediaQuery.sizeOf(context).width - 16.0;
           textPainter.layout(maxWidth: maxWidth);
 
           // 3. Add the exact calculated text height (capped at 3 lines) + 24px safe padding buffer


### PR DESCRIPTION
Fixes #9283

## Description
Previously, the `TextDetectionOverlayButton` ("Select text" pill) used a hardcoded bottom offset of `72.0`. This caused it to overlap with the image caption text, making the UI look broken.

This PR fixes the issue by dynamically calculating the height of the caption text and adjusting the button's position accordingly.

**Key Changes:**
* Uses `TextPainter` to accurately measure the text's pixel height based on the device's text scaling settings.
* Includes `maxLines: 3` in the `TextPainter` configuration to perfectly mirror the UI's native 3-line visual truncation. This ensures the button securely clears the text but doesn't float into the middle of the screen for extremely long paragraphs.
* Falls back to the default `72.0` safe offset if no caption is present.

## Tests
* Tested locally on Android Emulator.
* Verified proper baseline position with no caption.
* Verified dynamic scaling with 1-line and 2-line captions.
* Verified vertical height clamping with massive 10+ line paragraphs (button securely pins above the 3rd truncated line).

**Screenshots:**
*before
<img width="444" height="928" alt="Screenshot From 2026-02-22 04-00-35" src="https://github.com/user-attachments/assets/1d38f07c-c5e0-4b0e-85f3-502196745134" />

*after
<img width="444" height="928" alt="Screenshot From 2026-02-22 04-02-42" src="https://github.com/user-attachments/assets/b6363fed-ed6a-4881-8fac-6f29551970a1" />
