### PR TITLE
[mob][photos] fix add to shared album for copied files

### DIFF
--- a/mobile/apps/photos/lib/models/collection/collection.dart
+++ b/mobile/apps/photos/lib/models/collection/collection.dart
@@ -167,6 +167,14 @@ class Collection {
     return getRole(userID) == CollectionParticipantRole.admin;
   }
 
+  bool canAdd(int userID) {
+    final participantRole = getRole(userID);
+    final canEditCollection = isOwner(userID) ||
+        participantRole == CollectionParticipantRole.collaborator ||
+        participantRole == CollectionParticipantRole.admin;
+    return canEditCollection && !isDeleted;
+  }
+
   bool canAutoAdd(int userID) {
     final participantRole = getRole(userID);
     final canEditCollection = isOwner(userID) ||

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -1828,7 +1828,7 @@ class CollectionsService {
         final currentUserID = _config.getUserID()!;
         final shouldCopyViaUncategorized = dstCollection != null &&
             !dstCollection.isOwner(currentUserID) &&
-            dstCollection.canAutoAdd(currentUserID);
+            dstCollection.canAdd(currentUserID);
 
         final int copyDestinationCollectionID;
         if (shouldCopyViaUncategorized) {

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -1847,7 +1847,7 @@ class CollectionsService {
         if (shouldCopyViaUncategorized) {
           await _addToCollection(
             dstCollectionID,
-            copiedFiles.map((file) => file.copyWith()).toList(),
+            copiedFiles,
           );
         }
       }

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -39,6 +39,7 @@ import "package:photos/models/metadata/collection_magic.dart";
 import "package:photos/service_locator.dart";
 import 'package:photos/services/app_lifecycle_service.dart';
 import "package:photos/services/favorites_service.dart";
+import "package:photos/services/hidden_service.dart";
 import 'package:photos/services/memory_share_service.dart';
 import 'package:photos/services/sync/local_sync_service.dart';
 import 'package:photos/services/sync/remote_sync_service.dart';
@@ -1822,33 +1823,74 @@ class CollectionsService {
         await _addToCollection(dstCollectionID, filesToAdd);
       }
 
-      // group files by collectionID
-      final Map<int, List<EnteFile>> filesByCollection = {};
-      final Map<int, Set<int>> fileSeenByCollection = {};
-      for (final file in filesToCopy) {
-        fileSeenByCollection.putIfAbsent(file.collectionID!, () => <int>{});
-        if (fileSeenByCollection[file.collectionID]!
-            .contains(file.uploadedFileID)) {
-          _logger.warning(
-            "skip copy, duplicate ID: ${file.uploadedFileID} in collection "
-            "${file.collectionID}",
-          );
-          continue;
+      if (filesToCopy.isNotEmpty) {
+        final dstCollection = _collectionIDToCollections[dstCollectionID];
+        final currentUserID = _config.getUserID()!;
+        final shouldCopyViaUncategorized = dstCollection != null &&
+            !dstCollection.isOwner(currentUserID) &&
+            dstCollection.canAutoAdd(currentUserID);
+
+        final int copyDestinationCollectionID;
+        if (shouldCopyViaUncategorized) {
+          final uncategorizedCollection =
+              await CollectionsService.instance.getUncategorizedCollection();
+          copyDestinationCollectionID = uncategorizedCollection.id;
+        } else {
+          copyDestinationCollectionID = dstCollectionID;
         }
-        filesByCollection
-            .putIfAbsent(file.collectionID!, () => [])
-            .add(file.copyWith());
-      }
-      for (final entry in filesByCollection.entries) {
-        final srcCollectionID = entry.key;
-        final files = entry.value;
-        await _copyToCollection(
-          files,
-          dstCollectionID: dstCollectionID,
-          srcCollectionID: srcCollectionID,
+
+        final copiedFiles = await _copyFilesToCollection(
+          filesToCopy,
+          dstCollectionID: copyDestinationCollectionID,
         );
+
+        if (shouldCopyViaUncategorized) {
+          await _addToCollection(
+            dstCollectionID,
+            copiedFiles.map((file) => file.copyWith()).toList(),
+          );
+        }
       }
     }
+  }
+
+  Future<List<EnteFile>> _copyFilesToCollection(
+    List<EnteFile> filesToCopy, {
+    required int dstCollectionID,
+  }) async {
+    final copiedFiles = <EnteFile>[];
+    final filesByCollection = <int, List<EnteFile>>{};
+    final fileSeenByCollection = <int, Set<int>>{};
+
+    for (final file in filesToCopy) {
+      fileSeenByCollection.putIfAbsent(file.collectionID!, () => <int>{});
+      if (fileSeenByCollection[file.collectionID]!
+          .contains(file.uploadedFileID)) {
+        _logger.warning(
+          "skip copy, duplicate ID: ${file.uploadedFileID} in collection "
+          "${file.collectionID}",
+        );
+        continue;
+      }
+      final copiedFile = file.copyWith();
+      filesByCollection
+          .putIfAbsent(file.collectionID!, () => [])
+          .add(copiedFile);
+      fileSeenByCollection[file.collectionID]!.add(file.uploadedFileID!);
+      copiedFiles.add(copiedFile);
+    }
+
+    for (final entry in filesByCollection.entries) {
+      final srcCollectionID = entry.key;
+      final files = entry.value;
+      await _copyToCollection(
+        files,
+        dstCollectionID: dstCollectionID,
+        srcCollectionID: srcCollectionID,
+      );
+    }
+
+    return copiedFiles;
   }
 
   Future<void> _addToCollection(int collectionID, List<EnteFile> files) async {


### PR DESCRIPTION
## Description
Adding an already-uploaded photo from a shared album into another shared album fails when the acting user is a collaborator/admin but does not own the destination album.

The failure happens in apps/photos/lib/services/collections_service.dart:1987 because foreign-owned files go through _copyToCollection(...), and apps/photos/lib/services/collections_service.dart:2088 requires the destination collection to be
 owned by the current user. 
 
 For foreign-owned files:
  - if the destination album is owned by the current user, behavior stays the
    same and uses the old direct copy flow
  - if the destination album is not owned by the current user but canAutoAdd(...) is allowed, the service now:
      1. copies those files into the user’s uncategorized album
      2. takes those newly user-owned copies and adds them to the destination album through the normal add flow

   