### PR TITLE
[Docs]Add FAQ entries for common support issues

### DIFF
--- a/docs/docs/photos/faq/albums-and-organization.md
+++ b/docs/docs/photos/faq/albums-and-organization.md
@@ -100,15 +100,15 @@ Photos automatically move to Uncategorized in these situations:
 
 **Note**: Photos uploaded by others (from shared albums) do not go to Uncategorized when removed.
 
-### How do I bring my local album structure into Ente? {#import-local-album-structure}
+### If all my photos are in Uncategorized, how do I move them to resemble the local album structure I have on my device? {#move-uncategorized-to-albums}
 
-If your photos ended up in Uncategorized instead of their original albums (for example, because they were detected as duplicates during backup), you can reorganize them manually:
+If your photos are in Uncategorized instead of their original albums, you can reorganize them manually:
 
 1. Open **On device**, go to an album, select all photos, and add them to the corresponding album in Ente.
 2. Repeat for each album.
 3. Open Uncategorized, tap the three dots menu, and select **Clean up Uncategorized**. This removes any photos from Uncategorized that now exist in another album.
 
-Alternatively, if you have the original photos on your computer, you can delete them from Uncategorized and re-upload them using the desktop app's [Watch folders](/photos/features/backup-and-sync/watch-folders) feature with **Separate albums** mode. This creates one Ente album per subfolder automatically.
+Alternatively, if you have the original photos on your device, you can delete them from Uncategorized and re-upload them via **Backup folders** on mobile.
 
 ### How do I clean up Uncategorized items? {#clean-uncategorized}
 

--- a/docs/docs/photos/faq/albums-and-organization.md
+++ b/docs/docs/photos/faq/albums-and-organization.md
@@ -100,6 +100,16 @@ Photos automatically move to Uncategorized in these situations:
 
 **Note**: Photos uploaded by others (from shared albums) do not go to Uncategorized when removed.
 
+### How do I bring my local album structure into Ente? {#import-local-album-structure}
+
+If your photos ended up in Uncategorized instead of their original albums (for example, because they were detected as duplicates during backup), you can reorganize them manually:
+
+1. Open **On device**, go to an album, select all photos, and add them to the corresponding album in Ente.
+2. Repeat for each album.
+3. Open Uncategorized, tap the three dots menu, and select **Clean up Uncategorized**. This removes any photos from Uncategorized that now exist in another album.
+
+Alternatively, if you have the original photos on your computer, you can delete them from Uncategorized and re-upload them using the desktop app's [Watch folders](/photos/features/backup-and-sync/watch-folders) feature with **Separate albums** mode. This creates one Ente album per subfolder automatically.
+
 ### How do I clean up Uncategorized items? {#clean-uncategorized}
 
 **On mobile:**

--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -33,7 +33,7 @@ Once configured, new photos added to these albums will automatically sync in the
 Yes. You can enable this during signup/login on the permissions screen, or later via `Settings > Backup > Backup settings` by toggling on **Backup only new photos**.
 
 - **During onboarding**: Ente backs up from the **last 7 days** onward, so you have some recent photos available right away.
-- **Via the settings toggle**: Ente uses the current moment as the cutoff — only photos taken from that point forward are backed up.
+- **Via the settings toggle**: Ente uses the current moment as the cutoff - only photos taken from that point forward are backed up.
 
 In both cases, photos older than the cutoff will not be uploaded to Ente.
 
@@ -357,7 +357,7 @@ Learn more in the [Watch folders feature guide](/photos/features/backup-and-sync
 
 ### Does Ente keep my phone and PC folders in sync with each other? {#folder-sync-phone-pc}
 
-Ente backs up photos from your phone and computer to Ente's servers, making them available across all your Ente apps. However, Ente is not a two-way folder sync service — it won't automatically mirror a folder on your PC and your phone's local storage with each other.
+Ente backs up photos from your phone and computer to Ente's servers, making them available across all your Ente apps. However, Ente is not a two-way folder sync service - it won't automatically mirror a folder on your PC and your phone's local storage with each other.
 
 - **On mobile**: Your photos remain in your device photo library. Ente backs up the albums you select.
 - **On desktop**: Your photos remain in the folder you chose to watch. The desktop app uploads them to Ente using Watch folders.

--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -355,6 +355,25 @@ Watch folders allow the Ente desktop app to automatically monitor specific direc
 
 Learn more in the [Watch folders feature guide](/photos/features/backup-and-sync/watch-folders).
 
+### Does Ente keep my phone and PC folders in sync with each other? {#folder-sync-phone-pc}
+
+Ente backs up photos from your phone and computer to Ente's servers, making them available across all your Ente apps. However, Ente is not a two-way folder sync service — it won't automatically mirror a folder on your PC and your phone's local storage with each other.
+
+- **On mobile**: Your photos remain in your device photo library. Ente backs up the albums you select.
+- **On desktop**: Your photos remain in the folder you chose to watch. The desktop app uploads them to Ente using Watch folders.
+
+Once uploaded, your library is accessible across all your devices through Ente.
+
+### Can Ente create albums automatically from my folder structure? {#albums-from-folder-structure}
+
+Yes. When you add a parent folder in Watch folders and choose **Separate albums**, each subfolder is created as its own Ente album.
+
+For example, if you have a `Photos` folder containing `Trip A` and `Trip B` subfolders, watching `Photos` in Separate albums mode creates two albums called "Trip A" and "Trip B".
+
+> **Note**: Ente albums are flat, not nested. All albums appear as top-level albums regardless of how your folders are structured on disk.
+
+Learn more in the [Watch folders guide](/photos/features/backup-and-sync/watch-folders).
+
 ### What are watch folders? {#what-are-watch-folders}
 
 Watch folders is a desktop app feature that automatically syncs specific folders on your computer to Ente. Once you add a folder to watch, the app will:

--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -364,7 +364,7 @@ Ente backs up photos from your phone and computer to Ente's servers, making them
 
 Once uploaded, your library is accessible across all your devices through Ente.
 
-### Can Ente create albums automatically from my folder structure? {#albums-from-folder-structure}
+### Can Ente create albums automatically from my watch folder structure? {#albums-from-watch-folder-structure}
 
 Yes. When you add a parent folder in Watch folders and choose **Separate albums**, each subfolder is created as its own Ente album.
 

--- a/docs/docs/photos/faq/migration.md
+++ b/docs/docs/photos/faq/migration.md
@@ -9,7 +9,7 @@ description: Frequently asked questions about migrating to Ente Photos from othe
 
 ### How much Ente storage do I need when importing my Google Photos Takeout? {#google-takeout-storage}
 
-When importing your Google Photos Takeout into Ente, your storage usage is based on your actual Google Photos library size — not the (much larger) Takeout ZIP size.
+When importing your Google Photos Takeout into Ente, your storage usage is based on your actual Google Photos library size - not the (much larger) Takeout ZIP size.
 
 For example, if Google Photos reports 30 GB used, but your Takeout export is 100 GB, you will need around 30 GB of Ente storage.
 
@@ -122,7 +122,7 @@ Google Photos Partner Sharing automatically shares one person's entire library (
 
 Each partner should export their own library via [Google Takeout](/photos/migration/from-google-photos/) and import it into their own Ente account.
 
-> **Note**: Photos only visible to you through Partner Sharing (not saved to your library) are **not** included in your Takeout. Only the partner who originally took those photos will have them in their export. There is also no built-in filter to remove partner-shared photos from a Takeout import — so duplicates may occur if both partners import and then share entire libraries on Ente.
+> **Note**: Photos only visible to you through Partner Sharing (not saved to your library) are **not** included in your Takeout. Only the partner who originally took those photos will have them in their export. There is also no built-in filter to remove partner-shared photos from a Takeout import - so duplicates may occur if both partners import and then share entire libraries on Ente.
 
 #### 2. Set up sharing on Ente
 
@@ -176,7 +176,7 @@ It is highly recommended to import from Apple Photos via mobile rather than desk
 
 Some photos may not have EXIF metadata embedded directly within the image file. In these cases, Apple Photos exports metadata into separate `.XMP` sidecar files instead of writing it into the photo itself.
 
-Currently, the desktop app does not read metadata from separate XMP sidecar files — it can only recognize metadata that is embedded within the file.
+Currently, the desktop app does not read metadata from separate XMP sidecar files - it can only recognize metadata that is embedded within the file.
 
 We recommend to upload the photos using the iPhone app as iOS exports typically include embedded metadata, which ensures dates and other details are preserved correctly.
 

--- a/docs/docs/photos/faq/search-and-discovery.md
+++ b/docs/docs/photos/faq/search-and-discovery.md
@@ -130,6 +130,20 @@ Open `Settings > Preferences > Machine learning` and toggle ON face recognition 
 - ✅ ML only works on desktop and mobile apps
 - Initial indexing can take time depending on library size
 
+### Why aren't faces appearing on mobile even though ML is fully indexed on desktop? {#faces-not-syncing-to-mobile}
+
+If ML indexing shows 100% on desktop but faces aren't showing up on your mobile app, try clearing the app's cache and storage, then log back in and allow a few minutes for the face data to sync.
+
+**On Android:**
+
+Open device `Settings > Apps > Ente Photos > Storage`, then tap **Clear cache** and **Clear storage**. Log back in and wait a few minutes.
+
+**On iOS:**
+
+Delete and reinstall the app, then log back in and wait a few minutes.
+
+Faces should start appearing shortly after logging back in.
+
 ### Why is the People section empty even though Machine Learning shows 100%? {#people-section-empty}
 
 If Machine Learning shows 100% on both Android and Desktop, the People

--- a/docs/docs/photos/faq/sharing-and-collaboration.md
+++ b/docs/docs/photos/faq/sharing-and-collaboration.md
@@ -484,6 +484,10 @@ When you add a shared photo to your own album, Ente creates a hard copy that you
 
 We understand this uses extra storage in some use cases (like family photo sharing). We're exploring reference-based solutions in the future where storage would only count if the original is deleted. See [this discussion](https://github.com/ente-io/ente/discussions/790) for more details.
 
+### Why don't photos added via a shared link appear in my feed? {#shared-link-photos-not-in-feed}
+
+Only photos added by Ente users who joined the album directly will appear in your feed. Photos added through a public link by someone without an Ente account are not shown in the feed.
+
 ### Can I remove myself from a shared album? {#leave-shared-album}
 
 Yes, if someone has shared an album with you, you can leave it at any time:

--- a/docs/docs/photos/faq/sharing-and-collaboration.md
+++ b/docs/docs/photos/faq/sharing-and-collaboration.md
@@ -111,7 +111,7 @@ Learn more in the [Custom domains guide](/photos/features/sharing-and-collaborat
 
 You can do this by adding your partner as a viewer or collaborator to your camera folder, and asking them to do the same for you. On Android this is the **Camera** folder, and on iOS this is **Recents** (or equivalent).
 
-Any new photos backed up to these folders will automatically be shared and synced to the other person's device. This results in two separate albums — one for your photos and one for your partner's — where both of you can view and add photos.
+Any new photos backed up to these folders will automatically be shared and synced to the other person's device. This results in two separate albums - one for your photos and one for your partner's - where both of you can view and add photos.
 
 ### Does Ente have a shared library feature where all photos are shared with another account (similar to Google Photos Partner Sharing/iCloud Shared Photo Library)? {#shared-library}
 
@@ -428,7 +428,7 @@ Once you upgrade to a paid plan, all future public links will have no device lim
 
 On public links, contributor emails are masked by default to protect privacy.
 
-If you're an album member viewing comments or likes in the mobile app, you'll see names instead of masked emails — but only for people you've already added to your People list with their linked email address.
+If you're an album member viewing comments or likes in the mobile app, you'll see names instead of masked emails - but only for people you've already added to your People list with their linked email address.
 
 Anonymous viewers (people without an Ente account) can also show a name if they've entered one themselves when liking or commenting.
 

--- a/docs/docs/photos/faq/storage-and-plans.md
+++ b/docs/docs/photos/faq/storage-and-plans.md
@@ -257,6 +257,14 @@ Common reasons and solutions:
 - Family plans may have limited functionality for App Store purchases
 - Consider managing your subscription through [web.ente.io](https://web.ente.io) instead
 
+### How do I add a family member who already has a paid subscription? {#add-family-member-existing-subscriber}
+
+1. Subscribe to a paid plan on your account if you have not already.
+2. Ask your family member to cancel their existing subscription, then contact [support@ente.com](mailto:support@ente.com) so we can switch their account to the free plan.
+3. Once their account is on the free plan, add them via `Settings > Storage/Subscription > Manage subscription > Manage family`, or via `Settings > Account > Manage subscription`.
+
+> **Note**: Each family member gets their own private space. Members cannot see each other's files unless explicitly shared. Family plans are for sharing storage, not for sharing photos automatically.
+
 ### How do I remove someone from my family plan? {#remove-family-member}
 
 Open `Settings > Family plans`, find the member you want to remove, click the remove/trash icon next to their name, and confirm the removal.

--- a/docs/docs/photos/faq/storage-and-plans.md
+++ b/docs/docs/photos/faq/storage-and-plans.md
@@ -173,7 +173,7 @@ No. Storage from different accounts does not stack.
 
 When you create a family and add members, everyone in the family shares the storage of the admin's subscription.
 
-(Example: If you have a 1 TB plan and add someone with a 200 GB plan, your family will still have 1 TB total shared storage. Their 200 GB does not combine with yours. Once they join your family, their own individual subscription becomes redundant— they will use the shared family storage instead.)
+(Example: If you have a 1 TB plan and add someone with a 200 GB plan, your family will still have 1 TB total shared storage. Their 200 GB does not combine with yours. Once they join your family, their own individual subscription becomes redundant - they will use the shared family storage instead.)
 
 Family plans are designed to allow multiple people to use a single subscription, not to combine multiple plans into a larger pool.
 

--- a/docs/docs/photos/faq/troubleshooting.md
+++ b/docs/docs/photos/faq/troubleshooting.md
@@ -206,19 +206,21 @@ If you've granted permission but Ente still can't access photos, try:
 - Revoking and re-granting the permission
 - Reinstalling the app (your backed-up photos are safe in the cloud)
 
-### Why is the app stuck saying it is preserving one memory? {#stuck-preserving-one-memory}
+### Why is the app looping saying it is preserving one memory when all memories seem to be backed up? {#app-looping-preserving-one-memory}
 
-If the app shows it is preserving one photo or memory but never completes, the file is likely stuck in a retry loop. A common cause on iOS is that "Optimize iPhone Storage" is enabled and the original file has not been downloaded from iCloud to your device.
+If the app shows it is preserving one photo or memory but never completes, the file is likely stuck in a retry loop.
+
+Share debug logs with [support@ente.io](mailto:support@ente.io) so we can identify the specific file. Open `Settings > Help & Support > Export logs` and attach to email.
+
+A common cause on iOS is that "Optimize iPhone Storage" is enabled and the original file has not been downloaded from iCloud to your device.
 
 To fix this:
 
-1. Open your iOS Photos app and find the stuck photo.
+1. Open your iOS Photos app and find the stuck photo or video.
 2. Open it and let it fully load (or play, if it is a Live Photo or video). This forces iOS to download the original from iCloud.
 3. Once fully loaded, open Ente and keep it in the foreground on WiFi. The upload should complete shortly.
 
 If the photo won't load in your Photos app either, the file may be corrupted or inaccessible on iCloud's end.
-
-If the issue persists, share debug logs so we can identify the specific file. Open `Settings > Support > Report a Bug` to send logs.
 
 ## Desktop App Issues
 

--- a/docs/docs/photos/faq/troubleshooting.md
+++ b/docs/docs/photos/faq/troubleshooting.md
@@ -206,6 +206,20 @@ If you've granted permission but Ente still can't access photos, try:
 - Revoking and re-granting the permission
 - Reinstalling the app (your backed-up photos are safe in the cloud)
 
+### Why is the app stuck saying it is preserving one memory? {#stuck-preserving-one-memory}
+
+If the app shows it is preserving one photo or memory but never completes, the file is likely stuck in a retry loop. A common cause on iOS is that "Optimize iPhone Storage" is enabled and the original file has not been downloaded from iCloud to your device.
+
+To fix this:
+
+1. Open your iOS Photos app and find the stuck photo.
+2. Open it and let it fully load (or play, if it is a Live Photo or video). This forces iOS to download the original from iCloud.
+3. Once fully loaded, open Ente and keep it in the foreground on WiFi. The upload should complete shortly.
+
+If the photo won't load in your Photos app either, the file may be corrupted or inaccessible on iCloud's end.
+
+If the issue persists, share debug logs so we can identify the specific file. Open `Settings > Support > Report a Bug` to send logs.
+
 ## Desktop App Issues
 
 ### Why does my desktop app crash during large uploads? {#desktop-large-uploads}
@@ -477,6 +491,12 @@ Mobile browsers on web.ente.io are not supported. Use native apps for the best e
 - ✅ Mobile apps: Full features including ML, search, video streaming
 - ✅ Desktop/laptop web: Most features (no ML)
 - ❌ Mobile web browsers: Not supported
+
+### Why can I see my photos in the app but not in the browser? {#photos-visible-app-not-browser}
+
+If photos appear in the mobile or desktop app but not on web.ente.io, try logging out and logging back in on the browser. This clears any stale session data and refreshes your library view.
+
+You can also try opening web.ente.io in an incognito or private window to rule out browser caching issues.
 
 ### How do I identify which files failed to upload? {#identify-failed-uploads}
 


### PR DESCRIPTION
## Description

This PR adds 8 new FAQ entries across multiple documentation files to address common user questions and support issues:

**troubleshooting.md:**
- Added FAQ for app looping while preserving a single memory/photo (with iOS-specific troubleshooting steps for iCloud optimization)
- Added FAQ for photos visible in app but not in browser (with session refresh and incognito window suggestions)

**backup-and-sync.md:**
- Added FAQ clarifying that Ente is not a two-way folder sync service between phone and PC
- Added FAQ explaining automatic album creation from watch folder structure

**search-and-discovery.md:**
- Added FAQ for face recognition data not syncing to mobile despite desktop indexing completion (with platform-specific cache clearing steps)

**albums-and-organization.md:**
- Added FAQ with instructions for reorganizing photos from Uncategorized back to proper albums

**storage-and-plans.md:**
- Added FAQ for adding family members who already have paid subscriptions

**sharing-and-collaboration.md:**
- Added FAQ explaining why photos added via public shared links don't appear in feed

