### PR TITLE
Fix motion photo not responding on images without text

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
@@ -216,7 +216,11 @@ class _InlineTextDetectionState extends State<InlineTextDetection> {
 
     // During the wait period (hasText passed but 1s timer hasn't fired),
     // show a transparent gesture layer to capture long press.
-    if (!_overlayActive || _localFilePath == null) {
+    // Only show when we know text exists to avoid blocking motion photo gestures.
+    if (_localFilePath == null) {
+      return const SizedBox.shrink();
+    }
+    if (!_overlayActive) {
       return Positioned.fill(
         child: GestureDetector(
           behavior: HitTestBehavior.translucent,


### PR DESCRIPTION
## Summary
- Fix OCR gesture layer blocking motion photo long press on images without detected text
- The inline text detection widget was placing a full-screen GestureDetector even when no text was found, intercepting the long press meant for motion photo playback

