### PR TITLE
[mob][locker] Pin locker network dependencies  

### DIFF
--- a/mobile/apps/locker/pubspec.lock
+++ b/mobile/apps/locker/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   cross_file:
     dependency: transitive
     description:
@@ -747,10 +747,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -907,10 +907,10 @@ packages:
     dependency: transitive
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:
@@ -1646,4 +1646,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"

--- a/mobile/packages/accounts/pubspec.lock
+++ b/mobile/packages/accounts/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   cross_file:
     dependency: transitive
     description:
@@ -567,10 +567,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -711,10 +711,10 @@ packages:
     dependency: transitive
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:

--- a/mobile/packages/legacy/pubspec.lock
+++ b/mobile/packages/legacy/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   cross_file:
     dependency: transitive
     description:
@@ -589,10 +589,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -733,10 +733,10 @@ packages:
     dependency: transitive
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:

--- a/mobile/packages/lock_screen/pubspec.lock
+++ b/mobile/packages/lock_screen/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   cross_file:
     dependency: transitive
     description:
@@ -567,10 +567,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -711,10 +711,10 @@ packages:
     dependency: transitive
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:

--- a/mobile/packages/network/pubspec.lock
+++ b/mobile/packages/network/pubspec.lock
@@ -66,13 +66,13 @@ packages:
     source: hosted
     version: "3.1.2"
   cronet_http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   crypto:
     dependency: transitive
     description:
@@ -295,10 +295,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -383,10 +383,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:

--- a/mobile/packages/network/pubspec.yaml
+++ b/mobile/packages/network/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  cronet_http: 1.3.4
   dio: ^5.8.0+1
   ente_configuration:
     path: ../../packages/configuration
@@ -15,7 +16,7 @@ dependencies:
     path: ../../packages/events
   flutter:
     sdk: flutter
-  native_dio_adapter: ^1.4.0
+  native_dio_adapter: 1.4.0
   package_info_plus: ^8.3.0
   ua_client_hints: ^1.4.1
   uuid: ^4.5.1

--- a/mobile/packages/sharing/pubspec.lock
+++ b/mobile/packages/sharing/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: cronet_http
-      sha256: "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a"
+      sha256: "5ed075c59b2d4bd43af4e73d906b8082e98ecd2af9c625327370ef28361bf635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.3.4"
   cross_file:
     dependency: transitive
     description:
@@ -582,10 +582,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
+      sha256: "459727a9daf91bdfb39b014cf3c186cf77f0136124a274ac83c186e12262ac4e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.2"
+    version: "0.12.2"
   js:
     dependency: transitive
     description:
@@ -726,10 +726,10 @@ packages:
     dependency: transitive
     description:
       name: native_dio_adapter
-      sha256: "1c51bd42027861d27ccad462ba0903f5e3197461cc6d59a0bb8658cb5ad7bd01"
+      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.4.0"
   objective_c:
     dependency: transitive
     description:


### PR DESCRIPTION
Issue: Locker could drift to newer network dependency versions than Auth, causing inconsistent Cronet behavior on restricted devices.
Description: Pin network dependency versions in shared mobile network package and refresh dependent lockfiles so Locker resolves native_dio_adapter 1.4.0 + cronet_http 1.3.4.