### PR TITLE
[mob][photos] fix dedupe progress percentage behavior in tools

### DIFF
--- a/mobile/apps/photos/lib/ui/tools/deduplicate_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/deduplicate_page.dart
@@ -289,17 +289,16 @@ class _DeduplicatePageState extends State<DeduplicatePage> {
       if (!mounted) {
         return;
       }
-      if (collectionCnt > 0) {
-        progress++;
-        // calculate progress percentage upto 2 decimal places
-        final double percentage = (progress / collectionCnt) * 100;
-        _deleteProgress.value = '$percentage%';
-      }
       log("AddingNow ${collectionToFilesToAddMap[collectionID]!.length} files to $collectionID");
       await CollectionsService.instance.addSilentlyToCollection(
         collectionID,
         collectionToFilesToAddMap[collectionID]!,
       );
+      if (collectionCnt > 0) {
+        progress++;
+        final int percentage = ((progress * 100) / collectionCnt).round();
+        _deleteProgress.value = '$percentage%';
+      }
     }
     _deleteProgress.value = "";
     if (filesToDelele.isNotEmpty) {

--- a/mobile/apps/photos/lib/ui/tools/similar_images_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/similar_images_page.dart
@@ -1135,12 +1135,6 @@ class _SimilarImagesPageState extends State<SimilarImagesPage>
         if (!mounted) {
           return;
         }
-        if (collectionCnt > 2 && showUIFeedback) {
-          progress++;
-          // calculate progress percentage upto 2 decimal places
-          final double percentage = (progress / collectionCnt) * 100;
-          _deleteProgress.value = '${percentage.toStringAsFixed(1)}%';
-        }
         // Check permission before attempting to add symlinks
         final collection =
             CollectionsService.instance.getCollectionByID(collectionID);
@@ -1153,6 +1147,11 @@ class _SimilarImagesPageState extends State<SimilarImagesPage>
           _logger.warning(
             "Skipping adding symlinks to collection $collectionID due to missing permissions (${collection?.canAutoAdd(userID!) ?? false}) or collection not found. (${collection == null})",
           );
+        }
+        if (collectionCnt > 2 && showUIFeedback) {
+          progress++;
+          final int percentage = ((progress * 100) / collectionCnt).round();
+          _deleteProgress.value = '$percentage%';
         }
       }
     }

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Prateek: Fix dedupe cleanup progress percentage display
 - Neeraj: Fix Added by visibility in file details
 - Neeraj: Contacts
 - Neeraj: Fix grey screen when collections search result is empty 


### PR DESCRIPTION
## Summary
- update deduplicate tool delete progress to display whole-number percentages
- update progress after each collection add completes so percentage reflects completed work
- apply the same post-operation progress update and whole-number formatting in similar images cleanup
- add a minimal internal changes note for this fix in mobile/apps/photos/scripts/internal_changes.txt

## Validation
- flutter analyze lib/ui/tools/deduplicate_page.dart lib/ui/tools/similar_images_page.dart
