### PR TITLE
[mob] [auth] Fix spacing between social menu items

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/social_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/social_section_widget.dart
@@ -47,6 +47,7 @@ class SocialSectionWidget extends StatelessWidget {
         "https://shop.ente.io",
         launchInExternalApp: !Platform.isAndroid,
       ),
+      sectionOptionSpacing,
       const SocialsMenuItemWidget("Mastodon", "https://fosstodon.org/@ente"),
       sectionOptionSpacing,
       const SocialsMenuItemWidget("Twitter", "https://twitter.com/enteio"),


### PR DESCRIPTION
## Description

Spotted a small spacing inconsistency between the “Merchandise” and “Mastodon” links and couldn’t unsee it, so I fixed it. Thanks for being open source!