### PR TITLE
[server] Update the recovery time in the recovery mail

### DIFF
--- a/server/mail-templates/legacy/recovery_started.html
+++ b/server/mail-templates/legacy/recovery_started.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <p>Hello,</p>
 
-<p>{{.TrustedContact}} has initiated recovery on your account. After 30 days, they will be able to change the password and access your account.</p>
+<p>{{.TrustedContact}} has initiated recovery on your account. After {{.DaysLeft}} days, they will be able to change the password and access your account.</p>
 
 <p>If you want to block the recovery, please navigate to <strong>Settings > Account > Legacy </strong> in the Ente Photos app.</p>
 

--- a/server/pkg/controller/emergency/email.go
+++ b/server/pkg/controller/emergency/email.go
@@ -145,6 +145,9 @@ func (c *Controller) createRecoveryEmailData(legacyUser, trustedUser ente.User, 
 
 	switch newStatus {
 	case ente.RecoveryStatusInitiated:
+		if _, ok := templateData["DaysLeft"]; !ok {
+			templateData["DaysLeft"] = int64(30)
+		}
 		emailDatas = append(emailDatas, emailData{
 			title:        "Ente account recovery initiated",
 			templateName: RecoveryStartedTemplate,

--- a/server/pkg/controller/emergency/recovery_contact.go
+++ b/server/pkg/controller/emergency/recovery_contact.go
@@ -27,7 +27,8 @@ func (c *Controller) StartRecovery(ctx *gin.Context,
 		log.WithField("userID", actorUserID).WithField("req", req).
 			Warn("No need to send email")
 	} else {
-		go c.sendRecoveryNotification(ctx, req.UserID, req.EmergencyContactID, ente.RecoveryStatusInitiated, nil)
+		recoveryNoticeInDays := int64(contact.NoticePeriodInHrs / 24)
+		go c.sendRecoveryNotification(ctx, req.UserID, req.EmergencyContactID, ente.RecoveryStatusInitiated, &recoveryNoticeInDays)
 	}
 	if err != nil {
 		return stacktrace.Propagate(err, "")


### PR DESCRIPTION
## Description

Issue: Legacy recovery-started email always says 30 days and ignores the configured recovery notice period.

- Pass the configured recovery notice days when recovery is initiated.
- Update `legacy/recovery_started.html` to use `{{.DaysLeft}}` instead of a hardcoded value.
- Keep a safe fallback of 30 days if `DaysLeft` is unavailable.
