### PR TITLE
[mob][photos] Fix changelog copy

### DIFF
--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,5 +1,5 @@
 Latest changes:
-- Prateek: Fix dedupe cleanup progress percentage display
+- Neeraj: Fix dedupe cleanup progress percentage display
 - Neeraj: Fix Added by visibility in file details
 - Neeraj: Contacts
 - Neeraj: Fix grey screen when collections search result is empty 


### PR DESCRIPTION
## Summary
- update the mobile photos internal changelog entry author name from Prateek to Neeraj for the dedupe progress fix

## Validation
- verified one-line change in mobile/apps/photos/scripts/internal_changes.txt