### PR TITLE
Fix slow unlock on iOS by disabling privacy screen immediately

### DIFF
--- a/mobile/packages/lock_screen/lib/ui/lock_screen.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:logging/logging.dart';
+import 'package:privacy_screen/privacy_screen.dart';
 
 class LockScreen extends StatefulWidget {
   final BaseConfiguration config;
@@ -331,6 +332,7 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
       _isShowingLockScreen = false;
       if (result) {
         lastAuthenticatingTime = DateTime.now().millisecondsSinceEpoch;
+        await PrivacyScreen.instance.disable();
         AppLock.of(context)?.didUnlock();
         await _lockscreenSetting.setInvalidAttemptCount(0);
         setState(() {


### PR DESCRIPTION
## Description
Fix slow unlock on iOS when using Face ID (device lock). The blur/privacy screen was persisting briefly after successful authentication before showing the codes.

## Changes
- Added `await PrivacyScreen.instance.disable()` immediately after successful authentication in `_showLockScreen()`, before calling `didUnlock()`
- This immediately removes the blur overlay instead of waiting for the lock screen navigation to complete

## Issue
Fixes https://github.com/ente-io/ente/issues/4749

## Testing
- Tested on iOS with Face ID enabled as device lock
- Verified that codes appear immediately when keyboard pops up with "Focus search on app start" option enabled

## Screenshots
Before: Noticeable delay between Face ID success and codes appearing
After: Codes appear instantly when keyboard pops up