### PR TITLE
[meta] update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/auth-beta-release.yml
+++ b/.github/workflows/auth-beta-release.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -267,7 +267,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -344,7 +344,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -451,7 +451,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/auth-beta-release.yml
+++ b/.github/workflows/auth-beta-release.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -267,7 +267,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -344,7 +344,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
                   fetch-depth: 1
@@ -451,7 +451,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/auth-crowdin-push.yml
+++ b/.github/workflows/auth-crowdin-push.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/auth-crowdin-push.yml
+++ b/.github/workflows/auth-crowdin-push.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/auth-crowdin-sync.yml
+++ b/.github/workflows/auth-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/auth-crowdin-sync.yml
+++ b/.github/workflows/auth-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/auth-internal-release.yml
+++ b/.github/workflows/auth-internal-release.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 

--- a/.github/workflows/auth-internal-release.yml
+++ b/.github/workflows/auth-internal-release.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -21,7 +21,7 @@ jobs:
                 working-directory: mobile/apps/auth
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/.github/workflows/auth-lint.yml
+++ b/.github/workflows/auth-lint.yml
@@ -21,7 +21,7 @@ jobs:
                 working-directory: mobile/apps/auth
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 

--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -44,7 +44,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 
@@ -212,7 +212,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 
@@ -289,7 +289,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 

--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -44,7 +44,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 
@@ -212,7 +212,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 
@@ -289,7 +289,7 @@ jobs:
 
         steps:
             - name: Checkout code and submodules
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Build binaries and add to the release
               uses: wangyoucao577/go-release-action@v1

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Build binaries and add to the release
               uses: wangyoucao577/go-release-action@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v3

--- a/.github/workflows/copycat-db-release.yml
+++ b/.github/workflows/copycat-db-release.yml
@@ -10,7 +10,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               name: Check out code
 
             - uses: mr-smithers-excellent/docker-build-push@v6

--- a/.github/workflows/copycat-db-release.yml
+++ b/.github/workflows/copycat-db-release.yml
@@ -10,7 +10,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
               name: Check out code
 
             - uses: mr-smithers-excellent/docker-build-push@v6

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: desktop
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: desktop
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/docs-deploy-redirect.yml
+++ b/.github/workflows/docs-deploy-redirect.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Deploy redirect to help.ente.io
               uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/docs-deploy-redirect.yml
+++ b/.github/workflows/docs-deploy-redirect.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Deploy redirect to help.ente.io
               uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/docs-sync-photos-changelog.yml
+++ b/.github/workflows/docs-sync-photos-changelog.yml
@@ -45,7 +45,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Sync changelog entry
               id: sync

--- a/.github/workflows/docs-sync-photos-changelog.yml
+++ b/.github/workflows/docs-sync-photos-changelog.yml
@@ -45,7 +45,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Sync changelog entry
               id: sync

--- a/.github/workflows/docs-verify-build.yml
+++ b/.github/workflows/docs-verify-build.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/docs-verify-build.yml
+++ b/.github/workflows/docs-verify-build.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/ensu-desktop-lint.yml
+++ b/.github/workflows/ensu-desktop-lint.yml
@@ -28,7 +28,7 @@ jobs:
                 working-directory: rust/apps/ensu/src-tauri
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/ensu-desktop-lint.yml
+++ b/.github/workflows/ensu-desktop-lint.yml
@@ -28,7 +28,7 @@ jobs:
                 working-directory: rust/apps/ensu/src-tauri
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/ensu-release.yml
+++ b/.github/workflows/ensu-release.yml
@@ -50,10 +50,10 @@ jobs:
                   echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"
@@ -243,7 +243,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Set release tag
               shell: bash

--- a/.github/workflows/ensu-release.yml
+++ b/.github/workflows/ensu-release.yml
@@ -50,10 +50,10 @@ jobs:
                   echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"
@@ -243,7 +243,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Set release tag
               shell: bash

--- a/.github/workflows/infra-deploy-staff.yml
+++ b/.github/workflows/infra-deploy-staff.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/infra-deploy-staff.yml
+++ b/.github/workflows/infra-deploy-staff.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/infra-lint-staff.yml
+++ b/.github/workflows/infra-lint-staff.yml
@@ -20,10 +20,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/infra-lint-staff.yml
+++ b/.github/workflows/infra-lint-staff.yml
@@ -20,10 +20,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/locker-crowdin-push.yml
+++ b/.github/workflows/locker-crowdin-push.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/locker-crowdin-push.yml
+++ b/.github/workflows/locker-crowdin-push.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/locker-crowdin-sync.yml
+++ b/.github/workflows/locker-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/locker-crowdin-sync.yml
+++ b/.github/workflows/locker-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/locker-internal-release.yml
+++ b/.github/workflows/locker-internal-release.yml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup JDK 17
               uses: actions/setup-java@v1

--- a/.github/workflows/locker-internal-release.yml
+++ b/.github/workflows/locker-internal-release.yml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup JDK 17
               uses: actions/setup-java@v1

--- a/.github/workflows/locker-lint.yml
+++ b/.github/workflows/locker-lint.yml
@@ -26,7 +26,7 @@ jobs:
                 working-directory: mobile/apps/locker
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/locker

--- a/.github/workflows/locker-lint.yml
+++ b/.github/workflows/locker-lint.yml
@@ -26,7 +26,7 @@ jobs:
                 working-directory: mobile/apps/locker
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/locker

--- a/.github/workflows/locker-release.yml
+++ b/.github/workflows/locker-release.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Free up disk space
               run: |

--- a/.github/workflows/locker-release.yml
+++ b/.github/workflows/locker-release.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Free up disk space
               run: |

--- a/.github/workflows/mobile-crowdin-push.yml
+++ b/.github/workflows/mobile-crowdin-push.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/mobile-crowdin-push.yml
+++ b/.github/workflows/mobile-crowdin-push.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/mobile-crowdin-sync.yml
+++ b/.github/workflows/mobile-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/mobile-crowdin-sync.yml
+++ b/.github/workflows/mobile-crowdin-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/mobile-daily-internal.yml
+++ b/.github/workflows/mobile-daily-internal.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Free Disk Space (Ubuntu)
               uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/mobile-daily-internal.yml
+++ b/.github/workflows/mobile-daily-internal.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Free Disk Space (Ubuntu)
               uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -26,7 +26,7 @@ jobs:
                 working-directory: mobile/apps/photos
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/photos

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -26,7 +26,7 @@ jobs:
                 working-directory: mobile/apps/photos
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/photos

--- a/.github/workflows/mobile-packages-lint.yml
+++ b/.github/workflows/mobile-packages-lint.yml
@@ -36,7 +36,7 @@ jobs:
             rust_changed: ${{ steps.filter.outputs.rust_changed }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Detect changed files
               uses: dorny/paths-filter@v3
@@ -97,7 +97,7 @@ jobs:
         if: github.event_name == 'pull_request'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile
@@ -109,7 +109,7 @@ jobs:
         if: needs.detect-changes.outputs.lint_all == 'true' || needs.detect-changes.outputs.packages != ''
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2
@@ -251,7 +251,7 @@ jobs:
         if: needs.detect-changes.outputs.rust_changed == 'true'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2
@@ -325,13 +325,13 @@ jobs:
         steps:
             - name: Checkout code and submodules
               if: needs.detect-changes.outputs.lint_auth == 'true'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   submodules: recursive
 
             - name: Checkout code
               if: needs.detect-changes.outputs.lint_auth != 'true'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2

--- a/.github/workflows/mobile-packages-lint.yml
+++ b/.github/workflows/mobile-packages-lint.yml
@@ -36,7 +36,7 @@ jobs:
             rust_changed: ${{ steps.filter.outputs.rust_changed }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Detect changed files
               uses: dorny/paths-filter@v3
@@ -97,7 +97,7 @@ jobs:
         if: github.event_name == 'pull_request'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Verify frozen mobile pubspecs
               run: ruby mobile/scripts/check_frozen_pubspecs.rb mobile
@@ -109,7 +109,7 @@ jobs:
         if: needs.detect-changes.outputs.lint_all == 'true' || needs.detect-changes.outputs.packages != ''
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2
@@ -251,7 +251,7 @@ jobs:
         if: needs.detect-changes.outputs.rust_changed == 'true'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2
@@ -325,13 +325,13 @@ jobs:
         steps:
             - name: Checkout code and submodules
               if: needs.detect-changes.outputs.lint_auth == 'true'
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   submodules: recursive
 
             - name: Checkout code
               if: needs.detect-changes.outputs.lint_auth != 'true'
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Install Flutter ${{ env.FLUTTER_VERSION  }}
               uses: subosito/flutter-action@v2

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Free up disk space
               run: |

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Free up disk space
               run: |

--- a/.github/workflows/photos-internal-release.yml
+++ b/.github/workflows/photos-internal-release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Common Setup
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1

--- a/.github/workflows/photos-internal-release.yml
+++ b/.github/workflows/photos-internal-release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Common Setup
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup JDK 17
         uses: actions/setup-java@v1

--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -28,7 +28,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Cache cargo artifacts
               uses: actions/cache@v4

--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -28,7 +28,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cache cargo artifacts
               uses: actions/cache@v4

--- a/.github/workflows/rust-lint-cli.yml
+++ b/.github/workflows/rust-lint-cli.yml
@@ -30,7 +30,7 @@ jobs:
                 working-directory: rust/cli
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/rust-lint-cli.yml
+++ b/.github/workflows/rust-lint-cli.yml
@@ -30,7 +30,7 @@ jobs:
                 working-directory: rust/cli
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cache
               uses: actions/cache@v4

--- a/.github/workflows/security-check-workflows.yml
+++ b/.github/workflows/security-check-workflows.yml
@@ -16,7 +16,7 @@ jobs:
       # This requires admin approval in repository settings
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-check-workflows.yml
+++ b/.github/workflows/security-check-workflows.yml
@@ -16,7 +16,7 @@ jobs:
       # This requires admin approval in repository settings
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -18,7 +18,7 @@ jobs:
                 working-directory: server
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup go
               uses: actions/setup-go@v5

--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -18,7 +18,7 @@ jobs:
                 working-directory: server
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup go
               uses: actions/setup-go@v5

--- a/.github/workflows/server-publish-ghcr.yml
+++ b/.github/workflows/server-publish-ghcr.yml
@@ -20,7 +20,7 @@ jobs:
                   echo "museum_commit=$(curl -s https://api.ente.io/ping | jq -r .id)" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   ref: ${{ env.museum_commit }}
 

--- a/.github/workflows/server-publish-ghcr.yml
+++ b/.github/workflows/server-publish-ghcr.yml
@@ -20,7 +20,7 @@ jobs:
                   echo "museum_commit=$(curl -s https://api.ente.io/ping | jq -r .id)" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: ${{ env.museum_commit }}
 

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Build and push
               uses: mr-smithers-excellent/docker-build-push@v6

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Build and push
               uses: mr-smithers-excellent/docker-build-push@v6

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Run server tests in Docker
               run: ./scripts/test-in-docker.sh

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -22,8 +22,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Run server tests in Docker
               run: ./scripts/test-in-docker.sh
-

--- a/.github/workflows/web-crowdin-push-both.yml
+++ b/.github/workflows/web-crowdin-push-both.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin push
               uses: crowdin/github-action@v2

--- a/.github/workflows/web-crowdin-push-both.yml
+++ b/.github/workflows/web-crowdin-push-both.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin push
               uses: crowdin/github-action@v2

--- a/.github/workflows/web-crowdin-sync.yml
+++ b/.github/workflows/web-crowdin-sync.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/web-crowdin-sync.yml
+++ b/.github/workflows/web-crowdin-sync.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Crowdin's action
               uses: crowdin/github-action@v2

--- a/.github/workflows/web-deploy-2of3.yml
+++ b/.github/workflows/web-deploy-2of3.yml
@@ -16,12 +16,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-deploy-2of3.yml
+++ b/.github/workflows/web-deploy-2of3.yml
@@ -16,12 +16,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -32,12 +32,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -32,12 +32,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -24,12 +24,12 @@ jobs:
                 working-directory: web
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -24,12 +24,12 @@ jobs:
                 working-directory: web
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   persist-credentials: false
 
             - name: Setup node and enable yarn caching
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: "yarn"

--- a/.github/workflows/web-publish-ghcr.yml
+++ b/.github/workflows/web-publish-ghcr.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Build and push
               uses: mr-smithers-excellent/docker-build-push@v6

--- a/.github/workflows/web-publish-ghcr.yml
+++ b/.github/workflows/web-publish-ghcr.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Build and push
               uses: mr-smithers-excellent/docker-build-push@v6

--- a/desktop/.github/workflows/desktop-release.yml
+++ b/desktop/.github/workflows/desktop-release.yml
@@ -39,7 +39,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   # If triggered by a tag, checkout photosd-$tag from the source
                   # repository. Otherwise checkout $source (default: "main").
@@ -49,7 +49,7 @@ jobs:
                       || 'main' ) }}"
 
             - name: Setup node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 


### PR DESCRIPTION
Fixes the deprecation warnings

<img width="1105" height="305" alt="Screenshot 2026-04-15 at 5 53 31 PM" src="https://github.com/user-attachments/assets/57f7f568-be63-4d97-acfe-f9e73db83c64" />
