### PR TITLE
[mob][photos] Refresh Home favorites state on toggle

### DIFF
--- a/mobile/apps/photos/lib/services/favorites_service.dart
+++ b/mobile/apps/photos/lib/services/favorites_service.dart
@@ -9,6 +9,7 @@ import 'package:photos/db/files_db.dart';
 import 'package:photos/events/collection_updated_event.dart';
 import "package:photos/events/favorites_service_init_complete_event.dart";
 import 'package:photos/events/files_updated_event.dart';
+import 'package:photos/events/local_photos_updated_event.dart';
 import 'package:photos/gateways/collections/models/create_request.dart';
 import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/file/file.dart';
@@ -157,6 +158,12 @@ class FavoritesService {
       await _collectionsService.addOrCopyToCollection(collectionID, files);
     }
     _updateFavoriteFilesCache(files, favFlag: true);
+    Bus.instance.fire(
+      LocalPhotosUpdatedEvent(
+        files,
+        source: "favoriteAdd",
+      ),
+    );
     RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
@@ -184,12 +191,20 @@ class FavoritesService {
       );
     }
     _updateFavoriteFilesCache(files, favFlag: favFlag);
+    Bus.instance.fire(
+      LocalPhotosUpdatedEvent(
+        files,
+        source: favFlag ? "favoriteAdd" : "favoriteRemove",
+      ),
+    );
+    RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
   Future<void> removeFromFavorites(
     BuildContext context,
     EnteFile file,
   ) async {
+    final EnteFile originalFile = file;
     final inUploadID = file.uploadedFileID;
     if (inUploadID == null) {
       // Do nothing, ignore
@@ -213,6 +228,13 @@ class FavoritesService {
       file = favFile;
     }
     _updateFavoriteFilesCache([file], favFlag: false);
+    Bus.instance.fire(
+      LocalPhotosUpdatedEvent(
+        [originalFile],
+        source: "favoriteRemove",
+      ),
+    );
+    RemoteSyncService.instance.sync(silently: true).ignore();
   }
 
   Future<EnteFile?> _resolveFavoritesEntryForRemoval(

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Refresh Home favorites state on toggle
 - Ashil: Stop showing unknown user avatar on shared albums opened via deeplinking
 - Ashil: Fix album sorting state not persisting
 


### PR DESCRIPTION
## Summary
- fire `LocalPhotosUpdatedEvent` when photo/video favorites are added or removed
- trigger a silent sync after favorite removal, matching the add flow
- cover both single-item and bulk favorite update paths in `FavoritesService`

## Behavior Changes
- Returning to Home after favoriting or unfavoriting a photo/video now refreshes the thumbnail star state instead of waiting for an unrelated rebuild.
- Bulk favorite updates also emit the same local refresh signal used by the Home gallery.
- Favorite removals now kick the same silent remote sync path that adds already used.

## Operational Notes
- The Home gallery already listens to `LocalPhotosUpdatedEvent`, so this change reuses the existing reload path instead of adding a new favorites-specific notifier.
- The branch scope is limited to `mobile/apps/photos/lib/services/favorites_service.dart`.

## Testing
- `flutter analyze lib/services/favorites_service.dart`
