### PR TITLE
[desktop] Fix dock icon hiding on macOS occlusion

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -416,22 +416,16 @@ const createMainWindow = () => {
     window.on("close", (event) => {
         if (!shouldAllowWindowClose) {
             event.preventDefault();
+            // Only hide the dock icon when we are intercepting an explicit
+            // close action. On macOS, the generic "hide" event is also emitted
+            // for occlusion changes, so reacting there causes the dock icon to
+            // disappear when the window is fully covered by another window.
+            if (shouldHideDockIcon()) {
+                app.dock?.hide();
+            }
             window.hide();
         }
         return false;
-    });
-
-    window.on("hide", () => {
-        // On macOS, when hiding the window also hide the app's icon in the dock
-        // unless the user has unchecked the Settings > Hide dock icon checkbox.
-        if (shouldHideDockIcon()) {
-            // macOS emits a window "hide" event when going fullscreen, and if
-            // we hide the dock icon there then the window disappears. So ignore
-            // this scenario.
-            if (!window.isFullScreen()) {
-                app.dock?.hide();
-            }
-        }
     });
 
     window.on("show", () => void app.dock?.show());

--- a/desktop/src/main/services/store.ts
+++ b/desktop/src/main/services/store.ts
@@ -111,10 +111,10 @@ export const setLastShownChangelogVersion = (version: number) =>
  * Return true if the dock icon should be hidden when the window is closed
  * [macOS only].
  *
- * On macOS, if this function returns true then when hiding ("closing" it with
- * the x traffic light) the window we also hide the app's icon in the dock. The
- * user can modify their preference using the Menu bar > ente > Settings > Hide
- * dock icon checkbox.
+ * On macOS, if this function returns true then when the user closes the window
+ * using the x traffic light we also hide the app's icon in the dock. The user
+ * can modify their preference using the Menu bar > ente > Settings > Hide dock
+ * icon checkbox.
  *
  * If the user has not set a value for this preference (i.e., the value is
  * `undefined`), we use the default `true`. This is confusing, but this way we

--- a/desktop/src/main/stores/user-preferences.ts
+++ b/desktop/src/main/stores/user-preferences.ts
@@ -3,8 +3,8 @@ import Store, { Schema } from "electron-store";
 interface UserPreferences {
     /**
      * If true, then the user has set a preference to also hide the dock icon on
-     * macOS whenever the app is hidden. The tray icon is always visible and can
-     * then be used to reopen the app when needed.
+     * macOS when the window is closed using the x traffic light. The tray icon
+     * remains visible and can then be used to reopen the app when needed.
      */
     hideDockIcon?: boolean;
     skipAppVersion?: string;


### PR DESCRIPTION
When the hide dock icon option was enabled on macOS (true by default)

<img width="350" height="159" alt="Screenshot 2026-04-14 at 10 54 48 AM" src="https://github.com/user-attachments/assets/746c5445-5a61-4f9d-bd9e-4aaf93a2ec6a" />

the app was hiding its Dock icon just because the window got fully covered by another window. I changed it so the Dock icon only hides when you actually close the window.