### PR TITLE
Disable FVM melos prompt

### DIFF
--- a/mobile/apps/auth/.fvmrc
+++ b/mobile/apps/auth/.fvmrc
@@ -1,3 +1,4 @@
 {
-  "flutter": "3.32.8"
+  "flutter": "3.32.8",
+  "updateMelosSettings": false
 }

--- a/mobile/apps/photos/.fvmrc
+++ b/mobile/apps/photos/.fvmrc
@@ -1,3 +1,4 @@
 {
-  "flutter": "3.32.8"
+  "flutter": "3.32.8",
+  "updateMelosSettings": false
 }


### PR DESCRIPTION
Summary:
- FVM 4.0.0 added an interactive prompt asking to configure melos.yaml with the FVM SDK path.
- When flutter_rust_bridge_codegen runs fvm install non-interactively (stdin is /dev/null), FVM spins at 100% CPU waiting for input, causing codegen to hang indefinitely.
- Set "updateMelosSettings": false in both .fvmrc files to skip the prompt.
