### PR TITLE
[mob][photos] fix: memory share init sync

### DIFF
--- a/mobile/apps/photos/lib/services/memory_share_service.dart
+++ b/mobile/apps/photos/lib/services/memory_share_service.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:ente_crypto/ente_crypto.dart';
 import 'package:logging/logging.dart';
+import "package:photos/core/configuration.dart";
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/core/network/network.dart';
 import 'package:photos/db/files_db.dart';
@@ -43,6 +44,9 @@ class MemoryShareService {
     _enteDio = NetworkClient.instance.enteDio;
     _db = MemorySharesDB.instance;
     await _loadMemoryShareHashCache();
+    if (!Configuration.instance.isLoggedIn()) {
+      return;
+    }
     try {
       await listMemoryShares();
     } catch (e, s) {


### PR DESCRIPTION
 ## Summary
 Add a login guard before the init-time memory share refresh
  
  ## Problem
  `MemoryShareService.init()` always attempted to refresh memory shares during
  startup.

  That could trigger unnecessary `/memory-share` requests even when the app
  was not in a logged-in state, and it also made the init path less defensive
  around auth availability.

  ## Fix

  Before calling `listMemoryShares()` in `MemoryShareService.init()`, check:
  `Configuration.instance.isLoggedIn()`
