### PR TITLE
[infra] Remove public endpoint from the backup-intent DB instance

### DIFF
--- a/infra/copycat-db/src/backup.sh
+++ b/infra/copycat-db/src/backup.sh
@@ -55,6 +55,20 @@ else
         fi
 
         scw rdb instance wait "$BACKUP_INSTANCE_ID" timeout=12h
+
+        PUBLIC_ENDPOINT_ID="$(
+            scw rdb endpoint list "$BACKUP_INSTANCE_ID" -o json \
+                | jq -er '
+                    map(select(.load_balancer != null))
+                    | if length == 1 then .[0].id
+                      else error("copycat-db: expected exactly one public endpoint on temp instance")
+                      end
+                '
+        )"
+
+        scw rdb endpoint delete endpoint-id="$PUBLIC_ENDPOINT_ID" instance-id="$BACKUP_INSTANCE_ID"
+        scw rdb instance wait "$BACKUP_INSTANCE_ID" timeout=12h
+
         DELETE_INSTANCE_ID=$BACKUP_INSTANCE_ID
     fi
 


### PR DESCRIPTION
Summary
- explicitly gather public endpoints and fail if the API/JQ pipeline does not return exactly one so we no longer mask endpoint listing failures
- delete the discovered endpoint before waiting on the temp instance to ensure the copycat cleanup happens as a single flow

Testing
- Not run (not requested)