### PR TITLE
[server] Set ConnMaxLifetime to recycle stale DB connections

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1056,6 +1056,8 @@ func setupDatabase() *sql.DB {
 
 	db.SetMaxIdleConns(6)
 	db.SetMaxOpenConns(45)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(10 * time.Minute)
 
 	log.Println("Database was configured successfully.")
 


### PR DESCRIPTION
## Summary

- Add `db.SetConnMaxLifetime(30 * time.Minute)` to periodically recycle all connections
- Add `db.SetConnMaxIdleTime(10 * time.Minute)` to close idle connections after inactivity

## Problem

The database pool in `setupDatabase()` sets `MaxIdleConns` and `MaxOpenConns` but does not set `ConnMaxLifetime` or `ConnMaxIdleTime`. This means connections live indefinitely.

If PostgreSQL restarts or a network disruption breaks the TCP connection, the pool keeps using the dead connection. All background jobs (trash collection, push notifications, embeddings cleanup, etc.) fail in a loop with `connection reset by peer` errors — **indefinitely**, until a manual restart of museum.

Observed in production (self-hosted on Clever Cloud): a single network blip on March 19 caused **5 days of continuous errors** (~36,500 errors) across all cron jobs until a manual restart.

## Fix

Set `ConnMaxLifetime` to 30 minutes and `ConnMaxIdleTime` to 10 minutes so that Go's `database/sql` pool periodically closes and recreates connections, allowing automatic recovery from transient failures.

This is a well-known Go best practice — the [database/sql documentation](https://pkg.go.dev/database/sql#DB.SetConnMaxLifetime) recommends setting this value in production environments.

## Test plan

- Verified the change compiles successfully with `go build ./cmd/museum/`
- The change only affects connection pool lifecycle — no behavioral change to queries or transactions