### PR TITLE
[desktop] Update Electron to 41.2.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -45,7 +45,7 @@
         "ajv": "8.17.1",
         "concurrently": "9.2.1",
         "cross-env": "10.1.0",
-        "electron": "41.0.0",
+        "electron": "41.2.0",
         "electron-builder": "26.0.14",
         "eslint": "9.9.1",
         "prettier": "3.6.2",

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -1277,10 +1277,10 @@ electron-updater@6.6.5:
     semver "^7.6.3"
     tiny-typed-emitter "^2.1.0"
 
-electron@41.0.0:
-  version "41.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-41.0.0.tgz#5c5dcc8f38f7a53700ccd24c2abda962fa9a1d2b"
-  integrity sha512-U7QueSj1cFj9QM0Qamgh/MK08662FVK555iMfapqU7mcAmIm4A8bZuZptpjMXrT4JNAMGjgWu9sOeO1+RPCJNw==
+electron@41.2.0:
+  version "41.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.2.0.tgz#7598019461b3cde346a9d59cc6ba11229d7717f0"
+  integrity sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^24.9.0"


### PR DESCRIPTION
From https://www.electronjs.org/blog/electron-41-0

<img width="667" height="176" alt="Screenshot 2026-04-14 at 11 08 46 AM" src="https://github.com/user-attachments/assets/0b56a60d-4739-4cac-a0c9-7f5547e65d7b" />

Then I also saw a further Windows shortcut bugfix that might impact us in

https://github.com/electron/electron/releases/tag/v41.2.0

So have updated to the latest in the 41.x series.