### PR TITLE
[mob][photos] Ensure syncAll triggers remote sync when mappings change

### DIFF
--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -239,7 +239,9 @@ class LocalSyncService {
     }
 
     _logger.info("syncAll took ${stopwatch.elapsed.inMilliseconds}ms ");
-    return hasUnsyncedFiles;
+    // syncAll can repair mappings without inserting new local files.
+    // We still need the follow-up remote sync to promote those entries.
+    return hasUnsyncedFiles || hasAnyMappingChanged;
   }
 
   Future<void> ignoreUpload(EnteFile file, InvalidFileError error) async {


### PR DESCRIPTION
Summary
- make `syncAll` report success when existing mappings change so the follow-up remote sync still runs
- document that repairing mappings without new files still needs the remote sync path to promote entries

Testing
- Not run (not requested)