### PR TITLE
[mob][photos] Fix Android image dimensions for rotated EXIF orientations

### DIFF
--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -193,8 +193,15 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   isDeleted = !(await asset.exists);
   int? h, w;
   if (asset.width != 0 && asset.height != 0) {
-    h = asset.height;
     w = asset.width;
+    h = asset.height;
+    if (Platform.isAndroid &&
+        file.fileType == FileType.image &&
+        _shouldSwapDimensionsForExifOrientation(exifData)) {
+      final temp = w;
+      w = h;
+      h = temp;
+    }
   }
   int? motionPhotoStartingIndex;
   if (Platform.isAndroid && asset.type == AssetType.image) {
@@ -217,6 +224,12 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     motionPhotoStartIndex: motionPhotoStartingIndex,
     exifData: exifData,
   );
+}
+
+bool _shouldSwapDimensionsForExifOrientation(Map<String, IfdTag>? exifData) {
+  final orientation = exifData?['Image Orientation']?.values.firstAsInt() ?? 1;
+  // EXIF orientations 5-8 are rotated 90/270 variants and require w/h swap.
+  return orientation >= 5 && orientation <= 8;
 }
 
 Future<int?> motionVideoIndex(Map<String, dynamic> args) async {


### PR DESCRIPTION
I took a normal portrait (vertical) photo from my Android device. In a public link with the masonry layout, it showed up as horizontal and got cropped.

On some Android uploads, EXIF rotation (90/270 cases) was not reflected in uploaded width/height metadata. Masonry used that metadata, so portrait images could render like landscape tiles.

For Android image uploads, check EXIF orientation. If orientation is 5-8 (rotated variants), swap width and height before upload.

Old logic (shows issue): [link](https://albums.ente.io/?t=C3NFREBPVH#2e9y6a4ZFrcShF8p59Uv2XAV3WobWQgH9Lh7EnCY2xap)
New logic (after fix): [link](https://albums.ente.io/?t=FPZOVNXDMG#FPY7NPbNbeiV5FXMMGfMuuZKJ7out7ig8kqcNxEfVRzu)