### PR TITLE
[mob][photos] Fix rust indexing issue

### DIFF
--- a/mobile/apps/photos/lib/services/machine_learning/ml_indexing_isolate.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_indexing_isolate.dart
@@ -31,6 +31,8 @@ class MLIndexingIsolate extends SuperIsolate {
   @override
   bool get shouldAutomaticDispose => true;
 
+  bool get _shouldUseRustMl => flagService.useRustForML || isOfflineMode;
+
   int _loadedModelsCount = 0;
   int _deloadedModelsCount = 0;
 
@@ -112,8 +114,6 @@ class MLIndexingIsolate extends SuperIsolate {
     return result;
   }
 
-  bool get _shouldUseRustMl => flagService.useRustForML || isOfflineMode;
-
   Future<void> prepareRustRuntime() async {
     if (!_shouldUseRustMl) {
       return;
@@ -131,6 +131,9 @@ class MLIndexingIsolate extends SuperIsolate {
   }
 
   Future<void> releaseRustRuntime() async {
+    if (!_shouldUseRustMl) {
+      return;
+    }
     if (!isIsolateSpawned) {
       _cachedRustRuntimeArgs = null;
       return;
@@ -256,6 +259,10 @@ class MLIndexingIsolate extends SuperIsolate {
 
   /// WARNING: This method is only for debugging purposes. It should not be used in production.
   Future<void> debugLoadSingleModel(MLModels model) {
+    if (_shouldUseRustMl) {
+      _logger.severe("Can't use legacy ML models when using rust");
+      return Future.value();
+    }
     return _initModelLock.synchronized(() async {
       final modelInstance = model.model;
       if (modelInstance.isInitialized) {
@@ -298,6 +305,10 @@ class MLIndexingIsolate extends SuperIsolate {
   }
 
   Future<void> _releaseModels() async {
+    if (_shouldUseRustMl) {
+      _logger.severe("Can't release legacy ML models when using rust");
+      return Future.value();
+    }
     final List<String> modelNames = [];
     final List<int> modelAddresses = [];
     final List<MLModels> models = [];


### PR DESCRIPTION
## Description

Indexing is rust was not working because a legacy dart:ui issue was causing the ML indexing isolate setup to fail. This PR fixes that issue and adds some extra safeguards. 