### PR TITLE
[docs] Update Photos and Auth changelogs for March 2026

### DIFF
--- a/docs/docs/auth/changelog.md
+++ b/docs/docs/auth/changelog.md
@@ -7,6 +7,11 @@ description: Release notes of recent updates to Ente Auth
 
 A short summary list of changes to the Ente Auth mobile and desktop apps. For a more descriptive list with screenshots and blog post links, see the [news](https://ente.io/news).
 
+## v4.4.17 - Feb 2026
+
+- New login/sign up screens
+- Bug fixes and improvements
+
 ## v4.4.15 - Dec 2025
 
 - Icon picker

--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -7,6 +7,24 @@ description: Release notes of recent updates to Ente Photos mobile and desktop a
 
 A short summary list of changes to the Ente Photos mobile and desktop apps. For a more descriptive list with screenshots and blog post links, see the [news](https://ente.io/news).
 
+## v1.3.22 (mobile) - Mar 2026
+
+- Gallery mode to use Ente Photos without an account
+- New shared albums card in feed
+- Shared albums and shared photos notifications redirect to feed
+- Friendlier help & support page
+- Better people suggestions in person overview
+- Bug fixes and performance improvements
+
+## v1.7.21 (desktop) - Mar 2026
+
+- Masonry layout for public albums
+- Quick links
+- Full viewer experience for single-photo/video links
+- Update album cover
+- Public album improvements
+- Catalan language support
+
 ## v1.3.16 (mobile) - Feb 2026
 
 - Fix broken map view
@@ -29,15 +47,6 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Delete hidden files from device
 - Hide shared albums
 - Search in device albums
-
-## v1.7.21 (desktop) - Feb 2026
-
-- Masonry layout for public albums
-- Quick links
-- Full viewer experience for single-photo/video links
-- Update album cover
-- Public album improvements
-- Catalan language support
 
 ## v1.3.10 (mobile) - Feb 2026
 


### PR DESCRIPTION
## Summary
- Add Photos mobile v1.3.22 and desktop v1.7.21 changelog entries for March 2026
- Add Auth v4.4.17 changelog entry for February 2026
- Move desktop v1.7.21 date from Feb to Mar and reposition chronologically