### PR TITLE
auth: prevent black screen after QR scan on iOS

### DIFF
--- a/mobile/apps/auth/lib/ui/scanner_gauth_page.dart
+++ b/mobile/apps/auth/lib/ui/scanner_gauth_page.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
+import 'package:ente_auth/ui/scanner_utils.dart';
 import 'package:ente_auth/ui/settings/data/import/google_auth_import.dart';
 import 'package:ente_auth/utils/toast_util.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +21,8 @@ class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
   QRViewController? controller;
   String? totp;
+  StreamSubscription<Barcode>? _scanSubscription;
+  bool _hasHandledResult = false;
 
   // In order to get hot reload to work we need to pause the camera if the platform
   // is android, or resume the camera if the platform is iOS.
@@ -70,28 +74,46 @@ class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
       controller.pauseCamera();
       controller.resumeCamera();
     }
-    controller.scannedDataStream.listen((scanData) {
+    _scanSubscription?.cancel();
+    _scanSubscription = controller.scannedDataStream.listen((scanData) async {
+      if (!shouldHandleScanResult(
+        hasHandledResult: _hasHandledResult,
+        scannedCode: scanData.code,
+      )) {
+        return;
+      }
       try {
-        if (scanData.code == null) {
-          return;
-        }
         if (scanData.code!.startsWith(kGoogleAuthExportPrefix)) {
-          List<Code> codes = parseGoogleAuth(scanData.code!);
+          final List<Code> codes = parseGoogleAuth(scanData.code!);
+          _hasHandledResult = true;
+          await _scanSubscription?.cancel();
+          await controller.pauseCamera();
+          await controller.stopCamera();
           controller.dispose();
+          if (!mounted) {
+            return;
+          }
           Navigator.of(context).pop(codes);
         } else {
-          showToast(context, "Invalid QR code");
+          if (mounted) {
+            showToast(context, "Invalid QR code");
+          }
         }
       } catch (e) {
+        _hasHandledResult = true;
+        await _scanSubscription?.cancel();
         controller.dispose();
-        Navigator.of(context).pop();
-        showToast(context, "Error $e");
+        if (mounted) {
+          Navigator.of(context).pop();
+          showToast(context, "Error $e");
+        }
       }
     });
   }
 
   @override
   void dispose() {
+    _scanSubscription?.cancel();
     controller?.dispose();
     super.dispose();
   }

--- a/mobile/apps/auth/lib/ui/scanner_page.dart
+++ b/mobile/apps/auth/lib/ui/scanner_page.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/ui/components/buttons/icon_button_widget.dart';
+import 'package:ente_auth/ui/scanner_utils.dart';
 import 'package:ente_auth/utils/gallery_import_util.dart';
 import 'package:ente_auth/utils/toast_util.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
@@ -33,6 +35,8 @@ class ScannerPageState extends State<ScannerPage> {
   QRViewController? controller;
   String? totp;
   bool _isImportingFromGallery = false;
+  StreamSubscription<Barcode>? _scanSubscription;
+  bool _hasHandledResult = false;
 
   // In order to get hot reload to work we need to pause the camera if the platform
   // is android, or resume the camera if the platform is iOS.
@@ -134,16 +138,31 @@ class ScannerPageState extends State<ScannerPage> {
       controller.pauseCamera();
       controller.resumeCamera();
     }
-    controller.scannedDataStream.listen((scanData) {
+    _scanSubscription?.cancel();
+    _scanSubscription = controller.scannedDataStream.listen((scanData) async {
+      if (!shouldHandleScanResult(
+        hasHandledResult: _hasHandledResult,
+        scannedCode: scanData.code,
+      )) {
+        return;
+      }
       try {
         final code = Code.fromOTPAuthUrl(scanData.code!);
+        _hasHandledResult = true;
+        await _scanSubscription?.cancel();
+        await controller.pauseCamera();
+        await controller.stopCamera();
         controller.dispose();
+        if (!mounted) {
+          return;
+        }
         Navigator.of(context).pop(
           ScannerPageResult(code: code, fromGallery: false),
         );
       } catch (e) {
-        // Log
-        showToast(context, context.l10n.invalidQRCode);
+        if (mounted) {
+          showToast(context, context.l10n.invalidQRCode);
+        }
       }
     });
   }
@@ -160,6 +179,8 @@ class ScannerPageState extends State<ScannerPage> {
       if (code == null) {
         return;
       }
+      _hasHandledResult = true;
+      await _scanSubscription?.cancel();
       controller?.dispose();
       if (!mounted) {
         return;
@@ -180,6 +201,7 @@ class ScannerPageState extends State<ScannerPage> {
 
   @override
   void dispose() {
+    _scanSubscription?.cancel();
     controller?.dispose();
     super.dispose();
   }

--- a/mobile/apps/auth/lib/ui/scanner_utils.dart
+++ b/mobile/apps/auth/lib/ui/scanner_utils.dart
@@ -1,0 +1,9 @@
+bool shouldHandleScanResult({
+  required bool hasHandledResult,
+  required String? scannedCode,
+}) {
+  if (hasHandledResult) {
+    return false;
+  }
+  return scannedCode != null && scannedCode.trim().isNotEmpty;
+}

--- a/mobile/apps/auth/test/ui/scanner_page_flow_test.dart
+++ b/mobile/apps/auth/test/ui/scanner_page_flow_test.dart
@@ -1,0 +1,29 @@
+import 'package:ente_auth/ui/scanner_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldHandleScanResult', () {
+    test('returns false after first successful handling', () {
+      final first = shouldHandleScanResult(
+        hasHandledResult: false,
+        scannedCode: 'otpauth://totp/test?secret=ABC',
+      );
+      final second = shouldHandleScanResult(
+        hasHandledResult: true,
+        scannedCode: 'otpauth://totp/test?secret=ABC',
+      );
+
+      expect(first, isTrue);
+      expect(second, isFalse);
+    });
+
+    test('returns false for null scan content', () {
+      final value = shouldHandleScanResult(
+        hasHandledResult: false,
+        scannedCode: null,
+      );
+
+      expect(value, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- handle scanner results once per session to avoid duplicate stream processing
- stop camera and cancel scan subscriptions before route pop
- add mounted guards around pop/toast paths for lifecycle safety

## Test Plan
- flutter analyze lib/ui/scanner_page.dart lib/ui/scanner_gauth_page.dart lib/ui/scanner_utils.dart
- flutter test test/ui/scanner_page_flow_test.dart