### PR TITLE
[web] Use interpolation for app-lock cooldown copy

### DIFF
--- a/web/packages/base/locales/ca-ES/translation.json
+++ b/web/packages/base/locales/ca-ES/translation.json
@@ -847,7 +847,7 @@
     "app_lock_password_mismatch": "Les contrasenyes de bloqueig de l'aplicació no coincideixen",
     "app_lock_enter_pin_to_unlock": "Introdueix el PIN de bloqueig de l'aplicació per desbloquejar.",
     "app_lock_pin_digit_label": "Dígit del PIN {{index}}",
-    "app_lock_please_try_again_in": "Massa intents, si us plau, torna-ho a provar d'aquí a",
+    "app_lock_please_try_again_in": "Massa intents, si us plau, torna-ho a provar d'aquí a {{time}}",
     "app_lock_set_pin": "Estableix el PIN",
     "device_lock": "Bloqueig del dispositiu",
     "device_lock_not_supported": "El bloqueig del dispositiu no és compatible amb aquest dispositiu",

--- a/web/packages/base/locales/cs-CZ/translation.json
+++ b/web/packages/base/locales/cs-CZ/translation.json
@@ -847,7 +847,7 @@
     "app_lock_password_mismatch": "Hesla zámku aplikace se neshodují",
     "app_lock_enter_pin_to_unlock": "Zadejte PIN pro odemknutí aplikace.",
     "app_lock_pin_digit_label": "PIN číslice {{index}}",
-    "app_lock_please_try_again_in": "Příliš mnoho pokusů, zkuste to prosím znovu za",
+    "app_lock_please_try_again_in": "Příliš mnoho pokusů, zkuste to prosím znovu za {{time}}",
     "app_lock_set_pin": "Nastavit PIN",
     "device_lock": "Zámek zařízení",
     "device_lock_not_supported": "Zámek zařízení není na tomto zařízení podporován",

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -847,7 +847,7 @@
     "app_lock_password_mismatch": "App lock passwords don't match",
     "app_lock_enter_pin_to_unlock": "Enter your app lock pin to unlock.",
     "app_lock_pin_digit_label": "PIN digit {{index}}",
-    "app_lock_please_try_again_in": "Too many attempts, Please try again in",
+    "app_lock_please_try_again_in": "Too many attempts, Please try again in {{time}}",
     "app_lock_set_pin": "Set PIN",
     "device_lock": "Device lock",
     "device_lock_not_supported": "Device lock is not supported on this device",

--- a/web/packages/base/locales/fr-FR/translation.json
+++ b/web/packages/base/locales/fr-FR/translation.json
@@ -847,7 +847,7 @@
     "app_lock_password_mismatch": "Les mots de passe de verrouillage d'application ne correspondent pas",
     "app_lock_enter_pin_to_unlock": "Entrez votre code PIN de verrouillage pour le déverrouiller.",
     "app_lock_pin_digit_label": "Numéro PIN {{index}}",
-    "app_lock_please_try_again_in": "Trop de tentatives, veuillez réessayer dans",
+    "app_lock_please_try_again_in": "Trop de tentatives, veuillez réessayer dans {{time}}",
     "app_lock_set_pin": "Définir le code PIN",
     "device_lock": "Verrouillage de l'appareil",
     "device_lock_not_supported": "Le verrouillage de l'appareil n'est pas pris en charge sur ce périphérique",

--- a/web/packages/base/locales/vi-VN/translation.json
+++ b/web/packages/base/locales/vi-VN/translation.json
@@ -847,7 +847,7 @@
     "app_lock_password_mismatch": "Mật khẩu khóa ứng dụng không khớp",
     "app_lock_enter_pin_to_unlock": "Nhập mã pin để mở khóa.",
     "app_lock_pin_digit_label": "Mã PIN {{index}}",
-    "app_lock_please_try_again_in": "Thử quá nhiều lần. Hãy thử lại sau",
+    "app_lock_please_try_again_in": "Thử quá nhiều lần. Hãy thử lại sau {{time}}",
     "app_lock_set_pin": "Đặt mã PIN",
     "device_lock": "Khóa thiết bị",
     "device_lock_not_supported": "Không hỗ trợ khóa thiết bị trên thiết bị này",

--- a/web/packages/new/photos/components/app-lock/AppLockFeedback.tsx
+++ b/web/packages/new/photos/components/app-lock/AppLockFeedback.tsx
@@ -178,7 +178,9 @@ export const CooldownScreen = ({
 }: CooldownScreenProps) => {
     void remainingMs;
     void attemptCount;
-    const retryDescriptionText = `${t("app_lock_please_try_again_in")}\u00A0${cooldownText}`;
+    const retryDescriptionText = t("app_lock_please_try_again_in", {
+        time: cooldownText,
+    });
 
     return (
         <Stack


### PR DESCRIPTION
Switch `app_lock_please_try_again_in` to use `{{time}}` interpolation