### PR TITLE
[mob][photos] Remove x86 from ndk abiFilters of defaultConfig

### DIFF
--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -63,7 +63,7 @@ android {
         multiDexEnabled true
         consumerProguardFiles 'proguard-rules.pro'
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86_64"
+            abiFilters "armeabi-v7a", "arm64-v8a"
         }
     }
 


### PR DESCRIPTION
## Description

Missed this in https://github.com/ente-io/ente/pull/9345
