### PR TITLE
[mob][photos] Fix download issue in not clearing local file reference correctly

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -432,4 +432,8 @@ class EnteFile {
       ..pubMmdVersion = pubMmdVersion ?? this.pubMmdVersion
       ..pubMagicMetadata = pubMagicMetadata ?? this.pubMagicMetadata;
   }
+
+  EnteFile copyForRemoteDownload() {
+    return copyWith()..localID = null;
+  }
 }

--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -184,7 +184,7 @@ class GalleryDownloadQueueService {
         continue;
       }
       final queuedFile =
-          file.isRemoteFile ? file.copyWith() : file.copyWith(localID: null);
+          file.isRemoteFile ? file.copyWith() : file.copyForRemoteDownload();
       _queuedFilesByID[uploadID] = queuedFile;
       final sourceFileJson = _serializeQueuedFile(queuedFile);
       if (_tasks.containsKey(uploadID)) {
@@ -473,7 +473,7 @@ class GalleryDownloadQueueService {
     }
     file.fileSize ??= _tasks[fileID]?.totalBytes;
     final fileToDownload =
-        file.isRemoteFile ? file.copyWith() : file.copyWith(localID: null);
+        file.isRemoteFile ? file.copyWith() : file.copyForRemoteDownload();
     await downloadToGallery(
       fileToDownload,
       forceResumableDownload: true,

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -1118,7 +1118,7 @@ class _FileSelectionActionsWidgetState
         continue;
       }
       filesToDownload.add(
-        file.isRemoteFile ? file.copyWith() : file.copyWith(localID: null),
+        file.isRemoteFile ? file.copyWith() : file.copyForRemoteDownload(),
       );
     }
     final skippedFilesCount = skippedFiles.length;

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -659,7 +659,7 @@ class FileAppBarState extends State<FileAppBar> {
     }
 
     final fileToDownload =
-        !file.isRemoteFile ? file.copyWith(localID: null) : file;
+        !file.isRemoteFile ? file.copyForRemoteDownload() : file;
     if (flagService.internalUser) {
       try {
         await galleryDownloadQueueService.enqueueFiles([fileToDownload]);

--- a/mobile/apps/photos/test/models/ente_file_test.dart
+++ b/mobile/apps/photos/test/models/ente_file_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photos/models/file/file.dart';
+import 'package:photos/models/file/file_type.dart';
+
+void main() {
+  group('EnteFile.copyForRemoteDownload', () {
+    test('returns a clone with localID cleared', () {
+      final file = EnteFile()
+        ..uploadedFileID = 123
+        ..localID = "asset-id"
+        ..title = "IMG_0001.jpg"
+        ..fileType = FileType.image;
+
+      final cloned = file.copyForRemoteDownload();
+
+      expect(cloned, isNot(same(file)));
+      expect(cloned.localID, isNull);
+      expect(cloned.uploadedFileID, file.uploadedFileID);
+      expect(cloned.title, file.title);
+      expect(cloned.isRemoteFile, isTrue);
+      expect(file.localID, "asset-id");
+    });
+  });
+}


### PR DESCRIPTION
## Description

We were clearing `localID` with `copyWith(localID: null)`, but `EnteFile.copyWith()` cannot clear nullable fields because it uses `localID ?? this.localID`. This caused downloads to fail as client kept trying an incorrect local reference. 
