### PR TITLE
fix(desktop): extend CORS workaround to cover Access-Control-Allow-Headers

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -670,6 +670,8 @@ const allowAllCORSOrigins = (webContents: WebContents) =>
                 if (key.toLowerCase() == "access-control-allow-origin") {
                     headers["Access-Control-Allow-Origin"] =
                         value[0] == "null" ? ["*"] : value;
+                } else if (key.toLowerCase() == "access-control-allow-headers") {
+                    headers["Access-Control-Allow-Headers"] = ["*"];
                 } else {
                     headers[key] = value;
                 }


### PR DESCRIPTION
## Description

The allowAllCORSOrigins function already patches Access-Control-Allow-Origin when S3 providers return null. This PR does the same for Access-Control-Allow-Headers.

Problem
Some S3 providers have a hardcoded header whitelist in their server config that doesn't include all headers the desktop app sends (like x-client-version). When this happens, the browser blocks the request before it even goes out:


```
Request header field x-client-version is not allowed by 
Access-Control-Allow-Headers in preflight response
```

This broke uploads and downloads completely for me on a hosted setup using FileLu S5 as the S3 backend. The bucket CORS config was correct (<AllowedHeader>*</AllowedHeader>), but the provider's nginx was overriding it with a fixed list — so the bucket config had no effect.

Fix
When Access-Control-Allow-Headers comes back in a preflight response, override it with *. Same pattern as the existing ACAO fix.

## Tests
Tested on Ente Desktop v1.7.21 against a self-hosted museum instance with FileLu S5 as the S3 backend.

**Before:** uploads and downloads failed with `x-client-version is not allowed by Access-Control-Allow-Headers in preflight response`

**After:** error is gone, uploads and downloads work as expected.