### PR TITLE
Add QR code detection in photo viewer

### DIFF
--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -106,7 +106,7 @@ class FlagService {
 
   bool get petEnabled => internalUser;
 
-  bool get qrFeatureEnabled => internalUser;
+  bool get qrFeatureEnabled => true;
 
   bool get enableBgLocalUploadPriority => internalUser;
 


### PR DESCRIPTION
## Summary
- Add `ente_qr` plugin for detecting QR codes in images using ZXing-CPP (Android) and Vision framework (iOS)
- Display interactive highlight overlay on detected QR codes in the detail page viewer
- Support tap to view content, copy, open URLs, and share QR payloads
- Enable QR detection for all users (previously internal-only)
