### PR TITLE
Fix added-by visibility in file details

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
@@ -13,18 +13,25 @@ class AddedByWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!file.isUploaded || (!file.isOwner && file.isCollect)) {
+    if (!file.isUploaded) {
       return const SizedBox.shrink();
     }
-    String? addedBy;
-    if (file.isOwner && file.isCollect) {
-      addedBy = file.uploaderName;
+    late final String addedBy;
+    if (file.isOwner) {
+      final uploaderName = file.uploaderName?.trim();
+      if (uploaderName == null || uploaderName.isEmpty) {
+        return const SizedBox.shrink();
+      }
+      addedBy = uploaderName;
     } else {
+      if (file.ownerID == null) {
+        return const SizedBox.shrink();
+      }
       final fileOwner = CollectionsService.instance
           .getFileOwner(file.ownerID!, file.collectionID);
       addedBy = resolveDisplayName(fileOwner);
     }
-    if (addedBy == null || addedBy.isEmpty) {
+    if (addedBy.isEmpty) {
       return const SizedBox.shrink();
     }
     return Padding(

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Fix Added by visibility in file details
 - Neeraj: Contacts
 - Neeraj: Fix grey screen when collections search result is empty 
 - Ashil: Fix app going blank on iOS on deleting all empty albums


### PR DESCRIPTION
## Summary
- fix `Added by` visibility in file details for owner and non-owner files
- resolve non-owner labels from the owner contact name or email instead of hiding the row for collect files
- add the fix to `mobile/apps/photos/scripts/internal_changes.txt`

## Root cause
- regression introduced in `3a599c0b63` (`Hide added-by for shared collect files`), which hid `Added by` for non-owner collect files
- the file details sheet also rendered `Added by` for owned non-collect files, which could fall back to `Someone`

## Validation
- `dart format lib/ui/viewer/file_details/added_by_widget.dart`
- `flutter analyze lib/ui/viewer/file_details/added_by_widget.dart`
- `flutter analyze` still fails because of pre-existing localization errors outside this diff
