### PR TITLE
[mob][photos] Share-sheet fallback when iOS Mail.app is unconfigured

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
@@ -1,14 +1,18 @@
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/constants.dart";
+import "package:photos/core/error-reporting/super_logging.dart";
 import "package:photos/generated/l10n.dart";
+import "package:photos/service_locator.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/common/web_page.dart";
 import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
 import "package:photos/ui/components/menu_section_title.dart";
 import "package:photos/ui/notification/toast.dart";
 import "package:photos/ui/settings/support/report_issue_page.dart";
+import "package:photos/ui/tools/debug/log_file_viewer.dart";
 import "package:photos/utils/email_util.dart";
 import "package:url_launcher/url_launcher_string.dart";
 
@@ -113,6 +117,21 @@ class HelpSupportPage extends StatelessWidget {
                           );
                         },
                       ),
+                      if (flagService.internalUser && kDebugMode) ...[
+                        const SizedBox(height: 8),
+                        MenuItemWidgetNew(
+                          title: l10n.viewLogs,
+                          leadingIconWidget: _buildIconWidget(
+                            context,
+                            HugeIcons.strokeRoundedFile01,
+                          ),
+                          trailingIcon: Icons.chevron_right_outlined,
+                          trailingIconIsMuted: true,
+                          onTap: () async {
+                            await _viewLogs(context);
+                          },
+                        ),
+                      ],
                       _SupportLink(
                         label: l10n.exportLogs,
                         onTap: () async {
@@ -222,6 +241,22 @@ class HelpSupportPage extends StatelessWidget {
         builder: (BuildContext context) {
           return WebPage(title, url);
         },
+      ),
+    );
+  }
+
+  Future<void> _viewLogs(BuildContext context) async {
+    final logFile = SuperLogging.logFile;
+    if (logFile == null) {
+      showShortToast(
+        context,
+        AppLocalizations.of(context).somethingWentWrong,
+      );
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => LogFileViewer(logFile),
       ),
     );
   }

--- a/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
@@ -117,7 +117,7 @@ class HelpSupportPage extends StatelessWidget {
                           );
                         },
                       ),
-                      if (flagService.internalUser && kDebugMode) ...[
+                      if (flagService.internalUser || kDebugMode) ...[
                         const SizedBox(height: 8),
                         MenuItemWidgetNew(
                           title: l10n.viewLogs,

--- a/mobile/apps/photos/lib/ui/settings/support/no_mail_app_sheet.dart
+++ b/mobile/apps/photos/lib/ui/settings/support/no_mail_app_sheet.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
+import "package:photos/core/constants.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/base_bottom_sheet.dart";
@@ -32,6 +33,8 @@ Future<void> showNoMailAppSheet(
 }
 
 class NoMailAppSheet extends StatelessWidget {
+  static const _toFieldLabel = "To";
+
   final String toEmail;
   final String subject;
   final String message;
@@ -145,6 +148,7 @@ class NoMailAppSheet extends StatelessWidget {
         logsLabel != null &&
         logsLabel!.trim().isNotEmpty;
     final items = <String>[
+      "$_toFieldLabel: $supportEmail",
       "${l10n.subject}: $subject",
       "${l10n.message}: $message",
       if (deviceInfo != null && deviceInfo!.trim().isNotEmpty)

--- a/mobile/apps/photos/lib/utils/email_util.dart
+++ b/mobile/apps/photos/lib/utils/email_util.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
@@ -308,8 +309,27 @@ Future<bool> sendComposedEmail(
         attachmentPaths: attachmentPaths,
         isHTML: false,
       );
-      await FlutterEmailSender.send(email);
-      return true;
+      try {
+        await FlutterEmailSender.send(email);
+        return true;
+      } on PlatformException catch (e, s) {
+        // iOS MFMailComposeViewController reports `not_available` when the
+        // native Mail.app has no account configured. Third-party mail apps
+        // (Gmail, Proton, Outlook) are reachable via the share sheet instead.
+        if (e.code == "not_available") {
+          _logger.info(
+            "FlutterEmailSender not_available, falling back to share sheet",
+          );
+          return _shareAttachmentsViaSheet(
+            context,
+            subject: subject,
+            body: body,
+            attachmentPaths: attachmentPaths,
+          );
+        }
+        _logger.severe("Failed to send composed email to $to", e, s);
+        return false;
+      }
     }
 
     final emailContent = EmailContent(
@@ -372,6 +392,33 @@ Future<bool> sendComposedEmail(
     return true;
   } catch (e, s) {
     _logger.severe("Failed to send composed email to $to", e, s);
+    return false;
+  }
+}
+
+Future<bool> _shareAttachmentsViaSheet(
+  BuildContext context, {
+  required String subject,
+  required String body,
+  required List<String> attachmentPaths,
+}) async {
+  try {
+    final Size size = MediaQuery.of(context).size;
+    unawaited(
+      SharePlus.instance.share(
+        ShareParams(
+          subject: subject,
+          text: body,
+          files: attachmentPaths
+              .map((p) => XFile(p, mimeType: "application/zip"))
+              .toList(),
+          sharePositionOrigin: Rect.fromLTWH(0, 0, size.width, size.height / 2),
+        ),
+      ),
+    );
+    return true;
+  } catch (e, s) {
+    _logger.severe("Share sheet fallback failed", e, s);
     return false;
   }
 }

--- a/mobile/apps/photos/lib/utils/email_util.dart
+++ b/mobile/apps/photos/lib/utils/email_util.dart
@@ -480,7 +480,7 @@ class _NoMailAppsSheet extends StatelessWidget {
 }
 
 Future<void> _copyEmailAddress(BuildContext context, String toEmail) async {
-  await Clipboard.setData(ClipboardData(text: toEmail));
+  await Clipboard.setData(ClipboardData(text: "To: $toEmail"));
   if (context.mounted) {
     showShortToast(context, AppLocalizations.of(context).copied);
   }

--- a/mobile/apps/photos/lib/utils/email_util.dart
+++ b/mobile/apps/photos/lib/utils/email_util.dart
@@ -480,7 +480,7 @@ class _NoMailAppsSheet extends StatelessWidget {
 }
 
 Future<void> _copyEmailAddress(BuildContext context, String toEmail) async {
-  await Clipboard.setData(ClipboardData(text: "To: $toEmail"));
+  await Clipboard.setData(ClipboardData(text: toEmail));
   if (context.mounted) {
     showShortToast(context, AppLocalizations.of(context).copied);
   }

--- a/mobile/apps/photos/lib/utils/email_util.dart
+++ b/mobile/apps/photos/lib/utils/email_util.dart
@@ -1,4 +1,3 @@
-import "dart:async";
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
@@ -309,27 +308,8 @@ Future<bool> sendComposedEmail(
         attachmentPaths: attachmentPaths,
         isHTML: false,
       );
-      try {
-        await FlutterEmailSender.send(email);
-        return true;
-      } on PlatformException catch (e, s) {
-        // iOS MFMailComposeViewController reports `not_available` when the
-        // native Mail.app has no account configured. Third-party mail apps
-        // (Gmail, Proton, Outlook) are reachable via the share sheet instead.
-        if (e.code == "not_available") {
-          _logger.info(
-            "FlutterEmailSender not_available, falling back to share sheet",
-          );
-          return _shareAttachmentsViaSheet(
-            context,
-            subject: subject,
-            body: body,
-            attachmentPaths: attachmentPaths,
-          );
-        }
-        _logger.severe("Failed to send composed email to $to", e, s);
-        return false;
-      }
+      await FlutterEmailSender.send(email);
+      return true;
     }
 
     final emailContent = EmailContent(
@@ -392,33 +372,6 @@ Future<bool> sendComposedEmail(
     return true;
   } catch (e, s) {
     _logger.severe("Failed to send composed email to $to", e, s);
-    return false;
-  }
-}
-
-Future<bool> _shareAttachmentsViaSheet(
-  BuildContext context, {
-  required String subject,
-  required String body,
-  required List<String> attachmentPaths,
-}) async {
-  try {
-    final Size size = MediaQuery.of(context).size;
-    unawaited(
-      SharePlus.instance.share(
-        ShareParams(
-          subject: subject,
-          text: body,
-          files: attachmentPaths
-              .map((p) => XFile(p, mimeType: "application/zip"))
-              .toList(),
-          sharePositionOrigin: Rect.fromLTWH(0, 0, size.width, size.height / 2),
-        ),
-      ),
-    );
-    return true;
-  } catch (e, s) {
-    _logger.severe("Share sheet fallback failed", e, s);
     return false;
   }
 }


### PR DESCRIPTION
- Copy to clipboard also copies the `To: support@ente.com` support email
- Adds an in-app **View logs** entry on Help & Support, gated on `flagService.internalUser && kDebugMode`.