### PR TITLE
[mob][photos] Fix thumbnail fallback preview info

### DIFF
--- a/mobile/apps/photos/lib/states/detail_page_state.dart
+++ b/mobile/apps/photos/lib/states/detail_page_state.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
+import "package:photos/models/file/file.dart";
 
 enum FullScreenRequestReason {
   userInteraction,
@@ -11,13 +12,26 @@ typedef FullScreenRequestCallback = void Function(
   FullScreenRequestReason reason,
 );
 
+String? detailPageFileIdentifier(EnteFile file) {
+  if (file.uploadedFileID != null) {
+    return "uploaded_${file.uploadedFileID}";
+  }
+  if (file.localID != null) {
+    return "local_${file.localID}";
+  }
+  if (file.generatedID != null) {
+    return "generated_${file.generatedID}";
+  }
+  return null;
+}
+
 class InheritedDetailPageState extends InheritedWidget {
   final ValueNotifier<bool> enableFullScreenNotifier;
   final ValueNotifier<bool> isInSharedCollectionNotifier;
 
-  /// Holds the generatedID of the file currently showing thumbnail fallback.
-  /// Only the file with matching ID should display the fallback indicator.
-  final ValueNotifier<int?> showingThumbnailFallbackNotifier;
+  /// Holds the stable identifier of the file currently showing thumbnail
+  /// fallback. Only the file with matching ID should display the indicator.
+  final ValueNotifier<String?> showingThumbnailFallbackNotifier;
   // Cannot be const because we accept a ValueNotifier instance at runtime
   // ignore: prefer_const_constructors_in_immutables
   InheritedDetailPageState({

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -89,7 +89,7 @@ class DetailPage extends StatefulWidget {
 class _DetailPageState extends State<DetailPage> {
   final _enableFullScreenNotifier = ValueNotifier(false);
   final _isInSharedCollectionNotifier = ValueNotifier(false);
-  final _showingThumbnailFallbackNotifier = ValueNotifier<int?>(null);
+  final _showingThumbnailFallbackNotifier = ValueNotifier<String?>(null);
 
   @override
   void dispose() {

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -77,7 +77,8 @@ class FileAppBarState extends State<FileAppBar> {
   @override
   void didUpdateWidget(FileAppBar oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.file.generatedID != widget.file.generatedID) {
+    if (detailPageFileIdentifier(oldWidget.file) !=
+        detailPageFileIdentifier(widget.file)) {
       _getActions();
     }
   }
@@ -226,7 +227,9 @@ class FileAppBarState extends State<FileAppBar> {
     final fallbackFileId = InheritedDetailPageState.maybeOf(context)
         ?.showingThumbnailFallbackNotifier
         .value;
-    final showingFallback = fallbackFileId == widget.file.generatedID;
+    final currentFileId = detailPageFileIdentifier(widget.file);
+    final showingFallback =
+        fallbackFileId != null && fallbackFileId == currentFileId;
     if (showingFallback) {
       _actions.add(
         Tooltip(

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -521,7 +521,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
         });
         InheritedDetailPageState.maybeOf(context)
             ?.showingThumbnailFallbackNotifier
-            .value = _photo.generatedID;
+            .value = detailPageFileIdentifier(_photo);
       }
       return;
     }
@@ -575,7 +575,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
         });
         InheritedDetailPageState.maybeOf(context)
             ?.showingThumbnailFallbackNotifier
-            .value = _photo.generatedID;
+            .value = detailPageFileIdentifier(_photo);
       }
     }
   }


### PR DESCRIPTION
## Description

- We show an info to the user when an unsupported file is being viewing letting them know that it's large thumbnail is being displayed. When opening a file in a shared album opened via deeplink, `generatedID` is null and this was causing the info to come up even when the file is supported. 
