### PR TITLE
server: remove locker rollout gating so Locker is open to all users

### DIFF
--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -16,8 +16,6 @@ type UserAuthRepository struct {
 	DB *sql.DB
 }
 
-const lockerRolloutLimit = 11150
-
 // AddOTT saves the provided one time token for the specified user
 func (repo *UserAuthRepository) AddOTT(emailHash string, app ente.App, ott string, expirationTime int64) error {
 	_, err := repo.DB.Exec(`INSERT INTO otts(email_hash, ott, creation_time, expiration_time, app)
@@ -186,49 +184,6 @@ func (repo *UserAuthRepository) RemoveDeletedTokens(expiryTime int64) error {
 func (repo *UserAuthRepository) RemoveAllTokens(userID int64) error {
 	_, err := repo.DB.Exec(`UPDATE tokens SET is_deleted = true WHERE user_id = $1`, userID)
 	return stacktrace.Propagate(err, "")
-}
-
-// EnsureLockerRolloutAccess allows registration for locker users if they already own a locker collection
-// or if the rollout is still under the configured limit.
-func (repo *UserAuthRepository) EnsureLockerRolloutAccess(userID int64) error {
-	var hasLockerCollection bool
-	if err := repo.DB.QueryRow(`
-		SELECT EXISTS(
-			SELECT 1 FROM collections
-			WHERE owner_id = $1 AND app = $2
-		)
-	`, userID, ente.Locker).Scan(&hasLockerCollection); err != nil {
-		return stacktrace.Propagate(err, "failed to check locker collections")
-	}
-	if hasLockerCollection {
-		return nil
-	}
-
-	var alreadyLockerUser bool
-	if err := repo.DB.QueryRow(`
-		SELECT EXISTS(
-			SELECT 1 FROM tokens
-			WHERE user_id = $1 AND app = $2
-		)
-	`, userID, ente.Locker).Scan(&alreadyLockerUser); err != nil {
-		return stacktrace.Propagate(err, "failed to check locker tokens for user")
-	}
-	if alreadyLockerUser {
-		return nil
-	}
-
-	var currentLockerUsers int
-	if err := repo.DB.QueryRow(`
-		SELECT COUNT(DISTINCT user_id)
-		FROM tokens
-		WHERE app = $1
-	`, ente.Locker).Scan(&currentLockerUsers); err != nil {
-		return stacktrace.Propagate(err, "failed to count locker users")
-	}
-	if currentLockerUsers >= lockerRolloutLimit {
-		return stacktrace.Propagate(ente.ErrLockerRollOutLimit, "locker rollout cap reached")
-	}
-	return nil
 }
 
 // GetActiveSessions returns the list of tokens that are valid for a given user


### PR DESCRIPTION
## Summary
- remove the locker rollout cap logic from UserAuthRepository
- remove ensureLockerAccess and its auth token checks in UserController
- keep locker token creation path unchanged apart from eliminating rollout gating

## Testing
- go test ./pkg/repo ./pkg/controller/user
