### PR TITLE
[mob][photos] Fix incremental fromTime guard

### DIFF
--- a/mobile/apps/photos/lib/services/sync/import/local_assets.dart
+++ b/mobile/apps/photos/lib/services/sync/import/local_assets.dart
@@ -254,7 +254,7 @@ Future<Tuple2<Set<String>, List<EnteFile>>> _getLocalIDsAndFilesFromAssets(
       'modifiedDateTime',
     );
     final bool assetCreatedOrUpdatedAfterGivenTime =
-        max(createMs, modifiedMs) >= (fromTime / ~1000);
+        max(createMs, modifiedMs) >= (fromTime ~/ 1000);
     if (!alreadySeenLocalIDs.contains(entity.id) &&
         assetCreatedOrUpdatedAfterGivenTime) {
       final file = await EnteFile.fromAsset(pathEntity.name, entity);


### PR DESCRIPTION
## Description
### Summary
Fixes the incremental local-asset guard in `local_assets.dart`.

The current code uses:

```dart
fromTime / ~1000
```

which is not a microseconds-to-milliseconds conversion. `~1000` is bitwise-not, so the comparison ends up using a negative divisor and the guard becomes effectively meaningless.

This PR changes it to:

```dart
fromTime ~/ 1000
```

so the in-app filter correctly compares `max(createTime, modificationTime)` against the incremental watermark in milliseconds.

## Why
Incremental sync relies on a time-bounded discovery window. This guard is supposed to reject assets that fall outside that window after path enumeration, but the current expression does not do that correctly.

Fixing it makes the secondary in-app filter match the intended semantics.
