### PR TITLE
[mob][locker] Fix window controls hiding app UI on iPadOS 26

### DIFF
--- a/mobile/apps/locker/ios/Runner/Info.plist
+++ b/mobile/apps/locker/ios/Runner/Info.plist
@@ -28,6 +28,9 @@
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>
 		<string>Main</string>
+		<!-- Temporary workaround for iPad iOS 26 layout issue. Remove when fixed in Flutter: https://github.com/flutter/flutter/issues/170461 -->
+		<key>UIDesignRequiresCompatibility</key>
+		<true/>
 		<key>UISupportedInterfaceOrientations</key>
 		<array>
 			<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Description

Locker counterpart for #9229.

Temporary workaround for iPad iOS 26 layout issue. Remove when fixed in Flutter: https://github.com/flutter/flutter/issues/170461

- Adds `UIDesignRequiresCompatibility` in `mobile/apps/locker/ios/Runner/Info.plist`
- Prevents iPadOS 26 window controls from overlapping/hiding app UI in Locker

## Screenshots

<img width="300" height="650" alt="Screenshot 2026-03-06 at 12 20 17 PM" src="https://github.com/user-attachments/assets/4e5687c3-9df2-4cb5-b348-a5f475760233" />
<img width="300" height="650" alt="Screenshot 2026-03-06 at 12 20 48 PM" src="https://github.com/user-attachments/assets/6960be85-7201-4748-8988-1a847c084caa" />

## Tests

Tested on iPad Pro 11-inch (M5), iOS 26.2
