### PR TITLE
[server] Add key attribute validation regression tests

### DIFF
--- a/server/ente/user_test.go
+++ b/server/ente/user_test.go
@@ -1,0 +1,69 @@
+package ente
+
+import "testing"
+
+const (
+	validArgonMemLimit = 128 * 1024 * 1024
+	validArgonOpsLimit = 32
+)
+
+func TestSetUserAttributesRequestValidate_RejectsUnexpectedKDFStrength(t *testing.T) {
+	req := SetUserAttributesRequest{
+		KeyAttributes: KeyAttributes{
+			MemLimit: validArgonMemLimit,
+			OpsLimit: validArgonOpsLimit - 1,
+		},
+	}
+
+	assertBadRequestMessage(t, req.Validate(), "Unexpected KDF strength")
+}
+
+func TestSetUserAttributesRequestValidate_RejectsLowMemoryLimit(t *testing.T) {
+	req := SetUserAttributesRequest{
+		KeyAttributes: KeyAttributes{
+			MemLimit: 64 * 1024 * 1024,
+			OpsLimit: 64,
+		},
+	}
+
+	assertBadRequestMessage(t, req.Validate(), "memory limit must be at least 128MB")
+}
+
+func TestUpdateKeysRequestValidate_RejectsUnexpectedKDFStrength(t *testing.T) {
+	req := UpdateKeysRequest{
+		MemLimit: validArgonMemLimit,
+		OpsLimit: validArgonOpsLimit - 1,
+	}
+
+	assertBadRequestMessage(t, req.Validate(), "Unexpected KDF strength")
+}
+
+func TestUpdateKeysRequestValidate_RejectsLowMemoryLimit(t *testing.T) {
+	req := UpdateKeysRequest{
+		MemLimit: 64 * 1024 * 1024,
+		OpsLimit: 64,
+	}
+
+	assertBadRequestMessage(t, req.Validate(), "memory limit must be at least 128MB")
+}
+
+func assertBadRequestMessage(t *testing.T, err error, wantMessage string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected validation error %q, got nil", wantMessage)
+	}
+
+	apiErr, ok := err.(*ApiError)
+	if !ok {
+		t.Fatalf("expected *ApiError, got %T", err)
+	}
+
+	if apiErr.Code != BadRequest {
+		t.Fatalf("expected error code %q, got %q", BadRequest, apiErr.Code)
+	}
+
+	if apiErr.Message != wantMessage {
+		t.Fatalf("expected error message %q, got %q", wantMessage, apiErr.Message)
+	}
+}

--- a/server/pkg/api/user_test.go
+++ b/server/pkg/api/user_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/ente-io/museum/ente"
+	"github.com/ente-io/museum/internal/testutil"
+	usercontroller "github.com/ente-io/museum/pkg/controller/user"
+	"github.com/ente-io/museum/pkg/repo"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSetAttributesHandlerRejectsUnexpectedKDFStrength(t *testing.T) {
+	handler, db := setupUserHandlerTest(t)
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       101,
+		Email:        "set-attributes-kdf@ente.io",
+		CreationTime: 1,
+	})
+
+	body := map[string]any{
+		"keyAttributes": validSetAttributesPayload(128*1024*1024, 31),
+	}
+
+	recorder := performSetAttributesRequest(t, handler, userID, body)
+
+	assertAPIErrorResponse(t, recorder, http.StatusBadRequest, ente.BadRequest, "Unexpected KDF strength")
+}
+
+func TestSetAttributesHandlerRejectsLowMemoryLimit(t *testing.T) {
+	handler, db := setupUserHandlerTest(t)
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       102,
+		Email:        "set-attributes-low-mem@ente.io",
+		CreationTime: 1,
+	})
+
+	body := map[string]any{
+		"keyAttributes": validSetAttributesPayload(64*1024*1024, 64),
+	}
+
+	recorder := performSetAttributesRequest(t, handler, userID, body)
+
+	assertAPIErrorResponse(t, recorder, http.StatusBadRequest, ente.BadRequest, "memory limit must be at least 128MB")
+}
+
+func setupUserHandlerTest(t *testing.T) (*UserHandler, *sql.DB) {
+	t.Helper()
+
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		testutil.ResetTables(t, db)
+	})
+
+	userRepo := &repo.UserRepository{
+		DB:                  db,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+
+	return &UserHandler{
+		UserController: &usercontroller.UserController{
+			UserRepo: userRepo,
+		},
+	}, db
+}
+
+func performSetAttributesRequest(t *testing.T, handler *UserHandler, userID int64, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/user/attributes", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+
+	router := gin.New()
+	router.POST("/user/attributes", handler.SetAttributes)
+	router.ServeHTTP(recorder, req)
+
+	return recorder
+}
+
+func validSetAttributesPayload(memLimit, opsLimit int) map[string]any {
+	return map[string]any{
+		"kekSalt":                  "kek-salt",
+		"encryptedKey":             "encrypted-key",
+		"keyDecryptionNonce":       "key-nonce",
+		"publicKey":                "public-key",
+		"encryptedSecretKey":       "encrypted-secret-key",
+		"secretKeyDecryptionNonce": "secret-key-nonce",
+		"memLimit":                 memLimit,
+		"opsLimit":                 opsLimit,
+	}
+}
+
+func assertAPIErrorResponse(t *testing.T, recorder *httptest.ResponseRecorder, wantStatus int, wantCode ente.ErrorCode, wantMessage string) {
+	t.Helper()
+
+	if recorder.Code != wantStatus {
+		t.Fatalf("unexpected status code: got %d want %d; body=%s", recorder.Code, wantStatus, recorder.Body.String())
+	}
+
+	var apiErr ente.ApiError
+	if err := json.Unmarshal(recorder.Body.Bytes(), &apiErr); err != nil {
+		t.Fatalf("failed to decode response body %q: %v", recorder.Body.String(), err)
+	}
+
+	if apiErr.Code != wantCode {
+		t.Fatalf("unexpected error code: got %q want %q", apiErr.Code, wantCode)
+	}
+
+	if apiErr.Message != wantMessage {
+		t.Fatalf("unexpected error message: got %q want %q", apiErr.Message, wantMessage)
+	}
+}


### PR DESCRIPTION
## Summary
- add request-level regression tests for key attribute validation failures in `SetUserAttributesRequest` and `UpdateKeysRequest`
- add handler-level regression tests for `UserHandler.SetAttributes` covering weak KDF strength and low Argon memory limits
- exercise the handler path with the shared test database so the full server validation flow is covered

## Validation
- `ENV=test go test ./ente ./pkg/api`
- `./scripts/test-in-docker.sh -run 'TestSetAttributesHandlerRejects|TestSetUserAttributesRequestValidate|TestUpdateKeysRequestValidate'`
