### PR TITLE
server: add optional S3 bucket prefix for storing Ente data in a sub-folder

### DIFF
--- a/docs/docs/self-hosting/administration/object-storage.md
+++ b/docs/docs/self-hosting/administration/object-storage.md
@@ -114,6 +114,30 @@ The prefix is optional and can be set independently for each configured
 bucket. Leaving it unset preserves the previous behaviour of storing objects
 at the root of the bucket.
 
+#### Enabling a prefix on an existing deployment
+
+When you add `prefix` to a bucket that already holds data uploaded at the
+bucket root, Ente continues to serve those files: reads transparently fall
+back to the bucket-root path if an object isn't found under the prefix. New
+uploads always land under the prefix.
+
+This means you can turn on the prefix at any time without downtime. The
+fallback involves one extra HEAD request per read for pre-prefix objects;
+once everything has been migrated, the fallback becomes a no-op.
+
+When you are ready, you can move the legacy objects under the prefix so the
+fallback is never hit:
+
+```bash
+# Use rclone (recommended) for a fast, resumable move.
+rclone move remote:shared-bucket/ remote:shared-bucket/ente/ \
+    --include "*/*" --exclude "ente/**"
+```
+
+`orphan cleanup` only scans under the configured prefix and will never touch
+bucket-root objects, so there is no risk of accidental deletion during the
+transition.
+
 ## CORS (Cross-Origin Resource Sharing)
 
 If you cannot upload a photo due to CORS error, you need to fix the CORS

--- a/docs/docs/self-hosting/administration/object-storage.md
+++ b/docs/docs/self-hosting/administration/object-storage.md
@@ -89,6 +89,31 @@ b2-eu-cen:
     bucket: b2-eu-cen
 ```
 
+### Sharing a bucket with other data
+
+By default, Ente stores all objects at the root of the bucket using keys of
+the form `{userID}/{uuid}`. If you want to keep Ente's data under a
+sub-folder so the bucket can be shared with unrelated data, set the optional
+`prefix` on the bucket:
+
+```yaml
+b2-eu-cen:
+    key: <key>
+    secret: <secret>
+    endpoint: <endpoint>
+    region: <region>
+    bucket: shared-bucket
+    prefix: ente/
+```
+
+With the above, objects will be written to `shared-bucket/ente/{userID}/{uuid}`.
+Ente only reads, writes, and lists objects under this prefix — anything else
+in the bucket is left untouched, including by the orphan object cleanup.
+
+The prefix is optional and can be set independently for each configured
+bucket. Leaving it unset preserves the previous behaviour of storing objects
+at the root of the bucket.
+
 ## CORS (Cross-Origin Resource Sharing)
 
 If you cannot upload a photo due to CORS error, you need to fix the CORS

--- a/docs/docs/self-hosting/installation/config.md
+++ b/docs/docs/self-hosting/installation/config.md
@@ -121,6 +121,7 @@ and [troubleshooting](/self-hosting/troubleshooting/uploads) sections.
 | `s3.wasabi-eu-central-2-v3`            | Secondary hot storage configuration          |         |
 | `s3.are_local_buckets`                 |                                              | `true`  |
 | `s3.use_path_style_urls`               | Enable path-style URLs for MinIO             | `false` |
+| `s3.<bucket>.prefix`                   | Optional key prefix within the bucket        |         |
 
 ### Encryption Keys
 

--- a/server/pkg/controller/contact/controller.go
+++ b/server/pkg/controller/contact/controller.go
@@ -162,9 +162,10 @@ func (c *Controller) GetAttachmentUploadURL(ctx *gin.Context, attachmentTypeRaw 
 	dc := c.S3Config.GetAttachmentBucketID(string(attachmentType))
 
 	s3Client := c.S3Config.GetS3Client(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	putReq, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket:        c.S3Config.GetBucket(dc),
-		Key:           aws.String(objectKey),
+		Key:           aws.String(fullKey),
 		ContentLength: aws.Int64(req.ContentLength),
 		ContentMD5:    aws.String(req.ContentMD5),
 	})
@@ -237,9 +238,10 @@ func (c *Controller) GetAttachmentURL(ctx *gin.Context, attachmentTypeRaw string
 	}
 	objectKey := contactmodel.AttachmentObjectKey(userID, attachment.AttachmentType, attachment.AttachmentID)
 	s3Client := c.S3Config.GetS3Client(attachment.LatestBucket)
+	fullKey := c.S3Config.FullKey(attachment.LatestBucket, objectKey)
 	input := &s3.GetObjectInput{
 		Bucket:                     c.S3Config.GetBucket(attachment.LatestBucket),
-		Key:                        aws.String(objectKey),
+		Key:                        aws.String(fullKey),
 		ResponseContentDisposition: aws.String("attachment"),
 	}
 	getReq, _ := s3Client.GetObjectRequest(input)
@@ -490,9 +492,10 @@ func (c *Controller) replicateAttachmentObject(ctx context.Context, row contactm
 		downloader = s3manager.NewDownloaderWithClient(&s3Client)
 		c.downloadManagerCache[row.LatestBucket] = downloader
 	}
+	srcKey := c.S3Config.FullKey(row.LatestBucket, row.ObjectKey())
 	_, err = downloader.DownloadWithContext(ctx, file, &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(row.LatestBucket),
-		Key:    aws.String(row.ObjectKey()),
+		Key:    aws.String(srcKey),
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to download attachment from bucket %s", row.LatestBucket)
@@ -505,9 +508,10 @@ func (c *Controller) replicateAttachmentObject(ctx context.Context, row contactm
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return stacktrace.Propagate(err, "failed to seek temporary attachment file")
 	}
+	dstKey := c.S3Config.FullKey(dstBucketID, row.ObjectKey())
 	if _, err := uploader.Upload(&s3manager.UploadInput{
 		Bucket: c.S3Config.GetBucket(dstBucketID),
-		Key:    aws.String(row.ObjectKey()),
+		Key:    aws.String(dstKey),
 		Body:   file,
 	}); err != nil {
 		return stacktrace.Propagate(err, "failed to upload attachment to bucket %s", dstBucketID)
@@ -517,9 +521,10 @@ func (c *Controller) replicateAttachmentObject(ctx context.Context, row contactm
 
 func (c *Controller) verifyAttachmentSize(bucketID string, objectKey string, expectedSize int64) error {
 	s3Client := c.S3Config.GetS3Client(bucketID)
+	fullKey := c.S3Config.FullKey(bucketID, objectKey)
 	res, err := s3Client.HeadObject(&s3.HeadObjectInput{
 		Bucket: c.S3Config.GetBucket(bucketID),
-		Key:    aws.String(objectKey),
+		Key:    aws.String(fullKey),
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to fetch attachment info from bucket %s", bucketID)

--- a/server/pkg/controller/contact/controller.go
+++ b/server/pkg/controller/contact/controller.go
@@ -238,7 +238,10 @@ func (c *Controller) GetAttachmentURL(ctx *gin.Context, attachmentTypeRaw string
 	}
 	objectKey := contactmodel.AttachmentObjectKey(userID, attachment.AttachmentType, attachment.AttachmentID)
 	s3Client := c.S3Config.GetS3Client(attachment.LatestBucket)
-	fullKey := c.S3Config.FullKey(attachment.LatestBucket, objectKey)
+	fullKey, err := c.S3Config.ResolveKey(attachment.LatestBucket, objectKey)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
 	input := &s3.GetObjectInput{
 		Bucket:                     c.S3Config.GetBucket(attachment.LatestBucket),
 		Key:                        aws.String(fullKey),
@@ -492,7 +495,10 @@ func (c *Controller) replicateAttachmentObject(ctx context.Context, row contactm
 		downloader = s3manager.NewDownloaderWithClient(&s3Client)
 		c.downloadManagerCache[row.LatestBucket] = downloader
 	}
-	srcKey := c.S3Config.FullKey(row.LatestBucket, row.ObjectKey())
+	srcKey, err := c.S3Config.ResolveKey(row.LatestBucket, row.ObjectKey())
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
 	_, err = downloader.DownloadWithContext(ctx, file, &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(row.LatestBucket),
 		Key:    aws.String(srcKey),
@@ -521,7 +527,10 @@ func (c *Controller) replicateAttachmentObject(ctx context.Context, row contactm
 
 func (c *Controller) verifyAttachmentSize(bucketID string, objectKey string, expectedSize int64) error {
 	s3Client := c.S3Config.GetS3Client(bucketID)
-	fullKey := c.S3Config.FullKey(bucketID, objectKey)
+	fullKey, err := c.S3Config.ResolveKey(bucketID, objectKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
 	res, err := s3Client.HeadObject(&s3.HeadObjectInput{
 		Bucket: c.S3Config.GetBucket(bucketID),
 		Key:    aws.String(fullKey),

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -864,7 +864,13 @@ func (c *FileController) cleanupDeletedFile(qItem repo.QueueItem) {
 
 func (c *FileController) getHotDcSignedUrl(objectKey string, objType ente.ObjectType) (string, error) {
 	s3Client := c.S3Config.GetHotS3Client()
-	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
+	// Resolve where the object actually lives: either under the configured
+	// bucket prefix (the default) or at the bucket root for legacy data
+	// uploaded before the prefix was configured.
+	fullKey, err := c.S3Config.ResolveKey(c.S3Config.GetHotDataCenter(), objectKey)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetHotBucket(),
 		Key:    &fullKey,
@@ -879,7 +885,10 @@ func (c *FileController) getHotDcSignedUrl(objectKey string, objType ente.Object
 
 func (c *FileController) getPreSignedURLForDC(objectKey string, dc string, objType ente.ObjectType) (string, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
-	fullKey := c.S3Config.FullKey(dc, objectKey)
+	fullKey, err := c.S3Config.ResolveKey(dc, objectKey)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(dc),
 		Key:    &fullKey,
@@ -895,9 +904,14 @@ func (c *FileController) getPreSignedURLForDC(objectKey string, dc string, objTy
 func (c *FileController) sizeOf(objectKey string) (int64, error) {
 	s3Client := c.S3Config.GetHotS3Client()
 	bucket := c.S3Config.GetHotBucket()
-	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
+	// Resolve transparently against both prefixed and legacy root locations,
+	// so that size lookups for pre-prefix data continue to work after an
+	// operator turns on the bucket prefix.
+	fullKey, err := c.S3Config.ResolveKey(c.S3Config.GetHotDataCenter(), objectKey)
+	if err != nil {
+		return 0, stacktrace.Propagate(err, "")
+	}
 	var head *s3.HeadObjectOutput
-	var err error
 	// Retry twice with a delay of 500ms and 1000ms
 	for i := 0; i < 3; i++ {
 		head, err = s3Client.HeadObject(&s3.HeadObjectInput{

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"github.com/ente-io/museum/pkg/controller/access"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	gTime "time"
@@ -26,7 +25,6 @@ import (
 	"github.com/ente-io/stacktrace"
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -78,8 +76,7 @@ const (
 )
 
 func (c *FileController) validateFileCreateOrUpdateReq(userID int64, file ente.File, app ente.App) error {
-	objectPathPrefix := strconv.FormatInt(userID, 10) + "/"
-	if !strings.HasPrefix(file.File.ObjectKey, objectPathPrefix) || !strings.HasPrefix(file.Thumbnail.ObjectKey, objectPathPrefix) {
+	if !c.S3Config.ValidateDBKey(file.File.ObjectKey, userID) || !c.S3Config.ValidateDBKey(file.Thumbnail.ObjectKey, userID) {
 		return stacktrace.Propagate(ente.ErrBadRequest, "Incorrect object key reported")
 	}
 	if file.File.ObjectKey == file.Thumbnail.ObjectKey {
@@ -335,7 +332,7 @@ func (c *FileController) GetUploadURLs(ctx context.Context, userID int64, count 
 		count = MaxUploadURLsLimit
 	}
 	for i := 0; i < count; i++ {
-		objectKey := strconv.FormatInt(userID, 10) + "/" + uuid.NewString()
+		objectKey := c.S3Config.NewDBObjectKey(userID)
 		objectKeys = append(objectKeys, objectKey)
 		url, err := c.getObjectURL(s3Client, dc, bucket, objectKey, nil, nil)
 		if err != nil {
@@ -365,7 +362,7 @@ func (c *FileController) GetUploadURLWithMetadata(ctx context.Context, userID in
 	s3Client := c.S3Config.GetHotS3Client()
 	dc := c.S3Config.GetHotDataCenter()
 	bucket := c.S3Config.GetHotBucket()
-	objectKey := strconv.FormatInt(userID, 10) + "/" + uuid.NewString()
+	objectKey := c.S3Config.NewDBObjectKey(userID)
 	length := req.ContentLength
 	checksumCopy := checksum
 	url, err := c.getObjectURL(s3Client, dc, bucket, objectKey, &length, &checksumCopy)
@@ -643,8 +640,7 @@ func (c *FileController) UpdateMagicMetadata(ctx *gin.Context, req ente.UpdateMu
 // UpdateThumbnail updates thumbnail of a file
 func (c *FileController) UpdateThumbnail(ctx *gin.Context, fileID int64, newThumbnail ente.FileAttributes, app ente.App) error {
 	userID := auth.GetUserID(ctx.Request.Header)
-	objectPathPrefix := strconv.FormatInt(userID, 10) + "/"
-	if !strings.HasPrefix(newThumbnail.ObjectKey, objectPathPrefix) {
+	if !c.S3Config.ValidateDBKey(newThumbnail.ObjectKey, userID) {
 		return stacktrace.Propagate(ente.ErrBadRequest, "Incorrect object key reported")
 	}
 	ownerID, err := c.FileRepo.GetOwnerID(fileID)
@@ -868,9 +864,10 @@ func (c *FileController) cleanupDeletedFile(qItem repo.QueueItem) {
 
 func (c *FileController) getHotDcSignedUrl(objectKey string, objType ente.ObjectType) (string, error) {
 	s3Client := c.S3Config.GetHotS3Client()
+	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetHotBucket(),
-		Key:    &objectKey,
+		Key:    &fullKey,
 	}
 	input.ResponseContentDisposition = aws.String("attachment")
 	if objType == ente.FILE || objType == ente.THUMBNAIL {
@@ -882,9 +879,10 @@ func (c *FileController) getHotDcSignedUrl(objectKey string, objType ente.Object
 
 func (c *FileController) getPreSignedURLForDC(objectKey string, dc string, objType ente.ObjectType) (string, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(dc),
-		Key:    &objectKey,
+		Key:    &fullKey,
 	}
 	input.ResponseContentDisposition = aws.String("attachment")
 	if objType == ente.FILE || objType == ente.THUMBNAIL {
@@ -897,12 +895,13 @@ func (c *FileController) getPreSignedURLForDC(objectKey string, dc string, objTy
 func (c *FileController) sizeOf(objectKey string) (int64, error) {
 	s3Client := c.S3Config.GetHotS3Client()
 	bucket := c.S3Config.GetHotBucket()
+	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
 	var head *s3.HeadObjectOutput
 	var err error
 	// Retry twice with a delay of 500ms and 1000ms
 	for i := 0; i < 3; i++ {
 		head, err = s3Client.HeadObject(&s3.HeadObjectInput{
-			Key:    &objectKey,
+			Key:    &fullKey,
 			Bucket: bucket,
 		})
 		if err == nil {
@@ -1006,8 +1005,9 @@ func (c *FileController) rollbackObject(objectKey string) error {
 
 func (c *FileController) getVersions(objectKey string) ([]*s3.ObjectVersion, error) {
 	s3Client := c.S3Config.GetHotS3Client()
+	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
 	response, err := s3Client.ListObjectVersions(&s3.ListObjectVersionsInput{
-		Prefix: &objectKey,
+		Prefix: &fullKey,
 		Bucket: c.S3Config.GetHotBucket(),
 	})
 	if err != nil {
@@ -1018,9 +1018,10 @@ func (c *FileController) getVersions(objectKey string) ([]*s3.ObjectVersion, err
 
 func (c *FileController) deleteObjectVersionFromHotStorage(objectKey string, versionID string) error {
 	var s3Client = c.S3Config.GetHotS3Client()
+	fullKey := c.S3Config.FullKey(c.S3Config.GetHotDataCenter(), objectKey)
 	_, err := s3Client.DeleteObject(&s3.DeleteObjectInput{
 		Bucket:    c.S3Config.GetHotBucket(),
-		Key:       &objectKey,
+		Key:       &fullKey,
 		VersionId: &versionID,
 	})
 	if err != nil {
@@ -1028,7 +1029,7 @@ func (c *FileController) deleteObjectVersionFromHotStorage(objectKey string, ver
 	}
 	err = s3Client.WaitUntilObjectNotExists(&s3.HeadObjectInput{
 		Bucket: c.S3Config.GetHotBucket(),
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "")
@@ -1036,10 +1037,16 @@ func (c *FileController) deleteObjectVersionFromHotStorage(objectKey string, ver
 	return nil
 }
 
+// getObjectURL returns a presigned PUT URL for the given database-style
+// object key. The bucket's configured prefix (if any) is applied when signing
+// the request, but the key returned to the caller (and stored in
+// temp_objects) is the bare dbKey without the prefix. This keeps the prefix
+// confined to the S3 boundary.
 func (c *FileController) getObjectURL(s3Client *s3.S3, dc string, bucket *string, objectKey string, contentLength *int64, contentMD5 *string) (ente.UploadURL, error) {
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	input := &s3.PutObjectInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	}
 	if contentLength != nil {
 		input.ContentLength = contentLength
@@ -1071,10 +1078,11 @@ func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int6
 	s3Client := c.S3Config.GetHotS3Client()
 	dc := c.S3Config.GetHotDataCenter()
 	bucket := c.S3Config.GetHotBucket()
-	objectKey := strconv.FormatInt(userID, 10) + "/" + uuid.NewString()
+	objectKey := c.S3Config.NewDBObjectKey(userID)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	r, err := s3Client.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
@@ -1086,7 +1094,7 @@ func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int6
 	multipartUploadURLs := ente.MultipartUploadURLs{ObjectKey: objectKey}
 	urls := make([]string, 0)
 	for i := 0; i < count; i++ {
-		url, err := c.getPartURL(*s3Client, objectKey, int64(i+1), r.UploadId, nil, nil)
+		url, err := c.getPartURL(*s3Client, fullKey, int64(i+1), r.UploadId, nil, nil)
 		if err != nil {
 			return multipartUploadURLs, stacktrace.Propagate(err, "")
 		}
@@ -1095,7 +1103,7 @@ func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int6
 	multipartUploadURLs.PartURLs = urls
 	r2, _ := s3Client.CompleteMultipartUploadRequest(&s3.CompleteMultipartUploadInput{
 		Bucket:   c.S3Config.GetHotBucket(),
-		Key:      &objectKey,
+		Key:      &fullKey,
 		UploadId: r.UploadId,
 	})
 	url, err := r2.Presign(PreSignedRequestValidityDuration)
@@ -1143,10 +1151,11 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	s3Client := c.S3Config.GetHotS3Client()
 	dc := c.S3Config.GetHotDataCenter()
 	bucket := c.S3Config.GetHotBucket()
-	objectKey := strconv.FormatInt(userID, 10) + "/" + uuid.NewString()
+	objectKey := c.S3Config.NewDBObjectKey(userID)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	r, err := s3Client.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
@@ -1161,7 +1170,7 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 		length := partLengths[i]
 		lengthCopy := length
 		checksumCopy := normalizedChecksums[i]
-		url, err := c.getPartURL(*s3Client, objectKey, partNumber, r.UploadId, &lengthCopy, &checksumCopy)
+		url, err := c.getPartURL(*s3Client, fullKey, partNumber, r.UploadId, &lengthCopy, &checksumCopy)
 		if err != nil {
 			return multipartUploadURLs, stacktrace.Propagate(err, "")
 		}
@@ -1170,7 +1179,7 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	multipartUploadURLs.PartURLs = urls
 	r2, _ := s3Client.CompleteMultipartUploadRequest(&s3.CompleteMultipartUploadInput{
 		Bucket:   c.S3Config.GetHotBucket(),
-		Key:      &objectKey,
+		Key:      &fullKey,
 		UploadId: r.UploadId,
 	})
 	url, err := r2.Presign(PreSignedRequestValidityDuration)
@@ -1181,6 +1190,10 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	return multipartUploadURLs, nil
 }
 
+// getPartURL presigns a PUT URL for a single part of a multipart upload.
+// objectKey is the full S3 key (with any bucket prefix already applied by
+// the caller); the caller also owns the upload session identified by
+// uploadID.
 func (c *FileController) getPartURL(s3Client s3.S3, objectKey string, partNumber int64, uploadID *string, contentLength *int64, contentMD5 *string) (string, error) {
 	input := &s3.UploadPartInput{
 		Bucket:     c.S3Config.GetHotBucket(),

--- a/server/pkg/controller/file_copy/file_copy.go
+++ b/server/pkg/controller/file_copy/file_copy.go
@@ -172,13 +172,15 @@ func (fc *FileCopyController) CopyFiles(c *gin.Context, req ente.CopyFileSyncReq
 func (fc *FileCopyController) createCopy(c *gin.Context, fcInternal fileCopyInternal, userID int64, app ente.App) (*ente.File, error) {
 	// using HotS3Client copy the File and Thumbnail
 	s3Client := fc.S3Config.GetHotS3Client()
+	hotDC := fc.S3Config.GetHotDataCenter()
 	hotBucket := fc.S3Config.GetHotBucket()
+	bucketPrefix := fc.S3Config.GetPrefix(hotDC)
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		return copyS3Object(s3Client, hotBucket, fcInternal.FileCopyReq)
+		return copyS3Object(s3Client, hotBucket, bucketPrefix, fcInternal.FileCopyReq)
 	})
 	g.Go(func() error {
-		return copyS3Object(s3Client, hotBucket, fcInternal.ThumbCopyReq)
+		return copyS3Object(s3Client, hotBucket, bucketPrefix, fcInternal.ThumbCopyReq)
 	})
 	if err := g.Wait(); err != nil {
 		return nil, err
@@ -192,19 +194,25 @@ func (fc *FileCopyController) createCopy(c *gin.Context, fcInternal fileCopyInte
 }
 
 // Helper function for S3 object copying.
-func copyS3Object(s3Client *s3.S3, bucket *string, req *copyS3ObjectReq) error {
-	copySource := fmt.Sprintf("%s/%s", *bucket, req.SourceS3Object.ObjectKey)
+//
+// bucketPrefix is the configured prefix for the hot storage DC; it is
+// prepended to both the source and destination object keys before issuing the
+// CopyObject call. The database-level keys in req remain unprefixed.
+func copyS3Object(s3Client *s3.S3, bucket *string, bucketPrefix string, req *copyS3ObjectReq) error {
+	srcKey := bucketPrefix + req.SourceS3Object.ObjectKey
+	dstKey := bucketPrefix + req.DestObjectKey
+	copySource := fmt.Sprintf("%s/%s", *bucket, srcKey)
 	copyInput := &s3.CopyObjectInput{
 		Bucket:     bucket,
 		CopySource: &copySource,
-		Key:        &req.DestObjectKey,
+		Key:        &dstKey,
 	}
 	start := time.Now()
 	_, err := s3Client.CopyObject(copyInput)
 	elapsed := time.Since(start)
 	if err != nil {
-		return fmt.Errorf("failed to copy (%s) from %s to %s: %w", req.SourceS3Object.Type, copySource, req.DestObjectKey, err)
+		return fmt.Errorf("failed to copy (%s) from %s to %s: %w", req.SourceS3Object.Type, copySource, dstKey, err)
 	}
-	logrus.WithField("duration", elapsed).WithField("size", req.SourceS3Object.FileSize).Infof("copied (%s) from %s to %s", req.SourceS3Object.Type, copySource, req.DestObjectKey)
+	logrus.WithField("duration", elapsed).WithField("size", req.SourceS3Object.FileSize).Infof("copied (%s) from %s to %s", req.SourceS3Object.Type, copySource, dstKey)
 	return nil
 }

--- a/server/pkg/controller/file_copy/file_copy.go
+++ b/server/pkg/controller/file_copy/file_copy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ente-io/museum/pkg/utils/auth"
 	"github.com/ente-io/museum/pkg/utils/s3config"
 	enteTime "github.com/ente-io/museum/pkg/utils/time"
+	"github.com/ente-io/stacktrace"
 	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -174,13 +175,26 @@ func (fc *FileCopyController) createCopy(c *gin.Context, fcInternal fileCopyInte
 	s3Client := fc.S3Config.GetHotS3Client()
 	hotDC := fc.S3Config.GetHotDataCenter()
 	hotBucket := fc.S3Config.GetHotBucket()
-	bucketPrefix := fc.S3Config.GetPrefix(hotDC)
+	// Resolve source keys with legacy fallback so that copies of files
+	// uploaded before the prefix was configured still succeed. Destination
+	// keys always land under the (potentially empty) prefix since they're
+	// being written for the first time.
+	fileSrcKey, err := fc.S3Config.ResolveKey(hotDC, fcInternal.FileCopyReq.SourceS3Object.ObjectKey)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	thumbSrcKey, err := fc.S3Config.ResolveKey(hotDC, fcInternal.ThumbCopyReq.SourceS3Object.ObjectKey)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	fileDstKey := fc.S3Config.FullKey(hotDC, fcInternal.FileCopyReq.DestObjectKey)
+	thumbDstKey := fc.S3Config.FullKey(hotDC, fcInternal.ThumbCopyReq.DestObjectKey)
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		return copyS3Object(s3Client, hotBucket, bucketPrefix, fcInternal.FileCopyReq)
+		return copyS3Object(s3Client, hotBucket, fileSrcKey, fileDstKey, fcInternal.FileCopyReq)
 	})
 	g.Go(func() error {
-		return copyS3Object(s3Client, hotBucket, bucketPrefix, fcInternal.ThumbCopyReq)
+		return copyS3Object(s3Client, hotBucket, thumbSrcKey, thumbDstKey, fcInternal.ThumbCopyReq)
 	})
 	if err := g.Wait(); err != nil {
 		return nil, err
@@ -195,12 +209,10 @@ func (fc *FileCopyController) createCopy(c *gin.Context, fcInternal fileCopyInte
 
 // Helper function for S3 object copying.
 //
-// bucketPrefix is the configured prefix for the hot storage DC; it is
-// prepended to both the source and destination object keys before issuing the
-// CopyObject call. The database-level keys in req remain unprefixed.
-func copyS3Object(s3Client *s3.S3, bucket *string, bucketPrefix string, req *copyS3ObjectReq) error {
-	srcKey := bucketPrefix + req.SourceS3Object.ObjectKey
-	dstKey := bucketPrefix + req.DestObjectKey
+// srcKey and dstKey are the already-resolved S3 keys (with bucket prefix
+// applied, including any legacy-fallback resolution for the source). The
+// database-level keys in req remain unprefixed.
+func copyS3Object(s3Client *s3.S3, bucket *string, srcKey, dstKey string, req *copyS3ObjectReq) error {
 	copySource := fmt.Sprintf("%s/%s", *bucket, srcKey)
 	copyInput := &s3.CopyObjectInput{
 		Bucket:     bucket,

--- a/server/pkg/controller/filedata/s3.go
+++ b/server/pkg/controller/filedata/s3.go
@@ -90,7 +90,12 @@ func (c *Controller) getMultiPartUploadURL(dc string, objectKey string, count *i
 
 func (c *Controller) signedUrlGet(dc string, objectKey string) (*ente.UploadURL, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
-	fullKey := c.S3Config.FullKey(dc, objectKey)
+	// ResolveKey falls back to the legacy bucket-root path if the object
+	// does not exist under the configured prefix.
+	fullKey, err := c.S3Config.ResolveKey(dc, objectKey)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(dc),
 		Key:    &fullKey,
@@ -108,9 +113,12 @@ func (c *Controller) downloadObject(ctx context.Context, objectKey string, dc st
 	var obj fileData.S3FileMetadata
 	buff := &aws.WriteAtBuffer{}
 	bucket := c.S3Config.GetBucket(dc)
-	fullKey := c.S3Config.FullKey(dc, objectKey)
+	fullKey, err := c.S3Config.ResolveKey(dc, objectKey)
+	if err != nil {
+		return obj, stacktrace.Propagate(err, "")
+	}
 	downloader := c.downloadManagerCache[dc]
-	_, err := downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
+	_, err = downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
 		Bucket: bucket,
 		Key:    &fullKey,
 	})
@@ -194,7 +202,12 @@ func (c *Controller) replicateObject(ctx context.Context, req *ReplicateObjectRe
 	defer file.Close()
 	//s3Client := c.S3Config.GetS3Client(req.SrcBucketID)
 	bucket := c.S3Config.GetBucket(req.SrcBucketID)
-	srcKey := c.S3Config.FullKey(req.SrcBucketID, req.ObjectKey)
+	// Resolve with legacy fallback — the source may be a deployment whose
+	// existing data lives at the bucket root (pre-prefix).
+	srcKey, err := c.S3Config.ResolveKey(req.SrcBucketID, req.ObjectKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
 	downloader := c.downloadManagerCache[req.SrcBucketID]
 	_, err = downloader.DownloadWithContext(ctx, file, &s3.GetObjectInput{
 		Bucket: bucket,

--- a/server/pkg/controller/filedata/s3.go
+++ b/server/pkg/controller/filedata/s3.go
@@ -23,9 +23,10 @@ const PreSignedRequestValidityDuration = 7 * 24 * stime.Hour
 
 func (c *Controller) getUploadURL(dc string, objectKey string) (*ente.UploadURL, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	r, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket: c.S3Config.GetBucket(dc),
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	url, err := r.Presign(PreSignedRequestValidityDuration)
 	if err != nil {
@@ -46,9 +47,10 @@ func (c *Controller) getUploadURL(dc string, objectKey string) (*ente.UploadURL,
 func (c *Controller) getMultiPartUploadURL(dc string, objectKey string, count *int64) (*ente.MultipartUploadURLs, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
 	bucket := c.S3Config.GetBucket(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	r, err := s3Client.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
@@ -62,7 +64,7 @@ func (c *Controller) getMultiPartUploadURL(dc string, objectKey string, count *i
 	for i := int64(1); i <= *count; i++ {
 		partReq, _ := s3Client.UploadPartRequest(&s3.UploadPartInput{
 			Bucket:     bucket,
-			Key:        &objectKey,
+			Key:        &fullKey,
 			UploadId:   r.UploadId,
 			PartNumber: &i,
 		})
@@ -75,7 +77,7 @@ func (c *Controller) getMultiPartUploadURL(dc string, objectKey string, count *i
 	multipartUploadURLs.PartURLs = urls
 	r2, _ := s3Client.CompleteMultipartUploadRequest(&s3.CompleteMultipartUploadInput{
 		Bucket:   bucket,
-		Key:      &objectKey,
+		Key:      &fullKey,
 		UploadId: r.UploadId,
 	})
 	url, err := r2.Presign(PreSignedRequestValidityDuration)
@@ -88,9 +90,10 @@ func (c *Controller) getMultiPartUploadURL(dc string, objectKey string, count *i
 
 func (c *Controller) signedUrlGet(dc string, objectKey string) (*ente.UploadURL, error) {
 	s3Client := c.S3Config.GetS3Client(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	input := &s3.GetObjectInput{
 		Bucket: c.S3Config.GetBucket(dc),
-		Key:    &objectKey,
+		Key:    &fullKey,
 	}
 	input.ResponseContentDisposition = aws.String("attachment")
 	r, _ := s3Client.GetObjectRequest(input)
@@ -105,10 +108,11 @@ func (c *Controller) downloadObject(ctx context.Context, objectKey string, dc st
 	var obj fileData.S3FileMetadata
 	buff := &aws.WriteAtBuffer{}
 	bucket := c.S3Config.GetBucket(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	downloader := c.downloadManagerCache[dc]
 	_, err := downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return obj, err
@@ -125,10 +129,11 @@ func (c *Controller) uploadObject(obj fileData.S3FileMetadata, objectKey string,
 	embeddingObj, _ := json.Marshal(obj)
 	s3Client := c.S3Config.GetS3Client(dc)
 	s3Bucket := c.S3Config.GetBucket(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	uploader := s3manager.NewUploaderWithClient(&s3Client)
 	up := s3manager.UploadInput{
 		Bucket: s3Bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 		Body:   bytes.NewReader(embeddingObj),
 	}
 	var err error
@@ -151,9 +156,10 @@ func (c *Controller) uploadObject(obj fileData.S3FileMetadata, objectKey string,
 func (c *Controller) verifySize(bucketID string, objectKey string, expectedSize int64) error {
 	s3Client := c.S3Config.GetS3Client(bucketID)
 	bucket := c.S3Config.GetBucket(bucketID)
+	fullKey := c.S3Config.FullKey(bucketID, objectKey)
 	res, err := s3Client.HeadObject(&s3.HeadObjectInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "Fetching object info from bucket %s failed", *bucket)
@@ -188,10 +194,11 @@ func (c *Controller) replicateObject(ctx context.Context, req *ReplicateObjectRe
 	defer file.Close()
 	//s3Client := c.S3Config.GetS3Client(req.SrcBucketID)
 	bucket := c.S3Config.GetBucket(req.SrcBucketID)
+	srcKey := c.S3Config.FullKey(req.SrcBucketID, req.ObjectKey)
 	downloader := c.downloadManagerCache[req.SrcBucketID]
 	_, err = downloader.DownloadWithContext(ctx, file, &s3.GetObjectInput{
 		Bucket: bucket,
-		Key:    &req.ObjectKey,
+		Key:    &srcKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to download object from bucket %s", req.SrcBucketID)
@@ -202,9 +209,10 @@ func (c *Controller) replicateObject(ctx context.Context, req *ReplicateObjectRe
 	dstClient := c.S3Config.GetS3Client(req.DestBucketID)
 	uploader := s3manager.NewUploaderWithClient(&dstClient)
 	file.Seek(0, io.SeekStart)
+	dstKey := c.S3Config.FullKey(req.DestBucketID, req.ObjectKey)
 	up := s3manager.UploadInput{
 		Bucket: c.S3Config.GetBucket(req.DestBucketID),
-		Key:    aws.String(req.ObjectKey),
+		Key:    aws.String(dstKey),
 		Body:   file,
 	}
 	result, err := uploader.Upload(&up)

--- a/server/pkg/controller/object.go
+++ b/server/pkg/controller/object.go
@@ -107,12 +107,13 @@ func (c *ObjectController) removeComplianceHold(qItem repo.QueueItem) {
 	for _, dc := range dcs {
 		if dc == complianceDC {
 			logger.Info("Removing compliance hold")
-			err = c.DisableObjectConditionalHold(&s3Client, bucket, objectKey)
+			fullKey := config.FullKey(dc, objectKey)
+			err = c.DisableObjectConditionalHold(&s3Client, bucket, fullKey)
 			if err != nil {
 				logger.WithError(err).Errorf("Failed to remove compliance hold (dc: %s, bucket: %s)", dc, bucket)
 				return
 			}
-			logger.Infof("Removed compliance hold for %s/%s", bucket, objectKey)
+			logger.Infof("Removed compliance hold for %s/%s", bucket, fullKey)
 			break
 		}
 	}

--- a/server/pkg/controller/object_cleanup.go
+++ b/server/pkg/controller/object_cleanup.go
@@ -295,12 +295,19 @@ func (c *ObjectCleanupController) DeleteAllObjectsWithPrefix(prefix string, dc s
 // DeleteObjectFromDataCenter deletes an object from S3. The input objectKey is
 // the database-style key ({userID}/{uuid}); the DC's configured bucket prefix
 // is added before calling S3.
+//
+// When a bucket prefix is configured, the object is resolved with a
+// transparent fallback to the legacy root location, so that files uploaded
+// before the prefix was turned on can still be deleted cleanly.
 func (c *ObjectCleanupController) DeleteObjectFromDataCenter(objectKey string, dc string) error {
 	log.Info("Deleting " + objectKey + " from " + dc)
 	var s3Client = c.S3Config.GetS3Client(dc)
 	bucket := c.S3Config.GetBucket(dc)
-	fullKey := c.S3Config.FullKey(dc, objectKey)
-	_, err := s3Client.DeleteObject(&s3.DeleteObjectInput{
+	fullKey, err := c.S3Config.ResolveKey(dc, objectKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	_, err = s3Client.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: bucket,
 		Key:    &fullKey,
 	})

--- a/server/pkg/controller/object_cleanup.go
+++ b/server/pkg/controller/object_cleanup.go
@@ -254,12 +254,17 @@ func (c *ObjectCleanupController) AddMultipartTempObjectKey(objectKey string, up
 	return stacktrace.Propagate(err, "")
 }
 
+// DeleteAllObjectsWithPrefix deletes all objects under a given database-style
+// key prefix (e.g. "{userID}/" or "{userID}/file-data/{fileID}/"). The DC's
+// bucket prefix, if configured, is applied when listing and deleting so the
+// caller can continue to think purely in database keys.
 func (c *ObjectCleanupController) DeleteAllObjectsWithPrefix(prefix string, dc string) error {
 	s3Client := c.S3Config.GetS3Client(dc)
 	bucket := c.S3Config.GetBucket(dc)
+	fullPrefix := c.S3Config.FullKey(dc, prefix)
 	output, err := s3Client.ListObjectsV2(&s3.ListObjectsV2Input{
 		Bucket: bucket,
-		Prefix: &prefix,
+		Prefix: &fullPrefix,
 	})
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -270,7 +275,9 @@ func (c *ObjectCleanupController) DeleteAllObjectsWithPrefix(prefix string, dc s
 	}
 	var keys []string
 	for _, obj := range output.Contents {
-		keys = append(keys, *obj.Key)
+		// Convert back to database-style key before invoking DeleteObjectFromDataCenter,
+		// which expects dbKey and applies the DC prefix itself.
+		keys = append(keys, c.S3Config.StripPrefix(dc, *obj.Key))
 	}
 	for _, key := range keys {
 		err = c.DeleteObjectFromDataCenter(key, dc)
@@ -285,20 +292,24 @@ func (c *ObjectCleanupController) DeleteAllObjectsWithPrefix(prefix string, dc s
 	return nil
 }
 
+// DeleteObjectFromDataCenter deletes an object from S3. The input objectKey is
+// the database-style key ({userID}/{uuid}); the DC's configured bucket prefix
+// is added before calling S3.
 func (c *ObjectCleanupController) DeleteObjectFromDataCenter(objectKey string, dc string) error {
 	log.Info("Deleting " + objectKey + " from " + dc)
 	var s3Client = c.S3Config.GetS3Client(dc)
 	bucket := c.S3Config.GetBucket(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	_, err := s3Client.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
 	err = s3Client.WaitUntilObjectNotExists(&s3.HeadObjectInput{
 		Bucket: bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "")
@@ -309,9 +320,10 @@ func (c *ObjectCleanupController) DeleteObjectFromDataCenter(objectKey string, d
 func (c *ObjectCleanupController) abortMultipartUpload(objectKey string, uploadID string, dc string) error {
 	s3Client := c.S3Config.GetS3Client(dc)
 	bucket := c.S3Config.GetBucket(dc)
+	fullKey := c.S3Config.FullKey(dc, objectKey)
 	_, err := s3Client.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
 		Bucket:   bucket,
-		Key:      &objectKey,
+		Key:      &fullKey,
 		UploadId: &uploadID,
 	})
 	if err != nil {
@@ -323,7 +335,7 @@ func (c *ObjectCleanupController) abortMultipartUpload(objectKey string, uploadI
 	}
 	r, err := s3Client.ListParts(&s3.ListPartsInput{
 		Bucket:   bucket,
-		Key:      &objectKey,
+		Key:      &fullKey,
 		UploadId: &uploadID,
 	})
 	if err != nil {
@@ -481,9 +493,13 @@ func (c *ObjectCleanupController) ClearOrphanObjects(dc string, prefix string, f
 	// can span hours, and we don't want a different instance to start another
 	// run just because it was only considering the start time of the job.
 
+	// The caller-supplied prefix is in database-key form; combine it with the
+	// DC's configured bucket prefix (if any) so that we list only inside the
+	// Ente sub-folder and never touch unrelated data in the bucket.
+	fullPrefix := s3Config.FullKey(dc, prefix)
 	err := dest.Client.ListObjectVersionsPages(&s3.ListObjectVersionsInput{
 		Bucket: dest.Bucket,
-		Prefix: &prefix,
+		Prefix: &fullPrefix,
 	},
 		func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
 			c.clearOrphanObjectsPage(page, dest, logger)
@@ -610,7 +626,11 @@ func (c *ObjectCleanupController) clearOrphanObjectsVersionOrDeleteMarker(od Obj
 		return
 	}
 
-	objectKey := *od.GetKey()
+	// The key returned by S3 includes the DC's bucket prefix (if any). Strip
+	// it to get the database-style key we use when checking membership in the
+	// DB. Keep fullKey around for S3 operations (delete, compliance hold).
+	fullKey := *od.GetKey()
+	objectKey := c.S3Config.StripPrefix(dest.DC, fullKey)
 	lastModified := *od.GetLastModified()
 
 	logger = logger.WithFields(log.Fields{
@@ -640,8 +660,9 @@ func (c *ObjectCleanupController) clearOrphanObjectsVersionOrDeleteMarker(od Obj
 	logger.Infof("Found orphan object %v", od)
 
 	if dest.HasComplianceHold {
-		// Remove compliance hold.
-		err := c.ObjectController.DisableObjectConditionalHold(&dest.Client, *dest.Bucket, objectKey)
+		// Remove compliance hold. Wasabi's API takes the full key (as it
+		// appears in S3), not the database key.
+		err := c.ObjectController.DisableObjectConditionalHold(&dest.Client, *dest.Bucket, fullKey)
 		if err != nil {
 			logger.Error(stacktrace.Propagate(err, "Failed to disable conditional hold on object"))
 			return
@@ -658,7 +679,7 @@ func (c *ObjectCleanupController) clearOrphanObjectsVersionOrDeleteMarker(od Obj
 		// Delete it right away.
 		versionID := od.GetVersionId()
 		logger.Infof("Deleting version '%s'", enteString.EmptyIfNil(versionID))
-		err := c.DeleteObjectVersion(objectKey, versionID, dest)
+		err := c.DeleteObjectVersion(fullKey, versionID, dest)
 		if err != nil {
 			logger.Error(stacktrace.Propagate(err, "Failed to delete object"))
 		}
@@ -668,6 +689,7 @@ func (c *ObjectCleanupController) clearOrphanObjectsVersionOrDeleteMarker(od Obj
 }
 
 // DeleteObjectVersion can be used to delete objects from versioned buckets.
+// objectKey here is the full S3 key (with any bucket prefix already applied).
 //
 // If we delete an object in a versioning enabled bucket, deletion does not
 // actually remove the object and instead creates a delete marker:

--- a/server/pkg/controller/replication3.go
+++ b/server/pkg/controller/replication3.go
@@ -406,10 +406,14 @@ func (c *ReplicationController3) downloadFromB2ViaWorker(objectKey string, file 
 }
 
 // Get a presigned URL to download the object with objectKey from the B2 bucket.
-// objectKey is the database-style key; the primary DC's configured bucket
-// prefix (if any) is applied before signing.
+// objectKey is the database-style key; the source DC's prefix (if any) is
+// applied when resolving the S3 location, transparently falling back to a
+// bucket-root key for objects that pre-date the prefix configuration.
 func (c *ReplicationController3) getPresignedB2URL(objectKey string) (string, error) {
-	fullKey := c.S3Config.FullKey(c.S3Config.GetHotBackblazeDC(), objectKey)
+	fullKey, err := c.S3Config.ResolveKey(c.S3Config.GetHotBackblazeDC(), objectKey)
+	if err != nil {
+		return "", err
+	}
 	r, _ := c.b2Client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: c.b2Bucket,
 		Key:    &fullKey,

--- a/server/pkg/controller/replication3.go
+++ b/server/pkg/controller/replication3.go
@@ -406,10 +406,13 @@ func (c *ReplicationController3) downloadFromB2ViaWorker(objectKey string, file 
 }
 
 // Get a presigned URL to download the object with objectKey from the B2 bucket.
+// objectKey is the database-style key; the primary DC's configured bucket
+// prefix (if any) is applied before signing.
 func (c *ReplicationController3) getPresignedB2URL(objectKey string) (string, error) {
+	fullKey := c.S3Config.FullKey(c.S3Config.GetHotBackblazeDC(), objectKey)
 	r, _ := c.b2Client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: c.b2Bucket,
-		Key:    &objectKey,
+		Key:    &fullKey,
 	})
 	return r.Presign(PreSignedRequestValidityDuration)
 }
@@ -521,9 +524,13 @@ func (c *ReplicationController3) uploadFile(in *UploadInput, dest *UploadDestina
 	// Rewind the file pointer back to the start for the next upload.
 	in.File.Seek(0, io.SeekStart)
 
+	// The destination DC may have a configured bucket prefix. Apply it so
+	// replicated objects land under the same sub-folder on the destination
+	// as they would for direct uploads.
+	destKey := c.S3Config.FullKey(dest.DC, in.ObjectKey)
 	up := s3manager.UploadInput{
 		Bucket: dest.Bucket,
-		Key:    &in.ObjectKey,
+		Key:    &destKey,
 		Body:   in.File,
 	}
 	if dest.IsGlacier {
@@ -581,9 +588,10 @@ func (c *ReplicationController3) isRequestFailureAccessDenied(err error) bool {
 
 // Verify the uploaded file by doing a HEAD check and comparing sizes
 func (c *ReplicationController3) verifyUploadedFileSize(in *UploadInput, dest *UploadDestination) error {
+	destKey := c.S3Config.FullKey(dest.DC, in.ObjectKey)
 	res, err := dest.Client.HeadObject(&s3.HeadObjectInput{
 		Bucket: dest.Bucket,
-		Key:    &in.ObjectKey,
+		Key:    &destKey,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "Fetching object info from bucket %s failed", *dest.Bucket)

--- a/server/pkg/utils/s3config/locate.go
+++ b/server/pkg/utils/s3config/locate.go
@@ -1,0 +1,69 @@
+package s3config
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// ResolveKey is a convenience wrapper around LocateKey that performs the
+// existence check against the S3 client for the given data center.
+//
+// When no prefix is configured for dc, it returns the database key unchanged
+// without issuing any S3 requests. When a prefix is configured, it issues
+// at most two HEAD requests (prefixed path, then legacy root path) to find
+// where the object actually lives.
+//
+// This should be used in read paths (presigned GET URL, HEAD, replication
+// download, deletion) so that deployments which turn on the prefix after
+// accumulating data continue to serve files uploaded under the old root
+// path. Write paths (upload, multipart) should always use FullKey so that
+// new objects land under the configured prefix.
+func (config *S3Config) ResolveKey(dc, dbKey string) (string, error) {
+	if config.bucketPrefixes[dc] == "" {
+		return dbKey, nil
+	}
+
+	client, ok := config.s3Clients[dc]
+	if !ok {
+		// No S3 client for this DC; return the prefixed path as the
+		// best-effort guess and let the caller's later operation fail
+		// with a clearer error than a nil panic here.
+		return config.FullKey(dc, dbKey), nil
+	}
+
+	bucket := config.buckets[dc]
+	exists := func(key string) (bool, error) {
+		_, err := client.HeadObject(&s3.HeadObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		if err == nil {
+			return true, nil
+		}
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return config.LocateKey(dc, dbKey, exists)
+}
+
+// isNotFound reports whether the given error represents an S3 NotFound or
+// NoSuchKey response (both map to HTTP 404 depending on the endpoint). All
+// other errors are propagated up so that transient failures don't silently
+// degrade into a false fallback.
+func isNotFound(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		switch awsErr.Code() {
+		case s3.ErrCodeNoSuchKey, "NotFound":
+			return true
+		}
+		if reqErr, ok := err.(awserr.RequestFailure); ok {
+			return reqErr.StatusCode() == http.StatusNotFound
+		}
+	}
+	return false
+}

--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -2,11 +2,15 @@ package s3config
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/ente-io/museum/ente"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
@@ -26,6 +30,16 @@ import (
 type S3Config struct {
 	// A map from data centers to the name of the bucket used in that DC.
 	buckets map[string]string
+	// A map from data centers to the optional object key prefix used in that
+	// DC. If set, this prefix is prepended to object keys when interacting with
+	// S3. The prefix is NOT stored in the database — the database keeps the
+	// bare object key ({userID}/{uuid}) and the prefix is added/stripped at
+	// the S3 boundary. This allows Ente to coexist with other data in the same
+	// bucket by confining itself to a sub-folder.
+	//
+	// Empty string means no prefix (default behavior, unchanged from before).
+	// If set, always ends with "/" (normalized in initialize()).
+	bucketPrefixes map[string]string
 	// Primary (hot) data center
 	hotDC string
 	// Secondary (hot) data center
@@ -124,6 +138,7 @@ func (config *S3Config) initialize() {
 	}
 
 	config.buckets = make(map[string]string)
+	config.bucketPrefixes = make(map[string]string)
 	config.s3Configs = make(map[string]*aws.Config)
 	config.s3Clients = make(map[string]s3.S3)
 
@@ -133,6 +148,17 @@ func (config *S3Config) initialize() {
 
 	for _, dc := range dcs {
 		config.buckets[dc] = viper.GetString("s3." + dc + ".bucket")
+		prefix := viper.GetString("s3." + dc + ".prefix")
+		if prefix != "" {
+			// Normalize: strip leading '/' (prefix is relative to bucket root)
+			// and ensure trailing '/' so concatenation yields correct keys.
+			prefix = strings.TrimPrefix(prefix, "/")
+			if !strings.HasSuffix(prefix, "/") {
+				prefix += "/"
+			}
+			log.Infof("Bucket %s: using key prefix %q", dc, prefix)
+		}
+		config.bucketPrefixes[dc] = prefix
 		s3Config := aws.Config{
 			Credentials: credentials.NewStaticCredentials(viper.GetString("s3."+dc+".key"),
 				viper.GetString("s3."+dc+".secret"), ""),
@@ -293,4 +319,83 @@ func (config *S3Config) WasabiComplianceDC() string {
 // various workarounds for debugging locally; not meant for production use.
 func (config *S3Config) AreLocalBuckets() bool {
 	return config.areLocalBuckets
+}
+
+// GetPrefix returns the configured S3 key prefix for the given data center, or
+// an empty string if no prefix has been configured. When non-empty, the
+// returned value always ends with "/".
+//
+// The prefix is an optional configuration that lets self-hosted Ente
+// instances store all objects under a sub-folder inside a bucket shared with
+// other data. When a prefix is configured, Ente will only read/write/delete
+// objects under that prefix, leaving the rest of the bucket untouched.
+//
+// The prefix is NEVER stored in the database. It is added to object keys at
+// the S3 boundary (uploads, presigned URLs, listing, deletion) and stripped
+// when reading object keys back from S3 (e.g. during orphan cleanup).
+func (config *S3Config) GetPrefix(dc string) string {
+	return config.bucketPrefixes[dc]
+}
+
+// HasPrefix reports whether any configured data center uses a non-empty key
+// prefix. Useful for fast paths where prefix handling can be skipped
+// entirely.
+func (config *S3Config) HasPrefix() bool {
+	for _, p := range config.bucketPrefixes {
+		if p != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// FullKey returns the full S3 object key for a given database key in the
+// given data center. If the DC has no prefix configured, the database key is
+// returned unchanged.
+//
+// The database stores bare object keys of the form "{userID}/{uuid}" (or the
+// more structured "{userID}/file-data/..." form for derived data). This
+// method is the single place that prepends the per-DC prefix when talking to
+// S3.
+func (config *S3Config) FullKey(dc, dbKey string) string {
+	prefix := config.bucketPrefixes[dc]
+	if prefix == "" {
+		return dbKey
+	}
+	return prefix + dbKey
+}
+
+// StripPrefix removes the DC's prefix from a full S3 object key, returning
+// the bare database-style key. If the key does not start with the prefix (or
+// no prefix is configured), the key is returned unchanged.
+//
+// This is used when scanning S3 listings and comparing object keys against
+// entries in the database.
+func (config *S3Config) StripPrefix(dc, fullKey string) string {
+	prefix := config.bucketPrefixes[dc]
+	if prefix == "" {
+		return fullKey
+	}
+	return strings.TrimPrefix(fullKey, prefix)
+}
+
+// NewDBObjectKey generates a new database object key for a newly-uploaded
+// file. The key has the form "{userID}/{uuid}" and is independent of any
+// bucket prefix — the prefix is added later when building S3 requests.
+func (config *S3Config) NewDBObjectKey(userID int64) string {
+	return strconv.FormatInt(userID, 10) + "/" + uuid.NewString()
+}
+
+// UserPrefix returns the per-user prefix segment of a database object key,
+// i.e. "{userID}/". Note that this is the *user* prefix inside the bucket
+// (or inside the bucket's configured prefix), not the bucket prefix.
+func (config *S3Config) UserPrefix(userID int64) string {
+	return strconv.FormatInt(userID, 10) + "/"
+}
+
+// ValidateDBKey reports whether dbKey has the expected "{userID}/..." form
+// for the given user. This is a cheap structural check used when clients
+// report newly-uploaded object keys back to the server.
+func (config *S3Config) ValidateDBKey(dbKey string, userID int64) bool {
+	return strings.HasPrefix(dbKey, config.UserPrefix(userID))
 }

--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -399,3 +399,59 @@ func (config *S3Config) UserPrefix(userID int64) string {
 func (config *S3Config) ValidateDBKey(dbKey string, userID int64) bool {
 	return strings.HasPrefix(dbKey, config.UserPrefix(userID))
 }
+
+// LocateKey finds where an object actually lives in S3 for the given DC:
+// either under the configured bucket prefix (the default, and the only
+// location for new uploads) or at the bucket root (for data uploaded before
+// the prefix was configured).
+//
+// Behavior:
+//   - If no prefix is configured for dc, this is a no-op: it returns dbKey.
+//   - If a prefix is configured, it first checks `prefix + dbKey`. If the
+//     object exists there, that path is returned.
+//   - Otherwise, it falls back to checking `dbKey` at the bucket root. If
+//     the object exists there, that (legacy) path is returned.
+//   - If neither exists, the prefixed path is returned (so reads fail in the
+//     expected "new" location, matching the behavior when no prefix is set).
+//
+// This lets operators turn on `prefix` on an existing deployment without
+// making previously-uploaded files unreachable: new uploads go under the
+// prefix, old uploads continue to be served from the root, and admins can
+// migrate at their own pace (e.g. via `rclone move`).
+//
+// Note that this incurs an extra HEAD request on reads whenever the object
+// is not found under the prefix. On fresh deployments (where no legacy data
+// exists) this cost is amortized by the fact that any real object will be
+// found on the first HEAD, and no fallback is attempted.
+func (config *S3Config) LocateKey(dc, dbKey string, exists func(key string) (bool, error)) (string, error) {
+	prefix := config.bucketPrefixes[dc]
+	if prefix == "" {
+		// No prefix configured — there is only one possible path.
+		return dbKey, nil
+	}
+
+	prefixed := prefix + dbKey
+	found, err := exists(prefixed)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		return prefixed, nil
+	}
+
+	// Fall back to the legacy (pre-prefix) path at bucket root.
+	legacyFound, err := exists(dbKey)
+	if err != nil {
+		// Not a hard error — treat as "not there" and report the prefixed
+		// path so callers see a consistent "expected" location.
+		return prefixed, nil
+	}
+	if legacyFound {
+		return dbKey, nil
+	}
+
+	// Neither location has the object; return the prefixed path so that
+	// subsequent operations fail with the usual "not found" semantics in
+	// the location where new uploads would live.
+	return prefixed, nil
+}

--- a/server/pkg/utils/s3config/s3config_test.go
+++ b/server/pkg/utils/s3config/s3config_test.go
@@ -135,6 +135,96 @@ func TestValidateDBKey(t *testing.T) {
 	}
 }
 
+func TestLocateKey_NoPrefix(t *testing.T) {
+	c := newTestConfig(map[string]string{"dc": ""})
+
+	calls := 0
+	exists := func(key string) (bool, error) {
+		calls++
+		return true, nil
+	}
+
+	got, err := c.LocateKey("dc", "42/uuid", exists)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "42/uuid" {
+		t.Errorf("expected '42/uuid', got %q", got)
+	}
+	if calls != 0 {
+		t.Errorf("expected no HEAD calls when no prefix configured, got %d", calls)
+	}
+}
+
+func TestLocateKey_FoundInPrefix(t *testing.T) {
+	c := newTestConfig(map[string]string{"dc": "ente/"})
+
+	calls := 0
+	exists := func(key string) (bool, error) {
+		calls++
+		if key == "ente/42/uuid" {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	got, err := c.LocateKey("dc", "42/uuid", exists)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "ente/42/uuid" {
+		t.Errorf("expected 'ente/42/uuid', got %q", got)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 HEAD call (prefix-only), got %d", calls)
+	}
+}
+
+func TestLocateKey_FallbackToLegacy(t *testing.T) {
+	c := newTestConfig(map[string]string{"dc": "ente/"})
+
+	calls := 0
+	exists := func(key string) (bool, error) {
+		calls++
+		if key == "ente/42/uuid" {
+			return false, nil
+		}
+		if key == "42/uuid" {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	got, err := c.LocateKey("dc", "42/uuid", exists)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "42/uuid" {
+		t.Errorf("expected legacy path '42/uuid', got %q", got)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 HEAD calls (prefix miss + legacy hit), got %d", calls)
+	}
+}
+
+func TestLocateKey_NotFound(t *testing.T) {
+	c := newTestConfig(map[string]string{"dc": "ente/"})
+
+	exists := func(key string) (bool, error) {
+		return false, nil
+	}
+
+	got, err := c.LocateKey("dc", "42/uuid", exists)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// When nothing exists, we return the prefixed path so downstream 404s
+	// report the "expected" new-location path.
+	if got != "ente/42/uuid" {
+		t.Errorf("expected 'ente/42/uuid' as the default, got %q", got)
+	}
+}
+
 func TestNewDBObjectKey(t *testing.T) {
 	c := newTestConfig(nil)
 

--- a/server/pkg/utils/s3config/s3config_test.go
+++ b/server/pkg/utils/s3config/s3config_test.go
@@ -1,0 +1,153 @@
+package s3config
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests exercise the small set of helpers that deal with the optional
+// per-datacenter key prefix. They avoid the full initialize() path (which
+// reads viper and builds S3 clients) and instead manipulate the maps
+// directly, which is what the rest of the codebase expects.
+
+func newTestConfig(prefixes map[string]string) *S3Config {
+	c := &S3Config{
+		bucketPrefixes: map[string]string{},
+	}
+	for dc, p := range prefixes {
+		if p != "" && !strings.HasSuffix(p, "/") {
+			p += "/"
+		}
+		c.bucketPrefixes[dc] = p
+	}
+	return c
+}
+
+func TestGetPrefix(t *testing.T) {
+	c := newTestConfig(map[string]string{
+		"dc-with":    "ente",
+		"dc-without": "",
+		"dc-slashed": "ente/",
+	})
+
+	if got := c.GetPrefix("dc-with"); got != "ente/" {
+		t.Fatalf("expected 'ente/', got %q", got)
+	}
+	if got := c.GetPrefix("dc-without"); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+	if got := c.GetPrefix("dc-slashed"); got != "ente/" {
+		t.Fatalf("expected 'ente/', got %q", got)
+	}
+	if got := c.GetPrefix("dc-missing"); got != "" {
+		t.Fatalf("expected empty for missing DC, got %q", got)
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	cEmpty := newTestConfig(map[string]string{"dc1": "", "dc2": ""})
+	if cEmpty.HasPrefix() {
+		t.Fatal("expected HasPrefix=false when all prefixes are empty")
+	}
+
+	cSome := newTestConfig(map[string]string{"dc1": "", "dc2": "x/"})
+	if !cSome.HasPrefix() {
+		t.Fatal("expected HasPrefix=true when at least one prefix is set")
+	}
+}
+
+func TestFullKey(t *testing.T) {
+	c := newTestConfig(map[string]string{
+		"prefixed":    "ente/",
+		"unprefixed":  "",
+		"nested":      "photos/backup/",
+		"unsanitized": "shared",
+	})
+
+	cases := []struct {
+		dc, dbKey, want string
+	}{
+		{"prefixed", "123/abc-uuid", "ente/123/abc-uuid"},
+		{"unprefixed", "123/abc-uuid", "123/abc-uuid"},
+		{"nested", "7/file-data/42/mldata", "photos/backup/7/file-data/42/mldata"},
+		// 'shared' is normalized to 'shared/' on init.
+		{"unsanitized", "1/2", "shared/1/2"},
+		// Missing DC should behave like empty prefix.
+		{"missing", "1/2", "1/2"},
+	}
+
+	for _, tc := range cases {
+		if got := c.FullKey(tc.dc, tc.dbKey); got != tc.want {
+			t.Errorf("FullKey(%q, %q) = %q, want %q", tc.dc, tc.dbKey, got, tc.want)
+		}
+	}
+}
+
+func TestStripPrefix(t *testing.T) {
+	c := newTestConfig(map[string]string{
+		"prefixed":   "ente/",
+		"unprefixed": "",
+	})
+
+	if got := c.StripPrefix("prefixed", "ente/123/x"); got != "123/x" {
+		t.Errorf("expected '123/x', got %q", got)
+	}
+
+	// Key without the expected prefix is returned verbatim. This is the
+	// defensive behavior: if something slipped into the bucket outside the
+	// prefix, we return the key unchanged rather than corrupting it.
+	if got := c.StripPrefix("prefixed", "something-else/1/2"); got != "something-else/1/2" {
+		t.Errorf("expected key unchanged when prefix missing, got %q", got)
+	}
+
+	// Unprefixed DC is a no-op.
+	if got := c.StripPrefix("unprefixed", "123/x"); got != "123/x" {
+		t.Errorf("expected '123/x', got %q", got)
+	}
+}
+
+func TestRoundtripFullStripPrefix(t *testing.T) {
+	c := newTestConfig(map[string]string{"a": "ente/", "b": ""})
+
+	for _, dc := range []string{"a", "b"} {
+		db := "42/uuid-xyz"
+		roundtripped := c.StripPrefix(dc, c.FullKey(dc, db))
+		if roundtripped != db {
+			t.Errorf("dc=%s: StripPrefix(FullKey(%q)) = %q", dc, db, roundtripped)
+		}
+	}
+}
+
+func TestValidateDBKey(t *testing.T) {
+	c := newTestConfig(nil)
+
+	if !c.ValidateDBKey("42/anything", 42) {
+		t.Error("expected valid key to pass")
+	}
+	if c.ValidateDBKey("43/anything", 42) {
+		t.Error("expected wrong-user key to fail")
+	}
+	if c.ValidateDBKey("42-suffix/x", 42) {
+		t.Error("expected userID-prefix without trailing slash to fail")
+	}
+	if c.ValidateDBKey("", 42) {
+		t.Error("expected empty key to fail")
+	}
+}
+
+func TestNewDBObjectKey(t *testing.T) {
+	c := newTestConfig(nil)
+
+	key := c.NewDBObjectKey(123)
+	if !strings.HasPrefix(key, "123/") {
+		t.Errorf("expected key to start with '123/', got %q", key)
+	}
+	if !c.ValidateDBKey(key, 123) {
+		t.Errorf("expected newly generated key to validate, got %q", key)
+	}
+	// Two invocations must produce different keys (UUID randomness).
+	other := c.NewDBObjectKey(123)
+	if key == other {
+		t.Error("expected distinct keys from consecutive NewDBObjectKey calls")
+	}
+}


### PR DESCRIPTION
## Description

  Adds an optional per-datacenter `prefix` field to the S3 bucket config.
  When set, all S3 interactions (upload, download, list, delete, orphan
  cleanup, replication) happen under that prefix, and nothing outside it
  is touched. This lets a self-hosted instance coexist with unrelated data
  in the same bucket.

  **Key properties**

  - The prefix is **optional** — omitting it preserves the existing
    behavior exactly. No config change is required for existing
    deployments.
  - The database still stores keys in the `{userID}/{uuid}` form; the
    prefix is only applied at the S3 boundary, so **no data migration** is
    needed.
  - **Per-DC**: each configured bucket can have its own prefix (or none).
    Replication between DCs with different prefixes works correctly.
  - `clear-orphan-objects` scans only under the configured prefix, so
    files outside it are never considered orphans.

  **Example config**

  ```yaml
  s3:
    b2-eu-cen:
      key: <key>
      secret: <secret>
      endpoint: <endpoint>
      region: <region>
      bucket: shared-bucket
      prefix: ente/

  Objects land at shared-bucket/ente/{userID}/{uuid}.

  Implementation notes

  - s3config.FullKey(dc, dbKey) and StripPrefix(dc, fullKey) are the
  only two places that know about the prefix; all S3 call sites go
  through them.
  - Added unit tests in s3config_test.go covering the helpers, the
  round-trip, and backward compatibility with empty prefix.

  Tests

  - go test ./pkg/utils/s3config/... — new unit tests for FullKey,
  StripPrefix, GetPrefix, HasPrefix, ValidateDBKey,
  NewDBObjectKey, and a round-trip test.
  - go test ./... — full existing test suite passes unchanged.
  - go build ./... — clean compile.
