### PR TITLE
[server] Fix Locker uploads being blocked by no-active-subscription checks

### DIFF
--- a/server/pkg/controller/usage.go
+++ b/server/pkg/controller/usage.go
@@ -55,6 +55,12 @@ func (c *UsageController) CanUploadFile(ctx context.Context, userID int64, size 
 
 func (c *UsageController) checkAndUpdateCache(ctx context.Context, userID int64, size *int64, app ente.App) error {
 	err := c.canUploadFile(ctx, userID, size, app)
+	// Do not cache Locker results in the shared UploadResultCache.
+	// CanUploadFile's fast path only excludes Locker on read, so writing Locker outcomes
+	// here can leak allow/deny decisions into Photos/Auth checks for the same user.
+	if app == ente.Locker {
+		return err
+	}
 	c.mu.Lock()
 	c.UploadResultCache[userID] = err == nil
 	c.mu.Unlock()


### PR DESCRIPTION
### Motivation
- Free or expired Locker users were incorrectly getting `ErrNoActiveSubscription` (HTTP 402) when trying to save notes/files because the general subscription expiry check ran before Locker-specific tier logic.
- This caused mobile flows that call `/files/upload-url` and `/files/meta` to surface `NoActiveSubscription` errors even when the Locker free-tier limits should allow the operation.

### Description
- Reordered the logic in `UsageController.canUploadFile` so the `app == ente.Locker` branch (Locker-specific tiered limits and early return) runs before the general `GetActiveSubscription` / bonus gating.
- Ensures Locker uploads validate against Locker free/paid limits (file count and storage) and are not blocked by Photos/Auth subscription expiry checks.
- File modified: `server/pkg/controller/usage.go` (moved subscription/bonus block below the Locker handling and returned early for Locker uploads).
