### PR TITLE
auth: select all text on double-tap in search field

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1484,27 +1484,35 @@ class _HomePageState extends State<HomePage> {
       ),
       title: !_showSearchBox
           ? const AuthLogoWidget(height: 18)
-          : TextField(
-              autocorrect: false,
-              enableSuggestions: false,
-              autofocus: _autoFocusSearch,
-              controller: _textController,
-              onChanged: (val) {
-                _searchText = val;
-                _applyFilteringAndRefresh();
+          : GestureDetector(
+              onDoubleTap: () {
+                _textController.selection = TextSelection(
+                  baseOffset: 0,
+                  extentOffset: _textController.text.length,
+                );
               },
-              onSubmitted: (_) {
-                if (_filteredCodes.isNotEmpty) {
-                  // Move focus to the first item in the grid
-                  _firstItemFocusNode.requestFocus();
-                }
-              },
-              decoration: InputDecoration(
-                hintText: l10n.searchHint,
-                border: InputBorder.none,
-                focusedBorder: InputBorder.none,
+              child: TextField(
+                autocorrect: false,
+                enableSuggestions: false,
+                autofocus: _autoFocusSearch,
+                controller: _textController,
+                onChanged: (val) {
+                  _searchText = val;
+                  _applyFilteringAndRefresh();
+                },
+                onSubmitted: (_) {
+                  if (_filteredCodes.isNotEmpty) {
+                    // Move focus to the first item in the grid
+                    _firstItemFocusNode.requestFocus();
+                  }
+                },
+                decoration: InputDecoration(
+                  hintText: l10n.searchHint,
+                  border: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                ),
+                focusNode: searchBoxFocusNode,
               ),
-              focusNode: searchBoxFocusNode,
             ),
       centerTitle: true,
       actions: <Widget>[


### PR DESCRIPTION
## Summary
Wraps the search TextField in a GestureDetector that selects all text when the user double-taps the search input field. This makes it easy to replace the current search query without manually selecting text.

## Changes
- `mobile/apps/auth/lib/ui/home_page.dart`: Wrapped the search `TextField` in a `GestureDetector` with an `onDoubleTap` handler that sets the `TextEditingController` selection from offset 0 to the end of the text.

Co-Authored-By: Oz <oz-agent@warp.dev>