### PR TITLE
[web][locker] Pass trash sync time when emptying trash

### DIFF
--- a/web/apps/locker/src/pages/locker.tsx
+++ b/web/apps/locker/src/pages/locker.tsx
@@ -115,6 +115,7 @@ const Page: React.FC = () => {
 
     // View mode state
     const [trashItems, setTrashItems] = useState<LockerItem[]>([]);
+    const [trashLastUpdatedAt, setTrashLastUpdatedAt] = useState(0);
     const [isTrashView, setIsTrashView] = useState(false);
     const [isCollectionsView, setIsCollectionsView] = useState(false);
 
@@ -180,7 +181,8 @@ const Page: React.FC = () => {
                 const data = await fetchLockerData(key);
                 const trash = await fetchLockerTrash(key);
                 setCollections(data);
-                setTrashItems(trash);
+                setTrashItems(trash.items);
+                setTrashLastUpdatedAt(trash.lastUpdatedAt);
                 setInitialLoadError(null);
             } catch (e) {
                 log.error("Failed to refresh locker data", e);
@@ -209,7 +211,8 @@ const Page: React.FC = () => {
                 const data = await fetchLockerData(mk);
                 const trash = await fetchLockerTrash(mk);
                 setCollections(data);
-                setTrashItems(trash);
+                setTrashItems(trash.items);
+                setTrashLastUpdatedAt(trash.lastUpdatedAt);
                 setInitialLoadError(null);
             } catch (e) {
                 log.error("Failed to fetch locker data", e);
@@ -425,13 +428,13 @@ const Page: React.FC = () => {
                 text: t("empty_trash"),
                 color: "critical",
                 action: async () => {
-                    await emptyTrashAPI();
+                    await emptyTrashAPI(trashLastUpdatedAt);
                     await refreshData();
                     setToast(t("trashClearedSuccessfully"));
                 },
             },
         });
-    }, [showMiniDialog, refreshData]);
+    }, [showMiniDialog, refreshData, trashLastUpdatedAt]);
 
     // Collection management
 

--- a/web/apps/locker/src/services/remote.ts
+++ b/web/apps/locker/src/services/remote.ts
@@ -874,6 +874,11 @@ const TrashDiffResponse = z.object({
     hasMore: z.boolean(),
 });
 
+interface LockerTrashData {
+    items: LockerItem[];
+    lastUpdatedAt: number;
+}
+
 /**
  * Fetch trashed Locker items from remote, decrypt them, and return them
  * ready for display. Must be called after {@link fetchLockerData} so that
@@ -881,7 +886,7 @@ const TrashDiffResponse = z.object({
  */
 export const fetchLockerTrash = async (
     masterKey: string,
-): Promise<LockerItem[]> => {
+): Promise<LockerTrashData> => {
     const trashItems: LockerItem[] = [];
     let sinceTime = 0;
     let hasMore = true;
@@ -968,7 +973,7 @@ export const fetchLockerTrash = async (
 
     // Sort by most recently trashed first
     trashItems.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
-    return trashItems;
+    return { items: trashItems, lastUpdatedAt: sinceTime };
 };
 
 // ---------------------------------------------------------------------------
@@ -1459,14 +1464,14 @@ export const permanentlyDeleteFromTrash = async (
 /**
  * Empty the entire trash.
  */
-export const emptyTrash = async (): Promise<void> => {
+export const emptyTrash = async (lastUpdatedAt: number): Promise<void> => {
     const res = await fetch(await apiURL("/trash/empty"), {
         method: "POST",
         headers: {
             ...(await authenticatedRequestHeaders()),
             "Content-Type": "application/json",
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ lastUpdatedAt }),
     });
     ensureOk(res);
 };


### PR DESCRIPTION
## Summary
- pass the fetched trash sync timestamp to `/trash/empty`
- align locker web empty-trash behavior with mobile so the request scopes deletion to the latest synced trash state

## Testing
- `yarn tsc -p apps/locker/tsconfig.json --noEmit`
- `yarn prettier --check apps/locker/src/pages/locker.tsx apps/locker/src/services/remote.ts`