### PR TITLE
[mob][locker] Improve offline save UX and file open behavior

### DIFF
--- a/mobile/apps/locker/assets/svg/cloud-download-cancel.svg
+++ b/mobile/apps/locker/assets/svg/cloud-download-cancel.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="cloud-download-cancel">
+<g id="elements">
+<path id="Vector" d="M17.5 8.51009C17.5 8.67896 17.4924 8.84606 17.4776 9.01106M17.4776 9.01106C17.485 9.01102 17.4925 9.01101 17.5 9.01101C19.9853 9.01101 22 11.0294 22 13.5193C22 15.8398 20.25 17.7508 18 18M17.4776 9.01106C17.4251 9.59444 17.2819 10.1516 17.0621 10.6683M6.52042 8.03192C3.98398 8.27373 2 10.4139 2 13.0183C2 15.135 3.31048 16.9451 5.16295 17.6786M6.52042 8.03192C6.67826 8.01687 6.83823 8.00917 7 8.00917C7.5226 8.00917 8.02648 8.0895 8.5 8.23849M6.52042 8.03192C6.76233 5.21267 9.12324 3 12 3C13.9288 3 15.6257 3.9947 16.6075 5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M12 19V13.5M12 19C11.2998 19 9.99153 17.0057 9.5 16.5M12 19C12.7002 19 14.0085 17.0057 14.5 16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<path id="Vector 588" d="M7.5 22H16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector_3" d="M20.5 4L5 21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/mobile/apps/locker/assets/svg/cloud-download.svg
+++ b/mobile/apps/locker/assets/svg/cloud-download.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="cloud-download">
+<g id="elements">
+<path id="Vector" d="M17.4776 9.01106C17.485 9.01102 17.4925 9.01101 17.5 9.01101C19.9853 9.01101 22 11.0294 22 13.5193C22 15.8398 20.25 17.7508 18 18M17.4776 9.01106C17.4924 8.84606 17.5 8.67896 17.5 8.51009C17.5 5.46695 15.0376 3 12 3C9.12324 3 6.76233 5.21267 6.52042 8.03192M17.4776 9.01106C17.3753 10.1476 16.9286 11.1846 16.2428 12.0165M6.52042 8.03192C3.98398 8.27373 2 10.4139 2 13.0183C2 15.4417 3.71776 17.4632 6 17.9273M6.52042 8.03192C6.67826 8.01687 6.83823 8.00917 7 8.00917C8.12582 8.00917 9.16474 8.38194 10.0005 9.01101" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M12 19L12 11M12 19C11.2998 19 9.99153 17.0057 9.5 16.5M12 19C12.7002 19 14.0085 17.0057 14.5 16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<path id="Vector 588" d="M7.5 22H16.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -29,8 +29,8 @@
       }
     }
   },
-  "saveOffline": "Save offline",
-  "unsave": "Unsave",
+  "keepOffline": "Keep offline",
+  "cloudOnly": "Cloud only",
   "savingOffline": "Saving offline...",
   "filesAvailableOffline": "{count, plural, =1{1 file saved offline} other{{count} files saved offline}}",
   "@filesAvailableOffline": {

--- a/mobile/apps/locker/lib/l10n/app_localizations.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations.dart
@@ -270,17 +270,17 @@ abstract class AppLocalizations {
   /// **'Downloading... {percentage}%'**
   String downloadingProgress(int percentage);
 
-  /// No description provided for @saveOffline.
+  /// No description provided for @keepOffline.
   ///
   /// In en, this message translates to:
-  /// **'Save offline'**
-  String get saveOffline;
+  /// **'Keep offline'**
+  String get keepOffline;
 
-  /// No description provided for @unsave.
+  /// No description provided for @cloudOnly.
   ///
   /// In en, this message translates to:
-  /// **'Unsave'**
-  String get unsave;
+  /// **'Cloud only'**
+  String get cloudOnly;
 
   /// No description provided for @savingOffline.
   ///

--- a/mobile/apps/locker/lib/l10n/app_localizations_en.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations_en.dart
@@ -76,10 +76,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get saveOffline => 'Save offline';
+  String get keepOffline => 'Keep offline';
 
   @override
-  String get unsave => 'Unsave';
+  String get cloudOnly => 'Cloud only';
 
   @override
   String get savingOffline => 'Saving offline...';

--- a/mobile/apps/locker/lib/ui/components/file_list_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/file_list_widget.dart
@@ -2,6 +2,7 @@ import "package:ente_sharing/models/user.dart";
 import "package:ente_sharing/user_avator_widget.dart";
 import "package:ente_ui/theme/ente_theme.dart";
 import "package:flutter/material.dart";
+import "package:flutter_svg/flutter_svg.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:locker/models/selected_files.dart";
 import "package:locker/services/collections/collections_service.dart";
@@ -224,12 +225,12 @@ class FileListWidget extends StatelessWidget {
     }
 
     if (isMarkedOffline) {
-      return HugeIcon(
+      return SvgPicture.asset(
+        "assets/svg/cloud-download.svg",
         key: const ValueKey("offline"),
-        icon: HugeIcons.strokeRoundedBookmark02,
-        color: primaryColor,
-        size: 20.0,
-        strokeWidth: 2.0,
+        width: 20.0,
+        height: 20.0,
+        colorFilter: ColorFilter.mode(primaryColor, BlendMode.srcIn),
       );
     }
 

--- a/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -6,6 +6,7 @@ import "package:ente_ui/theme/ente_theme.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:flutter/material.dart";
+import "package:flutter_svg/flutter_svg.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:locker/events/collections_updated_event.dart";
 import "package:locker/l10n/l10n.dart";
@@ -357,9 +358,14 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
       actions.add(
         SelectionActionButton(
-          hugeIcon: HugeIcon(
-            icon: HugeIcons.strokeRoundedBookmark02,
-            color: colorScheme.textBase,
+          hugeIcon: SvgPicture.asset(
+            "assets/svg/cloud-download.svg",
+            width: 24,
+            height: 24,
+            colorFilter: ColorFilter.mode(
+              colorScheme.textBase,
+              BlendMode.srcIn,
+            ),
           ),
           label: shouldRemoveOffline
               ? context.l10n.cloudOnly

--- a/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -345,19 +345,33 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     final showImportant = viewType?.showMarkImportantOption ?? true;
     final showDelete = viewType?.showDeleteOption ?? true;
 
+    final eligibleOfflineFiles =
+        OfflineFilesService.instance.getEligibleFiles(files);
+    final showOffline = viewType?.showOfflineOption ?? true;
     final actions = <Widget>[];
 
-    actions.add(
-      SelectionActionButton(
-        hugeIcon: const HugeIcon(
-          icon: HugeIcons.strokeRoundedDownload01,
+    if (showOffline && eligibleOfflineFiles.isNotEmpty) {
+      final shouldRemoveOffline = isSingleSelection &&
+          eligibleOfflineFiles.length == 1 &&
+          LockerDB.instance.isFileMarkedOffline(eligibleOfflineFiles.first);
+
+      actions.add(
+        SelectionActionButton(
+          hugeIcon: HugeIcon(
+            icon: HugeIcons.strokeRoundedBookmark02,
+            color: colorScheme.textBase,
+          ),
+          label: shouldRemoveOffline
+              ? context.l10n.cloudOnly
+              : context.l10n.keepOffline,
+          onTap: () => _toggleOfflineAvailability(
+            context,
+            files,
+            shouldRemoveOffline: shouldRemoveOffline,
+          ),
         ),
-        label: context.l10n.download,
-        onTap: () => isSingleSelection
-            ? _downloadFile(context, file!)
-            : _downloadMultipleFiles(context, files),
-      ),
-    );
+      );
+    }
 
     if (showImportant) {
       actions.add(
@@ -467,15 +481,11 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     final file = isSingleSelection ? selectedFiles.first : null;
     final files = selectedFiles.toList();
     final viewType = widget.collectionViewType;
-    final colorScheme = getEnteColorScheme(context);
     final actions = <Widget>[];
-    final eligibleOfflineFiles =
-        OfflineFilesService.instance.getEligibleFiles(files);
 
     final showEdit = viewType?.showEditOption ?? true;
     final showShare = viewType?.showShareOption ?? true;
     final showAddTo = viewType?.showAddToCollectionOption ?? true;
-    final showOffline = viewType?.showOfflineOption ?? true;
 
     if (isSingleSelection && showEdit) {
       actions.add(
@@ -513,32 +523,17 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       );
     }
 
-    if (showOffline) {
-      if (eligibleOfflineFiles.isEmpty) {
-        return actions;
-      }
-
-      final shouldRemoveOffline = isSingleSelection &&
-          eligibleOfflineFiles.length == 1 &&
-          LockerDB.instance.isFileMarkedOffline(eligibleOfflineFiles.first);
-
-      actions.add(
-        SelectionActionButton(
-          hugeIcon: HugeIcon(
-            icon: HugeIcons.strokeRoundedBookmark02,
-            color: colorScheme.textBase,
-          ),
-          label: shouldRemoveOffline
-              ? context.l10n.unsave
-              : context.l10n.saveOffline,
-          onTap: () => _toggleOfflineAvailability(
-            context,
-            files,
-            shouldRemoveOffline: shouldRemoveOffline,
-          ),
+    actions.add(
+      SelectionActionButton(
+        hugeIcon: const HugeIcon(
+          icon: HugeIcons.strokeRoundedDownload01,
         ),
-      );
-    }
+        label: context.l10n.download,
+        onTap: () => isSingleSelection
+            ? _downloadFile(context, file!)
+            : _downloadMultipleFiles(context, files),
+      ),
+    );
 
     return actions;
   }

--- a/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -62,8 +62,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
   List<EnteFile> _getOwnedFiles(List<EnteFile> files) {
     final currentUserID = Configuration.instance.getUserID();
-    final ownedFiles =
-        files.where((file) => file.ownerID == currentUserID).toList();
+    final ownedFiles = files
+        .where((file) => file.ownerID == currentUserID)
+        .toList();
 
     final sharedCount = files.length - ownedFiles.length;
     if (sharedCount > 0 && mounted) {
@@ -182,10 +183,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
                                         widget.selectedFiles.files;
                                     final isAllSelected =
                                         widget.files.isNotEmpty &&
-                                            widget.files.every(
-                                              (file) =>
-                                                  selectedSet.contains(file),
-                                            );
+                                        widget.files.every(
+                                          (file) => selectedSet.contains(file),
+                                        );
                                     final buttonText = isAllSelected
                                         ? context.l10n.deselectAll
                                         : context.l10n.selectAll;
@@ -198,16 +198,18 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
                                         if (isAllSelected) {
                                           widget.selectedFiles.clearAll();
                                         } else {
-                                          widget.selectedFiles
-                                              .selectAll(widget.files.toSet());
+                                          widget.selectedFiles.selectAll(
+                                            widget.files.toSet(),
+                                          );
                                         }
                                       },
                                       child: Container(
                                         decoration: BoxDecoration(
                                           color:
                                               colorScheme.backgroundElevated2,
-                                          borderRadius:
-                                              BorderRadius.circular(50),
+                                          borderRadius: BorderRadius.circular(
+                                            50,
+                                          ),
                                         ),
                                         padding: const EdgeInsets.symmetric(
                                           horizontal: 12.0,
@@ -237,8 +239,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
                                   listenable: widget.selectedFiles,
                                   builder: (context, child) {
                                     final count = widget.selectedFiles.count;
-                                    final countText =
-                                        context.l10n.selectedCount(count);
+                                    final countText = context.l10n
+                                        .selectedCount(count);
 
                                     return InkWell(
                                       onTap: () {
@@ -248,8 +250,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
                                         decoration: BoxDecoration(
                                           color:
                                               colorScheme.backgroundElevated2,
-                                          borderRadius:
-                                              BorderRadius.circular(50),
+                                          borderRadius: BorderRadius.circular(
+                                            50,
+                                          ),
                                         ),
                                         padding: const EdgeInsets.symmetric(
                                           horizontal: 12.0,
@@ -339,27 +342,32 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     final file = isSingleSelection ? files.first : null;
     final viewType = widget.collectionViewType;
 
-    final isImportant = isSingleSelection &&
+    final isImportant =
+        isSingleSelection &&
         file != null &&
         FavoritesService.instance.isFavoriteCache(file);
 
     final showImportant = viewType?.showMarkImportantOption ?? true;
     final showDelete = viewType?.showDeleteOption ?? true;
 
-    final eligibleOfflineFiles =
-        OfflineFilesService.instance.getEligibleFiles(files);
+    final eligibleOfflineFiles = OfflineFilesService.instance.getEligibleFiles(
+      files,
+    );
     final showOffline = viewType?.showOfflineOption ?? true;
     final actions = <Widget>[];
 
     if (showOffline && eligibleOfflineFiles.isNotEmpty) {
-      final shouldRemoveOffline = isSingleSelection &&
+      final shouldRemoveOffline =
+          isSingleSelection &&
           eligibleOfflineFiles.length == 1 &&
           LockerDB.instance.isFileMarkedOffline(eligibleOfflineFiles.first);
 
       actions.add(
         SelectionActionButton(
           hugeIcon: SvgPicture.asset(
-            "assets/svg/cloud-download.svg",
+            shouldRemoveOffline
+                ? "assets/svg/cloud-download-cancel.svg"
+                : "assets/svg/cloud-download.svg",
             width: 24,
             height: 24,
             colorFilter: ColorFilter.mode(
@@ -389,8 +397,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
                   icon: HugeIcons.strokeRoundedStar,
                   color: colorScheme.textBase,
                 ),
-          label:
-              isImportant ? context.l10n.unimportant : context.l10n.important,
+          label: isImportant
+              ? context.l10n.unimportant
+              : context.l10n.important,
           onTap: () => isSingleSelection
               ? _markImportant(context, file!)
               : _markMultipleImportant(context, files),
@@ -414,9 +423,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       );
     }
 
-    return Row(
-      children: _buildActionRow(actions),
-    );
+    return Row(children: _buildActionRow(actions));
   }
 
   Widget _buildTrashActionRow(
@@ -431,9 +438,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       child: Row(
         children: _buildActionRow([
           SelectionActionButton(
-            hugeIcon: const HugeIcon(
-              icon: HugeIcons.strokeRoundedRefresh,
-            ),
+            hugeIcon: const HugeIcon(icon: HugeIcons.strokeRoundedRefresh),
             label: context.l10n.restore,
             onTap: () => _restoreFiles(context, files),
           ),
@@ -465,9 +470,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
         color: colorScheme.backgroundElevated2,
         borderRadius: BorderRadius.circular(24),
       ),
-      child: Row(
-        children: _buildActionRow(actions, spacing: 0),
-      ),
+      child: Row(children: _buildActionRow(actions, spacing: 0)),
     );
   }
 
@@ -496,9 +499,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     if (isSingleSelection && showEdit) {
       actions.add(
         SelectionActionButton(
-          hugeIcon: const HugeIcon(
-            icon: HugeIcons.strokeRoundedPencilEdit02,
-          ),
+          hugeIcon: const HugeIcon(icon: HugeIcons.strokeRoundedPencilEdit02),
           label: context.l10n.edit,
           onTap: () => _editFile(context, file!),
         ),
@@ -508,9 +509,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     if (isSingleSelection && showShare) {
       actions.add(
         SelectionActionButton(
-          hugeIcon: const HugeIcon(
-            icon: HugeIcons.strokeRoundedNavigation06,
-          ),
+          hugeIcon: const HugeIcon(icon: HugeIcons.strokeRoundedNavigation06),
           label: context.l10n.share,
           onTap: () => _shareFileLink(context, file!),
         ),
@@ -520,9 +519,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     if (showAddTo) {
       actions.add(
         SelectionActionButton(
-          hugeIcon: const HugeIcon(
-            icon: HugeIcons.strokeRoundedArrowRight03,
-          ),
+          hugeIcon: const HugeIcon(icon: HugeIcons.strokeRoundedArrowRight03),
           label: context.l10n.addTo,
           onTap: () => _showAddToDialog(context, files),
         ),
@@ -531,9 +528,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
     actions.add(
       SelectionActionButton(
-        hugeIcon: const HugeIcon(
-          icon: HugeIcons.strokeRoundedDownload01,
-        ),
+        hugeIcon: const HugeIcon(icon: HugeIcons.strokeRoundedDownload01),
         label: context.l10n.download,
         onTap: () => isSingleSelection
             ? _downloadFile(context, file!)
@@ -550,14 +545,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     required bool shouldRemoveOffline,
   }) async {
     final success = shouldRemoveOffline
-        ? await OfflineFilesService.instance.unmarkFilesOffline(
-            context,
-            files,
-          )
-        : await OfflineFilesService.instance.markFilesOffline(
-            context,
-            files,
-          );
+        ? await OfflineFilesService.instance.unmarkFilesOffline(context, files)
+        : await OfflineFilesService.instance.markFilesOffline(context, files);
 
     if (success) {
       widget.selectedFiles.clearAll();
@@ -573,10 +562,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     } catch (e, stackTrace) {
       _logger.severe("Failed to download file: $e", e, stackTrace);
       if (context.mounted) {
-        await showGenericErrorBottomSheet(
-          context: context,
-          error: e,
-        );
+        await showGenericErrorBottomSheet(context: context, error: e);
       }
     }
   }
@@ -597,10 +583,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     } catch (e, stackTrace) {
       _logger.severe("Failed to download files: $e", e, stackTrace);
       if (context.mounted) {
-        await showGenericErrorBottomSheet(
-          context: context,
-          error: e,
-        );
+        await showGenericErrorBottomSheet(context: context, error: e);
       }
     }
   }
@@ -637,8 +620,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       'Opening add-to dialog for ${ownedFiles.length} file(s); fetching collections.',
     );
 
-    final allCollections =
-        await CollectionService.instance.getCollectionsForUI();
+    final allCollections = await CollectionService.instance
+        .getCollectionsForUI();
     final dedupedCollections = uniqueCollectionsById(allCollections);
     _logger.info(
       'Presenting ${dedupedCollections.length} unique collection option(s) '
@@ -673,8 +656,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
           );
           List<Collection> currentCollections;
           try {
-            currentCollections =
-                await CollectionService.instance.getCollectionsForFile(file);
+            currentCollections = await CollectionService.instance
+                .getCollectionsForFile(file);
           } catch (_) {
             _logger.warning(
               'Failed to fetch existing collections for file ${file.uploadedFileID}',
@@ -682,8 +665,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
             currentCollections = <Collection>[];
           }
 
-          final currentCollectionIds =
-              currentCollections.map((collection) => collection.id).toSet();
+          final currentCollectionIds = currentCollections
+              .map((collection) => collection.id)
+              .toSet();
 
           final collectionsToAdd = result.selectedCollections.where(
             (collection) => !currentCollectionIds.contains(collection.id),
@@ -706,10 +690,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
         if (addFutures.isEmpty) {
           await dialog.hide();
           widget.selectedFiles.clearAll();
-          showToast(
-            context,
-            context.l10n.noChangesWereMade,
-          );
+          showToast(context, context.l10n.noChangesWereMade);
           return;
         }
 
@@ -723,20 +704,12 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
         widget.selectedFiles.clearAll();
 
-        showToast(
-          context,
-          context.l10n.fileUpdatedSuccessfully,
-        );
+        showToast(context, context.l10n.fileUpdatedSuccessfully);
       } catch (e) {
         await dialog.hide();
-        _logger.severe(
-          'Failed add-to operation: $e',
-        );
+        _logger.severe('Failed add-to operation: $e');
 
-        await showGenericErrorBottomSheet(
-          context: context,
-          error: e,
-        );
+        await showGenericErrorBottomSheet(context: context, error: e);
       }
     }
   }
@@ -788,8 +761,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       await dialog.show();
 
       for (final file in ownedFiles) {
-        final collections =
-            await CollectionService.instance.getCollectionsForFile(file);
+        final collections = await CollectionService.instance
+            .getCollectionsForFile(file);
 
         if (collections.isNotEmpty) {
           await CollectionService.instance.trashFile(file, collections.first);
@@ -800,10 +773,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
       widget.selectedFiles.clearAll();
 
-      showToast(
-        context,
-        context.l10n.fileDeletedSuccessfully,
-      );
+      showToast(context, context.l10n.fileDeletedSuccessfully);
     } catch (e, stackTrace) {
       await dialog.hide();
 
@@ -815,10 +785,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       if (!context.mounted) {
         return;
       }
-      await showGenericErrorBottomSheet(
-        context: context,
-        error: e,
-      );
+      await showGenericErrorBottomSheet(context: context, error: e);
     }
   }
 
@@ -860,8 +827,8 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
   Future<void> _restoreFiles(BuildContext context, List<EnteFile> files) async {
     _logger.info('Opening restore dialog for ${files.length} file(s)');
 
-    final allCollections =
-        await CollectionService.instance.getCollectionsForUI();
+    final allCollections = await CollectionService.instance
+        .getCollectionsForUI();
     final dedupedCollections = uniqueCollectionsById(allCollections);
 
     final result = await showAddToCollectionSheet(
@@ -904,10 +871,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       _logger.severe('Failed to restore files: $e', e, stackTrace);
 
       if (context.mounted) {
-        await showGenericErrorBottomSheet(
-          context: context,
-          error: e,
-        );
+        await showGenericErrorBottomSheet(context: context, error: e);
       }
     }
   }
@@ -946,20 +910,14 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       widget.selectedFiles.clearAll();
 
       if (context.mounted) {
-        showToast(
-          context,
-          context.l10n.filesDeletedPermanently(files.length),
-        );
+        showToast(context, context.l10n.filesDeletedPermanently(files.length));
       }
     } catch (e, stackTrace) {
       await dialog.hide();
       _logger.severe('Failed to delete files from trash: $e', e, stackTrace);
 
       if (context.mounted) {
-        await showGenericErrorBottomSheet(
-          context: context,
-          error: e,
-        );
+        await showGenericErrorBottomSheet(context: context, error: e);
       }
     }
   }

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -44,7 +44,11 @@ class FileUtil {
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));
     if (await cachedDecryptedFile.exists()) {
-      await _launchFile(context, cachedDecryptedFile, displayName: file.displayName);
+      await _launchFile(
+        context,
+        cachedDecryptedFile,
+        displayName: file.displayName,
+      );
       return;
     }
 
@@ -77,7 +81,11 @@ class FileUtil {
       await dialog.hide();
 
       if (decryptedFile != null) {
-        await _launchFile(context, decryptedFile, displayName: file.displayName);
+        await _launchFile(
+          context,
+          decryptedFile,
+          displayName: file.displayName,
+        );
       } else {
         await showAlertBottomSheet(
           context,
@@ -425,6 +433,12 @@ class FileUtil {
         context: context,
         error: e,
       );
+    } finally {
+      if (fileToOpen.path != file.path) {
+        try {
+          await fileToOpen.delete();
+        } catch (_) {}
+      }
     }
   }
 }

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -44,7 +44,7 @@ class FileUtil {
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));
     if (await cachedDecryptedFile.exists()) {
-      await _launchFile(context, cachedDecryptedFile);
+      await _launchFile(context, cachedDecryptedFile, displayName: file.displayName);
       return;
     }
 
@@ -77,7 +77,7 @@ class FileUtil {
       await dialog.hide();
 
       if (decryptedFile != null) {
-        await _launchFile(context, decryptedFile);
+        await _launchFile(context, decryptedFile, displayName: file.displayName);
       } else {
         await showAlertBottomSheet(
           context,
@@ -399,10 +399,24 @@ class FileUtil {
 
   static Future<void> _launchFile(
     BuildContext context,
-    File file,
-  ) async {
+    File file, {
+    String? displayName,
+  }) async {
+    File fileToOpen = file;
+
     try {
-      final result = await OpenFile.open(file.path);
+      if (displayName != null && displayName.isNotEmpty) {
+        try {
+          final sanitizedName = _sanitizeFileName(p.basename(displayName));
+          final launchPath = p.join(file.parent.path, sanitizedName);
+          await file.copy(launchPath);
+          fileToOpen = File(launchPath);
+        } catch (e) {
+          _logger.warning("Failed to create display-name copy: $e");
+        }
+      }
+
+      final result = await OpenFile.open(fileToOpen.path);
       if (result.type != ResultType.done) {
         throw Exception(result.message);
       }


### PR DESCRIPTION
## Summary
- Swap save offline and download buttons in selection bar so keep offline is in the primary row
- Fix system open-with sheet showing internal filenames like "123.decrypted.pdf" instead of the actual display name
- Update copy: "Save offline" to "Keep offline", "Unsave" to "Cloud only"

## Test plan
- [x] Select a file and verify "Keep offline" appears in the primary action row
- [x] Select a file and verify "Download" appears in the secondary (expandable) action row
- [x] Open a file that no app supports and verify the system sheet shows the actual filename, not "uniqueid.decrypted"
- [x] Mark a file offline, then select it and verify the label shows "Cloud only"