### PR TITLE
[mob][photos] Initialize Rust in background startup paths

### DIFF
--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -67,10 +67,11 @@ const kBGPushTimeout = Duration(seconds: 28);
 const kFGTaskDeathTimeoutInMicroseconds = 5000000;
 bool isProcessBg = true;
 bool _stopHearBeat = false;
+bool _isRustInitialized = false;
+Future<void>? _rustInitFuture;
 
 void main() async {
   debugRepaintRainbowEnabled = false;
-  await EntePhotosRust.init();
   WidgetsFlutterBinding.ensureInitialized();
   FFmpegKitConfig.init().ignore();
   await rive.RiveNative.init();
@@ -159,6 +160,7 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await _scheduleHeartBeat(prefs, true);
+    await _ensureRustInitialized(via: 'workmanager:$taskId');
 
     _logger.info("(for debugging) Configuration init $tlog");
     await Configuration.instance.init();
@@ -244,6 +246,9 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
     });
     if (!isBackground) _heartBeatOnInit(0);
     _logger.info("Initializing...  inBG =$isBackground via: $via $tlog");
+    await _ensureRustInitialized(
+      via: isBackground ? 'background:$via' : 'foreground:$via',
+    );
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     await _logFGHeartBeatInfo(preferences);
@@ -349,6 +354,27 @@ Future<void> _init(bool isBackground, {String via = ''}) async {
   } catch (e, s) {
     _logger.severe("Error in init ", e, s);
     rethrow;
+  }
+}
+
+Future<void> _ensureRustInitialized({required String via}) async {
+  if (_isRustInitialized) {
+    return;
+  }
+  final inFlightInit = _rustInitFuture;
+  if (inFlightInit != null) {
+    await inFlightInit;
+    return;
+  }
+
+  _logger.info("Initializing Rust bridge via $via");
+  final initFuture = EntePhotosRust.init();
+  _rustInitFuture = initFuture;
+  try {
+    await initFuture;
+    _isRustInitialized = true;
+  } finally {
+    _rustInitFuture = null;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared Rust init guard in `main.dart` instead of calling `EntePhotosRust.init()` only from `main()`
- initialize Rust before background-capable startup paths continue, including WorkManager tasks and background push startup
- keep init idempotent within a process so concurrent startup paths do not race duplicate bridge initialization

## Why
Some background flows can eventually reach Rust-backed code without going through the foreground `main()` path first. This change ensures the Rust bridge is available before those paths proceed, covering cases like background upload/motion-photo work and startup-triggered ML or memory-lane work.

## Operational details
- `_ensureRustInitialized()` caches in-flight initialization and marks Rust as initialized only after the bridge setup succeeds
- foreground startup still initializes Rust through the normal app init path
- background startup now does the same in both `_runMinimally()` and `_init()`

## Testing
- `dart format mobile/apps/photos/lib/main.dart`
- `dart analyze mobile/apps/photos/lib/main.dart`