### PR TITLE
[web][paste] improving ente paste onboarding copy, send loader, and link/QR actions

### DIFF
--- a/web/apps/paste/src/features/paste/components/PasteCreatePanel.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteCreatePanel.tsx
@@ -43,27 +43,14 @@ export const PasteCreatePanel = ({
     const isNearCharLimit = inputText.length >= nearLimitThreshold;
     const isCreateDisabled = isInputEmpty;
     const privacyPills = [
+        "Private",
         isMobile ? "E2EE" : "End-to-end encrypted",
+        "One-time view",
         "Auto-deletes after 24 hours",
     ];
 
     return (
         <Box sx={{ width: "100%", maxWidth: "100%", minWidth: 0 }}>
-            <Typography
-                component="h2"
-                sx={{
-                    color: tokens.text.primary,
-                    fontWeight: 600,
-                    fontSize: { xs: "1.08rem", sm: "1.18rem" },
-                    lineHeight: 1.35,
-                    letterSpacing: "0.01em",
-                    textAlign: "center",
-                    mb: { xs: 1.25, sm: 1.5 },
-                    maxWidth: "100%",
-                }}
-            >
-                Share private data with secure, one-time links
-            </Typography>
             <Box
                 sx={{
                     position: "relative",

--- a/web/apps/paste/src/features/paste/components/PasteCreatePanel.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteCreatePanel.tsx
@@ -43,14 +43,27 @@ export const PasteCreatePanel = ({
     const isNearCharLimit = inputText.length >= nearLimitThreshold;
     const isCreateDisabled = isInputEmpty;
     const privacyPills = [
-        "Private",
-        isMobile ? "E2EE" : "End To End Encrypted",
-        "One-Time View",
-        "Deletes In 24 Hrs",
+        isMobile ? "E2EE" : "End-to-end encrypted",
+        "Auto-deletes after 24 hours",
     ];
 
     return (
         <Box sx={{ width: "100%", maxWidth: "100%", minWidth: 0 }}>
+            <Typography
+                component="h2"
+                sx={{
+                    color: tokens.text.primary,
+                    fontWeight: 600,
+                    fontSize: { xs: "1.08rem", sm: "1.18rem" },
+                    lineHeight: 1.35,
+                    letterSpacing: "0.01em",
+                    textAlign: "center",
+                    mb: { xs: 1.25, sm: 1.5 },
+                    maxWidth: "100%",
+                }}
+            >
+                Share private data with secure, one-time links
+            </Typography>
             <Box
                 sx={{
                     position: "relative",
@@ -165,14 +178,21 @@ export const PasteCreatePanel = ({
                         disabled={isCreateDisabled}
                         sx={{
                             pointerEvents: "auto",
+                            boxSizing: "border-box",
                             width: { xs: 34, sm: 38 },
                             height: { xs: 34, sm: 38 },
+                            minWidth: { xs: 34, sm: 38 },
+                            minHeight: { xs: 34, sm: 38 },
+                            padding: 0,
                             marginBottom: { xs: "3px", sm: "4px" },
                             marginRight: { xs: "-1px", sm: "-2px" },
                             borderRadius: { xs: "12px", sm: "14px" },
                             bgcolor: tokens.button.primaryBg,
                             color: tokens.button.primaryText,
                             boxShadow: "none",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
                             "&:hover": {
                                 bgcolor: tokens.button.primaryHoverBg,
                                 boxShadow: "none",
@@ -184,11 +204,29 @@ export const PasteCreatePanel = ({
                         }}
                     >
                         {creating ? (
-                            <CircularProgress
-                                size={17}
-                                thickness={5.2}
-                                sx={{ color: tokens.button.primaryText }}
-                            />
+                            <Box
+                                sx={{
+                                    width: 18,
+                                    height: 18,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    lineHeight: 0,
+                                }}
+                            >
+                                <CircularProgress
+                                    size={17}
+                                    thickness={5.2}
+                                    sx={{
+                                        color: tokens.button.primaryText,
+                                        display: "block",
+                                        "& .MuiCircularProgress-svg": {
+                                            display: "block",
+                                            transformOrigin: "50% 50%",
+                                        },
+                                    }}
+                                />
+                            </Box>
                         ) : (
                             <Box
                                 sx={{

--- a/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
@@ -1,6 +1,8 @@
 import { Link01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
 import QrCode2RoundedIcon from "@mui/icons-material/QrCode2Rounded";
 import {
     Box,
@@ -253,9 +255,12 @@ export const PasteLinkCard = ({
                         flex: 1,
                         minWidth: 0,
                         display: "flex",
+                        flexDirection: "row",
                         alignItems: "center",
                         boxSizing: "border-box",
-                        px: { xs: 1.9, sm: 2.2 },
+                        gap: { xs: 0.75, sm: 1 },
+                        pl: { xs: 1.9, sm: 2.2 },
+                        pr: { xs: 0.85, sm: 1 },
                         py: { xs: 1.05, sm: 1.2 },
                         borderRadius: "14px",
                         border: `1px solid ${tokens.surface.linkRowBorder}`,
@@ -279,12 +284,10 @@ export const PasteLinkCard = ({
                         sx={{
                             display: "flex",
                             alignItems: "center",
-                            justifyContent: { xs: "flex-start", md: "center" },
-                            height: "100%",
-                            width: "100%",
-                            maxWidth: "100%",
-                            gap: 0.9,
+                            justifyContent: "flex-start",
+                            flex: 1,
                             minWidth: 0,
+                            gap: 0.9,
                             color: tokens.text.primary,
                             textDecoration: "none",
                             fontSize: { xs: "0.9rem", sm: "0.93rem" },
@@ -316,9 +319,7 @@ export const PasteLinkCard = ({
                         <Box
                             component="span"
                             sx={{
-                                flex: { xs: 1, md: "0 1 auto" },
                                 minWidth: 0,
-                                maxWidth: { md: "calc(100% - 28px)" },
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
@@ -328,6 +329,39 @@ export const PasteLinkCard = ({
                             {link}
                         </Box>
                     </Typography>
+                    <IconButton
+                        type="button"
+                        aria-label={showCopied ? "Copied" : "Copy link"}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            handleCopyClick();
+                        }}
+                        sx={{
+                            flexShrink: 0,
+                            width: { xs: 36, sm: 38 },
+                            height: { xs: 36, sm: 38 },
+                            borderRadius: "10px",
+                            color: tokens.text.primary,
+                            bgcolor: "transparent",
+                            "&:hover": {
+                                bgcolor: tokens.frame.headerIconHoverBg,
+                            },
+                        }}
+                    >
+                        {showCopied ? (
+                            <CheckRoundedIcon
+                                sx={{
+                                    fontSize: { xs: 20, sm: 21 },
+                                    color: tokens.text.copied,
+                                }}
+                            />
+                        ) : (
+                            <ContentCopyRoundedIcon
+                                sx={{ fontSize: { xs: 20, sm: 21 } }}
+                            />
+                        )}
+                    </IconButton>
                 </Box>
                 {arrow && (
                     <Box
@@ -599,9 +633,64 @@ export const PasteLinkCard = ({
                                 backdropFilter: "blur(8px) saturate(106%)",
                                 WebkitBackdropFilter:
                                     "blur(8px) saturate(106%)",
+                                minWidth: 0,
+                                overflow: "visible",
                             }}
                         >
-                            <PasteQrCode value={link} tokens={tokens} />
+                            <Box
+                                sx={{
+                                    position: "relative",
+                                    width: "fit-content",
+                                    maxWidth: "100%",
+                                    mx: "auto",
+                                    overflow: "visible",
+                                }}
+                            >
+                                <PasteQrCode value={link} tokens={tokens} />
+                                <IconButton
+                                    type="button"
+                                    aria-label="Close QR code"
+                                    disableRipple
+                                    onClick={() => {
+                                        setShowQr(false);
+                                    }}
+                                    sx={{
+                                        position: "absolute",
+                                        top: 0,
+                                        right: 0,
+                                        zIndex: 1,
+                                        width: 28,
+                                        height: 28,
+                                        minWidth: 28,
+                                        padding: 0,
+                                        borderRadius: "50%",
+                                        border: `1px solid ${tokens.button.qrToggleBorder}`,
+                                        color: tokens.text.secondary,
+                                        bgcolor: tokens.surface.floatingCardBg,
+                                        opacity: 1,
+                                        boxShadow:
+                                            "0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05)",
+                                        transform: "translate(50%, -50%) scale(1)",
+                                        transformOrigin: "center",
+                                        transition:
+                                            "transform 420ms cubic-bezier(0.22, 1, 0.36, 1), background-color 420ms cubic-bezier(0.22, 1, 0.36, 1)",
+                                        "&:hover": {
+                                            opacity: 1,
+                                            transform:
+                                                "translate(50%, -50%) scale(1.12)",
+                                            bgcolor:
+                                                resolvedMode === "dark"
+                                                    ? "rgba(26, 36, 72, 1)"
+                                                    : "rgba(237, 244, 255, 1)",
+                                        },
+                                        "& .MuiSvgIcon-root": {
+                                            opacity: 1,
+                                        },
+                                    }}
+                                >
+                                    <CloseRoundedIcon sx={{ fontSize: 16 }} />
+                                </IconButton>
+                            </Box>
                         </Box>
                     )}
                 </Stack>
@@ -762,18 +851,72 @@ export const PasteLinkCard = ({
                                     bgcolor: tokens.surface.floatingCardBg,
                                     boxShadow:
                                         tokens.surface.floatingCardShadow,
+                                    overflow: "visible",
                                 },
                             },
                         }}
                     >
-                        <Box sx={{ p: 1.15 }}>
-                            <PasteQrCode
-                                value={link}
-                                tokens={tokens}
-                                size={226}
-                                paperBg={tokens.qr.mobilePaperBg}
-                                borderRadius="12px"
-                            />
+                        <Box sx={{ p: 1.15, overflow: "visible" }}>
+                            <Box
+                                sx={{
+                                    position: "relative",
+                                    width: "fit-content",
+                                    maxWidth: "100%",
+                                    mx: "auto",
+                                    overflow: "visible",
+                                }}
+                            >
+                                <PasteQrCode
+                                    value={link}
+                                    tokens={tokens}
+                                    size={226}
+                                    paperBg={tokens.qr.mobilePaperBg}
+                                    borderRadius="12px"
+                                />
+                                <IconButton
+                                    type="button"
+                                    aria-label="Close QR code"
+                                    disableRipple
+                                    onClick={() => {
+                                        setShowQr(false);
+                                    }}
+                                    sx={{
+                                        position: "absolute",
+                                        top: 0,
+                                        right: 0,
+                                        zIndex: 1,
+                                        width: 28,
+                                        height: 28,
+                                        minWidth: 28,
+                                        padding: 0,
+                                        borderRadius: "50%",
+                                        border: `1px solid ${tokens.button.qrToggleBorder}`,
+                                        color: tokens.text.secondary,
+                                        bgcolor: tokens.surface.floatingCardBg,
+                                        opacity: 1,
+                                        boxShadow:
+                                            "0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05)",
+                                        transform: "translate(50%, -50%) scale(1)",
+                                        transformOrigin: "center",
+                                        transition:
+                                            "transform 420ms cubic-bezier(0.22, 1, 0.36, 1), background-color 420ms cubic-bezier(0.22, 1, 0.36, 1)",
+                                        "&:hover": {
+                                            opacity: 1,
+                                            transform:
+                                                "translate(50%, -50%) scale(1.12)",
+                                            bgcolor:
+                                                resolvedMode === "dark"
+                                                    ? "rgba(26, 36, 72, 1)"
+                                                    : "rgba(237, 244, 255, 1)",
+                                        },
+                                        "& .MuiSvgIcon-root": {
+                                            opacity: 1,
+                                        },
+                                    }}
+                                >
+                                    <CloseRoundedIcon sx={{ fontSize: 16 }} />
+                                </IconButton>
+                            </Box>
                         </Box>
                     </Dialog>
                 )}

--- a/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
@@ -1,8 +1,6 @@
 import { Link01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
-import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
 import QrCode2RoundedIcon from "@mui/icons-material/QrCode2Rounded";
 import {
     Box,
@@ -255,12 +253,9 @@ export const PasteLinkCard = ({
                         flex: 1,
                         minWidth: 0,
                         display: "flex",
-                        flexDirection: "row",
                         alignItems: "center",
                         boxSizing: "border-box",
-                        gap: { xs: 0.75, sm: 1 },
-                        pl: { xs: 1.9, sm: 2.2 },
-                        pr: { xs: 0.85, sm: 1 },
+                        px: { xs: 1.9, sm: 2.2 },
                         py: { xs: 1.05, sm: 1.2 },
                         borderRadius: "14px",
                         border: `1px solid ${tokens.surface.linkRowBorder}`,
@@ -284,9 +279,10 @@ export const PasteLinkCard = ({
                         sx={{
                             display: "flex",
                             alignItems: "center",
-                            justifyContent: "flex-start",
-                            flex: 1,
-                            minWidth: 0,
+                            justifyContent: { xs: "flex-start", md: "center" },
+                            height: "100%",
+                            width: "100%",
+                            maxWidth: "100%",
                             gap: 0.9,
                             color: tokens.text.primary,
                             textDecoration: "none",
@@ -319,7 +315,9 @@ export const PasteLinkCard = ({
                         <Box
                             component="span"
                             sx={{
+                                flex: { xs: 1, md: "0 1 auto" },
                                 minWidth: 0,
+                                maxWidth: { md: "calc(100% - 28px)" },
                                 overflow: "hidden",
                                 textOverflow: "ellipsis",
                                 whiteSpace: "nowrap",
@@ -329,39 +327,6 @@ export const PasteLinkCard = ({
                             {link}
                         </Box>
                     </Typography>
-                    <IconButton
-                        type="button"
-                        aria-label={showCopied ? "Copied" : "Copy link"}
-                        onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            handleCopyClick();
-                        }}
-                        sx={{
-                            flexShrink: 0,
-                            width: { xs: 36, sm: 38 },
-                            height: { xs: 36, sm: 38 },
-                            borderRadius: "10px",
-                            color: tokens.text.primary,
-                            bgcolor: "transparent",
-                            "&:hover": {
-                                bgcolor: tokens.frame.headerIconHoverBg,
-                            },
-                        }}
-                    >
-                        {showCopied ? (
-                            <CheckRoundedIcon
-                                sx={{
-                                    fontSize: { xs: 20, sm: 21 },
-                                    color: tokens.text.copied,
-                                }}
-                            />
-                        ) : (
-                            <ContentCopyRoundedIcon
-                                sx={{ fontSize: { xs: 20, sm: 21 } }}
-                            />
-                        )}
-                    </IconButton>
                 </Box>
                 {arrow && (
                     <Box

--- a/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteLinkCard.tsx
@@ -602,60 +602,14 @@ export const PasteLinkCard = ({
                                 overflow: "visible",
                             }}
                         >
-                            <Box
-                                sx={{
-                                    position: "relative",
-                                    width: "fit-content",
-                                    maxWidth: "100%",
-                                    mx: "auto",
-                                    overflow: "visible",
+                            <PasteQrCode
+                                value={link}
+                                tokens={tokens}
+                                onClose={() => {
+                                    setShowQr(false);
                                 }}
-                            >
-                                <PasteQrCode value={link} tokens={tokens} />
-                                <IconButton
-                                    type="button"
-                                    aria-label="Close QR code"
-                                    disableRipple
-                                    onClick={() => {
-                                        setShowQr(false);
-                                    }}
-                                    sx={{
-                                        position: "absolute",
-                                        top: 0,
-                                        right: 0,
-                                        zIndex: 1,
-                                        width: 28,
-                                        height: 28,
-                                        minWidth: 28,
-                                        padding: 0,
-                                        borderRadius: "50%",
-                                        border: `1px solid ${tokens.button.qrToggleBorder}`,
-                                        color: tokens.text.secondary,
-                                        bgcolor: tokens.surface.floatingCardBg,
-                                        opacity: 1,
-                                        boxShadow:
-                                            "0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05)",
-                                        transform: "translate(50%, -50%) scale(1)",
-                                        transformOrigin: "center",
-                                        transition:
-                                            "transform 420ms cubic-bezier(0.22, 1, 0.36, 1), background-color 420ms cubic-bezier(0.22, 1, 0.36, 1)",
-                                        "&:hover": {
-                                            opacity: 1,
-                                            transform:
-                                                "translate(50%, -50%) scale(1.12)",
-                                            bgcolor:
-                                                resolvedMode === "dark"
-                                                    ? "rgba(26, 36, 72, 1)"
-                                                    : "rgba(237, 244, 255, 1)",
-                                        },
-                                        "& .MuiSvgIcon-root": {
-                                            opacity: 1,
-                                        },
-                                    }}
-                                >
-                                    <CloseRoundedIcon sx={{ fontSize: 16 }} />
-                                </IconButton>
-                            </Box>
+                                resolvedMode={resolvedMode}
+                            />
                         </Box>
                     )}
                 </Stack>
@@ -822,66 +776,17 @@ export const PasteLinkCard = ({
                         }}
                     >
                         <Box sx={{ p: 1.15, overflow: "visible" }}>
-                            <Box
-                                sx={{
-                                    position: "relative",
-                                    width: "fit-content",
-                                    maxWidth: "100%",
-                                    mx: "auto",
-                                    overflow: "visible",
+                            <PasteQrCode
+                                value={link}
+                                tokens={tokens}
+                                size={226}
+                                paperBg={tokens.qr.mobilePaperBg}
+                                borderRadius="12px"
+                                onClose={() => {
+                                    setShowQr(false);
                                 }}
-                            >
-                                <PasteQrCode
-                                    value={link}
-                                    tokens={tokens}
-                                    size={226}
-                                    paperBg={tokens.qr.mobilePaperBg}
-                                    borderRadius="12px"
-                                />
-                                <IconButton
-                                    type="button"
-                                    aria-label="Close QR code"
-                                    disableRipple
-                                    onClick={() => {
-                                        setShowQr(false);
-                                    }}
-                                    sx={{
-                                        position: "absolute",
-                                        top: 0,
-                                        right: 0,
-                                        zIndex: 1,
-                                        width: 28,
-                                        height: 28,
-                                        minWidth: 28,
-                                        padding: 0,
-                                        borderRadius: "50%",
-                                        border: `1px solid ${tokens.button.qrToggleBorder}`,
-                                        color: tokens.text.secondary,
-                                        bgcolor: tokens.surface.floatingCardBg,
-                                        opacity: 1,
-                                        boxShadow:
-                                            "0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05)",
-                                        transform: "translate(50%, -50%) scale(1)",
-                                        transformOrigin: "center",
-                                        transition:
-                                            "transform 420ms cubic-bezier(0.22, 1, 0.36, 1), background-color 420ms cubic-bezier(0.22, 1, 0.36, 1)",
-                                        "&:hover": {
-                                            opacity: 1,
-                                            transform:
-                                                "translate(50%, -50%) scale(1.12)",
-                                            bgcolor:
-                                                resolvedMode === "dark"
-                                                    ? "rgba(26, 36, 72, 1)"
-                                                    : "rgba(237, 244, 255, 1)",
-                                        },
-                                        "& .MuiSvgIcon-root": {
-                                            opacity: 1,
-                                        },
-                                    }}
-                                >
-                                    <CloseRoundedIcon sx={{ fontSize: 16 }} />
-                                </IconButton>
-                            </Box>
+                                resolvedMode={resolvedMode}
+                            />
                         </Box>
                     </Dialog>
                 )}

--- a/web/apps/paste/src/features/paste/components/PasteQrCode.tsx
+++ b/web/apps/paste/src/features/paste/components/PasteQrCode.tsx
@@ -1,6 +1,10 @@
-import { Box } from "@mui/material";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import { Box, IconButton } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import type { PasteThemeTokens } from "features/paste/theme/pasteThemeTokens";
+import type {
+    PasteResolvedMode,
+    PasteThemeTokens,
+} from "features/paste/theme/pasteThemeTokens";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 interface PasteQrCodeProps {
@@ -9,6 +13,10 @@ interface PasteQrCodeProps {
     size?: number;
     paperBg?: string;
     borderRadius?: string;
+    /** When set, shows a floating close control (e.g. to dismiss the QR panel). */
+    onClose?: () => void;
+    /** Color mode for close button hover; pass when `onClose` is used. */
+    resolvedMode?: PasteResolvedMode;
 }
 
 interface QRCodeStylingInstance {
@@ -65,6 +73,8 @@ export const PasteQrCode = ({
     size,
     paperBg,
     borderRadius,
+    onClose,
+    resolvedMode,
 }: PasteQrCodeProps) => {
     const qrContainerRef = useRef<HTMLDivElement | null>(null);
     const qrCodeRef = useRef<QRCodeStylingInstance | null>(null);
@@ -185,7 +195,7 @@ export const PasteQrCode = ({
         [],
     );
 
-    return (
+    const qrBox = (
         <Box
             ref={qrContainerRef}
             role={qrLoadError ? "status" : "img"}
@@ -218,5 +228,64 @@ export const PasteQrCode = ({
                 },
             }}
         />
+    );
+
+    if (!onClose) {
+        return qrBox;
+    }
+
+    const isDark = resolvedMode === "dark";
+
+    return (
+        <Box
+            sx={{
+                position: "relative",
+                width: "fit-content",
+                maxWidth: "100%",
+                mx: "auto",
+                overflow: "visible",
+            }}
+        >
+            {qrBox}
+            <IconButton
+                type="button"
+                aria-label="Close QR code"
+                disableRipple
+                onClick={onClose}
+                sx={{
+                    position: "absolute",
+                    top: 0,
+                    right: 0,
+                    zIndex: 1,
+                    width: 28,
+                    height: 28,
+                    minWidth: 28,
+                    padding: 0,
+                    borderRadius: "50%",
+                    border: `1px solid ${tokens.button.qrToggleBorder}`,
+                    color: tokens.text.secondary,
+                    bgcolor: tokens.surface.floatingCardBg,
+                    opacity: 1,
+                    boxShadow:
+                        "0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.05)",
+                    transform: "translate(50%, -50%) scale(1)",
+                    transformOrigin: "center",
+                    transition:
+                        "transform 420ms cubic-bezier(0.22, 1, 0.36, 1), background-color 420ms cubic-bezier(0.22, 1, 0.36, 1)",
+                    "&:hover": {
+                        opacity: 1,
+                        transform: "translate(50%, -50%) scale(1.12)",
+                        bgcolor: isDark
+                            ? "rgba(26, 36, 72, 1)"
+                            : "rgba(237, 244, 255, 1)",
+                    },
+                    "& .MuiSvgIcon-root": {
+                        opacity: 1,
+                    },
+                }}
+            >
+                <CloseRoundedIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+        </Box>
     );
 };


### PR DESCRIPTION
## Ente Paste: clarifying the create flow, simplify trust cues, and improve link/QR actions

### Headline on the create screen
New visitors only see a paste field, so it isn’t obvious what happens next. I added a short headline so it’s clear upfront that you’re creating a secure, one-time link to share private text—not just “pasting” into nowhere.

### Fewer duplicate trust badges
The headline already explains the idea at a glance, so the extra pills felt repetitive. I trimmed them so the page doesn’t repeat the same message in two places.

### Send button loading state
In production, the spinner on the send button looked like it was orbiting instead of spinning in place. I adjusted the layout so the loader stays fixed in the center and only the indicator rotates.

### Copy next to the generated link
After a link is created, copying it is the natural next step. The “copy” hint below the row doesn’t read as a control, so I added a clear copy action beside the link, with feedback when it’s copied.

### Close control for the QR code
The QR toggle wasn’t obvious—I didn’t realize the same icon shows and hides the code. I added a dedicated close control on the QR view that doesn’t cover the code, so people can dismiss it without guessing.

![pr-review1](https://github.com/user-attachments/assets/3e74c9ca-fac0-4536-96b1-1ef72786299b)