### PR TITLE
[flathub] Fix metadata warnings

### DIFF
--- a/desktop/build/io.ente.photos.appdata.xml
+++ b/desktop/build/io.ente.photos.appdata.xml
@@ -29,6 +29,7 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/ente-io/ente/main/.github/assets/photos.png</image>
+      <caption>Browse and search your encrypted photo library across desktop and mobile devices</caption>
     </screenshot>
   </screenshots>
 

--- a/mobile/apps/auth/linux/packaging/enteauth.appdata.xml
+++ b/mobile/apps/auth/linux/packaging/enteauth.appdata.xml
@@ -12,9 +12,11 @@
     </description>
     <launchable type="desktop-id">enteauth.desktop</launchable>
     <url type="homepage">https://ente.com/auth</url>
+    <url type="vcs-browser">https://github.com/ente-io/ente</url>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/ente-io/ente/main/.github/assets/auth.png</image>
+            <caption>Import codes and access your saved 2FA tokens across devices</caption>
         </screenshot>
     </screenshots>
     <releases>


### PR DESCRIPTION
For auth, e.g. https://github.com/flathub/io.ente.auth/pull/112#issuecomment-4272847519

> 'appstream-screenshot-missing-caption' warning found in linter repo check. Details: One or more screenshots are missing captions in the Metainfo file
> 'appstream-missing-vcs-browser-url' warning found in linter repo check. Details: Please consider adding a vcs-browser URL to the Metainfo file

For photos, e.g. https://github.com/flathub/io.ente.photos/pull/35#issuecomment-4168982810

> 'appstream-screenshot-missing-caption' warning found in linter repo check. Details: One or more screenshots are missing captions in the Metainfo file
