### PR TITLE
[mob][photos] Refresh storage card on quota updates

### DIFF
--- a/mobile/apps/photos/lib/states/user_details_state.dart
+++ b/mobile/apps/photos/lib/states/user_details_state.dart
@@ -79,8 +79,7 @@ class InheritedUserDetails extends InheritedWidget {
 
   @override
   bool updateShouldNotify(covariant InheritedUserDetails oldWidget) {
-    return (userDetails?.usage != oldWidget.userDetails?.usage) ||
-        (userDetails?.fileCount != oldWidget.userDetails?.fileCount) ||
+    return (userDetails != oldWidget.userDetails) ||
         (isCached != oldWidget.isCached);
   }
 }


### PR DESCRIPTION
## Description
Refresh the settings storage card when fetched user details change only in quota-related fields.

## Tests
- [x] `flutter analyze lib/states/user_details_state.dart`
