### PR TITLE
[mob][photos] Fix Android build + some improvements

### DIFF
--- a/.github/workflows/mobile-daily-internal.yml
+++ b/.github/workflows/mobile-daily-internal.yml
@@ -53,11 +53,12 @@ jobs:
               with:
                   toolchain: ${{ env.RUST_VERSION }}
 
-            # Cargokit resolves the toolchain as "stable" (not a pinned
-            # version like "1.90.0"). Two Cargokit instances run in
-            # parallel during Gradle build, and both race to
-            # `rustup target add` if the targets are missing — causing
-            # download conflicts. Pre-install them here to prevent that.
+            # Cargokit resolves the toolchain as "stable" rather than the
+            # pinned Rust version used in CI. Our vendored Cargokit now
+            # serializes `rustup target add` per target, so this pre-install
+            # is no longer required for correctness. We still do it for now
+            # to keep the setup straightforward, and because this step may
+            # become more useful if we later cache Rust toolchain state.
             - name: Pre-install Android Rust targets
               run: |
                   rustup target add --toolchain stable armv7-linux-androideabi aarch64-linux-android
@@ -85,7 +86,7 @@ jobs:
 
                   sed -i "s/^version: .*/version: $NEW_VERSION/" pubspec.yaml
                   echo "Building with version ${NEW_VERSION}"
-                  
+
                   # Store version for later use
                   echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
                   echo "NEW_VERSION_CODE=${NEW_VERSION_CODE}" >> $GITHUB_ENV
@@ -125,11 +126,11 @@ jobs:
 
                   echo "✅ Changelog valid:"
                   cat "$OUTPUT_FILE"
-                  
+
                   # Store changelog for Play Store (with escaped newlines)
                   CHANGELOG_PLAYSTORE=$(cat "$OUTPUT_FILE" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
                   echo "CHANGELOG=${CHANGELOG_PLAYSTORE}" >> $GITHUB_ENV
-                  
+
                   # Store changelog for Discord (with proper newlines)
                   CHANGELOG_DISCORD=$(cat "$DISCORD_FILE" | sed 's/"/\\"/g')
                   echo "CHANGELOG_DISCORD<<EOF" >> $GITHUB_ENV

--- a/mobile/apps/auth/README.md
+++ b/mobile/apps/auth/README.md
@@ -53,7 +53,7 @@ or managing your secrets, please use our mobile or desktop app.
    - **Using Flutter directly:** Run `flutter pub get` in `packages/strings` and this folder
 
 4. Run the app:
-   - Android: `flutter run -t lib/main.dart --flavor independent`
+   - Android: `flutter run --flavor independent`
    - iOS: `flutter run`
 
 To build a release APK, [setup your keystore](https://docs.flutter.dev/deployment/android#create-an-upload-keystore) and run `flutter build apk --release --flavor independent`. For iOS, use `flutter build ios`.

--- a/mobile/apps/auth/docs/vscode/launch.json
+++ b/mobile/apps/auth/docs/vscode/launch.json
@@ -33,14 +33,14 @@
             "request": "launch",
             "type": "dart",
             "program": "mobile/apps/auth/lib/main.dart",
-            "args": ["--target", "lib/main.dart"]
+            "args": []
         },
         {
             "name": "Auth Android Prod",
             "request": "launch",
             "type": "dart",
             "program": "mobile/apps/auth/lib/main.dart",
-            "args": ["--target", "lib/main.dart", "--flavor", "independent"]
+            "args": ["--flavor", "independent"]
         }
     ]
 }

--- a/mobile/apps/locker/README.md
+++ b/mobile/apps/locker/README.md
@@ -12,7 +12,7 @@ important documents in the cloud with secure sharing capabilities.
    - **Using Flutter directly:** Run `flutter pub get` in `packages/strings` and this folder
 
 3. Run the app:
-   - Android: `flutter run -t lib/main.dart --flavor independent`
+   - Android: `flutter run --flavor independent`
    - iOS: `flutter run`
 
 To build a release APK, [setup your keystore](https://docs.flutter.dev/deployment/android#create-an-upload-keystore) and run `flutter build apk --release --flavor independent`. For iOS, use `flutter build ios`.

--- a/mobile/apps/photos/AGENTS.md
+++ b/mobile/apps/photos/AGENTS.md
@@ -13,7 +13,7 @@
 `lib/` houses the Flutter client (`core/`, `services/`, `ui/`, `db/`). Tests live in `test/` (unit & widget) and `integration_test/`. Platform shells are `android/` and `ios/`; Rust crates and bridge helpers sit in `rust/` and `rust_builder/`. Assets, fonts, and localization configs are in `assets/`, `fonts/`, `l10n.yaml`, with generated code in `lib/generated/`. Automation scripts include `scripts/` and release tooling under `fastlane/`.
 
 ## Build, Test & Development Commands
-Run `flutter pub get` after dependency edits. Launch the app with `flutter run -t lib/main.dart --flavor independent`. Regenerate Rust bindings with `flutter_rust_bridge_codegen generate` before builds. Android releases rely on `flutter build apk --release --flavor independent`; for iOS run `cd ios && pod install` then `flutter build ios`.
+Run `flutter pub get` after dependency edits. Launch the app with `flutter run --flavor independent`. Regenerate Rust bindings with `flutter_rust_bridge_codegen generate` before builds. Android releases rely on `flutter build apk --release --flavor independent`; for iOS run `cd ios && pod install` then `flutter build ios`.
 
 ## Coding Style & Naming Conventions
 Use 2-space indentation and format with `dart format .` (trailing commas preserved). `analysis_options.yaml` enforces rules such as `prefer_const_constructors`, `require_trailing_commas`, and `always_use_package_imports`. Keep files `snake_case.dart`, classes `PascalCase`, private members `_camelCase`. Avoid `print`; rely on the log utilities under `lib/core/`.

--- a/mobile/apps/photos/CLAUDE.md
+++ b/mobile/apps/photos/CLAUDE.md
@@ -79,7 +79,7 @@ melos clean:photos
 ### Direct Flutter Commands
 ```bash
 # Development run
-flutter run -t lib/main.dart --flavor independent
+flutter run --flavor independent
 
 # Build release APK
 flutter build apk --release --flavor independent

--- a/mobile/apps/photos/README.md
+++ b/mobile/apps/photos/README.md
@@ -53,7 +53,7 @@ You can alternatively install the build from PlayStore or F-Droid.
    - **Using Flutter directly:** Run `flutter pub get`, then install [Flutter Rust Bridge](https://cjycode.com/flutter_rust_bridge/) with `cargo install flutter_rust_bridge_codegen` and run `flutter_rust_bridge_codegen generate` in both this folder and in `mobile/packages/rust`.
 
 3. Run the app:
-   - Android: `flutter run -t lib/main.dart --flavor independent`
+   - Android: `flutter run --flavor independent`
    - iOS: `flutter run`
 
 To build a release APK, [setup your keystore](https://docs.flutter.dev/deployment/android#create-an-upload-keystore) and run `flutter build apk --release --flavor independent`. For iOS, use `flutter build ios`.

--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -1182,8 +1182,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "33fe482088f582cc4202b35cdd47a5bc84da45bc"
-      resolved-ref: "33fe482088f582cc4202b35cdd47a5bc84da45bc"
+      ref: "85a6ac0f36c4473ac1345727ca5dd8589e564b80"
+      resolved-ref: "85a6ac0f36c4473ac1345727ca5dd8589e564b80"
       url: "https://github.com/ente-io/flutter_sodium"
     source: git
     version: "0.2.0"

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -118,7 +118,7 @@ dependencies:
   flutter_sodium:
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 33fe482088f582cc4202b35cdd47a5bc84da45bc
+      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
   flutter_spinkit: 5.2.1
   flutter_staggered_grid_view: 0.7.0
   flutter_svg: 2.2.0
@@ -267,7 +267,7 @@ dependency_overrides:
   flutter_sodium: # update source if there is any update
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 33fe482088f582cc4202b35cdd47a5bc84da45bc
+      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
   intl: 0.20.2
   js: 0.6.7
   media_kit: # update media_kit* if there is any update

--- a/mobile/apps/photos/pubspec_overrides.yaml
+++ b/mobile/apps/photos/pubspec_overrides.yaml
@@ -13,7 +13,7 @@ dependency_overrides:
   flutter_sodium:
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 33fe482088f582cc4202b35cdd47a5bc84da45bc
+      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
   intl: 0.20.2
   js: 0.6.7
   media_kit:

--- a/mobile/apps/photos/rust_builder/cargokit/build_tool/lib/src/rustup.dart
+++ b/mobile/apps/photos/rust_builder/cargokit/build_tool/lib/src/rustup.dart
@@ -36,14 +36,34 @@ class Rustup {
     required String toolchain,
   }) {
     log.info("Installing Rust target: $target");
-    runCommand("rustup", [
-      'target',
-      'add',
-      '--toolchain',
-      toolchain,
-      target,
-    ]);
-    _installedTargets(toolchain)?.add(target);
+    final lockFile = File(path.join(
+      Directory.systemTemp.path,
+      'cargokit_rustup_target_${toolchain}_$target.lock',
+    ));
+    lockFile.createSync(recursive: true);
+    final lock = lockFile.openSync(mode: FileMode.write);
+    var lockAcquired = false;
+    try {
+      lock.lockSync(FileLock.blockingExclusive);
+      lockAcquired = true;
+      if (_getInstalledTargets(toolchain).contains(target)) {
+        _installedTargets(toolchain)?.add(target);
+        return;
+      }
+      runCommand("rustup", [
+        'target',
+        'add',
+        '--toolchain',
+        toolchain,
+        target,
+      ]);
+      _installedTargets(toolchain)?.add(target);
+    } finally {
+      if (lockAcquired) {
+        lock.unlockSync();
+      }
+      lock.closeSync();
+    }
   }
 
   final List<_Toolchain> _installedToolchains;

--- a/mobile/apps/photos/rust_builder/cargokit/gradle/plugin.gradle
+++ b/mobile/apps/photos/rust_builder/cargokit/gradle/plugin.gradle
@@ -134,12 +134,6 @@ class CargoKitPlugin implements Plugin<Project> {
 
             def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
 
-            // Same thing addFlutterDependencies does in flutter.gradle
-            if (buildType == "debug") {
-                platforms.add("android-x86")
-                platforms.add("android-x64")
-            }
-
             // The task name depends on plugin properties, which are not available
             // at this point
             project.getGradle().afterProject {

--- a/mobile/melos.yaml
+++ b/mobile/melos.yaml
@@ -76,15 +76,15 @@ scripts:
 
 
   run:photos:apk:
-    run: melos exec --scope="photos" -- "flutter run -t lib/main.dart --flavor independent"
+    run: melos exec --scope="photos" -- "flutter run --flavor independent"
     description: Run the 'photos' app in independent mode.
 
   run:auth:apk:
-    run: melos exec --scope="auth" -- "flutter run -t lib/main.dart --flavor independent"
+    run: melos exec --scope="auth" -- "flutter run --flavor independent"
     description: Run the 'auth' app in independent mode.
 
   run:locker:apk:
-    run: melos exec --scope="locker" -- "flutter run -t lib/main.dart --flavor independent"
+    run: melos exec --scope="locker" -- "flutter run --flavor independent"
     description: Run the 'locker' app in independent mode.
 
  # --- APP-SPECIFIC BUILD COMMANDS ---

--- a/mobile/packages/rust/cargokit/build_tool/lib/src/rustup.dart
+++ b/mobile/packages/rust/cargokit/build_tool/lib/src/rustup.dart
@@ -36,14 +36,34 @@ class Rustup {
     required String toolchain,
   }) {
     log.info("Installing Rust target: $target");
-    runCommand("rustup", [
-      'target',
-      'add',
-      '--toolchain',
-      toolchain,
-      target,
-    ]);
-    _installedTargets(toolchain)?.add(target);
+    final lockFile = File(path.join(
+      Directory.systemTemp.path,
+      'cargokit_rustup_target_${toolchain}_$target.lock',
+    ));
+    lockFile.createSync(recursive: true);
+    final lock = lockFile.openSync(mode: FileMode.write);
+    var lockAcquired = false;
+    try {
+      lock.lockSync(FileLock.blockingExclusive);
+      lockAcquired = true;
+      if (_getInstalledTargets(toolchain).contains(target)) {
+        _installedTargets(toolchain)?.add(target);
+        return;
+      }
+      runCommand("rustup", [
+        'target',
+        'add',
+        '--toolchain',
+        toolchain,
+        target,
+      ]);
+      _installedTargets(toolchain)?.add(target);
+    } finally {
+      if (lockAcquired) {
+        lock.unlockSync();
+      }
+      lock.closeSync();
+    }
   }
 
   final List<_Toolchain> _installedToolchains;

--- a/mobile/packages/rust/cargokit/gradle/plugin.gradle
+++ b/mobile/packages/rust/cargokit/gradle/plugin.gradle
@@ -134,12 +134,6 @@ class CargoKitPlugin implements Plugin<Project> {
 
             def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
 
-            // Same thing addFlutterDependencies does in flutter.gradle
-            if (buildType == "debug") {
-                platforms.add("android-x86")
-                platforms.add("android-x64")
-            }
-
             // The task name depends on plugin properties, which are not available
             // at this point
             project.getGradle().afterProject {


### PR DESCRIPTION
- Update to the latest flutter_sodium to fix the build (merges the 16kb fix)
- Stop building x86 targets when running a dev build on arm. This saves 4 extra rust unnecessary rust builds for a non-incremental `flutter run`
- Serialize the rust target download so that flutter run on a fresh machine doesn't randomly fail
- Drop redundant `--target lib/main.dart` from documentation etc

See commit messages for more details.