### PR TITLE
[mob][photos] Enable sentence capitalization for comment input field

### DIFF
--- a/mobile/apps/photos/lib/ui/social/widgets/comment_input_widget.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/comment_input_widget.dart
@@ -83,6 +83,7 @@ class _CommentInputWidgetState extends State<CommentInputWidget>
     });
   }
 
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -138,6 +139,7 @@ class _CommentInputWidgetState extends State<CommentInputWidget>
                 controller: widget.controller,
                 focusNode: widget.focusNode,
                 keyboardType: TextInputType.multiline,
+                textCapitalization: TextCapitalization.sentences,
                 textInputAction: TextInputAction.newline,
                 inputFormatters: [LengthLimitingTextInputFormatter(500)],
                 minLines: 1,

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Ashil: Enable sentence capitalization for comment input field
 - Ashil: Fix files uploaded by sharing from outside of Ente missing in map
 - Laurens: (I) Use vectorDB for more accurate suggestions in the people overview
 - Laurens: (I) Use cloudflare worker for upload for internal users


### PR DESCRIPTION
### Motivation
- Improve typing UX for comments by enabling sentence capitalization on the input field so mobile keyboards automatically start sentences with a capital letter.

### Description
- Add `textCapitalization: TextCapitalization.sentences` to the comment `TextField` in `comment_input_widget.dart` and record the change in `scripts/internal_changes.txt`.

### Testing
- No automated tests were run for this UI tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e888e1c7883279562c46bdebb926f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment input field now automatically capitalizes the first letter of sentences, improving the typing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->