### PR TITLE
Document Memory Lane in Photos docs

### DIFF
--- a/docs/docs/.vitepress/sidebar.ts
+++ b/docs/docs/.vitepress/sidebar.ts
@@ -201,6 +201,10 @@ export const sidebar = [
                                 link: "/photos/features/search-and-discovery/face-recognition",
                             },
                             {
+                                text: "Memory Lane",
+                                link: "/photos/features/search-and-discovery/memory-lane",
+                            },
+                            {
                                 text: "Map and location",
                                 link: "/photos/features/search-and-discovery/map-and-location",
                             },

--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -7,6 +7,14 @@ description: Release notes of recent updates to Ente Photos mobile and desktop a
 
 A short summary list of changes to the Ente Photos mobile and desktop apps. For a more descriptive list with screenshots and blog post links, see the [news](https://ente.com/news).
 
+## v1.3.32 (mobile) - Apr 2026
+
+- Memory Lane
+- Share any memory or Memory Lane as a link
+- Long press to detect QR codes in photos
+- Long press to select text in photos
+- Bug fixes and performance improvements
+
 ## v1.7.22 (desktop) - Mar 2026
 
 - App lock

--- a/docs/docs/photos/features/search-and-discovery/index.md
+++ b/docs/docs/photos/features/search-and-discovery/index.md
@@ -119,6 +119,12 @@ After enabling, the app will download and index your photos locally. This is fas
 
 Ente automatically creates collections of photos from past years on the same date, helping you rediscover memories.
 
+### Memory Lane
+
+Memory Lane creates a timeline for a person using photos of them from different years. When a person's timeline is ready, Ente shows a **Memory lane** banner on their page so you can open it and, on supported platforms, share it as a public link.
+
+**Learn more:** [Memory Lane](/photos/features/search-and-discovery/memory-lane)
+
 ### People section
 
 Browse all recognized faces and persons in your library. Name persons to organize and find photos of specific people quickly.
@@ -186,5 +192,6 @@ Learn more in [Security and Privacy FAQ](/photos/faq/security-and-privacy).
 - [Machine learning overview](/photos/features/search-and-discovery/machine-learning)
 - [Face recognition guide](/photos/features/search-and-discovery/face-recognition)
 - [Magic search guide](/photos/features/search-and-discovery/magic-search)
+- [Memory Lane](/photos/features/search-and-discovery/memory-lane)
 - [Map and location features](/photos/features/search-and-discovery/map-and-location)
 - [Search and Discovery FAQ](/photos/faq/search-and-discovery)

--- a/docs/docs/photos/features/search-and-discovery/memory-lane.md
+++ b/docs/docs/photos/features/search-and-discovery/memory-lane.md
@@ -1,0 +1,71 @@
+---
+title: Memory Lane
+description: Rediscover a person's photos across the years and share that timeline as a public link
+---
+
+# Memory Lane
+
+Memory Lane creates a timeline for a person using photos of them from different years. It helps you rediscover how someone has changed over time, and you can share that timeline as a public link.
+
+> **Note**: Memory Lane is currently available in the mobile apps.
+
+## How Memory Lane works
+
+Memory Lane uses Ente's people recognition to build a timeline for a person. When enough eligible photos are available, Ente shows a **Memory lane** banner on that person's page.
+
+The timeline can include:
+
+- photos from different years
+- captions such as how many years ago a photo was taken
+- age-based captions if that person's birth date is known
+
+Because the timeline depends on people recognition, hidden or ignored faces may affect whether Memory Lane appears.
+
+## Open Memory Lane
+
+**On mobile:**
+
+1. Open the Search tab.
+2. Open the People section.
+3. Select a person.
+4. Tap the **Memory lane** banner when it appears.
+
+If the banner does not appear yet, Ente may still be preparing the timeline or the person may not have enough eligible photos.
+
+## Share a Memory Lane link
+
+You can share a Memory Lane as a public link so others can view that person's timeline in a browser.
+
+**On mobile:**
+
+1. Open a person's **Memory lane**.
+2. Tap the share action.
+3. Create or copy the link.
+4. Share the link with anyone you want.
+
+Recipients can open the link without an Ente account.
+
+## What recipients see
+
+A shared Memory Lane opens as a public, browser-based viewer with the same timeline-style presentation.
+
+Recipients can:
+
+- view the timeline in order
+- play through the lane presentation
+- open the shared link without signing in
+
+If the link expires or is removed, it will stop working.
+
+## Availability and limits
+
+- Memory Lane depends on Ente's people recognition features.
+- It appears only when Ente can build a usable timeline for that person.
+- The feature and sharing flow may vary by platform.
+
+## Related topics
+
+- [Search and Discovery overview](/photos/features/search-and-discovery/)
+- [Face recognition](/photos/features/search-and-discovery/face-recognition)
+- [Machine learning overview](/photos/features/search-and-discovery/machine-learning)
+- [Public links](/photos/features/sharing-and-collaboration/public-links)


### PR DESCRIPTION
## Summary
- add a Memory Lane page under Photos > Search and Discovery
- link Memory Lane from the Search and Discovery overview and sidebar
- add the v1.3.32 mobile changelog entry

## Notes
- OCR / text selection already had a dedicated doc page, so this PR focuses on the actual missing gap
- includes the release-noted QR/text long-press items in the changelog for completeness