### PR TITLE
Change go.mod module url in cli folder

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/ente-io/cli
+module github.com/ente-io/ente/cli
 
 go 1.23
 


### PR DESCRIPTION
## Description
Right now, trying to run `go install github.com/ente-io/ente/cli@latest` fails with the error
```
go: github.com/ente-io/ente/cli@latest: version constraints conflict:
github.com/ente-io/ente/cli@v0.0.0-20260227123025-3fa139959082: parsing go.mod:
module declares its path as: github.com/ente-io/cli
but was required as: github.com/ente-io/ente/cli
```
because the module url is still from the old archived repo. This commit will change the url so go install should be possible again.