### PR TITLE
[mob][photos] Fix thumbnail cache keying for offline files

### DIFF
--- a/mobile/apps/photos/lib/utils/thumbnail_util.dart
+++ b/mobile/apps/photos/lib/utils/thumbnail_util.dart
@@ -239,15 +239,21 @@ Future<void> _downloadAndDecryptThumbnail(FileDownloadItem item) async {
 File cachedThumbnailPath(EnteFile file) {
   final thumbnailCacheDirectory =
       Configuration.instance.getThumbnailCacheDirectory();
-  if (file.uploadedFileID != null && file.uploadedFileID != -1) {
+  final uploadedFileID = file.uploadedFileID;
+  if (uploadedFileID != null && uploadedFileID != -1) {
+    return File("$thumbnailCacheDirectory/$uploadedFileID");
+  }
+
+  final localID = file.localID;
+  if (localID != null && localID.isNotEmpty) {
     return File(
-      thumbnailCacheDirectory + "/" + file.uploadedFileID.toString(),
-    );
-  } else {
-    return File(
-      thumbnailCacheDirectory + "/local-" + file.localID.toString(),
+      "$thumbnailCacheDirectory/local-${Uri.encodeComponent(localID)}",
     );
   }
+
+  return File(
+    "$thumbnailCacheDirectory/generated-${file.generatedID ?? "unknown"}",
+  );
 }
 
 File cachedFaceCropPath(String faceID, bool useTempCache) {


### PR DESCRIPTION
## Description
- update thumbnail cache path resolution to handle local-only/offline files that have `uploadedFileID = -1`
- use a URL-encoded `localID` for local cache keys so IDs with path separators are safe on disk
- fall back to `generatedID` when `localID` is unavailable to avoid null-based collisions

## Tests
- [x] `flutter analyze lib/utils/thumbnail_util.dart`
