### PR TITLE
Improve contacts TLS diagnostics and rustls root trust handling

### DIFF
--- a/mobile/packages/contacts/lib/src/service/contacts_service.dart
+++ b/mobile/packages/contacts/lib/src/service/contacts_service.dart
@@ -32,18 +32,28 @@ class ContactsService {
   Future<void> open(ContactsSession session) async {
     final accountKey = await session.resolveAccountKey();
     final cachedRootKey = _cachedRootKey(session.userId);
-    final opened = await _rustApi.open(
-      OpenContactsContextInput(
-        baseUrl: session.baseUrl,
-        authToken: session.authToken,
-        userId: session.userId,
-        accountKey: accountKey,
-        cachedRootKey: cachedRootKey,
-        userAgent: session.userAgent,
-        clientPackage: session.clientPackage,
-        clientVersion: session.clientVersion,
-      ),
-    );
+    final opened = await _rustApi
+        .open(
+          OpenContactsContextInput(
+            baseUrl: session.baseUrl,
+            authToken: session.authToken,
+            userId: session.userId,
+            accountKey: accountKey,
+            cachedRootKey: cachedRootKey,
+            userAgent: session.userAgent,
+            clientPackage: session.clientPackage,
+            clientVersion: session.clientVersion,
+          ),
+        )
+        .catchError((Object error, StackTrace stackTrace) {
+          _logger.warning(
+            "Failed to open contacts context for account user ${session.userId} "
+            "at ${session.baseUrl} (hasCachedRootKey: ${cachedRootKey != null})",
+            error,
+            stackTrace,
+          );
+          throw error;
+        });
 
     _ctx = opened.ctx;
     _session = session;

--- a/mobile/packages/rust/rust/Cargo.lock
+++ b/mobile/packages/rust/rust/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1408,6 +1409,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2026,6 +2028,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/rust/contacts/Cargo.lock
+++ b/rust/contacts/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2066,6 +2067,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2937,6 +2939,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/rust/contacts/src/client.rs
+++ b/rust/contacts/src/client.rs
@@ -477,6 +477,7 @@ async fn fetch_root_key(http: &HttpClient) -> Result<Option<RootKeyResponse>> {
     http.get_json_optional("/user-entity/key", &[("type", CONTACT_TYPE.to_string())])
         .await
         .map_err(Into::into)
+        .map_err(|error| with_http_context("contacts root key fetch failed", error))
 }
 
 async fn create_root_key(
@@ -495,10 +496,40 @@ async fn create_root_key(
             if let Some(remote_root_key) = fetch_root_key(http).await? {
                 Ok(Some(remote_root_key))
             } else {
-                Err(HttpError::Http { status, message }.into())
+                Err(with_http_context(
+                    "contacts root key create failed",
+                    HttpError::Http { status, message }.into(),
+                ))
             }
         }
-        Err(HttpError::Http { status, message }) => Err(HttpError::Http { status, message }.into()),
-        Err(err) => Err(err.into()),
+        Err(HttpError::Http { status, message }) => Err(with_http_context(
+            "contacts root key create failed",
+            HttpError::Http { status, message }.into(),
+        )),
+        Err(err) => Err(with_http_context(
+            "contacts root key create failed",
+            err.into(),
+        )),
+    }
+}
+
+fn with_http_context(context: &'static str, error: ContactsError) -> ContactsError {
+    match error {
+        ContactsError::Http(HttpError::Network(message)) => {
+            ContactsError::Http(HttpError::Network(format!("{context}: {message}")))
+        }
+        ContactsError::Http(HttpError::Http { status, message }) => {
+            ContactsError::Http(HttpError::Http {
+                status,
+                message: format!("{context}: {message}"),
+            })
+        }
+        ContactsError::Http(HttpError::Parse(message)) => {
+            ContactsError::Http(HttpError::Parse(format!("{context}: {message}")))
+        }
+        ContactsError::Http(HttpError::InvalidUrl(message)) => {
+            ContactsError::Http(HttpError::InvalidUrl(format!("{context}: {message}")))
+        }
+        other => other,
     }
 }

--- a/rust/core/Cargo.lock
+++ b/rust/core/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1192,6 +1193,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1838,6 +1840,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["http2", "charset", "system-proxy", "json", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "charset", "system-proxy", "json", "rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/rust/core/src/http.rs
+++ b/rust/core/src/http.rs
@@ -1,5 +1,7 @@
 //! HTTP client for communicating with the Ente API.
 
+use std::error::Error as StdError;
+use std::fmt::Write as _;
 use std::sync::RwLock;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
@@ -42,15 +44,40 @@ pub enum Error {
     InvalidUrl(String),
 }
 
+impl Error {
+    fn with_request_context(self, request_context: &str) -> Self {
+        fn append_context(message: String, request_context: &str) -> String {
+            if message.contains("[request:") {
+                message
+            } else {
+                format!("{message} {request_context}")
+            }
+        }
+
+        match self {
+            Error::Network(message) => Error::Network(append_context(message, request_context)),
+            Error::Http { status, message } => Error::Http {
+                status,
+                message: append_context(message, request_context),
+            },
+            Error::Parse(message) => Error::Parse(append_context(message, request_context)),
+            Error::InvalidUrl(message) => {
+                Error::InvalidUrl(append_context(message, request_context))
+            }
+        }
+    }
+}
+
 impl From<reqwest::Error> for Error {
     fn from(e: reqwest::Error) -> Self {
+        let message = format_reqwest_error(&e);
         if let Some(status) = e.status() {
             Error::Http {
                 status: status.as_u16(),
-                message: e.to_string(),
+                message,
             }
         } else {
-            Error::Network(e.to_string())
+            Error::Network(message)
         }
     }
 }
@@ -58,6 +85,82 @@ impl From<reqwest::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Parse(e.to_string())
+    }
+}
+
+fn format_reqwest_error(error: &reqwest::Error) -> String {
+    let mut message = error.to_string();
+
+    let mut kinds = Vec::new();
+    if error.is_timeout() {
+        kinds.push("timeout");
+    }
+    if error.is_connect() {
+        kinds.push("connect");
+    }
+    if error.is_request() {
+        kinds.push("request");
+    }
+    if error.is_body() {
+        kinds.push("body");
+    }
+    if error.is_decode() {
+        kinds.push("decode");
+    }
+    if error.is_redirect() {
+        kinds.push("redirect");
+    }
+    if !kinds.is_empty() {
+        let _ = write!(message, " [kind: {}]", kinds.join(","));
+    }
+
+    let mut source_chain = Vec::new();
+    let mut source = StdError::source(error);
+    while let Some(cause) = source {
+        source_chain.push(cause.to_string());
+        source = cause.source();
+    }
+    if !source_chain.is_empty() {
+        let _ = write!(message, " [caused by: {}]", source_chain.join(" -> "));
+    }
+
+    message
+}
+
+fn request_context(method: &str, url: &str) -> String {
+    format!("[request: {method} {}]", request_target(url))
+}
+
+fn request_context_with_query(method: &str, url: &str, query: &[(&str, String)]) -> String {
+    if query.is_empty() {
+        return request_context(method, url);
+    }
+
+    let Ok(mut parsed_url) = Url::parse(url) else {
+        return request_context(method, url);
+    };
+
+    {
+        let mut query_pairs = parsed_url.query_pairs_mut();
+        for (key, value) in query {
+            query_pairs.append_pair(key, value);
+        }
+    }
+
+    format!(
+        "[request: {method} {}]",
+        request_target(parsed_url.as_ref())
+    )
+}
+
+fn request_target(url: &str) -> String {
+    let Ok(parsed_url) = Url::parse(url) else {
+        return url.to_string();
+    };
+
+    match parsed_url.query() {
+        Some(query) => format!("{}?{query}", parsed_url.path()),
+        None => parsed_url.path().to_string(),
     }
 }
 
@@ -193,13 +296,18 @@ impl HttpClient {
     /// after basic validation, so attacker-controlled paths must not be passed.
     pub async fn get(&self, path: &str) -> Result<String, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context("GET", &url);
         let response = self
             .client
             .get(&url)
             .headers(self.build_headers()?)
             .send()
-            .await?;
-        parse_text_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_text_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// GET request returning JSON.
@@ -209,14 +317,19 @@ impl HttpClient {
         query: &[(&str, String)],
     ) -> Result<T, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context_with_query("GET", &url, query);
         let response = self
             .client
             .get(&url)
             .headers(self.build_headers()?)
             .query(query)
             .send()
-            .await?;
-        parse_json_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_json_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// GET request returning `None` for 404.
@@ -226,17 +339,23 @@ impl HttpClient {
         query: &[(&str, String)],
     ) -> Result<Option<T>, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context_with_query("GET", &url, query);
         let response = self
             .client
             .get(&url)
             .headers(self.build_headers()?)
             .query(query)
             .send()
-            .await?;
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
         if response.status().as_u16() == 404 {
             return Ok(None);
         }
-        parse_json_response(response).await.map(Some)
+        parse_json_response(response)
+            .await
+            .map(Some)
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// POST JSON request.
@@ -246,14 +365,19 @@ impl HttpClient {
         body: &B,
     ) -> Result<T, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context("POST", &url);
         let response = self
             .client
             .post(&url)
             .headers(self.build_headers()?)
             .json(body)
             .send()
-            .await?;
-        parse_json_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_json_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// POST JSON request expecting an empty response body.
@@ -263,14 +387,19 @@ impl HttpClient {
         body: &B,
     ) -> Result<(), Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context("POST", &url);
         let response = self
             .client
             .post(&url)
             .headers(self.build_headers()?)
             .json(body)
             .send()
-            .await?;
-        parse_empty_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_empty_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// PUT JSON request.
@@ -280,14 +409,19 @@ impl HttpClient {
         body: &B,
     ) -> Result<T, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context("PUT", &url);
         let response = self
             .client
             .put(&url)
             .headers(self.build_headers()?)
             .json(body)
             .send()
-            .await?;
-        parse_json_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_json_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// PUT JSON request expecting an empty response body.
@@ -297,27 +431,37 @@ impl HttpClient {
         body: &B,
     ) -> Result<(), Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context("PUT", &url);
         let response = self
             .client
             .put(&url)
             .headers(self.build_headers()?)
             .json(body)
             .send()
-            .await?;
-        parse_empty_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_empty_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// DELETE request expecting an empty response body.
     pub async fn delete_empty(&self, path: &str, query: &[(&str, String)]) -> Result<(), Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context_with_query("DELETE", &url, query);
         let response = self
             .client
             .delete(&url)
             .headers(self.build_headers()?)
             .query(query)
             .send()
-            .await?;
-        parse_empty_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_empty_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// DELETE request returning JSON.
@@ -327,14 +471,19 @@ impl HttpClient {
         query: &[(&str, String)],
     ) -> Result<T, Error> {
         let url = self.request_url(path)?;
+        let request_context = request_context_with_query("DELETE", &url, query);
         let response = self
             .client
             .delete(&url)
             .headers(self.build_headers()?)
             .query(query)
             .send()
-            .await?;
-        parse_json_response(response).await
+            .await
+            .map_err(Error::from)
+            .map_err(|error| error.with_request_context(&request_context))?;
+        parse_json_response(response)
+            .await
+            .map_err(|error| error.with_request_context(&request_context))
     }
 
     /// Download bytes from a URL, following redirects safely.

--- a/rust/core/src/http.rs
+++ b/rust/core/src/http.rs
@@ -95,6 +95,7 @@ fn format_reqwest_error(error: &reqwest::Error) -> String {
     if error.is_timeout() {
         kinds.push("timeout");
     }
+    #[cfg(not(target_arch = "wasm32"))]
     if error.is_connect() {
         kinds.push("connect");
     }

--- a/web/packages/wasm/Cargo.lock
+++ b/web/packages/wasm/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1084,6 +1085,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1717,6 +1719,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- enrich Rust HTTP error messages with request context (`[request: METHOD /path?query]`), error kind tags, and nested cause chains
- add contacts root-key operation context so open/fetch/create failures are actionable without endpoint duplication
- add mobile contacts-open failure logging with session context (user ID, base URL, cached root-key presence)
- enable `rustls-tls-webpki-roots` alongside native roots and update related lockfiles across core/contacts/mobile-rust/wasm
- fix wasm/web lint compatibility by gating `reqwest::Error::is_connect()` to non-wasm targets

## Validation
- `cargo check --manifest-path rust/contacts/Cargo.toml`
- `cargo check --manifest-path rust/core/Cargo.toml`
- `cargo test --manifest-path rust/core/Cargo.toml http::tests:: -- --nocapture`
- `cd web && yarn build:wasm`
