### PR TITLE
[photos] Update flutter_sodium prebuilts

### DIFF
--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -1182,8 +1182,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "85a6ac0f36c4473ac1345727ca5dd8589e564b80"
-      resolved-ref: "85a6ac0f36c4473ac1345727ca5dd8589e564b80"
+      ref: a05d5b1bfdce64a387f8f5970160b22ce7b88282
+      resolved-ref: a05d5b1bfdce64a387f8f5970160b22ce7b88282
       url: "https://github.com/ente-io/flutter_sodium"
     source: git
     version: "0.2.0"

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -118,7 +118,7 @@ dependencies:
   flutter_sodium:
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
+      ref: a05d5b1bfdce64a387f8f5970160b22ce7b88282
   flutter_spinkit: 5.2.1
   flutter_staggered_grid_view: 0.7.0
   flutter_svg: 2.2.0
@@ -267,7 +267,7 @@ dependency_overrides:
   flutter_sodium: # update source if there is any update
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
+      ref: a05d5b1bfdce64a387f8f5970160b22ce7b88282
   intl: 0.20.2
   js: 0.6.7
   media_kit: # update media_kit* if there is any update

--- a/mobile/apps/photos/pubspec_overrides.yaml
+++ b/mobile/apps/photos/pubspec_overrides.yaml
@@ -13,7 +13,7 @@ dependency_overrides:
   flutter_sodium:
     git:
       url: https://github.com/ente-io/flutter_sodium
-      ref: 85a6ac0f36c4473ac1345727ca5dd8589e564b80
+      ref: a05d5b1bfdce64a387f8f5970160b22ce7b88282
   intl: 0.20.2
   js: 0.6.7
   media_kit:

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,12 +1,13 @@
 Latest changes:
 - Neeraj: Fix Added by visibility in file details
 - Neeraj: Contacts
-- Neeraj: Fix grey screen when collections search result is empty 
+- Neeraj: Fix grey screen when collections search result is empty
 - Ashil: Fix app going blank on iOS on deleting all empty albums
 - Ashil: Show family dashboard for family non-admin members too
 - Ashil: Updated 'ente' branding
 - Ashil, Laurens: Fix file download not working for files with stale localID references
 - Ashil: Bug fixes and improvements on Gallery
+- Manav: Update flutter_sodium to reproducible libsodium 1.0.21 Android/iOS binaries
 
 
 Still behind internal flag:


### PR DESCRIPTION
Update the Android binaries too to the same way we'd updated the iOS ones, and also regen both of them in a way that uses the upstream build script as much as possible, our build script is just a small wrapper on top.

## Validation
- sanity-checked on iOS simulator and device
- sanity-checked on Android emulator