### PR TITLE
[mob][photos] Handle local storage full during backup

### DIFF
--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 enum InvalidReason {
   assetDeleted,
   assetDeletedEvent,
@@ -37,6 +39,8 @@ class SyncStopRequestedError extends Error {}
 class NoActiveSubscriptionError extends Error {}
 
 class StorageLimitExceededError extends Error {}
+
+class LocalDeviceStorageFullError extends Error {}
 
 // error when file size + current usage >= storage plan limit + buffer
 class FileTooLargeForPlanError extends Error {}
@@ -143,6 +147,27 @@ class InvalidDateTimeError implements Exception {
     return 'InvalidDateTimeError: $field is invalid for asset '
         '(id: $assetId, title: ${assetTitle ?? "unknown"}) - $originalError';
   }
+}
+
+bool isLocalDeviceStorageFullException(Object error) {
+  if (error is LocalDeviceStorageFullError) {
+    return true;
+  }
+  if (error is! FileSystemException) {
+    return false;
+  }
+
+  final osCode = error.osError?.errorCode;
+  if (osCode == 28) {
+    return true;
+  }
+
+  final text =
+      '${error.message} ${error.osError?.message ?? ''}'.toLowerCase();
+  return text.contains('no space left on device') ||
+      text.contains('enospc') ||
+      text.contains('disk full') ||
+      text.contains('not enough space');
 }
 
 class BadMD5DigestError implements Exception {

--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -747,10 +747,15 @@ class RemoteSyncService {
       await Future.wait(futures);
     } on InvalidFileError {
       // Do nothing
-    } on FileSystemException {
+    } on FileSystemException catch (e) {
+      if (isLocalDeviceStorageFullException(e)) {
+        throw LocalDeviceStorageFullError();
+      }
       // Do nothing since it's caused mostly due to concurrency issues
       // when the foreground app deletes temporary files, interrupting a background
       // upload
+    } on LocalDeviceStorageFullError {
+      rethrow;
     } on LockAlreadyAcquiredError {
       // Do nothing
     } on SilentlyCancelUploadsError {

--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -207,21 +207,24 @@ class RemoteSyncService {
       _existingSync = null;
       _logger.warning("Error executing remote sync", e, s);
 
-      if (flagService.internalUser ||
-          // rethrow whitelisted error so that UI status can be updated correctly.
-          {
-            UnauthorizedError,
-            NoActiveSubscriptionError,
-            WiFiUnavailableError,
-            StorageLimitExceededError,
-            SyncStopRequestedError,
-            NoMediaLocationAccessError,
-          }.contains(e.runtimeType)) {
+      if (flagService.internalUser || _shouldRethrowSyncError(e)) {
         rethrow;
       }
     } finally {
       _isExistingSyncSilent = false;
     }
+  }
+
+  bool _shouldRethrowSyncError(Object error) {
+    // Rethrow whitelisted errors so that SyncService can emit the
+    // corresponding user-visible status updates.
+    return error is UnauthorizedError ||
+        error is NoActiveSubscriptionError ||
+        error is WiFiUnavailableError ||
+        error is StorageLimitExceededError ||
+        error is SyncStopRequestedError ||
+        error is NoMediaLocationAccessError ||
+        error is LocalDeviceStorageFullError;
   }
 
   bool isFirstRemoteSyncDone() {

--- a/mobile/apps/photos/lib/services/sync/sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/sync_service.dart
@@ -269,7 +269,7 @@ class SyncService {
     if ((now - lastNotificationShownTime) > microSecondsInDay) {
       await _prefs.setInt(kLastLocalStorageFullNotificationPushTime, now);
       final s = await LanguageService.locals;
-      NotificationService.instance.showNotification(
+      await NotificationService.instance.showNotification(
         s.freeUpDeviceSpace,
         "Backup paused because device storage is full.",
       );

--- a/mobile/apps/photos/lib/services/sync/sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/sync_service.dart
@@ -35,6 +35,8 @@ class SyncService {
 
   static const kLastStorageLimitExceededNotificationPushTime =
       "last_storage_limit_exceeded_notification_push_time";
+  static const kLastLocalStorageFullNotificationPushTime =
+      "last_local_storage_full_notification_push_time";
 
   SyncService._privateConstructor() {
     Bus.instance.on<SubscriptionPurchasedEvent>().listen((event) {
@@ -114,6 +116,14 @@ class SyncService {
         SyncStatusUpdate(
           SyncStatus.error,
           error: StorageLimitExceededError(),
+        ),
+      );
+    } on LocalDeviceStorageFullError {
+      _showLocalStorageFullNotification();
+      Bus.instance.fire(
+        SyncStatusUpdate(
+          SyncStatus.error,
+          error: LocalDeviceStorageFullError(),
         ),
       );
     } on UnauthorizedError {
@@ -248,6 +258,20 @@ class SyncService {
       NotificationService.instance.showNotification(
         s.storageLimitExceeded,
         s.sorryWeHadToPauseYourBackups,
+      );
+    }
+  }
+
+  void _showLocalStorageFullNotification() async {
+    final lastNotificationShownTime =
+        _prefs.getInt(kLastLocalStorageFullNotificationPushTime) ?? 0;
+    final now = DateTime.now().microsecondsSinceEpoch;
+    if ((now - lastNotificationShownTime) > microSecondsInDay) {
+      await _prefs.setInt(kLastLocalStorageFullNotificationPushTime, now);
+      final s = await LanguageService.locals;
+      NotificationService.instance.showNotification(
+        s.freeUpDeviceSpace,
+        "Backup paused because device storage is full.",
       );
     }
   }

--- a/mobile/apps/photos/lib/ui/home/header_error_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/header_error_widget.dart
@@ -47,6 +47,24 @@ class HeaderErrorWidget extends StatelessWidget {
           },
         ),
       );
+    } else if (_error is LocalDeviceStorageFullError) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6),
+        child: NotificationWidget(
+          startIcon: Icons.sd_storage_rounded,
+          actionIcon: Icons.info_outline_rounded,
+          text: AppLocalizations.of(context).freeUpDeviceSpace,
+          subText: "Backup paused because device storage is full.",
+          onTap: () async => {
+            sendLogs(
+              context,
+              AppLocalizations.of(context).raiseTicket,
+              "support@ente.com",
+              subject: AppLocalizations.of(context).backupFailed,
+            ),
+          },
+        ),
+      );
     } else {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6),

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -924,8 +924,18 @@ class FileUploader {
       Bus.instance.fire(FileUploadedEvent(remoteFile));
       return remoteFile;
     } catch (e, s) {
+      if (isLocalDeviceStorageFullException(e)) {
+        uploadHardFailure = true;
+        _logger.warning(
+          "Device storage is full; pausing backup until storage is freed",
+          e,
+          s,
+        );
+        throw LocalDeviceStorageFullError();
+      }
       if (!(e is NoActiveSubscriptionError ||
           e is StorageLimitExceededError ||
+          e is LocalDeviceStorageFullError ||
           e is WiFiUnavailableError ||
           e is SilentlyCancelUploadsError ||
           e is InvalidFileError ||


### PR DESCRIPTION
## Summary

This is PR addresses the issue: https://github.com/ente-io/ente/issues/10031

- detect local device storage exhaustion during upload prep/encryption by mapping no-space filesystem failures to a dedicated LocalDeviceStorageFullError
- propagate this error through sync so backup pauses with an explicit local-storage-full state instead of generic retries
- show a user-facing backup error card and throttled notification prompting users to free device space before retrying

## Screenshot

<img width="396" height="469" alt="Screenshot 2026-04-13 at 2 33 55 PM" src="https://github.com/user-attachments/assets/abcfc796-46a1-454c-afb8-307a5386eb57" />
