### PR TITLE
[server][mob] Add non-profit storage bonus support

### DIFF
--- a/mobile/apps/photos/lib/ui/payment/add_on_page.dart
+++ b/mobile/apps/photos/lib/ui/payment/add_on_page.dart
@@ -13,6 +13,21 @@ class AddOnPage extends StatelessWidget {
 
   const AddOnPage(this.bonusData, {super.key});
 
+  String _sectionNameForBonusType(String bonusType) {
+    switch (bonusType) {
+      case "ADD_ON_BF_2023":
+        return "Black Friday 2023";
+      case "ADD_ON_BF_2024":
+        return "Black Friday 2024";
+      case "ADD_ON_SUPPORT":
+        return "Support";
+      case "ADD_ON_NON_PROFIT":
+        return "Non-profit";
+      default:
+        return bonusType.replaceAll("_", " ");
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -44,9 +59,7 @@ class AddOnPage extends StatelessWidget {
                   return Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: AddOnViewSection(
-                      sectionName: bonus.type == 'ADD_ON_BF_2023'
-                          ? "Black friday 2023"
-                          : bonus.type.replaceAll('_', ' '),
+                      sectionName: _sectionNameForBonusType(bonus.type),
                       bonus: bonus,
                     ),
                   );

--- a/server/ente/admin.go
+++ b/server/ente/admin.go
@@ -119,8 +119,8 @@ func (u SupportUpdateBonus) UpdateLog() string {
 }
 
 func (u SupportUpdateBonus) Validate() error {
-	isSupportBonus := u.BonusType == "ADD_ON_SUPPORT"
-	if u.BonusType != "ADD_ON_SUPPORT" && u.BonusType != "ADD_ON_BF_2023" && u.BonusType != "ADD_ON_BF_2024" {
+	usesFlexibleAddOnRules := u.BonusType == "ADD_ON_SUPPORT" || u.BonusType == "ADD_ON_NON_PROFIT"
+	if u.BonusType != "ADD_ON_SUPPORT" && u.BonusType != "ADD_ON_NON_PROFIT" && u.BonusType != "ADD_ON_BF_2023" && u.BonusType != "ADD_ON_BF_2024" {
 		return errors.New("invalid bonus type")
 	}
 	if u.Action == ADD || u.Action == UPDATE {
@@ -129,7 +129,7 @@ func (u SupportUpdateBonus) Validate() error {
 				return errors.New("invalid input, set in MB and minute for test")
 			}
 		} else {
-			if isSupportBonus {
+			if usesFlexibleAddOnRules {
 				if u.Year == 0 || u.Year > 100 {
 					return errors.New("invalid input for year, only 1-100")
 				}

--- a/server/ente/admin_test.go
+++ b/server/ente/admin_test.go
@@ -1,0 +1,31 @@
+package ente
+
+import "testing"
+
+func TestSupportUpdateBonusValidate_AllowsNonProfitBonus(t *testing.T) {
+	req := SupportUpdateBonus{
+		BonusType:   "ADD_ON_NON_PROFIT",
+		Action:      ADD,
+		UserID:      1,
+		Year:        3,
+		StorageInGB: 200,
+	}
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected non-profit bonus to be valid, got error: %v", err)
+	}
+}
+
+func TestSupportUpdateBonusValidate_RejectsInvalidNonProfitBonus(t *testing.T) {
+	req := SupportUpdateBonus{
+		BonusType:   "ADD_ON_NON_PROFIT",
+		Action:      ADD,
+		UserID:      1,
+		Year:        101,
+		StorageInGB: 200,
+	}
+
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected invalid non-profit bonus to be rejected")
+	}
+}

--- a/server/ente/storagebonus/storge_bonus.go
+++ b/server/ente/storagebonus/storge_bonus.go
@@ -10,23 +10,25 @@ const (
 	SignUp BonusType = "SIGN_UP"
 
 	// AddOnSupport is the bonus for users added by the support team
-	AddOnSupport = "ADD_ON_SUPPORT"
+	AddOnSupport BonusType = "ADD_ON_SUPPORT"
+	// AddOnNonProfit is the bonus for users on the non-profit program
+	AddOnNonProfit BonusType = "ADD_ON_NON_PROFIT"
 	// AddOnBf is the bonus for users who have opted for the Black Friday offers
-	AddOnBf2023 = "ADD_ON_BF_2023"
-	AddOnBf2024 = "ADD_ON_BF_2024"
+	AddOnBf2023 BonusType = "ADD_ON_BF_2023"
+	AddOnBf2024 BonusType = "ADD_ON_BF_2024"
 	// In the future, we can add various types of bonuses based on different events like Anniversary,
 	// or finishing tasks like ML indexing, enabling sharing etc etc
 )
 
 // PaidAddOnTypes : These add-ons can be purchased by the users and help in the expiry of an account
 // as long as the add-on is active.
-var PaidAddOnTypes = []BonusType{AddOnSupport, AddOnBf2023, AddOnBf2024}
+var PaidAddOnTypes = []BonusType{AddOnSupport, AddOnNonProfit, AddOnBf2023, AddOnBf2024}
 
 // ExtendsExpiry returns true if the bonus type extends the expiry of the account.
 // By default, all bonuses don't extend expiry.
 func (t BonusType) ExtendsExpiry() bool {
 	switch t {
-	case AddOnSupport, AddOnBf2023, AddOnBf2024:
+	case AddOnSupport, AddOnNonProfit, AddOnBf2023, AddOnBf2024:
 		return true
 	case Referral, SignUp:
 		return false
@@ -43,6 +45,8 @@ func BonusFromType(bonusType string) BonusType {
 		return SignUp
 	case "ADD_ON_SUPPORT":
 		return AddOnSupport
+	case "ADD_ON_NON_PROFIT":
+		return AddOnNonProfit
 	case "ADD_ON_BF_2023":
 		return AddOnBf2023
 	case "ADD_ON_BF_2024":
@@ -59,7 +63,7 @@ func (t BonusType) RestrictToDoublingStorage() bool {
 	switch t {
 	case Referral, SignUp:
 		return true
-	case AddOnSupport, AddOnBf2023, AddOnBf2024:
+	case AddOnSupport, AddOnNonProfit, AddOnBf2023, AddOnBf2024:
 		return false
 	default:
 		return true

--- a/server/ente/storagebonus/storge_bonus_test.go
+++ b/server/ente/storagebonus/storge_bonus_test.go
@@ -1,0 +1,26 @@
+package storagebonus
+
+import "testing"
+
+func TestAddOnNonProfitBonusProperties(t *testing.T) {
+	if got := BonusFromType("ADD_ON_NON_PROFIT"); got != AddOnNonProfit {
+		t.Fatalf("expected ADD_ON_NON_PROFIT to map to AddOnNonProfit, got %q", got)
+	}
+	if !AddOnNonProfit.ExtendsExpiry() {
+		t.Fatal("expected ADD_ON_NON_PROFIT to extend expiry")
+	}
+	if AddOnNonProfit.RestrictToDoublingStorage() {
+		t.Fatal("expected ADD_ON_NON_PROFIT to behave like an add-on bonus")
+	}
+
+	found := false
+	for _, bonusType := range PaidAddOnTypes {
+		if bonusType == AddOnNonProfit {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected ADD_ON_NON_PROFIT to be treated as a paid add-on type")
+	}
+}

--- a/server/migrations/117_add_non_profit_storage_bonus_type.down.sql
+++ b/server/migrations/117_add_non_profit_storage_bonus_type.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE storage_bonus
+    DROP CONSTRAINT IF EXISTS storage_bonus_type_check;
+
+ALTER TABLE storage_bonus
+    ADD CONSTRAINT storage_bonus_type_check
+        CHECK (type IN ('REFERRAL', 'SIGN_UP', 'ANNIVERSARY', 'ADD_ON_BF_2023', 'ADD_ON_SUPPORT', 'ADD_ON_BF_2024'));

--- a/server/migrations/117_add_non_profit_storage_bonus_type.up.sql
+++ b/server/migrations/117_add_non_profit_storage_bonus_type.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE storage_bonus
+    DROP CONSTRAINT IF EXISTS storage_bonus_type_check;
+
+ALTER TABLE storage_bonus
+    ADD CONSTRAINT storage_bonus_type_check
+        CHECK (type IN ('REFERRAL', 'SIGN_UP', 'ANNIVERSARY', 'ADD_ON_BF_2023', 'ADD_ON_SUPPORT', 'ADD_ON_BF_2024', 'ADD_ON_NON_PROFIT'));

--- a/server/pkg/repo/storagebonus/bf_addon.go
+++ b/server/pkg/repo/storagebonus/bf_addon.go
@@ -67,7 +67,7 @@ func (r *Repository) UpdateAddOnBonus(ctx context.Context, bonusType storagebonu
 }
 
 func _validate(bonusType storagebonus.BonusType) error {
-	if bonusType == storagebonus.AddOnBf2023 || bonusType == storagebonus.AddOnBf2024 || bonusType == storagebonus.AddOnSupport {
+	if bonusType == storagebonus.AddOnBf2023 || bonusType == storagebonus.AddOnBf2024 || bonusType == storagebonus.AddOnSupport || bonusType == storagebonus.AddOnNonProfit {
 		return nil
 	}
 	return fmt.Errorf("invalid bonus type: %s", bonusType)


### PR DESCRIPTION
## Summary
- add `ADD_ON_NON_PROFIT` as a storage bonus type
- allow the admin bonus API and repo layer to add, update, and remove it using the same validation rules as `ADD_ON_SUPPORT`
- include the new type in paid add-on and expiry semantics, add the DB migration, and show a cleaner label in the mobile add-on UI

## Testing
- `cd server && go test ./ente ./ente/storagebonus ./pkg/api`
- `cd server && go test ./pkg/controller ./pkg/repo ./pkg/api`
- `cd server && go test ./...` *(fails in existing `pkg/repo/storagebonus` DB-backed tests because `ENV=test` and the test database are not configured in this shell)*