### PR TITLE
[server] Add device, app, and IP to login notification email

### DIFF
--- a/server/mail-templates/on_login.html
+++ b/server/mail-templates/on_login.html
@@ -103,6 +103,7 @@
       <p>
       We detected a new login to your Ente account at {{ .Date }} UTC.
       </p>
+      {{ if .App }}
       <table>
         <tr>
           <td><strong>App</strong></td>
@@ -117,6 +118,7 @@
           <td>{{ .IP }}</td>
         </tr>
       </table>
+      {{ end }}
       <p>
       If this is not you, please reset your password. For any assistance or questions, please reply to this email.
       </p>

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -447,29 +447,34 @@ func (c *UserController) AddTokenAndNotify(ctx context.Context, userID int64, ap
 		return nil
 	}
 
-	appDisplayNames := map[ente.App]string{
-		ente.Photos: "Ente Photos",
-		ente.Auth:   "Ente Auth",
-		ente.Locker: "Ente Locker",
-	}
-	appName, ok := appDisplayNames[app]
-	if !ok {
-		appName = "Ente"
-	}
-	prettyUA := network.GetPrettyUA(userAgent)
-
 	go func() {
 		user, userErr := c.UserRepo.GetUserByIDInternal(userID)
 		if userErr != nil {
 			log.WithError(userErr).Error("Failed to get user")
 			return
 		}
-		emailSendErr := emailUtil.SendTemplatedEmail([]string{user.Email}, "Ente", "team@ente.io", emailCtrl.LoginSuccessSubject, emailCtrl.LoginSuccessTemplate, map[string]interface{}{
-			"Date":   t.Now().UTC().Format("02 Jan, 2006 15:04"),
-			"App":    appName,
-			"Device": prettyUA,
-			"IP":     ip,
-		}, nil)
+		templateData := map[string]interface{}{
+			"Date": t.Now().UTC().Format("02 Jan, 2006 15:04"),
+		}
+		if strings.HasSuffix(emailUtil.NormalizeEmail(user.Email), "@ente.io") {
+			appDisplayNames := map[ente.App]string{
+				ente.Photos: "Ente Photos",
+				ente.Auth:   "Ente Auth",
+				ente.Locker: "Ente Locker",
+			}
+			appName, ok := appDisplayNames[app]
+			if !ok {
+				appName = "Ente"
+			}
+			device := "Unknown Device"
+			if strings.TrimSpace(userAgent) != "" {
+				device = network.GetPrettyUA(userAgent)
+			}
+			templateData["App"] = appName
+			templateData["Device"] = device
+			templateData["IP"] = ip
+		}
+		emailSendErr := emailUtil.SendTemplatedEmail([]string{user.Email}, "Ente", "team@ente.com", emailCtrl.LoginSuccessSubject, emailCtrl.LoginSuccessTemplate, templateData, nil)
 		if emailSendErr != nil {
 			log.WithError(emailSendErr).Error("Failed to send email")
 		}


### PR DESCRIPTION
**TLDR: Include app name (Photos, Auth, Locker), device/browser info, and IP address in login notification emails**

The current login notification email only includes the timestamp, making it difficult for users to determine whether a login was legitimate. Since Ente has various different products and users may use multiple products with the same account, including the app name also helps distinguish which service was logged into and makes it easier to identify unauthorized access.

I saw some requests about this in GitHub issues/discussions and missed this myself as well. Feel free to close this PR if it doesn't align with your vision or priorities. It required minimal effort, most of the data (IP, user-agent, app) was already available in `AddTokenAndNotify` since it's used by the session manager. It just wasn't being passed to the email template.

## Changes

- **`server/mail-templates/on_login.html`** — Added a table displaying the app, device, and IP address
- **`server/pkg/controller/user/userauth.go`** — Resolved app to a display name, parsed user-agent into a readable string via `GetPrettyUA`, and passed all three new fields to the email template

<img width="663" height="618" alt="CleanShot 2026-03-17 at 18 59 33" src="https://github.com/user-attachments/assets/c9f8b5a2-5101-45f4-9fec-2db0bfc2afe2" />
