### PR TITLE
Add Yandex/YaTop support to auth

### DIFF
--- a/mobile/apps/auth/lib/models/code.dart
+++ b/mobile/apps/auth/lib/models/code.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:base32/base32.dart';
 import 'package:ente_auth/models/code_display.dart';
 import 'package:ente_auth/utils/totp_util.dart';
 import 'package:logging/logging.dart';
@@ -8,6 +10,10 @@ class Code {
   static const defaultDigits = 6;
   static const steamDigits = 5;
   static const defaultPeriod = 30;
+  static const yandexDigits = 8;
+  static const yandexSecretLength = 16;
+  static const yandexFullSecretLength = 26;
+  static const yandexDefaultIssuer = 'Yandex';
 
   int? generatedID;
   final String account;
@@ -17,6 +23,7 @@ class Code {
   final String secret;
   final Algorithm algorithm;
   final Type type;
+  final String? pin;
 
   /// otpauth url in the code
   final String rawData;
@@ -63,6 +70,7 @@ class Code {
     this.generatedID,
     required this.display,
     this.err,
+    this.pin,
   });
 
   factory Code.withError(Object error, String rawData) {
@@ -91,6 +99,7 @@ class Code {
     Type? type,
     int? counter,
     CodeDisplay? display,
+    String? pin,
   }) {
     final String updateAccount = account ?? this.account;
     final String updateIssuer = issuer ?? this.issuer;
@@ -101,22 +110,38 @@ class Code {
     final Type updatedType = type ?? this.type;
     final int updatedCounter = counter ?? this.counter;
     final CodeDisplay updatedDisplay = display ?? this.display;
-    final String encodedIssuer = Uri.encodeQueryComponent(updateIssuer);
+    final String? updatedPin = pin ?? this.pin;
+    final bool isYandex = updatedPin != null;
+    final String effectiveSecret =
+        isYandex ? _normalizeYandexSecret(updatedSecret) : updatedSecret;
+    final int effectiveDigits = isYandex ? yandexDigits : updatedDigits;
+    final int effectivePeriod = isYandex ? defaultPeriod : updatePeriod;
+    final Algorithm effectiveAlgo = isYandex ? Algorithm.sha256 : updatedAlgo;
+    final Type effectiveType = isYandex ? Type.totp : updatedType;
 
     return Code(
       updateAccount,
       updateIssuer,
-      updatedDigits,
-      updatePeriod,
-      updatedSecret,
-      updatedAlgo,
-      updatedType,
+      effectiveDigits,
+      effectivePeriod,
+      effectiveSecret,
+      effectiveAlgo,
+      effectiveType,
       updatedCounter,
-      "otpauth://${updatedType.name}/$updateIssuer:$updateAccount?algorithm=${updatedAlgo.name.toUpperCase()}"
-      "&digits=$updatedDigits&issuer=$encodedIssuer"
-      "&period=$updatePeriod&secret=$updatedSecret${updatedType == Type.hotp ? "&counter=$updatedCounter" : ""}",
+      _buildOtpAuthUrl(
+        type: effectiveType,
+        account: updateAccount,
+        issuer: updateIssuer,
+        secret: effectiveSecret,
+        algorithm: effectiveAlgo,
+        digits: effectiveDigits,
+        period: effectivePeriod,
+        counter: updatedCounter,
+        pin: updatedPin,
+      ),
       generatedID: generatedID,
       display: updatedDisplay,
+      pin: updatedPin,
     );
   }
 
@@ -129,39 +154,65 @@ class Code {
     int digits, {
     Algorithm algorithm = Algorithm.sha1,
     int period = defaultPeriod,
+    String? pin,
   }) {
-    final String encodedIssuer = Uri.encodeQueryComponent(issuer);
+    final bool isYandex = pin != null;
+    final String effectiveSecret =
+        isYandex ? _normalizeYandexSecret(secret) : secret;
+    final int effectiveDigits = isYandex ? yandexDigits : digits;
+    final int effectivePeriod = isYandex ? defaultPeriod : period;
+    final Algorithm effectiveAlgorithm =
+        isYandex ? Algorithm.sha256 : algorithm;
+    final Type effectiveType = isYandex ? Type.totp : type;
+
     return Code(
       account,
       issuer,
-      digits,
-      period,
-      secret,
-      algorithm,
-      type,
+      effectiveDigits,
+      effectivePeriod,
+      effectiveSecret,
+      effectiveAlgorithm,
+      effectiveType,
       0,
-      "otpauth://${type.name}/$issuer:$account?algorithm=${algorithm.name.toUpperCase()}&digits=$digits&issuer=$encodedIssuer&period=$period&secret=$secret",
+      _buildOtpAuthUrl(
+        type: effectiveType,
+        account: account,
+        issuer: issuer,
+        secret: effectiveSecret,
+        algorithm: effectiveAlgorithm,
+        digits: effectiveDigits,
+        period: effectivePeriod,
+        counter: 0,
+        pin: pin,
+      ),
       display: display ?? CodeDisplay(),
+      pin: pin,
     );
   }
 
   static Code fromOTPAuthUrl(String rawData, {CodeDisplay? display}) {
     Uri uri = Uri.parse(rawData);
-    final issuer = _getIssuer(uri);
+    final String? pin = _getPin(uri);
+    final bool isYandex = _isYandexCode(uri, pin);
+    if (isYandex && pin == null) {
+      throw UnsupportedError('Missing Yandex PIN');
+    }
+    final issuer = _getIssuer(uri, isYandex);
     final account = _getAccount(uri, issuer);
 
     try {
       final code = Code(
         account,
         issuer,
-        _getDigits(uri),
-        _getPeriod(uri),
-        getSanitizedSecret(uri.queryParameters['secret']!),
-        _getAlgorithm(uri),
+        _getDigits(uri, isYandex),
+        _getPeriod(uri, isYandex),
+        _getSecret(uri, isYandex),
+        _getAlgorithm(uri, isYandex),
         _getType(uri),
         _getCounter(uri),
         rawData,
         display: CodeDisplay.fromUri(uri) ?? CodeDisplay(),
+        pin: pin,
       );
       return code;
     } catch (e) {
@@ -170,10 +221,9 @@ class Code {
       if (rawData.contains("#")) {
         return Code.fromOTPAuthUrl(rawData.replaceAll("#", '%23'));
       } else {
-        Logger("Code").warning(
-          'Error while parsing code for issuer $issuer, $account',
-          e,
-        );
+        Logger(
+          "Code",
+        ).warning('Error while parsing code for issuer $issuer, $account', e);
         rethrow;
       }
     }
@@ -194,8 +244,9 @@ class Code {
       if (path.startsWith('$issuer:')) {
         return path.substring(issuer.length + 1);
       }
-      return path
-          .substring(path.indexOf(':') + 1); // return data after first colon
+      return path.substring(
+        path.indexOf(':') + 1,
+      ); // return data after first colon
     } catch (e, s) {
       Logger('_getAccount').severe('Error while parsing account', e, s);
       return "";
@@ -219,7 +270,7 @@ class Code {
     return jsonEncode(newUri.toString());
   }
 
-  static String _getIssuer(Uri uri) {
+  static String _getIssuer(Uri uri, [bool isYandex = false]) {
     try {
       if (uri.queryParameters.containsKey("issuer")) {
         String issuerName = uri.queryParameters['issuer']!;
@@ -231,13 +282,19 @@ class Code {
         return issuerName;
       }
       final String path = Uri.decodeComponent(uri.path);
+      if (!path.contains(':') && isYandex) {
+        return yandexDefaultIssuer;
+      }
       return path.split(':')[0].substring(1);
     } catch (e) {
       return "";
     }
   }
 
-  static int _getDigits(Uri uri) {
+  static int _getDigits(Uri uri, [bool isYandex = false]) {
+    if (isYandex) {
+      return yandexDigits;
+    }
     try {
       return int.parse(uri.queryParameters['digits']!);
     } catch (e) {
@@ -248,7 +305,10 @@ class Code {
     }
   }
 
-  static int _getPeriod(Uri uri) {
+  static int _getPeriod(Uri uri, [bool isYandex = false]) {
+    if (isYandex) {
+      return defaultPeriod;
+    }
     try {
       return int.parse(uri.queryParameters['period']!);
     } catch (e) {
@@ -268,7 +328,10 @@ class Code {
     }
   }
 
-  static Algorithm _getAlgorithm(Uri uri) {
+  static Algorithm _getAlgorithm(Uri uri, [bool isYandex = false]) {
+    if (isYandex) {
+      return Algorithm.sha256;
+    }
     try {
       final algorithm =
           uri.queryParameters['algorithm'].toString().toLowerCase();
@@ -284,7 +347,7 @@ class Code {
   }
 
   static Type _getType(Uri uri) {
-    if (uri.host == "totp") {
+    if (uri.host == "totp" || uri.host == "yaotp" || uri.host == "yandex") {
       return Type.totp;
     } else if (uri.host == "steam") {
       return Type.steam;
@@ -299,26 +362,212 @@ class Code {
     if (identical(this, other)) return true;
 
     return other is Code &&
-        other.account == account &&
+        _hasSameCanonicalData(other) &&
+        ((pin != null || other.pin != null) || other.rawData == rawData);
+  }
+
+  @override
+  int get hashCode {
+    final int canonicalHash = Object.hash(
+      account,
+      issuer,
+      digits,
+      period,
+      secret,
+      pin,
+      type,
+      counter,
+    );
+    return pin != null ? canonicalHash : Object.hash(canonicalHash, rawData);
+  }
+
+  bool _hasSameCanonicalData(Code other) {
+    return other.account == account &&
         other.issuer == issuer &&
         other.digits == digits &&
         other.period == period &&
         other.secret == secret &&
         other.counter == counter &&
-        other.type == type &&
-        other.rawData == rawData;
+        other.pin == pin &&
+        other.type == type;
   }
 
-  @override
-  int get hashCode {
-    return account.hashCode ^
-        issuer.hashCode ^
-        digits.hashCode ^
-        period.hashCode ^
-        secret.hashCode ^
-        type.hashCode ^
-        counter.hashCode ^
-        rawData.hashCode;
+  static String _getSecret(Uri uri, [bool isYandex = false]) {
+    final String secret = getSanitizedSecret(uri.queryParameters['secret']!);
+    return isYandex ? _normalizeYandexSecret(secret) : secret;
+  }
+
+  static String? _getPin(Uri uri) {
+    final String? pin = uri.queryParameters['pin'];
+    if (pin == null || pin.isEmpty) {
+      return null;
+    }
+
+    final String sanitizedPin =
+        pin.trim().replaceAll(' ', '').replaceAll('-', '');
+    if (RegExp(r'^\d{4,16}$').hasMatch(sanitizedPin)) {
+      return sanitizedPin;
+    }
+
+    try {
+      final decodedPin = utf8.decode(base32.decode(sanitizedPin.toUpperCase()));
+      if (RegExp(r'^\d{4,16}$').hasMatch(decodedPin)) {
+        return decodedPin;
+      }
+    } catch (e) {
+      // Let the error below surface for invalid pins.
+    }
+
+    throw UnsupportedError('Invalid Yandex PIN');
+  }
+
+  static bool _isYandexCode(Uri uri, String? pin) {
+    return uri.host == 'yaotp' ||
+        uri.host == 'yandex' ||
+        uri.queryParameters.containsKey('pin') ||
+        pin != null;
+  }
+
+  static String _normalizeYandexSecret(String secret) {
+    final Uint8List decodedSecret =
+        base32.decode(_sanitizeYandexSecret(secret));
+    _validateYandexSecret(decodedSecret);
+
+    final Uint8List normalizedSecret =
+        decodedSecret.length == yandexSecretLength
+            ? decodedSecret
+            : Uint8List.fromList(decodedSecret.sublist(0, yandexSecretLength));
+    return base32.encode(normalizedSecret).replaceAll('=', '').toUpperCase();
+  }
+
+  static String _sanitizeYandexSecret(String secret) {
+    return getSanitizedSecret(secret).replaceAll('-', '');
+  }
+
+  static void _validateYandexSecret(Uint8List secret) {
+    if (secret.length != yandexSecretLength &&
+        secret.length != yandexFullSecretLength) {
+      throw UnsupportedError(
+        'Invalid Yandex secret length: ${secret.length} bytes',
+      );
+    }
+
+    if (secret.length == yandexSecretLength) {
+      return;
+    }
+
+    final int originalChecksum =
+        ((secret[secret.length - 2] & 0x0F) << 8) | secret[secret.length - 1];
+
+    int accum = 0;
+    int accumBits = 0;
+    int inputTotalBitsAvailable = secret.length * 8 - 12;
+    int inputIndex = 0;
+    int inputBitsAvailable = 8;
+
+    while (inputTotalBitsAvailable > 0) {
+      int requiredBits = 13 - accumBits;
+      if (inputTotalBitsAvailable < requiredBits) {
+        requiredBits = inputTotalBitsAvailable;
+      }
+
+      while (requiredBits > 0) {
+        int curInput = secret[inputIndex] & ((1 << inputBitsAvailable) - 1);
+        final int bitsToRead = requiredBits < inputBitsAvailable
+            ? requiredBits
+            : inputBitsAvailable;
+
+        curInput >>= inputBitsAvailable - bitsToRead;
+        accum = ((accum << bitsToRead) | curInput) & 0xFFFF;
+
+        inputTotalBitsAvailable -= bitsToRead;
+        requiredBits -= bitsToRead;
+        inputBitsAvailable -= bitsToRead;
+        accumBits += bitsToRead;
+
+        if (inputBitsAvailable == 0) {
+          inputIndex += 1;
+          inputBitsAvailable = 8;
+        }
+      }
+
+      if (accumBits == 13) {
+        accum ^= 0x18F3;
+      }
+      accumBits = 16 - _countLeadingZeros(accum);
+    }
+
+    if (accum != originalChecksum) {
+      throw UnsupportedError('Yandex secret checksum invalid');
+    }
+  }
+
+  static int _countLeadingZeros(int value) {
+    if (value == 0) {
+      return 16;
+    }
+
+    int n = 0;
+    int current = value;
+    if ((current & 0xFF00) == 0) {
+      n += 8;
+      current <<= 8;
+    }
+    if ((current & 0xF000) == 0) {
+      n += 4;
+      current <<= 4;
+    }
+    if ((current & 0xC000) == 0) {
+      n += 2;
+      current <<= 2;
+    }
+    if ((current & 0x8000) == 0) {
+      n += 1;
+    }
+
+    return n;
+  }
+
+  static String _buildOtpAuthUrl({
+    required Type type,
+    required String account,
+    required String issuer,
+    required String secret,
+    required Algorithm algorithm,
+    required int digits,
+    required int period,
+    required int counter,
+    String? pin,
+  }) {
+    final String encodedIssuer = Uri.encodeQueryComponent(issuer);
+    final bool isYandex = pin != null;
+    final String host = isYandex ? 'yaotp' : type.name;
+    final String normalizedSecret =
+        isYandex ? _normalizeYandexSecret(secret) : secret;
+    final StringBuffer query = StringBuffer()
+      ..write(
+        'algorithm=${(isYandex ? Algorithm.sha256 : algorithm).name.toUpperCase()}',
+      )
+      ..write('&digits=${isYandex ? yandexDigits : digits}')
+      ..write('&issuer=$encodedIssuer')
+      ..write('&period=${isYandex ? defaultPeriod : period}')
+      ..write('&secret=$normalizedSecret');
+
+    if (type == Type.hotp && !isYandex) {
+      query.write('&counter=$counter');
+    }
+    if (isYandex) {
+      query.write('&pin=${_encodeYandexPin(pin)}');
+    }
+
+    return 'otpauth://$host/$issuer:$account?${query.toString()}';
+  }
+
+  static String _encodeYandexPin(String pin) {
+    return base32
+        .encode(Uint8List.fromList(utf8.encode(pin)))
+        .replaceAll('=', '')
+        .toUpperCase();
   }
 }
 
@@ -330,8 +579,4 @@ enum Type {
   bool get isTOTPCompatible => this == totp || this == steam;
 }
 
-enum Algorithm {
-  sha1,
-  sha256,
-  sha512,
-}
+enum Algorithm { sha1, sha256, sha512 }

--- a/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
+++ b/mobile/apps/auth/lib/onboarding/view/setup_enter_secret_key_page.dart
@@ -45,6 +45,7 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
   late TextEditingController _issuerController;
   late TextEditingController _accountController;
   late TextEditingController _secretController;
+  late TextEditingController _pinController;
   late TextEditingController _notesController;
   late TextEditingController _digitsController;
   late TextEditingController _periodController;
@@ -70,6 +71,9 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
     );
     _secretController = TextEditingController(
       text: widget.code?.secret,
+    );
+    _pinController = TextEditingController(
+      text: widget.code?.pin,
     );
     _notesController = TextEditingController(
       text: widget.code?.display.note,
@@ -108,6 +112,7 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
       _limitTextLength(_accountController, _otherTextLimit);
       _limitTextLength(_secretController, _otherTextLimit);
     }
+    _limitTextLength(_pinController, 16);
 
     isCustomIcon = widget.code?.display.isCustomIcon ?? false;
     if (isCustomIcon) {
@@ -144,6 +149,7 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
     _issuerController.dispose();
     _accountController.dispose();
     _notesController.dispose();
+    _pinController.dispose();
     _digitsController.dispose();
     _periodController.dispose();
     super.dispose();
@@ -263,6 +269,24 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
                       ),
                     ],
                   ),
+                  Row(
+                    children: [
+                      FieldLabel(l10n.pinText),
+                      Expanded(
+                        child: TextFormField(
+                          keyboardType: TextInputType.number,
+                          maxLength: 16,
+                          decoration: const InputDecoration(
+                            counterText: '',
+                            contentPadding:
+                                EdgeInsets.symmetric(vertical: 12.0),
+                          ),
+                          style: getEnteTextTheme(context).small,
+                          controller: _pinController,
+                        ),
+                      ),
+                    ],
+                  ),
                   const SizedBox(height: 12),
                   Row(
                     children: [
@@ -365,12 +389,33 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
 
                         final period =
                             int.tryParse(_periodController.text.trim());
+                        final pin = _pinController.text
+                            .trim()
+                            .replaceAll(' ', '')
+                            .replaceAll('-', '');
                         if (period != null && (period < 10 || period > 60)) {
                           String message =
                               "Period must be between 10 and 60 seconds";
                           _showIncorrectDetailsDialog(
                             context,
                             message: message,
+                          );
+                          return;
+                        }
+
+                        if (pin.isNotEmpty &&
+                            !RegExp(r'^\d{4,16}$').hasMatch(pin)) {
+                          _showIncorrectDetailsDialog(
+                            context,
+                            message: "PIN must be 4 to 16 digits",
+                          );
+                          return;
+                        }
+
+                        if (widget.code?.pin != null && pin.isEmpty) {
+                          _showIncorrectDetailsDialog(
+                            context,
+                            message: "PIN cannot be empty",
                           );
                           return;
                         }
@@ -420,7 +465,12 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
   Future<void> _saveCode() async {
     try {
       final account = _accountController.text.trim();
-      final issuer = _issuerController.text.trim();
+      final String enteredPin =
+          _pinController.text.trim().replaceAll(' ', '').replaceAll('-', '');
+      final String? pin = enteredPin.isEmpty ? widget.code?.pin : enteredPin;
+      final issuer = _issuerController.text.trim().isEmpty && pin != null
+          ? Code.yandexDefaultIssuer
+          : _issuerController.text.trim();
       final secret = _secretController.text.trim().replaceAll(' ', '');
       final notes = _notesController.text.trim();
       final digits = int.tryParse(_digitsController.text.trim());
@@ -468,11 +518,13 @@ class _SetupEnterSecretKeyPageState extends State<SetupEnterSecretKeyPage> {
               isStreamCode ? Code.steamDigits : digits!,
               algorithm: _algorithm,
               period: period!,
+              pin: pin,
             )
           : widget.code!.copyWith(
               account: account,
               issuer: issuer,
               secret: secret,
+              pin: pin,
               display: display,
               algorithm: _algorithm,
               digits: digits!,

--- a/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:base32/base32.dart';
 import 'package:convert/convert.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -56,13 +57,16 @@ Future<void> showAegisImportInstruction(BuildContext context) async {
 
 Future<void> _pickAegisJsonFile(BuildContext context) async {
   final l10n = context.l10n;
-  FilePickerResult? result = await FilePicker.platform
-      .pickFiles(dialogTitle: l10n.importSelectJsonFile);
+  FilePickerResult? result = await FilePicker.platform.pickFiles(
+    dialogTitle: l10n.importSelectJsonFile,
+  );
   if (result == null) {
     return;
   }
-  final ProgressDialog progressDialog =
-      createProgressDialog(context, l10n.pleaseWait);
+  final ProgressDialog progressDialog = createProgressDialog(
+    context,
+    l10n.pleaseWait,
+  );
   await progressDialog.show();
   try {
     String path = result.files.single.path!;
@@ -114,8 +118,9 @@ Future<int?> _processAegisExportFile(
       final content = decryptAegisVault(decodedJson, password: password!);
       aegisDB = jsonDecode(content);
     } catch (e, s) {
-      Logger("AegisImport")
-          .warning("exception while decrypting aegis vault", e, s);
+      Logger(
+        "AegisImport",
+      ).warning("exception while decrypting aegis vault", e, s);
       await dialog.hide();
       if (password != null) {
         await showErrorDialog(
@@ -163,9 +168,20 @@ Future<int?> _processAegisExportFile(
     // Build the OTP URL
     String otpUrl;
 
-    if (kind.toLowerCase() == 'totp' || kind.toLowerCase() == 'steam') {
-      otpUrl =
-          'otpauth://$kind/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$digits&period=$timer';
+    if (kind.toLowerCase() == 'totp' ||
+        kind.toLowerCase() == 'steam' ||
+        kind.toLowerCase() == 'yandex') {
+      final String host = kind.toLowerCase() == 'yandex' ? 'yaotp' : kind;
+      final StringBuffer otpUrlBuffer = StringBuffer(
+        'otpauth://$host/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$digits&period=$timer',
+      );
+      final String? pin = item['info']['pin'];
+      if (kind.toLowerCase() == 'yandex' && pin != null && pin.isNotEmpty) {
+        otpUrlBuffer.write(
+          '&pin=${base32.encode(Uint8List.fromList(utf8.encode(pin))).replaceAll('=', '').toUpperCase()}',
+        );
+      }
+      otpUrl = otpUrlBuffer.toString();
     } else if (kind.toLowerCase() == 'hotp') {
       otpUrl =
           'otpauth://$kind/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$digits&counter=$counter';
@@ -174,7 +190,9 @@ Future<int?> _processAegisExportFile(
     }
 
     Code code = Code.fromOTPAuthUrl(otpUrl);
-    code = code.copyWith(display: CodeDisplay(pinned: isFavorite, tags: tags));
+    code = code.copyWith(
+      display: CodeDisplay(pinned: isFavorite, tags: tags),
+    );
     parsedCodes.add(code);
   }
 
@@ -199,22 +217,15 @@ String decryptAegisVault(dynamic data, {required String password}) {
     final int p = slot["p"];
     const int derivedKeyLength = 32;
     final script = Scrypt()
-      ..init(
-        ScryptParameters(
-          iterations,
-          r,
-          p,
-          derivedKeyLength,
-          salt,
-        ),
-      );
+      ..init(ScryptParameters(iterations, r, p, derivedKeyLength, salt));
 
     final key = script.process(Uint8List.fromList(utf8.encode(password)));
 
     final params = slot["key_params"];
     final nonce = Uint8List.fromList(hex.decode(params["nonce"]));
-    final encryptedKeyWithTag =
-        Uint8List.fromList(hex.decode(slot["key"]) + hex.decode(params["tag"]));
+    final encryptedKeyWithTag = Uint8List.fromList(
+      hex.decode(slot["key"]) + hex.decode(params["tag"]),
+    );
 
     final cipher = GCMBlockCipher(AESEngine())
       ..init(

--- a/mobile/apps/auth/lib/utils/totp_util.dart
+++ b/mobile/apps/auth/lib/utils/totp_util.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+import 'package:base32/base32.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/services/preference_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:otp/otp.dart' as otp;
+import 'package:pointycastle/api.dart' as pc;
+import 'package:pointycastle/digests/sha256.dart';
+import 'package:pointycastle/macs/hmac.dart';
 import 'package:steam_totp/steam_totp.dart';
 
 int millisecondsSinceEpoch() {
@@ -12,6 +17,9 @@ int millisecondsSinceEpoch() {
 String getOTP(Code code) {
   if (code.type == Type.steam || code.issuer.toLowerCase() == 'steam') {
     return _getSteamCode(code);
+  }
+  if (code.pin != null) {
+    return _getYandexCode(code);
   }
   if (code.type == Type.hotp) {
     return _getHOTPCode(code);
@@ -48,6 +56,9 @@ String getNextTotp(Code code) {
   if (code.type == Type.steam || code.issuer.toLowerCase() == 'steam') {
     return _getSteamCode(code, true);
   }
+  if (code.pin != null) {
+    return _getYandexCode(code, true);
+  }
   return otp.OTP.generateTOTPCodeString(
     getSanitizedSecret(code.secret),
     millisecondsSinceEpoch() + code.period * 1000,
@@ -71,6 +82,11 @@ String getNextTotp(Code code) {
       int generatedTime = startTime + code.period * 1000 * i;
       codes.add(steamTotp.generate(generatedTime ~/ 1000));
     }
+  } else if (code.pin != null) {
+    for (int i = 0; i < count; i++) {
+      int generatedTime = startTime + code.period * 1000 * i;
+      codes.add(_generateYandexCode(code, generatedTime ~/ 1000));
+    }
   } else {
     for (int i = 0; i < count; i++) {
       int generatedTime = startTime + code.period * 1000 * i;
@@ -86,6 +102,53 @@ String getNextTotp(Code code) {
     }
   }
   return (startTime, codes);
+}
+
+String _getYandexCode(Code code, [bool isNext = false]) {
+  final int secondsSinceEpoch =
+      millisecondsSinceEpoch() ~/ 1000 + (isNext ? code.period : 0);
+  return _generateYandexCode(code, secondsSinceEpoch);
+}
+
+String _generateYandexCode(Code code, int secondsSinceEpoch) {
+  final String pin = code.pin!;
+  final Uint8List secretBytes = base32.decode(getSanitizedSecret(code.secret));
+  final Uint8List pinBytes = Uint8List.fromList(utf8.encode(pin));
+  final Uint8List pinWithSecret =
+      Uint8List(pinBytes.length + secretBytes.length)
+        ..setRange(0, pinBytes.length, pinBytes)
+        ..setRange(
+          pinBytes.length,
+          pinBytes.length + secretBytes.length,
+          secretBytes,
+        );
+
+  final Uint8List keyHash = SHA256Digest().process(pinWithSecret);
+  final Uint8List key =
+      keyHash.first == 0 ? Uint8List.fromList(keyHash.sublist(1)) : keyHash;
+  final Uint8List digest = _hmacSha256(
+    key,
+    _uintToArray(secondsSinceEpoch ~/ code.period),
+  );
+
+  final int offset = digest.last & 0x0F;
+  final Uint8List truncated = Uint8List.fromList(
+    digest.sublist(offset, offset + 8),
+  )..[0] &= 0x7F;
+
+  int otpValue = 0;
+  for (final int byte in truncated) {
+    otpValue = (otpValue * 256 + byte) % 208827064576;
+  }
+
+  const String alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  final List<String> chars = List<String>.filled(code.digits, '');
+  for (int i = code.digits - 1; i >= 0; i--) {
+    chars[i] = alphabet[otpValue % alphabet.length];
+    otpValue ~/= alphabet.length;
+  }
+
+  return chars.join();
 }
 
 otp.Algorithm _getAlgorithm(Code code) {
@@ -111,4 +174,19 @@ String safeDecode(String value) {
     debugPrint("Failed to decode $e");
     return value;
   }
+}
+
+Uint8List _hmacSha256(Uint8List key, Uint8List message) {
+  final HMac hmac = HMac(SHA256Digest(), 64)..init(pc.KeyParameter(key));
+  return hmac.process(message);
+}
+
+Uint8List _uintToArray(int n) {
+  final Uint8List result = Uint8List(8);
+  int remaining = n;
+  for (int i = 7; i >= 0; i--) {
+    result[i] = remaining & 0xFF;
+    remaining ~/= 256;
+  }
+  return result;
 }

--- a/mobile/apps/auth/test/models/code_test.dart
+++ b/mobile/apps/auth/test/models/code_test.dart
@@ -51,7 +51,7 @@ void main() {
     final secondDataToStore = restoredCode.toOTPAuthUrlFormat();
     expect(dataToStore, secondDataToStore);
   });
-//
+  //
 
   test("parseWithFunnyAccountName", () {
     final code = Code.fromOTPAuthUrl(
@@ -72,5 +72,80 @@ void main() {
     final updateCode = Code.fromOTPAuthUrl(updatedRawCode);
     expect(updateCode.account, '伍迪', reason: 'updated accountMismatch');
     expect(updateCode.issuer, '鸭子', reason: 'updated issuerMismatch');
+  });
+
+  test("parseYandexOtpAuthUrl", () {
+    final code = Code.fromOTPAuthUrl(
+      'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI&issuer=Yandex&pin=G42TQNQ',
+    );
+    expect(code.type, Type.totp);
+    expect(code.issuer, 'Yandex');
+    expect(code.account, 'alice');
+    expect(code.pin, '7586');
+    expect(code.secret, 'LA2V6KMCGYMWWVEW64RNP3JA3I');
+    expect(code.algorithm, Algorithm.sha256);
+    expect(code.digits, Code.yandexDigits);
+    expect(code.period, Code.defaultPeriod);
+  });
+
+  test("copyWithPreservesYandexPin", () {
+    final code = Code.fromOTPAuthUrl(
+      'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI&issuer=Yandex&pin=G42TQNQ',
+    );
+    final updatedCode = code.copyWith(account: 'bob');
+    expect(updatedCode.pin, '7586');
+    expect(updatedCode.rawData, contains('otpauth://yaotp/'));
+    expect(updatedCode.rawData, contains('pin=G42TQNQ'));
+  });
+
+  test("copyWithNormalizesYandexSecret", () {
+    final code = Code.fromOTPAuthUrl(
+      'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3I&issuer=Yandex&pin=7586',
+    );
+    final updatedCode = code.copyWith(
+      secret: 'la2v6kmc-gymwwvew64rnp3ja3iaaaaaahtsg4hrzpi',
+    );
+
+    expect(updatedCode.secret, 'LA2V6KMCGYMWWVEW64RNP3JA3I');
+    expect(
+      updatedCode.rawData,
+      contains('secret=LA2V6KMCGYMWWVEW64RNP3JA3I'),
+    );
+  });
+
+  test("fromAccountAndSecretNormalizesYandexSecret", () {
+    final code = Code.fromAccountAndSecret(
+      Type.totp,
+      'alice',
+      'Yandex',
+      'la2v6kmc-gymwwvew64rnp3ja3iaaaaaahtsg4hrzpi',
+      CodeDisplay(),
+      Code.defaultDigits,
+      pin: '7586',
+    );
+
+    expect(code.secret, 'LA2V6KMCGYMWWVEW64RNP3JA3I');
+    expect(code.rawData, contains('secret=LA2V6KMCGYMWWVEW64RNP3JA3I'));
+  });
+
+  test("rejectsPinLessYandexOtpAuthUrl", () {
+    expect(
+      () => Code.fromOTPAuthUrl(
+        'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3I&issuer=Yandex',
+      ),
+      throwsUnsupportedError,
+    );
+  });
+
+  test("yandexEqualityIgnoresRawEncodingDifferences", () {
+    final aegisEncoded = Code.fromOTPAuthUrl(
+      'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI&issuer=Yandex&pin=G42TQNQ',
+    );
+    final canonical = Code.fromOTPAuthUrl(
+      'otpauth://yaotp/Yandex:alice?secret=LA2V6KMCGYMWWVEW64RNP3JA3I&issuer=Yandex&pin=7586',
+    );
+
+    expect(aegisEncoded, canonical);
+    expect(aegisEncoded.hashCode, canonical.hashCode);
   });
 }

--- a/mobile/apps/auth/test/utils/yandex_totp_test.dart
+++ b/mobile/apps/auth/test/utils/yandex_totp_test.dart
@@ -1,0 +1,63 @@
+import 'package:ente_auth/models/code.dart';
+import 'package:ente_auth/services/preference_service.dart';
+import 'package:ente_auth/utils/totp_util.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await PreferenceService.instance.init();
+  });
+
+  tearDown(() {
+    PreferenceService.instance.computeAndStoreTimeOffset(null);
+  });
+
+  test('generates Yandex OTPs from Aegis vectors', () {
+    const testCases = [
+      (
+        pin: 'GUZDGOI',
+        secret: '6SB2IKNM6OBZPAVBVTOHDKS4FAAAAAAADFUTQMBTRY',
+        timestamp: 1641559648,
+        expected: 'umozdicq',
+      ),
+      (
+        pin: 'G42TQNQ',
+        secret: 'LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI',
+        timestamp: 1581064020,
+        expected: 'oactmacq',
+      ),
+      (
+        pin: 'G42TQNQ',
+        secret: 'LA2V6KMCGYMWWVEW64RNP3JA3IAAAAAAHTSG4HRZPI',
+        timestamp: 1581090810,
+        expected: 'wemdwrix',
+      ),
+      (
+        pin: 'GUZDCMBUHAYTEMJWGA4DMNZQGI',
+        secret: 'JBGSAU4G7IEZG6OY4UAXX62JU4AAAAAAHTSG4HXU3M',
+        timestamp: 1581091469,
+        expected: 'dfrpywob',
+      ),
+      (
+        pin: 'GUZDCMBUHAYTEMJWGA4DMNZQGI',
+        secret: 'JBGSAU4G7IEZG6OY4UAXX62JU4AAAAAAHTSG4HXU3M',
+        timestamp: 1581093059,
+        expected: 'vunyprpd',
+      ),
+    ];
+
+    for (final testCase in testCases) {
+      PreferenceService.instance.computeAndStoreTimeOffset(
+        testCase.timestamp * 1000000,
+      );
+      final code = Code.fromOTPAuthUrl(
+        'otpauth://yaotp/Yandex:test?secret=${testCase.secret}&issuer=Yandex&pin=${testCase.pin}',
+      );
+      expect(getOTP(code), testCase.expected);
+    }
+  });
+}

--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -3,6 +3,7 @@ import { nullToUndefined } from "ente-utils/transform";
 import { HOTP, TOTP } from "otpauth";
 import { z } from "zod";
 import { Steam } from "./steam";
+import { normalizeYandexSecret, parseYandexPin, Yandex } from "./yandex";
 /**
  * A parsed representation of an *OTP code URI.
  *
@@ -39,6 +40,8 @@ export interface Code {
      * which case we should start from 0.
      */
     counter?: number;
+    /** Optional Yandex PIN for YAOTP variants. */
+    pin?: string;
     /**
      * The secret that is used to drive the OTP generator.
      *
@@ -101,6 +104,9 @@ const CodeDisplay = z.object({
  * - (Steam)
  *   otpauth://steam/Steam:SteamAccount?algorithm=SHA1&digits=5&issuer=Steam&period=30&secret=AAABBBCCCDDDEEEFFF
  *
+ * - (Yandex)
+ *   otpauth://yaotp/Yandex:user@example.org?secret=ALPHANUM&pin=GUZDGOI&issuer=Yandex
+ *
  * See also `auth/test/models/code_test.dart`.
  */
 export const codeFromURIString = (id: string, uriString: string): Code => {
@@ -120,17 +126,20 @@ const _codeFromURIString = (id: string, uriString: string): Code => {
     const url = new URL(uriString);
 
     const [type, path] = parsePathname(url);
+    const isYandex = isYandexCode(url);
+    const pin = parsePin(url, isYandex);
 
     return {
         id,
         type,
         account: parseAccount(path),
-        issuer: parseIssuer(url, path),
-        length: parseLength(url, type),
-        period: parsePeriod(url),
-        algorithm: parseAlgorithm(url),
+        issuer: parseIssuer(url, path, isYandex),
+        length: parseLength(url, type, isYandex),
+        period: parsePeriod(url, isYandex),
+        algorithm: parseAlgorithm(url, isYandex),
         counter: parseCounter(url),
-        secret: parseSecret(url),
+        pin,
+        secret: parseSecret(url, isYandex),
         codeDisplay: parseCodeDisplay(url),
         uriString,
     };
@@ -168,6 +177,9 @@ const parsePathname = (url: URL): [type: Code["type"], path: string] => {
             return ["hotp", url.pathname.toLowerCase()];
         case "steam":
             return ["steam", url.pathname.toLowerCase()];
+        case "yaotp":
+        case "yandex":
+            return ["totp", url.pathname.toLowerCase()];
         default:
             break;
     }
@@ -176,6 +188,8 @@ const parsePathname = (url: URL): [type: Code["type"], path: string] => {
     if (p.startsWith("//totp")) return ["totp", url.pathname.slice(6)];
     if (p.startsWith("//hotp")) return ["hotp", url.pathname.slice(6)];
     if (p.startsWith("//steam")) return ["steam", url.pathname.slice(7)];
+    if (p.startsWith("//yaotp")) return ["totp", url.pathname.slice(7)];
+    if (p.startsWith("//yandex")) return ["totp", url.pathname.slice(8)];
 
     throw new Error(`Unsupported code or unparseable path "${url.pathname}"`);
 };
@@ -188,7 +202,7 @@ const parseAccount = (path: string): string | undefined => {
     return p;
 };
 
-const parseIssuer = (url: URL, path: string): string => {
+const parseIssuer = (url: URL, path: string, isYandex: boolean): string => {
     // If there is a "issuer" search param, use that.
     let issuer = url.searchParams.get("issuer");
     if (issuer) {
@@ -205,6 +219,7 @@ const parseIssuer = (url: URL, path: string): string => {
     if (p.startsWith("/")) p = p.slice(1);
 
     if (p.includes(":")) p = p.split(":")[0]!;
+    else if (isYandex) return "Yandex";
     else if (p.includes("-")) p = p.split("-")[0]!;
 
     return p;
@@ -217,15 +232,23 @@ const parseIssuer = (url: URL, path: string): string => {
  * this for generating numeric codes. Now we also support steam, which instead
  * shows non-numeric codes, and also with a different default length of 5.
  */
-const parseLength = (url: URL, type: Code["type"]): number => {
+const parseLength = (
+    url: URL,
+    type: Code["type"],
+    isYandex: boolean,
+): number => {
+    if (isYandex) return Yandex.digits;
     const defaultLength = type == "steam" ? 5 : 6;
     return parseInt(url.searchParams.get("digits") ?? "", 10) || defaultLength;
 };
 
-const parsePeriod = (url: URL): number =>
-    parseInt(url.searchParams.get("period") ?? "", 10) || 30;
+const parsePeriod = (url: URL, isYandex: boolean): number =>
+    isYandex
+        ? Yandex.period
+        : parseInt(url.searchParams.get("period") ?? "", 10) || 30;
 
-const parseAlgorithm = (url: URL): Code["algorithm"] => {
+const parseAlgorithm = (url: URL, isYandex: boolean): Code["algorithm"] => {
+    if (isYandex) return "sha256";
     switch (url.searchParams.get("algorithm")?.toLowerCase()) {
         case "sha256":
             return "sha256";
@@ -241,8 +264,28 @@ const parseCounter = (url: URL): number | undefined => {
     return c ? parseInt(c, 10) : undefined;
 };
 
-const parseSecret = (url: URL): string =>
-    url.searchParams.get("secret")!.replaceAll(" ", "").toUpperCase();
+const parsePin = (url: URL, isYandex: boolean): string | undefined => {
+    const pin = url.searchParams.get("pin");
+    if (pin) {
+        return parseYandexPin(pin);
+    }
+    if (isYandex) {
+        throw new Error("Missing Yandex PIN");
+    }
+    return undefined;
+};
+
+const parseSecret = (url: URL, isYandex: boolean): string => {
+    const secret = url.searchParams
+        .get("secret")!
+        .replaceAll(" ", "")
+        .toUpperCase();
+    return isYandex ? normalizeYandexSecret(secret) : secret;
+};
+
+const isYandexCode = (url: URL) =>
+    ["yaotp", "yandex"].includes(url.host.toLowerCase()) ||
+    url.searchParams.has("pin");
 
 /**
  * Parse a JSON string containing Ente specific metadata attached to the code.
@@ -279,16 +322,27 @@ export const generateOTPs = (
     const timestamp = Date.now() + timeOffset;
     switch (code.type) {
         case "totp": {
-            const totp = new TOTP({
-                secret: code.secret,
-                algorithm: code.algorithm,
-                period: code.period,
-                digits: code.length,
-            });
-            otp = totp.generate({ timestamp });
-            nextOTP = totp.generate({
-                timestamp: timestamp + code.period * 1000,
-            });
+            if (code.pin) {
+                const yandex = new Yandex({
+                    secret: code.secret,
+                    pin: code.pin,
+                });
+                otp = yandex.generate({ timestamp });
+                nextOTP = yandex.generate({
+                    timestamp: timestamp + code.period * 1000,
+                });
+            } else {
+                const totp = new TOTP({
+                    secret: code.secret,
+                    algorithm: code.algorithm,
+                    period: code.period,
+                    digits: code.length,
+                });
+                otp = totp.generate({ timestamp });
+                nextOTP = totp.generate({
+                    timestamp: timestamp + code.period * 1000,
+                });
+            }
             break;
         }
 

--- a/web/apps/auth/src/services/yandex.ts
+++ b/web/apps/auth/src/services/yandex.ts
@@ -1,0 +1,192 @@
+import jsSHA from "jssha";
+import { Secret } from "otpauth";
+
+const defaultDigits = 8;
+const defaultPeriod = 30;
+const secretLength = 16;
+const fullSecretLength = 26;
+const checksumPolynomial = 0x18f3;
+const yandexAlphabet = "abcdefghijklmnopqrstuvwxyz";
+const yandexModulo = yandexAlphabet.length ** defaultDigits;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export class Yandex {
+    static readonly digits = defaultDigits;
+    static readonly period = defaultPeriod;
+
+    secret: Secret;
+    pin: string;
+    period: number;
+
+    constructor({ secret, pin }: { secret: string; pin: string }) {
+        this.secret = Secret.fromBase32(normalizeYandexSecret(secret));
+        this.pin = pin;
+        this.period = defaultPeriod;
+    }
+
+    generate({ timestamp }: { timestamp: number } = { timestamp: Date.now() }) {
+        const pinBytes = textEncoder.encode(this.pin);
+        const secretBytes = new Uint8Array(this.secret.buffer);
+        const pinWithSecret = new Uint8Array(
+            pinBytes.length + secretBytes.length,
+        );
+        pinWithSecret.set(pinBytes, 0);
+        pinWithSecret.set(secretBytes, pinBytes.length);
+
+        const keyHash = sha256Digest(pinWithSecret);
+        const key = keyHash[0] === 0 ? keyHash.slice(1) : keyHash;
+
+        const counter = Math.floor(timestamp / 1000 / this.period);
+        const digest = sha256HMACDigest(
+            toArrayBuffer(key),
+            uintToArray(counter),
+        );
+        const offset = digest[digest.length - 1]! & 0x0f;
+        const truncated = digest.slice(offset, offset + 8);
+        const firstByte = truncated[0];
+        if (firstByte == undefined) {
+            throw new Error("Unable to derive Yandex OTP");
+        }
+        truncated[0] = firstByte & 0x7f;
+
+        let otp = 0;
+        for (const byte of truncated) {
+            otp = (otp * 256 + byte) % yandexModulo;
+        }
+
+        const chars = Array.from({ length: defaultDigits });
+        for (let i = defaultDigits - 1; i >= 0; i--) {
+            chars[i] = yandexAlphabet[otp % yandexAlphabet.length]!;
+            otp = Math.trunc(otp / yandexAlphabet.length);
+        }
+        return chars.join("");
+    }
+}
+
+export const normalizeYandexSecret = (secret: string): string => {
+    const bytes = decodeBase32(secret);
+    validateSecret(bytes);
+    const normalized =
+        bytes.length === secretLength ? bytes : bytes.slice(0, secretLength);
+    return new Secret({ buffer: toArrayBuffer(normalized) }).base32;
+};
+
+export const parseYandexPin = (pin: string): string => {
+    const sanitizedPin = sanitizeBase32(pin);
+    if (/^\d{4,16}$/.test(sanitizedPin)) return sanitizedPin;
+
+    const decodedPin = textDecoder.decode(decodeBase32(sanitizedPin));
+    if (!/^\d{4,16}$/.test(decodedPin)) {
+        throw new Error("Invalid Yandex PIN");
+    }
+
+    return decodedPin;
+};
+
+const decodeBase32 = (value: string): Uint8Array =>
+    new Uint8Array(Secret.fromBase32(sanitizeBase32(value)).buffer);
+
+const toArrayBuffer = (value: Uint8Array): ArrayBuffer => value.slice().buffer;
+
+const sanitizeBase32 = (value: string) =>
+    value.trim().replaceAll(" ", "").replaceAll("-", "").toUpperCase();
+
+const validateSecret = (secret: Uint8Array) => {
+    if (![secretLength, fullSecretLength].includes(secret.length)) {
+        throw new Error(`Invalid Yandex secret length: ${secret.length} bytes`);
+    }
+
+    if (secret.length === secretLength) return;
+
+    const originalChecksum =
+        ((secret[secret.length - 2]! & 0x0f) << 8) | secret[secret.length - 1]!;
+
+    let accum = 0;
+    let accumBits = 0;
+    let inputTotalBitsAvailable = secret.length * 8 - 12;
+    let inputIndex = 0;
+    let inputBitsAvailable = 8;
+
+    while (inputTotalBitsAvailable > 0) {
+        let requiredBits = 13 - accumBits;
+        if (inputTotalBitsAvailable < requiredBits) {
+            requiredBits = inputTotalBitsAvailable;
+        }
+
+        while (requiredBits > 0) {
+            let curInput =
+                secret[inputIndex]! & ((1 << inputBitsAvailable) - 1);
+            const bitsToRead = Math.min(requiredBits, inputBitsAvailable);
+
+            curInput >>= inputBitsAvailable - bitsToRead;
+            accum = ((accum << bitsToRead) | curInput) & 0xffff;
+
+            inputTotalBitsAvailable -= bitsToRead;
+            requiredBits -= bitsToRead;
+            inputBitsAvailable -= bitsToRead;
+            accumBits += bitsToRead;
+
+            if (inputBitsAvailable === 0) {
+                inputIndex += 1;
+                inputBitsAvailable = 8;
+            }
+        }
+
+        if (accumBits === 13) {
+            accum ^= checksumPolynomial;
+        }
+        accumBits = 16 - countLeadingZeros(accum);
+    }
+
+    if (accum !== originalChecksum) {
+        throw new Error("Yandex secret checksum invalid");
+    }
+};
+
+const countLeadingZeros = (value: number) => {
+    if (value === 0) return 16;
+
+    let n = 0;
+    let current = value;
+    if ((current & 0xff00) === 0) {
+        n += 8;
+        current <<= 8;
+    }
+    if ((current & 0xf000) === 0) {
+        n += 4;
+        current <<= 4;
+    }
+    if ((current & 0xc000) === 0) {
+        n += 2;
+        current <<= 2;
+    }
+    if ((current & 0x8000) === 0) {
+        n += 1;
+    }
+
+    return n;
+};
+
+const uintToArray = (n: number): Uint8Array => {
+    const result = new Uint8Array(8);
+    let remaining = n;
+    for (let i = 7; i >= 0; i--) {
+        result[i] = remaining & 0xff;
+        remaining = Math.trunc(remaining / 256);
+    }
+    return result;
+};
+
+const sha256Digest = (message: Uint8Array) => {
+    const sha = new jsSHA("SHA-256", "UINT8ARRAY");
+    sha.update(message);
+    return sha.getHash("UINT8ARRAY");
+};
+
+const sha256HMACDigest = (key: ArrayBuffer, message: Uint8Array) => {
+    const hmac = new jsSHA("SHA-256", "UINT8ARRAY");
+    hmac.setHMACKey(key, "ARRAYBUFFER");
+    hmac.update(message);
+    return hmac.getHMAC("UINT8ARRAY");
+};


### PR DESCRIPTION
## Summary
- add Yandex/YaTop OTP parsing and generation in the mobile and web auth apps
- support Aegis Yandex imports and manual PIN entry on mobile
- normalize and validate Yandex secrets using Aegis-compatible behavior

## Validation
- `dart analyze lib/models/code.dart lib/utils/totp_util.dart lib/ui/settings/data/import/aegis_import.dart lib/onboarding/view/setup_enter_secret_key_page.dart test/models/code_test.dart test/utils/yandex_totp_test.dart`
- `yarn workspace auth tsc --noEmit`

## Note
- `flutter test` is blocked in this worktree because asset directories referenced by `mobile/apps/auth/pubspec.yaml` are missing here.