### PR TITLE
Add FAQ section on Google Takeout storage discrepancies

### DIFF
--- a/docs/docs/photos/faq/migration.md
+++ b/docs/docs/photos/faq/migration.md
@@ -21,6 +21,13 @@ If any duplicates slip through and you temporarily hit your storage limit, you c
 
 This removes exact duplicates while keeping one original safely.
 
+### What causes storage discrepancies after a Google Takeout import? {#google-takeout-storage-discrepancies}
+
+- Older Google Photos uploads that didn't count toward Google storage are stored fully in Ente.
+- Edited photos, motion photos, videos, and shared or partner-shared items often appear as separate files.
+- Takeout exports frequently repeat files across folders, leading to duplicates.
+- Duplicates due to storage saver/simultaneous backup. [Learn more](https://ente.com/help/photos/faq/migration#prevent-duplicates-migration)
+
 ### How does Ente handle Google Takeout metadata? {#google-takeout-metadata}
 
 When you export your data using Google Takeout, Google provides both your photos and their associated metadata JSON files. However, Google sometimes splits the JSON and photo across different zip files.


### PR DESCRIPTION
## Description

Added a new FAQ section to the migration documentation explaining common causes of storage discrepancies after importing photos from Google Takeout. This addresses a frequently asked question by clarifying:

- Why older Google Photos uploads consume full storage in Ente (they didn't count toward Google storage limits)
- How edited photos, motion photos, videos, and shared items appear as separate files
- Why Takeout exports often contain duplicate files across folders
- Reference to duplicate prevention strategies

This new section is positioned logically between the duplicate prevention guidance and the metadata handling FAQ, providing users with clear expectations about storage usage after migration.

## Tests

N/A - Documentation only change

https://claude.ai/code/session_01CFvNy7PMjDCYagVGtPQbMJ