### PR TITLE
Use wasm-pack 0.14.0 on Apple Silicon

### DIFF
--- a/web/packages/wasm/package.json
+++ b/web/packages/wasm/package.json
@@ -21,6 +21,6 @@
         "ente-build-config": "*",
         "vite-plugin-wasm": "^3.2.4",
         "vitest": "^3.2.4",
-        "wasm-pack": "^0.13.1"
+        "wasm-pack": "^0.14.0"
     }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1811,9 +1811,9 @@ base-x@5.0.1, base-x@^5.0.0:
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
   integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
-binary-install@^1.0.1:
+binary-install@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/binary-install/-/binary-install-1.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/binary-install/-/binary-install-1.1.2.tgz#06f059e5475e2a208d65ead8cb523d7845a83038"
   integrity sha512-ZS2cqFHPZOy4wLxvzqfQvDjCOifn+7uCPqNmYRIBM/03+yllON+4fNnsD0VJdW0p97y+E+dTRNPStWNqMBq+9g==
   dependencies:
     axios "^0.26.1"
@@ -5708,12 +5708,12 @@ void-elements@3.1.0:
   resolved "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
-wasm-pack@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.13.1.tgz"
-  integrity sha512-P9exD4YkjpDbw68xUhF3MDm/CC/3eTmmthyG5bHJ56kalxOTewOunxTke4SyF8MTXV6jUtNjXggPgrGmMtczGg==
+wasm-pack@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/wasm-pack/-/wasm-pack-0.14.0.tgz#ef9d1328a6fd708686883c505873d763d462ee02"
+  integrity sha512-7uKj+483b6ETTnuWHK3zKNB3Ca3M159tPZ5shyXxI4j7i9Lk82rL2ck/L6E9O5VMWk9JgowdtTBOSfWmGBRFtw==
   dependencies:
-    binary-install "^1.0.1"
+    binary-install "^1.1.2"
 
 web-namespaces@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
yarn dev failed in packages/wasm on Apple Silicon with:

> Error: spawnSync /Users/m/Desktop/Code/ente/web/node_modules/wasm-pack/binary/wasm-pack Unknown system error -86

The repo was pinned to wasm-pack 0.13.1, whose npm package installed an x86_64 macOS binary. On Apple Silicon that surfaced as Bad CPU type in executable.

Bump to wasm-pack 0.14.0 so Yarn installs the native arm64 binary instead.

