### PR TITLE
[auth] Add icon for Alter

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -72,6 +72,14 @@
       "slug": "allegro"
     },
     {
+      "title": "Alter",
+      "hex": "E5E5E5",
+      "altNames": [
+        "~Alter",
+        "~alter"
+      ]
+    },
+    {
       "title": "Amazon"
     },
     {

--- a/mobile/apps/auth/assets/custom-icons/icons/alter.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/alter.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"><path d="M2 13.5 C 4.5 3, 10.5 2.5, 14.4 12 C 17 18, 20.5 17.5, 22 10.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
## Description

Add SVG icon for Alter (https://truealter.com) — an identity protocol that uses TOTP MFA. Adds our brand mark so users enrolling Alter as an issuer see the brand icon instead of the generic fallback avatar.

- `assets/custom-icons/icons/alter.svg` — 239-byte pure-vector single-stroke path (no raster, well under the 20 KB limit).
- `assets/custom-icons/_data/custom-icons.json` — entry for `Alter` with `hex: "E5E5E5"` so Ente's adaptive-colour logic remaps the stroke to the theme's `iconColor` in light mode while rendering as-is in dark mode.
- `altNames` covers the tilde-prefixed issuer form (`~Alter` / `~alter`) that some of our enrolment flows emit, since the matcher normalises issuer strings with `replaceAll(' ', '').toLowerCase()` and a leading tilde would otherwise miss the base `Alter` key.

The icon is our own original mark, submitted for use in Ente Auth.

## Tests

N/A — icon-only change. Visually verified the SVG parses and matches the viewBox/stroke conventions used by other vector entries in the directory.