### PR TITLE
[mob][photos] Exclude deleted albums from auto-move targets during album deletion

### DIFF
--- a/mobile/apps/photos/lib/ui/actions/collection/collection_sharing_actions.dart
+++ b/mobile/apps/photos/lib/ui/actions/collection/collection_sharing_actions.dart
@@ -748,9 +748,10 @@ class CollectionActions {
     }
     final Collection? targetCollection =
         collectionsService.getCollectionByID(toCollectionID);
-    // ignore non-cached collections, uncategorized and favorite
-    // collections and collections ignored by others
+    // ignore non-cached, deleted, uncategorized and favorite collections,
+    // and collections ignored by others
     if (targetCollection == null ||
+        targetCollection.isDeleted ||
         (CollectionType.uncategorized == targetCollection.type ||
             targetCollection.type == CollectionType.favorites) ||
         targetCollection.owner.id != userID) {


### PR DESCRIPTION
Issue
When deleting an album with "keep photos", the app first moves the files out of the album before deleting the album itself. In some cases, the auto-move logic can choose another owned album that is already marked deleted locally. The subsequent move request then targets a deleted destination collection and fails, causing album deletion to error for specific albums.

Description
This change fixes the "keep photos & delete album" flow by excluding deleted collections from auto-move destination candidates.

Root cause:
- `moveFilesFromCurrentCollection()` builds candidate destinations from local file memberships.
- `_isAutoMoveCandidate()` previously rejected non-cached, uncategorized, favorite, and non-owned collections, but did not reject deleted collections.
- Owned deleted collections can still exist in the local collection cache with `isDeleted = true`, so `getCollectionByID()` may return a deleted collection object.
- If local file memberships still reference that collection, the client can attempt to move files into a deleted album, which the server rejects.

Fix:
- Reject `targetCollection.isDeleted` in `_isAutoMoveCandidate()`.
- This ensures the flow only moves files into active owned albums, otherwise it falls back to Uncategorized.