### PR TITLE
[auth] keep OTP code readable with larger text scales

### DIFF
--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -15,6 +15,7 @@ import 'package:ente_auth/store/code_display_store.dart';
 import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/code_timer_progress.dart';
+import 'package:ente_auth/ui/code_widget_layout_utils.dart';
 import 'package:ente_auth/ui/components/auth_qr_dialog.dart';
 import 'package:ente_auth/ui/components/note_dialog.dart';
 import 'package:ente_auth/ui/home/shortcuts.dart';
@@ -337,7 +338,8 @@ class _CodeWidgetState extends State<CodeWidget> {
       );
     }
 
-    return Container(
+    final bool isIOS = !kIsWeb && Platform.isIOS;
+    final Widget content = Container(
       margin: widget.isCompactMode
           ? const EdgeInsets.only(left: 16, right: 16, bottom: 6, top: 6)
           : const EdgeInsets.only(left: 16, right: 16, bottom: 8, top: 8),
@@ -368,34 +370,56 @@ class _CodeWidgetState extends State<CodeWidget> {
         },
       ),
     );
+    if (!isIOS) return content;
+    final double scale =
+        MediaQuery.textScalerOf(context).scale(1.0).clamp(1.0, 2.0);
+    return MediaQuery(
+      data:
+          MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(scale)),
+      child: content,
+    );
   }
 
   Widget _getBottomRow(AppLocalizations l10n) {
-    return Container(
-      padding: const EdgeInsets.only(left: 16, right: 16),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Expanded(
-            child: ValueListenableBuilder<String>(
-              valueListenable: _currentCode,
-              builder: (context, value, child) {
-                return Material(
-                  type: MaterialType.transparency,
-                  child: AutoSizeText(
-                    _getFormattedCode(value),
-                    style: TextStyle(fontSize: widget.isCompactMode ? 14 : 24),
-                    maxLines: 1,
-                    textDirection: TextDirection.ltr,
-                  ),
-                );
-              },
-            ),
-          ),
-          const SizedBox(width: 8),
-          widget.code.type.isTOTPCompatible
-              ? IgnorePointer(
+    final textScaleFactor = MediaQuery.textScalerOf(context).scale(1.0);
+    final isIOS = !kIsWeb && Platform.isIOS;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final showNextTotp = widget.code.type.isTOTPCompatible &&
+            shouldShowNextTotpCode(
+              isIOS: isIOS,
+              availableWidth: constraints.maxWidth,
+              textScaleFactor: textScaleFactor,
+              isCompactMode: widget.isCompactMode,
+            );
+        return Container(
+          padding: const EdgeInsets.only(left: 16, right: 16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: ValueListenableBuilder<String>(
+                  valueListenable: _currentCode,
+                  builder: (context, value, child) {
+                    return Material(
+                      type: MaterialType.transparency,
+                      child: AutoSizeText(
+                        _getFormattedCode(value),
+                        style: TextStyle(
+                          fontSize: widget.isCompactMode ? 14 : 24,
+                        ),
+                        maxLines: 1,
+                        minFontSize: widget.isCompactMode ? 12 : 16,
+                        textDirection: TextDirection.ltr,
+                      ),
+                    );
+                  },
+                ),
+              ),
+              if (showNextTotp) ...[
+                const SizedBox(width: 8),
+                IgnorePointer(
                   ignoring:
                       CodeDisplayStore.instance.isSelectionModeActive.value,
                   child: GestureDetector(
@@ -428,8 +452,10 @@ class _CodeWidgetState extends State<CodeWidget> {
                       ],
                     ),
                   ),
-                )
-              : IgnorePointer(
+                ),
+              ] else if (!widget.code.type.isTOTPCompatible) ...[
+                const SizedBox(width: 8),
+                IgnorePointer(
                   ignoring:
                       CodeDisplayStore.instance.isSelectionModeActive.value,
                   child: Column(
@@ -450,8 +476,11 @@ class _CodeWidgetState extends State<CodeWidget> {
                     ],
                   ),
                 ),
-        ],
-      ),
+              ],
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -371,8 +371,9 @@ class _CodeWidgetState extends State<CodeWidget> {
       ),
     );
     if (!isIOS) return content;
-    final double scale =
-        MediaQuery.textScalerOf(context).scale(1.0).clamp(1.0, 2.0);
+    final double scale = capCodeWidgetTextScaleForIOS(
+      MediaQuery.textScalerOf(context).scale(1.0),
+    );
     return MediaQuery(
       data:
           MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(scale)),
@@ -381,45 +382,31 @@ class _CodeWidgetState extends State<CodeWidget> {
   }
 
   Widget _getBottomRow(AppLocalizations l10n) {
-    final textScaleFactor = MediaQuery.textScalerOf(context).scale(1.0);
-    final isIOS = !kIsWeb && Platform.isIOS;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final showNextTotp = widget.code.type.isTOTPCompatible &&
-            shouldShowNextTotpCode(
-              isIOS: isIOS,
-              availableWidth: constraints.maxWidth,
-              textScaleFactor: textScaleFactor,
-              isCompactMode: widget.isCompactMode,
-            );
-        return Container(
-          padding: const EdgeInsets.only(left: 16, right: 16),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Expanded(
-                child: ValueListenableBuilder<String>(
-                  valueListenable: _currentCode,
-                  builder: (context, value, child) {
-                    return Material(
-                      type: MaterialType.transparency,
-                      child: AutoSizeText(
-                        _getFormattedCode(value),
-                        style: TextStyle(
-                          fontSize: widget.isCompactMode ? 14 : 24,
-                        ),
-                        maxLines: 1,
-                        minFontSize: widget.isCompactMode ? 12 : 16,
-                        textDirection: TextDirection.ltr,
-                      ),
-                    );
-                  },
-                ),
-              ),
-              if (showNextTotp) ...[
-                const SizedBox(width: 8),
-                IgnorePointer(
+    return Container(
+      padding: const EdgeInsets.only(left: 16, right: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Expanded(
+            child: ValueListenableBuilder<String>(
+              valueListenable: _currentCode,
+              builder: (context, value, child) {
+                return Material(
+                  type: MaterialType.transparency,
+                  child: AutoSizeText(
+                    _getFormattedCode(value),
+                    style: TextStyle(fontSize: widget.isCompactMode ? 14 : 24),
+                    maxLines: 1,
+                    textDirection: TextDirection.ltr,
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          widget.code.type.isTOTPCompatible
+              ? IgnorePointer(
                   ignoring:
                       CodeDisplayStore.instance.isSelectionModeActive.value,
                   child: GestureDetector(
@@ -452,10 +439,8 @@ class _CodeWidgetState extends State<CodeWidget> {
                       ],
                     ),
                   ),
-                ),
-              ] else if (!widget.code.type.isTOTPCompatible) ...[
-                const SizedBox(width: 8),
-                IgnorePointer(
+                )
+              : IgnorePointer(
                   ignoring:
                       CodeDisplayStore.instance.isSelectionModeActive.value,
                   child: Column(
@@ -476,11 +461,8 @@ class _CodeWidgetState extends State<CodeWidget> {
                     ],
                   ),
                 ),
-              ],
-            ],
-          ),
-        );
-      },
+        ],
+      ),
     );
   }
 

--- a/mobile/apps/auth/lib/ui/code_widget_layout_utils.dart
+++ b/mobile/apps/auth/lib/ui/code_widget_layout_utils.dart
@@ -1,0 +1,14 @@
+bool shouldShowNextTotpCode({
+  required bool isIOS,
+  required double availableWidth,
+  required double textScaleFactor,
+  required bool isCompactMode,
+}) {
+  if (isIOS) return true;
+
+  final double minWidth = isCompactMode ? 230 : 320;
+  final double scaleAdjustedMinWidth = textScaleFactor >= 1.2
+      ? minWidth + (textScaleFactor - 1.2) * 140
+      : minWidth;
+  return availableWidth >= scaleAdjustedMinWidth;
+}

--- a/mobile/apps/auth/lib/ui/code_widget_layout_utils.dart
+++ b/mobile/apps/auth/lib/ui/code_widget_layout_utils.dart
@@ -1,14 +1,3 @@
-bool shouldShowNextTotpCode({
-  required bool isIOS,
-  required double availableWidth,
-  required double textScaleFactor,
-  required bool isCompactMode,
-}) {
-  if (isIOS) return true;
-
-  final double minWidth = isCompactMode ? 230 : 320;
-  final double scaleAdjustedMinWidth = textScaleFactor >= 1.2
-      ? minWidth + (textScaleFactor - 1.2) * 140
-      : minWidth;
-  return availableWidth >= scaleAdjustedMinWidth;
+double capCodeWidgetTextScaleForIOS(double textScaleFactor) {
+  return textScaleFactor > 2.0 ? 2.0 : textScaleFactor;
 }

--- a/mobile/apps/auth/test/ui/code_widget_layout_test.dart
+++ b/mobile/apps/auth/test/ui/code_widget_layout_test.dart
@@ -1,0 +1,39 @@
+import 'package:ente_auth/ui/code_widget_layout_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldShowNextTotpCode', () {
+    test('returns false for constrained width and large text scale', () {
+      final value = shouldShowNextTotpCode(
+        isIOS: false,
+        availableWidth: 260,
+        textScaleFactor: 1.4,
+        isCompactMode: false,
+      );
+
+      expect(value, isFalse);
+    });
+
+    test('returns true for comfortable width', () {
+      final value = shouldShowNextTotpCode(
+        isIOS: false,
+        availableWidth: 420,
+        textScaleFactor: 1.0,
+        isCompactMode: false,
+      );
+
+      expect(value, isTrue);
+    });
+
+    test('returns true on iOS regardless of width', () {
+      final value = shouldShowNextTotpCode(
+        isIOS: true,
+        availableWidth: 260,
+        textScaleFactor: 3.12,
+        isCompactMode: false,
+      );
+
+      expect(value, isTrue);
+    });
+  });
+}

--- a/mobile/apps/auth/test/ui/code_widget_layout_test.dart
+++ b/mobile/apps/auth/test/ui/code_widget_layout_test.dart
@@ -2,38 +2,23 @@ import 'package:ente_auth/ui/code_widget_layout_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('shouldShowNextTotpCode', () {
-    test('returns false for constrained width and large text scale', () {
-      final value = shouldShowNextTotpCode(
-        isIOS: false,
-        availableWidth: 260,
-        textScaleFactor: 1.4,
-        isCompactMode: false,
-      );
+  group('capCodeWidgetTextScaleForIOS', () {
+    test('caps iOS text scale at 2.0', () {
+      final value = capCodeWidgetTextScaleForIOS(3.12);
 
-      expect(value, isFalse);
+      expect(value, 2.0);
     });
 
-    test('returns true for comfortable width', () {
-      final value = shouldShowNextTotpCode(
-        isIOS: false,
-        availableWidth: 420,
-        textScaleFactor: 1.0,
-        isCompactMode: false,
-      );
+    test('preserves iOS text scale exactly at 2.0', () {
+      final value = capCodeWidgetTextScaleForIOS(2.0);
 
-      expect(value, isTrue);
+      expect(value, 2.0);
     });
 
-    test('returns true on iOS regardless of width', () {
-      final value = shouldShowNextTotpCode(
-        isIOS: true,
-        availableWidth: 260,
-        textScaleFactor: 3.12,
-        isCompactMode: false,
-      );
+    test('preserves smaller iOS text scales', () {
+      final value = capCodeWidgetTextScaleForIOS(0.85);
 
-      expect(value, isTrue);
+      expect(value, 0.85);
     });
   });
 }


### PR DESCRIPTION
## Summary

This fixes the iOS accessibility text scaling issue in the Auth code card.

At the largest iOS text sizes, the OTP card could become too tall and cramped, making the title/account name and codes hard to use. The fix keeps the existing layout, but caps the card text scale on iOS at `2.0x`, matching the effective ceiling Android already has.

The latest maintainer feedback is addressed by keeping the change narrow:
- Android behavior is unchanged.
- Smaller iOS text sizes are preserved.
- The next-code/HOTP action is not hidden when space is tight.

## Changes

- Add an iOS-only `MediaQuery` override around the code card.
- Cap only text scales above `2.0`; smaller user-selected scales still pass through.
- Add unit coverage for the text-scale cap behavior.

## Test plan

- `flutter analyze lib/ui/code_widget.dart lib/ui/code_widget_layout_utils.dart test/ui/code_widget_layout_test.dart`
- `flutter test test/ui/code_widget_layout_test.dart`

<details>
<summary>Screenshots</summary>

<details>
<summary>Android accessibility</summary>
<img width="1080" height="2400" alt="Android - Max Accessibility" src="https://github.com/user-attachments/assets/c6c25c88-5696-4896-8024-2c815fa64a0d" />
</details>

<details>
<summary>iOS clipping issue at max accessibility settings</summary>
<img width="1206" height="2622" alt="iOS clipping issue" src="https://github.com/user-attachments/assets/a1252c74-3a9c-4e51-968b-7ca32d42f4d6" />
</details>

<details>
<summary>iOS after fix at max accessibility settings</summary>
<img width="1206" height="2622" alt="iOS after fix" src="https://github.com/user-attachments/assets/27859836-2047-4585-b4d1-767c1b79ad97" />
</details>

</details>
