### PR TITLE
[mob][photos] Handle legacy numeric public captions

### DIFF
--- a/mobile/apps/photos/lib/models/metadata/file_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/file_magic.dart
@@ -108,7 +108,8 @@ class PubMagicMetadata {
     return PubMagicMetadata(
       editedTime: map[editTimeKey],
       editedName: map[editNameKey],
-      caption: map[captionKey],
+      // Some legacy remote records have been seen with numeric captions.
+      caption: safeParseCaption(map[captionKey]),
       uploaderName: map[uploaderNameKey],
       w: safeParseInt(map[widthKey], widthKey),
       h: safeParseInt(map[heightKey], heightKey),
@@ -123,6 +124,13 @@ class PubMagicMetadata {
       offsetTime: map[offsetTimeKey],
       sv: safeParseInt(map[streamVersionKey], streamVersionKey),
     );
+  }
+
+  static String? safeParseCaption(dynamic value) {
+    if (value == null) return null;
+    if (value is String) return value;
+    if (value is num) return value.toString();
+    return null;
   }
 
   static int? safeParseInt(dynamic value, String key) {


### PR DESCRIPTION
## Description

Sync was failing since caption is `int` for a particular file but client excepts it to be `String?`. This is the same fix applied on web/desktop in https://github.com/ente-io/ente/commit/2cac3f548ff080ad625ce6ea125386907c5945f7
