### PR TITLE
[server] Track collection share time and return it in shared diff

### DIFF
--- a/server/ente/collection.go
+++ b/server/ente/collection.go
@@ -23,6 +23,7 @@ type Collection struct {
 	Sharees             []CollectionUser     `json:"sharees"`
 	PublicURLs          []PublicURL          `json:"publicURLs"`
 	UpdationTime        int64                `json:"updationTime"`
+	SharedAt            *int64               `json:"sharedAt,omitempty"`
 	IsDeleted           bool                 `json:"isDeleted,omitempty"`
 	MagicMetadata       *MagicMetadata       `json:"magicMetadata,omitempty"`
 	App                 string               `json:"app"`

--- a/server/migrations/115_add_shared_at_collection_shares.down.sql
+++ b/server/migrations/115_add_shared_at_collection_shares.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collection_shares
+    DROP COLUMN IF EXISTS shared_at;

--- a/server/migrations/115_add_shared_at_collection_shares.up.sql
+++ b/server/migrations/115_add_shared_at_collection_shares.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collection_shares
+    ADD COLUMN IF NOT EXISTS shared_at BIGINT;


### PR DESCRIPTION
## Summary
- add nullable `shared_at` to `collection_shares`
- expose `sharedAt` on `ente.Collection` for API responses
- set `shared_at` when a share row is inserted, and refresh it when a previously deleted share is re-shared
- include `collection_shares.shared_at` in `GetCollectionsSharedWithUser` so shared collections diff includes share time

## Why
Clients need a stable "shared with me at" value that is separate from `updation_time` (which changes for other share-row updates like metadata and unshare events).

## Testing
- `go test ./pkg/repo ./pkg/controller/collections ./pkg/api -run TestDoesNotExist -count=0`
