### PR TITLE
[mob][photos] Use titleAsync for iOS upload filenames

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -95,8 +95,10 @@ class EnteFile {
     file.localID = asset.id;
     file.title = asset.title;
     file.deviceFolder = pathName;
-    file.location =
-        Location(latitude: asset.latitude, longitude: asset.longitude);
+    file.location = Location(
+      latitude: asset.latitude,
+      longitude: asset.longitude,
+    );
     file.fileType = fileTypeFromAsset(asset);
     file.creationTime = parseFileCreationTime(file.title, asset);
     file.modificationTime = _safeGetMicroseconds(
@@ -212,8 +214,10 @@ class EnteFile {
       creationTime = exifTime.time!.microsecondsSinceEpoch;
     }
     if (mediaUploadData.exifData != null) {
-      mediaUploadData.isPanorama =
-          checkPanoramaFromEXIF(null, mediaUploadData.exifData);
+      mediaUploadData.isPanorama = checkPanoramaFromEXIF(
+        null,
+        mediaUploadData.exifData,
+      );
     }
     if (mediaUploadData.isPanorama != true &&
         fileType == FileType.image &&

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -359,6 +359,13 @@ Future<void> _decorateEnteFileData(
       file.location = exifLocation;
     }
   }
+  if (Platform.isIOS) {
+    final originalTitle = await asset.titleAsync;
+    if (originalTitle.isNotEmpty) {
+      file.title = originalTitle;
+      return;
+    }
+  }
   if (file.title == null || file.title!.isEmpty) {
     _logger.warning("Title was missing ${file.tag}");
     file.title = await asset.titleAsync;


### PR DESCRIPTION
## Summary
- move the iOS filename correction to upload-time metadata decoration
- use `AssetEntity.titleAsync` for iOS uploads so optimized-storage assets keep their original filename metadata
- leave `EnteFile.fromAsset` on the cheap `asset.title` path to avoid scan/import performance regressions

## Root cause
Ente was storing `asset.title` as the upload title on iOS. In `photo_manager`, `title` follows the current PhotoKit resource filename, which can be UUID-like for some iCloud optimized assets. The original filename is exposed through `titleAsync`, so the upload path should use that instead.
