### PR TITLE
Fix QR detection for offline images and improve scan gating

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -151,7 +151,8 @@ class _BodyState extends State<_Body> {
         swipeLocked = event.swipeLocked;
       });
     });
-    if (flagService.qrFeatureEnabled) {
+    if (flagService.qrFeatureEnabled &&
+        widget.config.mode != DetailPageMode.minimalistic) {
       _qrHelper = QrCodeDetectionHelper();
     }
 
@@ -159,7 +160,7 @@ class _BodyState extends State<_Body> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _updateSharedCollectionState(_files![_selectedIndexNotifier.value]);
-      _qrHelper?.evaluateFile(_files![_selectedIndexNotifier.value]);
+      _evaluateQrIfEligible(_files![_selectedIndexNotifier.value]);
       widget.config.onPageReady?.call(context);
     });
   }
@@ -286,9 +287,6 @@ class _BodyState extends State<_Body> {
                         return QrCodeHighlightOverlay(
                           detections: detections,
                           file: _files![selectedIndex],
-                          enableFullScreenNotifier:
-                              InheritedDetailPageState.of(context)
-                                  .enableFullScreenNotifier,
                         );
                       },
                     );
@@ -414,7 +412,7 @@ class _BodyState extends State<_Body> {
         }
         Bus.instance.fire(GuestViewEvent(isGuestView, swipeLocked));
         _updateSharedCollectionState(_files![index]);
-        _qrHelper?.evaluateFile(_files![index]);
+        _evaluateQrIfEligible(_files![index]);
       },
       physics: _shouldDisableScroll || swipeLocked
           ? const NeverScrollableScrollPhysics()
@@ -422,6 +420,11 @@ class _BodyState extends State<_Body> {
       controller: _pageController,
       itemCount: _files!.length,
     );
+  }
+
+  void _evaluateQrIfEligible(EnteFile file) {
+    if (_qrHelper == null || isGuestView || file is TrashFile) return;
+    _qrHelper!.evaluateFile(file);
   }
 
   bool shouldAutoPlay() {

--- a/mobile/apps/photos/lib/ui/viewer/file/qr_code_highlight_overlay.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/qr_code_highlight_overlay.dart
@@ -1,5 +1,4 @@
 import "package:ente_qr/ente_qr.dart";
-import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:photos/models/file/file.dart";
@@ -8,12 +7,10 @@ import "package:photos/ui/viewer/file/qr_code_content_sheet.dart";
 class QrCodeHighlightOverlay extends StatelessWidget {
   final List<QrDetection> detections;
   final EnteFile file;
-  final ValueListenable<bool> enableFullScreenNotifier;
 
   const QrCodeHighlightOverlay({
     required this.detections,
     required this.file,
-    required this.enableFullScreenNotifier,
     super.key,
   });
 
@@ -23,14 +20,7 @@ class QrCodeHighlightOverlay extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return ValueListenableBuilder<bool>(
-      valueListenable: enableFullScreenNotifier,
-      builder: (context, isFullScreen, _) {
-        if (isFullScreen) {
-          return const SizedBox.shrink();
-        }
-
-        return LayoutBuilder(
+    return LayoutBuilder(
           builder: (context, constraints) {
             final screenWidth = constraints.maxWidth;
             final screenHeight = constraints.maxHeight;
@@ -71,8 +61,6 @@ class QrCodeHighlightOverlay extends StatelessWidget {
             );
           },
         );
-      },
-    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix QR overlay not rendering for on-device images that lack width/height metadata
- Keep QR overlay visible in fullscreen mode
- Skip QR scan entirely for guest view, trash files, and minimalistic mode (dedup, similar images) to avoid wasted computation
- Enable QR detection for all users

