### PR TITLE
[web][photos] Infer MIME type for gallery download blobs

### DIFF
--- a/web/packages/gallery/services/download.ts
+++ b/web/packages/gallery/services/download.ts
@@ -19,6 +19,7 @@ import type { EnteFile } from "ente-media/file";
 import { fileFileName } from "ente-media/file-metadata";
 import { FileType } from "ente-media/file-type";
 import { decodeLivePhoto } from "ente-media/live-photo";
+import { detectFileTypeInfoFromChunk } from "../utils/detect-type";
 import { playableVideoURL, renderableImageBlob } from "./convert";
 
 /**
@@ -355,7 +356,9 @@ class DownloadManager {
      * it into a {@link Blob}.
      */
     async fileBlob(file: EnteFile, opts?: FileDownloadOpts) {
-        return this.fileStream(file, opts).then((s) => new Response(s).blob());
+        return this.fileStream(file, opts).then((stream) =>
+            this.blobWithInferredType(file, stream),
+        );
     }
 
     /**
@@ -397,7 +400,7 @@ class DownloadManager {
         if (cachedURL) return cachedURL;
 
         const url = this.downloadFile(file)
-            .then((stream) => new Response(stream).blob())
+            .then((stream) => this.blobWithInferredType(file, stream))
             .then((blob) => URL.createObjectURL(blob));
         this.fileURLPromises.set(file.id, url);
 
@@ -533,6 +536,25 @@ class DownloadManager {
             );
         } else {
             return photos_downloadFile(file, opts);
+        }
+    }
+
+    private async blobWithInferredType(
+        file: EnteFile,
+        stream: ReadableStream<Uint8Array> | null,
+    ) {
+        const blob = await new Response(stream).blob();
+        if (blob.type) return blob;
+
+        try {
+            const { mimeType } = await detectFileTypeInfoFromChunk(
+                async () =>
+                    new Uint8Array(await blob.slice(0, 4100).arrayBuffer()),
+                fileFileName(file),
+            );
+            return mimeType ? blob.slice(0, blob.size, mimeType) : blob;
+        } catch {
+            return blob;
         }
     }
 


### PR DESCRIPTION
On DuckDuckGo Android, downloading a jpg photo from a quick link was resulting in a .bin file. This is the fix for that.