### PR TITLE
[mob][photos] Fix writing of public album files download to filesDB

### DIFF
--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -194,7 +194,8 @@ class GalleryDownloadQueueService {
       );
       if (_tasks.containsKey(uploadID)) {
         final existingTask = _tasks[uploadID];
-        if (existingTask != null && existingTask.sourceFileJson == null) {
+        if (existingTask != null &&
+            existingTask.sourceFileJson != sourceFileJson) {
           await _updateTask(
             existingTask.copyWith(sourceFileJson: sourceFileJson),
           );

--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -163,8 +163,9 @@ class GalleryDownloadQueueService {
   }
 
   Future<GalleryDownloadEnqueueResult> enqueueFiles(
-    List<EnteFile> files,
-  ) async {
+    List<EnteFile> files, {
+    bool persistToFilesDB = true,
+  }) async {
     await init();
     if (files.isEmpty) {
       return const GalleryDownloadEnqueueResult(
@@ -187,7 +188,10 @@ class GalleryDownloadQueueService {
           ? file.copyWith()
           : (file.copyWith()..localID = null);
       _queuedFilesByID[uploadID] = queuedFile;
-      final sourceFileJson = _serializeQueuedFile(queuedFile);
+      final sourceFileJson = _serializeQueuedFile(
+        queuedFile,
+        persistToFilesDB: persistToFilesDB,
+      );
       if (_tasks.containsKey(uploadID)) {
         final existingTask = _tasks[uploadID];
         if (existingTask != null && existingTask.sourceFileJson == null) {
@@ -456,9 +460,11 @@ class GalleryDownloadQueueService {
 
   Future<void> _downloadAndSaveToGallery(int fileID) async {
     EnteFile? file = _queuedFilesByID[fileID];
+    String? sourceFileJson;
     if (file == null) {
       final task = _tasks[fileID];
       if (task != null) {
+        sourceFileJson = task.sourceFileJson;
         file = _deserializeQueuedFile(task.sourceFileJson);
         if (file != null) {
           _queuedFilesByID[fileID] = file;
@@ -478,6 +484,9 @@ class GalleryDownloadQueueService {
     await downloadToGallery(
       fileToDownload,
       forceResumableDownload: true,
+      persistToFilesDB: _deserializePersistToFilesDB(
+        sourceFileJson ?? _tasks[fileID]?.sourceFileJson,
+      ),
     );
   }
 
@@ -594,7 +603,10 @@ class GalleryDownloadQueueService {
     Bus.instance.fire(GalleryDownloadsUpdatedEvent());
   }
 
-  String _serializeQueuedFile(EnteFile file) {
+  String _serializeQueuedFile(
+    EnteFile file, {
+    required bool persistToFilesDB,
+  }) {
     return jsonEncode({
       "uploadedFileID": file.uploadedFileID,
       "ownerID": file.ownerID,
@@ -609,7 +621,22 @@ class GalleryDownloadQueueService {
       "fileSize": file.fileSize,
       "pubMmdEncodedJson": file.pubMmdEncodedJson,
       "pubMmdVersion": file.pubMmdVersion,
+      "persistToFilesDB": persistToFilesDB,
     });
+  }
+
+  bool _deserializePersistToFilesDB(String? sourceFileJson) {
+    if (sourceFileJson == null || sourceFileJson.isEmpty) {
+      return true;
+    }
+    try {
+      final Map<String, dynamic> map =
+          jsonDecode(sourceFileJson) as Map<String, dynamic>;
+      return map["persistToFilesDB"] as bool? ?? true;
+    } catch (e, s) {
+      _logger.warning("Failed to deserialize gallery download metadata", e, s);
+      return true;
+    }
   }
 
   EnteFile? _deserializeQueuedFile(String? sourceFileJson) {

--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -195,6 +195,7 @@ class GalleryDownloadQueueService {
       if (_tasks.containsKey(uploadID)) {
         final existingTask = _tasks[uploadID];
         if (existingTask != null &&
+            persistToFilesDB &&
             existingTask.sourceFileJson != sourceFileJson) {
           await _updateTask(
             existingTask.copyWith(sourceFileJson: sourceFileJson),

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -36,6 +36,7 @@ import "package:photos/l10n/l10n.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/collection/collection_items.dart";
 import "package:photos/models/file/file.dart";
+import "package:photos/models/gallery_type.dart";
 import "package:photos/models/search/index_of_indexed_stack.dart";
 import "package:photos/models/selected_albums.dart";
 import "package:photos/models/selected_files.dart";
@@ -500,6 +501,7 @@ class _HomeWidgetState extends State<HomeWidget> {
                 sharedFiles,
                 0,
                 "sharedPublicCollection",
+                galleryType: GalleryType.sharedPublicCollection,
               ),
             ),
           );

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -820,6 +820,7 @@ class _FileSelectionActionsWidgetState
           selectedFiles,
           0,
           "guest_view",
+          galleryType: widget.type,
         ),
       );
       await localSettings.setOnGuestView(true);
@@ -1127,8 +1128,10 @@ class _FileSelectionActionsWidgetState
     if (filesToDownload.isNotEmpty) {
       if (flagService.internalUser) {
         try {
-          final enqueueResult =
-              await galleryDownloadQueueService.enqueueFiles(filesToDownload);
+          final enqueueResult = await galleryDownloadQueueService.enqueueFiles(
+            filesToDownload,
+            persistToFilesDB: widget.type != GalleryType.sharedPublicCollection,
+          );
           addedToQueueCount = enqueueResult.addedCount;
         } catch (e) {
           _logger.warning("Failed to enqueue files for download", e);
@@ -1152,7 +1155,11 @@ class _FileSelectionActionsWidgetState
           for (final file in filesToDownload) {
             futures.add(
               taskQueue.add(() async {
-                await downloadToGallery(file);
+                await downloadToGallery(
+                  file,
+                  persistToFilesDB:
+                      widget.type != GalleryType.sharedPublicCollection,
+                );
                 downloadedFiles++;
                 dialog.update(
                   message: AppLocalizations.of(context).downloading +

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -16,6 +16,7 @@ import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/file/trash_file.dart";
+import "package:photos/models/gallery_type.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
 import "package:photos/services/local_authentication_service.dart";
@@ -47,6 +48,7 @@ class DetailPageConfiguration {
   final String tagPrefix;
   final DetailPageMode mode;
   final bool isLocalOnlyContext;
+  final GalleryType? galleryType;
 
   /// Callback invoked with the page context after the page is ready.
   /// Useful for showing bottom sheets or dialogs after navigation completes.
@@ -58,6 +60,7 @@ class DetailPageConfiguration {
     this.tagPrefix, {
     this.mode = DetailPageMode.full,
     this.isLocalOnlyContext = false,
+    this.galleryType,
     this.onPageReady,
   });
 
@@ -67,12 +70,14 @@ class DetailPageConfiguration {
     int? selectedIndex,
     String? tagPrefix,
     bool? isLocalOnlyContext,
+    GalleryType? galleryType,
   }) {
     return DetailPageConfiguration(
       files ?? this.files,
       selectedIndex ?? this.selectedIndex,
       tagPrefix ?? this.tagPrefix,
       isLocalOnlyContext: isLocalOnlyContext ?? this.isLocalOnlyContext,
+      galleryType: galleryType ?? this.galleryType,
     );
   }
 }
@@ -225,6 +230,7 @@ class _BodyState extends State<_Body> {
                 _onEditFileRequested,
                 enableFullScreenNotifier: InheritedDetailPageState.of(context)
                     .enableFullScreenNotifier,
+                galleryType: widget.config.galleryType,
                 mode: widget.config.mode,
               );
             },

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -19,6 +19,7 @@ import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import "package:photos/models/file/trash_file.dart";
+import "package:photos/models/gallery_type.dart";
 import "package:photos/models/metadata/common_keys.dart";
 import 'package:photos/models/selected_files.dart';
 import "package:photos/service_locator.dart";
@@ -49,6 +50,7 @@ class FileAppBar extends StatefulWidget {
   final Function(EnteFile) onFileRemoved;
   final Function(EnteFile) onEditRequested;
   final ValueNotifier<bool> enableFullScreenNotifier;
+  final GalleryType? galleryType;
   final DetailPageMode mode;
 
   const FileAppBar(
@@ -56,6 +58,7 @@ class FileAppBar extends StatefulWidget {
     this.onFileRemoved,
     this.onEditRequested, {
     required this.enableFullScreenNotifier,
+    this.galleryType,
     this.mode = DetailPageMode.full,
     super.key,
   });
@@ -660,9 +663,14 @@ class FileAppBarState extends State<FileAppBar> {
 
     final fileToDownload =
         !file.isRemoteFile ? (file.copyWith()..localID = null) : file;
+    final persistToFilesDB =
+        widget.galleryType != GalleryType.sharedPublicCollection;
     if (flagService.internalUser) {
       try {
-        await galleryDownloadQueueService.enqueueFiles([fileToDownload]);
+        await galleryDownloadQueueService.enqueueFiles(
+          [fileToDownload],
+          persistToFilesDB: persistToFilesDB,
+        );
       } catch (e) {
         _logger.warning("Failed to save file", e);
         await showGenericErrorDialog(context: context, error: e);
@@ -677,7 +685,10 @@ class FileAppBarState extends State<FileAppBar> {
     );
     await dialog.show();
     try {
-      await downloadToGallery(fileToDownload);
+      await downloadToGallery(
+        fileToDownload,
+        persistToFilesDB: persistToFilesDB,
+      );
       showToast(context, AppLocalizations.of(context).fileSavedToGallery);
       await dialog.hide();
     } catch (e) {

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -278,6 +278,7 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
         galleryFiles.indexOf(file),
         widget.tag,
         isLocalOnlyContext: isLocalOnlyContext,
+        galleryType: galleryType,
       ),
     );
     routeToPage(context, page, forceCustomPageRoute: true);

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -787,7 +787,10 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     }
     if (flagService.internalUser) {
       try {
-        await galleryDownloadQueueService.enqueueFiles(files);
+        await galleryDownloadQueueService.enqueueFiles(
+          files,
+          persistToFilesDB: false,
+        );
       } catch (e, s) {
         _logger.severe("Failed to download album", e, s);
         await showGenericErrorDialog(context: context, error: e);
@@ -805,7 +808,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
 
     try {
       for (var i = 0; i < files.length; i++) {
-        await downloadToGallery(files[i]);
+        await downloadToGallery(files[i], persistToFilesDB: false);
         dialog.update(message: "Downloading... ${i + 1}/$totalFiles");
       }
     } catch (e, s) {
@@ -1244,6 +1247,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
           collectionFiles,
           0,
           "guest_view",
+          galleryType: galleryType,
         ),
       );
       await localSettings.setOnGuestView(true);

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -75,10 +75,15 @@ Future<String?> getExistingLocalFolderNameForDownloadSkipToast(
   if (folderNames.isNotEmpty) {
     return folderNames.last;
   }
-  throw StateError(
-    "Expected non-empty device collection name for localID=${file.localID}, "
-    "but found none.",
+  // The asset exists on device but no device-collection mapping is recorded
+  // yet (e.g. LocalSyncService hasn't ingested it). Treat this as "not
+  // skippable" rather than crashing; a duplicate save is preferable to an
+  // unhandled StateError surfacing in the download flow.
+  _logger.severe(
+    "No device collection name found for localID=${file.localID} "
+    "despite asset existing on device.",
   );
+  return null;
 }
 
 Future<File?> downloadAndDecryptPublicFile(
@@ -315,6 +320,11 @@ Future<String> _getFileMetadataForLogging(
   return buffer.toString();
 }
 
+// Note: callers that tap Download repeatedly on a public-link file
+// (persistToFilesDB == false) may produce duplicate on-device copies, because
+// the in-memory EnteFile they hold is not updated with the saved localID and
+// LocalSyncService ingests the asset as a new local row rather than marking
+// the existing remote entry. Revisit if this surfaces as a user complaint.
 Future<void> downloadToGallery(
   EnteFile file, {
   bool forceResumableDownload = false,

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -318,6 +318,7 @@ Future<String> _getFileMetadataForLogging(
 Future<void> downloadToGallery(
   EnteFile file, {
   bool forceResumableDownload = false,
+  bool persistToFilesDB = true,
 }) async {
   try {
     final FileType type = file.fileType;
@@ -365,14 +366,19 @@ Future<void> downloadToGallery(
       }
 
       if (savedAsset != null) {
-        file.localID = savedAsset!.id;
-        await FilesDB.instance.insert(file);
-        Bus.instance.fire(
-          LocalPhotosUpdatedEvent(
-            [file],
-            source: "download",
-          ),
-        );
+        // Public-link downloads should be discovered by local sync so they are
+        // materialized as true on-device files instead of remote/shared
+        // entries in FilesDB.
+        if (persistToFilesDB) {
+          file.localID = savedAsset!.id;
+          await FilesDB.instance.insert(file);
+          Bus.instance.fire(
+            LocalPhotosUpdatedEvent(
+              [file],
+              source: "download",
+            ),
+          );
+        }
       } else if (!downloadLivePhotoOnDroid && savedAsset == null) {
         _logger.severe('Failed to save assert of type $type');
       }


### PR DESCRIPTION
## Description

Fixes an issue where downloading a files from a public album causes it to be written in FilesDB, giving a stale EnteFile that the user doesn't normally have permissions to and causing issues elsewhere in the app. 