### PR TITLE
Use nginx-unprivileged as base image for web container

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,10 @@
+docs/
+
+.dockerignore
+.gitignore
+.prettierignore
+.prettierrc
+Dockerfile
+CLAUDE.md
+crowdin.yml
+README.md

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -28,45 +28,64 @@ RUN yarn build:cast
 RUN yarn build:share
 RUN yarn build:embed
 
-FROM nginx
+FROM nginxinc/nginx-unprivileged:1.29-alpine-otel
 
-WORKDIR /out
+USER root
 
-COPY --from=builder /build/web/apps/photos/out /out/photos
-COPY --from=builder /build/web/apps/accounts/out /out/accounts
-COPY --from=builder /build/web/apps/auth/out /out/auth
-COPY --from=builder /build/web/apps/cast/out /out/cast
-COPY --from=builder /build/web/apps/share/out /out/share
-COPY --from=builder /build/web/apps/embed/out /out/embed
+COPY --chmod=755 <<EOF /docker-entrypoint.d/90-replace-ente-env.sh
+sed -i'' "s#ENTE_API_ORIGIN_PLACEHOLDER#\$ENTE_API_ORIGIN#g" /etc/nginx/conf.d/default.conf
+find /usr/share/nginx/html -name '*.js' |
+    xargs sed -i'' "s#ENTE_API_ORIGIN_PLACEHOLDER#\$ENTE_API_ORIGIN#g"
+find /usr/share/nginx/html/photos -name '*.js' |
+    xargs sed -i'' "s#ENTE_ALBUMS_ORIGIN_PLACEHOLDER#\$ENTE_ALBUMS_ORIGIN#g"
+find /usr/share/nginx/html/photos -name '*.js' |
+    xargs sed -i'' "s#ENTE_PHOTOS_ORIGIN_PLACEHOLDER#\$ENTE_PHOTOS_ORIGIN#g"
+EOF
+
+USER nginx
+
+COPY --from=builder --chown=nginx:nginx /build/web/apps/photos/out /usr/share/nginx/html/photos
+COPY --from=builder --chown=nginx:nginx /build/web/apps/accounts/out /usr/share/nginx/html/accounts
+COPY --from=builder --chown=nginx:nginx /build/web/apps/auth/out /usr/share/nginx/html/auth
+COPY --from=builder --chown=nginx:nginx /build/web/apps/cast/out /usr/share/nginx/html/cast
+COPY --from=builder --chown=nginx:nginx /build/web/apps/share/out /usr/share/nginx/html/share
+COPY --from=builder --chown=nginx:nginx /build/web/apps/embed/out /usr/share/nginx/html/embed
 
 COPY <<EOF /etc/nginx/conf.d/default.conf
 server {
-    listen 3000; root /out/photos;
+    listen 3000; root /usr/share/nginx/html/photos;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3001; root /out/accounts;
+    listen 3001; root /usr/share/nginx/html/accounts;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3002; root /out/photos;
+    listen 3002; root /usr/share/nginx/html/photos;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3003; root /out/auth;
+    listen 3003; root /usr/share/nginx/html/auth;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3004; root /out/cast;
+    listen 3004; root /usr/share/nginx/html/cast;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3005; root /out/share;
+    listen 3005; root /usr/share/nginx/html/share;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 server {
-    listen 3006; root /out/embed;
+    listen 3006; root /usr/share/nginx/html/embed;
     location / { try_files \$uri \$uri.html /index.html; }
+    add_header 'Access-Control-Allow-Origin' 'ENTE_API_ORIGIN_PLACEHOLDER';
 }
 EOF
 
@@ -81,14 +100,3 @@ EXPOSE 3006
 ENV ENTE_API_ORIGIN=http://localhost:8080
 ENV ENTE_ALBUMS_ORIGIN=https://localhost:3002
 ENV ENTE_PHOTOS_ORIGIN=https://localhost:3000
-
-COPY <<EOF /docker-entrypoint.d/90-replace-ente-env.sh
-find /out -name '*.js' |
-    xargs sed -i'' "s#ENTE_API_ORIGIN_PLACEHOLDER#\$ENTE_API_ORIGIN#g"
-find /out/photos -name '*.js' |
-    xargs sed -i'' "s#ENTE_ALBUMS_ORIGIN_PLACEHOLDER#\$ENTE_ALBUMS_ORIGIN#g"
-find /out/photos -name '*.js' |
-    xargs sed -i'' "s#ENTE_PHOTOS_ORIGIN_PLACEHOLDER#\$ENTE_PHOTOS_ORIGIN#g"
-EOF
-
-RUN chmod +x /docker-entrypoint.d/90-replace-ente-env.sh


### PR DESCRIPTION
## Description

It is strongly discouraged to run containers as `root` unless absolutely necessary. For `nginx`, there is an official `-unprivileged` image variant available for use.

This simplifies deploying **Ente Web** in **Kubernetes** environments with the **Pod Security Admission** controller enabled. Without explicit exclusion, the controller blocks the creation of containers or pods that run—or could run—as the **root** user.

The modifications applied to the `Dockerfile` now enable rootless container execution, though running the container with a read-only root filesystem remains challenging.

## Tests

The build is working and I'm running the image in my private cluster for a few days already. If there are any further things you would like me to test / document, please let me know :)