### PR TITLE
[mob][web] Handle public-link device-limit status in clients

### DIFF
--- a/mobile/apps/photos/lib/gateways/collections/collection_share_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/collections/collection_share_gateway.dart
@@ -2,6 +2,8 @@ import "package:dio/dio.dart";
 import "package:photos/gateways/collections/models/public_url.dart";
 import "package:photos/models/api/collection/user.dart";
 
+const _linkDeviceLimitExceededCode = "LINK_DEVICE_LIMIT_EXCEEDED";
+
 /// Gateway for collection sharing API endpoints.
 ///
 /// Handles sharing collections with other users and managing public links.
@@ -162,6 +164,14 @@ class CollectionShareGateway {
           throw PublicCollectionInfoUnauthorizedException();
         case 410:
           throw PublicCollectionInfoExpiredException();
+        case 403:
+          if (_hasErrorCode(
+            e.response?.data,
+            _linkDeviceLimitExceededCode,
+          )) {
+            throw PublicCollectionDeviceLimitExceededException();
+          }
+          rethrow;
         case 429:
           final errorMessage = _extractErrorMessage(e.response?.data);
           if (errorMessage?.toLowerCase().contains("device limit") ?? false) {
@@ -221,6 +231,16 @@ String? _extractErrorMessage(dynamic data) {
     return data["error"]?.toString();
   }
   return null;
+}
+
+bool _hasErrorCode(dynamic data, String code) {
+  if (data is Map<String, dynamic>) {
+    return data["code"] == code;
+  }
+  if (data is Map) {
+    return data["code"] == code;
+  }
+  return false;
 }
 
 class PublicCollectionInfoUnauthorizedException implements Exception {}

--- a/web/apps/albums/src/public-album/page/PublicAlbumPage.tsx
+++ b/web/apps/albums/src/public-album/page/PublicAlbumPage.tsx
@@ -66,6 +66,7 @@ import { useBaseContext } from "ente-base/context";
 import {
     isHTTP401Error,
     isHTTPErrorWithStatus,
+    isMuseumHTTPError,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
 import log from "ente-base/log";
@@ -134,6 +135,10 @@ const loadJoinPublicAlbumRedirect = () =>
     import("@/public-album/access/services/join-public-album-redirect");
 
 const publicAlbumAllFilesCollectionID = 0;
+
+const isDeviceLimitExceededError = async (e: unknown) =>
+    isHTTPErrorWithStatus(e, 429) ||
+    (await isMuseumHTTPError(e, 403, "LINK_DEVICE_LIMIT_EXCEEDED"));
 
 export default function PublicAlbumPage() {
     const { showMiniDialog, onGenericError } = useBaseContext();
@@ -413,7 +418,8 @@ export default function PublicAlbumPage() {
                 }
             }
         } catch (e) {
-            // The 410 Gone or 429 Rate limited can arise from either the
+            const isDeviceLimitExceeded = await isDeviceLimitExceededError(e);
+            // The 410 Gone or device-limit failure can arise from either the
             // collection pull or the files pull since they're part of the
             // remote's access token check sequence.
             //
@@ -425,7 +431,7 @@ export default function PublicAlbumPage() {
             if (
                 isHTTPErrorWithStatus(e, 401) ||
                 isHTTPErrorWithStatus(e, 410) ||
-                isHTTPErrorWithStatus(e, 429)
+                isDeviceLimitExceeded
             ) {
                 const [
                     { removePublicCollectionFileData },
@@ -435,7 +441,7 @@ export default function PublicAlbumPage() {
                     loadPublicAlbumsFDB(),
                 ]);
                 setErrorMessage(
-                    isHTTPErrorWithStatus(e, 429)
+                    isDeviceLimitExceeded
                         ? t("link_request_limit_exceeded")
                         : t("link_expired_message"),
                 );

--- a/web/apps/embed/src/pages/index.tsx
+++ b/web/apps/embed/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { useBaseContext } from "ente-base/context";
 import {
     isHTTP401Error,
     isHTTPErrorWithStatus,
+    isMuseumHTTPError,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
 import log from "ente-base/log";
@@ -36,6 +37,10 @@ import {
     removePublicCollectionFileData,
     verifyPublicAlbumPassword,
 } from "../services/public-collection";
+
+const isDeviceLimitExceededError = async (e: unknown) =>
+    isHTTPErrorWithStatus(e, 429) ||
+    (await isMuseumHTTPError(e, 403, "LINK_DEVICE_LIMIT_EXCEEDED"));
 
 export default function EmbedGallery() {
     const { onGenericError } = useBaseContext();
@@ -99,13 +104,14 @@ export default function EmbedGallery() {
                 }
             }
         } catch (e) {
+            const isDeviceLimitExceeded = await isDeviceLimitExceededError(e);
             if (
                 isHTTPErrorWithStatus(e, 401) ||
                 isHTTPErrorWithStatus(e, 410) ||
-                isHTTPErrorWithStatus(e, 429)
+                isDeviceLimitExceeded
             ) {
                 setErrorMessage(
-                    isHTTPErrorWithStatus(e, 429)
+                    isDeviceLimitExceeded
                         ? t("link_request_limit_exceeded")
                         : t("link_expired_message"),
                 );

--- a/web/apps/share/src/services/file-share.ts
+++ b/web/apps/share/src/services/file-share.ts
@@ -16,6 +16,25 @@ import type {
     LockerInfo,
 } from "../types/file-share";
 
+const deviceLimitExceededMessage =
+    "This link has been viewed on too many devices. Please contact the owner.";
+
+const isDeviceLimitExceededResponse = async (response: Response) => {
+    if (response.status === 429) {
+        return true;
+    }
+    if (response.status !== 403) {
+        return false;
+    }
+
+    try {
+        const payload = (await response.clone().json()) as { code?: string };
+        return payload.code === "LINK_DEVICE_LIMIT_EXCEEDED";
+    } catch {
+        return false;
+    }
+};
+
 /**
  * Extract file key from URL hash (similar to extractCollectionKeyFromShareURL)
  */
@@ -58,6 +77,9 @@ export const fetchFileInfo = async (
     });
 
     if (!response.ok) {
+        if (await isDeviceLimitExceededResponse(response)) {
+            throw new Error(deviceLimitExceededMessage);
+        }
         throw new Error(`Failed to fetch file`);
     }
 
@@ -393,6 +415,9 @@ export const downloadFile = async (
     });
 
     if (!response.ok) {
+        if (await isDeviceLimitExceededResponse(response)) {
+            throw new Error(deviceLimitExceededMessage);
+        }
         throw new Error(`Failed to download file: ${response.statusText}`);
     }
 


### PR DESCRIPTION
## Summary
- handle both legacy 429 and new typed device-limit responses for public album flows
- handle both legacy 429 and new typed device-limit responses for file-share flows

## Validation
- `dart analyze lib/gateways/collections/collection_share_gateway.dart` from the main checkout
- web typecheck not run in this environment (`pnpm` unavailable)

Paired server PR: https://github.com/ente-io/ente/pull/10052
