### PR TITLE
[mob][photos] fix: queue locally updated assets for re-upload

### DIFF
--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -394,7 +394,7 @@ class LocalSyncService {
       _logger.info(
         "track ${updatedLocalIDs.length}/ $updateCount files due to modification change",
       );
-      if (updatedLocalIDs.isEmpty) {
+      if (updatedLocalIDs.isNotEmpty) {
         await FileUpdationDB.instance.insertMultiple(
           updatedLocalIDs,
           FileUpdationDB.modificationTimeUpdated,


### PR DESCRIPTION
## Summary
- queue modified local asset IDs for re-upload after filtering out origin-fetch noise

## Issue
Locally modified photos can appear updated on the device where the edit happened, but not on other devices. In `_trackUpdatedFiles()`, we compute `updatedLocalIDs` and log them, but only insert them into `FileUpdationDB` when the list is empty. That means real local updates are never queued for re-upload.

## Fix
- change the insert guard from `updatedLocalIDs.isEmpty` to `updatedLocalIDs.isNotEmpty`
- preserve the existing filtering of IDs tracked via `trackOriginFetchForUploadOrML`

Fixes #9302

## Validation
- Test by uploading a file from one device and then edited that file locally on the same device and update on the other clients as well