### PR TITLE
[mob][photos][locker] Handle numeric public metadata coordinates

### DIFF
--- a/mobile/apps/locker/lib/services/files/sync/models/file_magic.dart
+++ b/mobile/apps/locker/lib/services/files/sync/models/file_magic.dart
@@ -113,8 +113,8 @@ class PubMagicMetadata {
       uploaderName: map[uploaderNameKey],
       w: safeParseInt(map[widthKey], widthKey),
       h: safeParseInt(map[heightKey], heightKey),
-      lat: map[latKey],
-      long: map[longKey],
+      lat: safeParseDouble(map[latKey], latKey),
+      long: safeParseDouble(map[longKey], longKey),
       mvi: map[motionVideoIndexKey],
       noThumb: map[noThumbKey],
       mediaType: map[mediaTypeKey],
@@ -128,8 +128,16 @@ class PubMagicMetadata {
   static int? safeParseInt(dynamic value, String key) {
     if (value == null) return null;
     if (value is int) return value;
-    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
     if (value is String) return int.tryParse(value);
+    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
+    return null;
+  }
+
+  static double? safeParseDouble(dynamic value, String key) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
     return null;
   }
 }

--- a/mobile/apps/photos/lib/models/metadata/file_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/file_magic.dart
@@ -112,8 +112,8 @@ class PubMagicMetadata {
       uploaderName: map[uploaderNameKey],
       w: safeParseInt(map[widthKey], widthKey),
       h: safeParseInt(map[heightKey], heightKey),
-      lat: map[latKey],
-      long: map[longKey],
+      lat: safeParseDouble(map[latKey], latKey),
+      long: safeParseDouble(map[longKey], longKey),
       cameraMake: map[cameraMakeKey],
       cameraModel: map[cameraModelKey],
       mvi: map[motionVideoIndexKey],
@@ -128,8 +128,16 @@ class PubMagicMetadata {
   static int? safeParseInt(dynamic value, String key) {
     if (value == null) return null;
     if (value is int) return value;
-    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
     if (value is String) return int.tryParse(value);
+    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
+    return null;
+  }
+
+  static double? safeParseDouble(dynamic value, String key) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
     return null;
   }
 }


### PR DESCRIPTION
## Description
Issue: Mobile remote sync can crash when `pubMagicMetadata.lat` or `long` is encoded as an integer.
Description: Parse public coordinate metadata as generic numeric values so mobile sync accepts integer and decimal coordinates from other clients.
