### PR TITLE
[auth] Add search-by-intent via ente-auth://search?query= deep link

### DIFF
--- a/mobile/apps/auth/android/app/src/main/AndroidManifest.xml
+++ b/mobile/apps/auth/android/app/src/main/AndroidManifest.xml
@@ -17,13 +17,6 @@
                   android:windowSoftInputMode="adjustResize">
 
             <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="ente-auth"/>
-            </intent-filter>
-
-            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1914,14 +1914,18 @@ class _HomePageState extends State<HomePage> {
     lastScanTime = DateTime.now().millisecondsSinceEpoch;
     final lowerLink = link.toLowerCase();
     if (mounted && (lowerLink.startsWith("ente-auth://") || lowerLink.startsWith("enteauth://"))) {
-      final uri = Uri.parse(link);
-      if (uri.host != "search") return;
-      final searchQuery = uri.queryParameters['query'];
-      if (searchQuery != null && searchQuery.isNotEmpty) {
-        _showSearchBox = true;
-        _textController.text = searchQuery;
-        _searchText = searchQuery;
-        _applyFilteringAndRefresh();
+      try {
+        final uri = Uri.parse(link);
+        if (uri.host != "search") return;
+        final searchQuery = uri.queryParameters['query'];
+        if (searchQuery != null && searchQuery.isNotEmpty) {
+          _showSearchBox = true;
+          _textController.text = searchQuery;
+          _searchText = searchQuery;
+          _applyFilteringAndRefresh();
+        }
+      } catch (e) {
+        _logger.warning("Malformed ente-auth deep link: $link", e);
       }
     } else if (mounted && lowerLink.startsWith("otpauth://")) {
       try {

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1907,11 +1907,6 @@ class _HomePageState extends State<HomePage> {
     if (!(isAccountConfigured || isOfflineModeEnabled) || link == null) {
       return;
     }
-    if (DateTime.now().millisecondsSinceEpoch - lastScanTime < 1000) {
-      _logger.info("Ignoring potential event for same deeplink");
-      return;
-    }
-    lastScanTime = DateTime.now().millisecondsSinceEpoch;
     final lowerLink = link.toLowerCase();
     if (mounted && (lowerLink.startsWith("ente-auth://") || lowerLink.startsWith("enteauth://"))) {
       try {
@@ -1928,6 +1923,11 @@ class _HomePageState extends State<HomePage> {
         _logger.warning("Malformed ente-auth deep link: $link", e);
       }
     } else if (mounted && lowerLink.startsWith("otpauth://")) {
+      if (DateTime.now().millisecondsSinceEpoch - lastScanTime < 1000) {
+        _logger.info("Ignoring potential event for same deeplink");
+        return;
+      }
+      lastScanTime = DateTime.now().millisecondsSinceEpoch;
       try {
         final newCode = Code.fromOTPAuthUrl(link);
         getNextTotp(newCode);

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1908,10 +1908,9 @@ class _HomePageState extends State<HomePage> {
       return;
     }
     final lowerLink = link.toLowerCase();
-    if (mounted && (lowerLink.startsWith("ente-auth://") || lowerLink.startsWith("enteauth://"))) {
+    if (mounted && lowerLink.startsWith("enteauth://search")) {
       try {
         final uri = Uri.parse(link);
-        if (uri.host != "search") return;
         final searchQuery = uri.queryParameters['query'];
         if (searchQuery != null && searchQuery.isNotEmpty) {
           _showSearchBox = true;
@@ -1920,7 +1919,7 @@ class _HomePageState extends State<HomePage> {
           _applyFilteringAndRefresh();
         }
       } catch (e) {
-        _logger.warning("Malformed ente-auth deep link: $link", e);
+        _logger.warning("Malformed enteauth deep link: $link", e);
       }
     } else if (mounted && lowerLink.startsWith("otpauth://")) {
       if (DateTime.now().millisecondsSinceEpoch - lastScanTime < 1000) {

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -93,6 +93,7 @@ class _HomePageState extends State<HomePage> {
   List<String> tags = [];
   List<Code> _filteredCodes = [];
   StreamSubscription<CodesUpdatedEvent>? _streamSubscription;
+  StreamSubscription<String>? _deepLinkSubscription;
   StreamSubscription<TriggerLogoutEvent>? _triggerLogoutEvent;
   StreamSubscription<IconsChangedEvent>? _iconsChangedEvent;
   StreamSubscription<MultiSelectActionRequestedEvent>?
@@ -1191,6 +1192,7 @@ class _HomePageState extends State<HomePage> {
   @override
   void dispose() {
     _streamSubscription?.cancel();
+    _deepLinkSubscription?.cancel();
     _triggerLogoutEvent?.cancel();
     _iconsChangedEvent?.cancel();
     _multiSelectActionSubscription?.cancel();
@@ -1865,29 +1867,26 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  late final AppLinks _appLinks = AppLinks();
+
   Future<bool> _initDeepLinks() async {
     // Platform messages may fail, so we use a try/catch PlatformException.
-    final appLinks = AppLinks();
+    bool hadInitialLink = false;
     try {
-      String? initialLink;
-      initialLink = await appLinks.getInitialLinkString();
-      // Parse the link and warn the user, if it is not correct,
-      // but keep in mind it could be `null`.
+      final initialLink = await _appLinks.getInitialLinkString();
       if (initialLink != null) {
         _handleDeeplink(context, initialLink);
-        return true;
+        hadInitialLink = true;
       } else {
         _logger.info("No initial link received.");
       }
     } on PlatformException {
-      // Handle exception by warning the user their action did not succeed
-      // return?
       _logger.severe("PlatformException thrown while getting initial link");
     }
 
-    // Attach a listener to the stream
+    // Always attach a listener for future deep links
     if (!kIsWeb && !Platform.isLinux) {
-      appLinks.stringLinkStream.listen(
+      _deepLinkSubscription = _appLinks.stringLinkStream.listen(
         (link) {
           _handleDeeplink(context, link);
         },
@@ -1896,7 +1895,7 @@ class _HomePageState extends State<HomePage> {
         },
       );
     }
-    return false;
+    return hadInitialLink;
   }
 
   int lastScanTime = DateTime.now().millisecondsSinceEpoch - 1000;
@@ -1913,7 +1912,18 @@ class _HomePageState extends State<HomePage> {
       return;
     }
     lastScanTime = DateTime.now().millisecondsSinceEpoch;
-    if (mounted && link.toLowerCase().startsWith("otpauth://")) {
+    final lowerLink = link.toLowerCase();
+    if (mounted && (lowerLink.startsWith("ente-auth://") || lowerLink.startsWith("enteauth://"))) {
+      final uri = Uri.parse(link);
+      if (uri.host != "search") return;
+      final searchQuery = uri.queryParameters['query'];
+      if (searchQuery != null && searchQuery.isNotEmpty) {
+        _showSearchBox = true;
+        _textController.text = searchQuery;
+        _searchText = searchQuery;
+        _applyFilteringAndRefresh();
+      }
+    } else if (mounted && lowerLink.startsWith("otpauth://")) {
       try {
         final newCode = Code.fromOTPAuthUrl(link);
         getNextTotp(newCode);


### PR DESCRIPTION
## Description

- Support launching Ente Auth with a pre-filled search query via deep link, e.g. `ente-auth://search?query=gmail`
- Useful for automation tools (Tasker, shortcuts) to jump directly to a specific OTP code
- Fix deep link stream listener not being retained, so deep links now work when the app is already open

## Tests

- Build and install the app
- `adb shell am start -a android.intent.action.VIEW -d "enteauth://search?query=gmail"` with app closed: should open with search filtered
- Same command with app already open: should update the search
- `adb shell am start -a android.intent.action.VIEW -d "enteauth://abcd?query=gmail"`: should be ignored (only `/search` path is accepted)
- Verify existing `otpauth://` deep links still work