### PR TITLE
[web][photos] Auto hide gradient and controls in the FileViewer

### DIFF
--- a/web/apps/albums/src/app/styles/photoswipe.css
+++ b/web/apps/albums/src/app/styles/photoswipe.css
@@ -9,6 +9,7 @@
    entire amount. See also: [Note: Customize the desktop title bar] */
 .pswp-ente .pswp__top-bar {
     top: calc(env(titlebar-area-height, 0px) * 0.4);
+    transition: opacity 0.3s ease;
 }
 
 @media (width >= 450px) {
@@ -525,6 +526,14 @@ body:has(
     flex-direction: column-reverse;
     align-items: flex-end;
     gap: 12px;
+    transition: opacity 0.3s ease;
+}
+
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls {
+    opacity: 0;
+    pointer-events: none;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/albums/src/app/styles/photoswipe.css
+++ b/web/apps/albums/src/app/styles/photoswipe.css
@@ -48,11 +48,11 @@
    As a workaround, repeat the CSS, but with a higher specificity by including
    the button selector */
 
-.pswp .pswp__hide-on-close button {
+.pswp .pswp__hide-on-close * {
     pointer-events: none;
 }
 
-.pswp--ui-visible .pswp__hide-on-close button {
+.pswp--ui-visible .pswp__hide-on-close * {
     pointer-events: auto;
 }
 
@@ -527,24 +527,6 @@ body:has(
     align-items: flex-end;
     gap: 12px;
     transition: opacity 0.3s ease;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls {
-    opacity: 0;
-    pointer-events: none;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-:fullscreen
-    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__top-bar:focus-within,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls:focus-within {
-    opacity: 1;
-    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/albums/src/app/styles/photoswipe.css
+++ b/web/apps/albums/src/app/styles/photoswipe.css
@@ -529,11 +529,20 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
+/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
+}
+
+/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls:focus-within {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/albums/src/app/styles/photoswipe.css
+++ b/web/apps/albums/src/app/styles/photoswipe.css
@@ -529,17 +529,19 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
-/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
 }
 
-/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+:fullscreen
+    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__top-bar:focus-within,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls:focus-within {
     opacity: 1;
     pointer-events: auto;

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -821,6 +821,7 @@ export class FileViewerPhotoSwipe {
                     "mousemove",
                     handleMouseMoveInFullscreen,
                 );
+                handleFullscreenControlsActivity();
             }
         };
 
@@ -836,6 +837,11 @@ export class FileViewerPhotoSwipe {
                     "mousemove",
                     handleMouseMoveInFullscreen,
                 );
+                clearFullscreenControlsTimer();
+            } else if (
+                pswp.element?.classList.contains("pswp--video-fullscreen")
+            ) {
+                handleFullscreenControlsActivity();
             }
             handleViewerActivity();
         };
@@ -845,23 +851,61 @@ export class FileViewerPhotoSwipe {
          */
         let hideControlsTimer: ReturnType<typeof setTimeout> | undefined;
 
-        /**
-         * Show video controls on mouse movement, hide after inactivity.
-         */
-        const handleMouseMoveInFullscreen = () => {
-            pswp.element?.classList.add("pswp--controls-visible");
-
-            // Clear any pending hide timer
+        const clearFullscreenControlsTimer = () => {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
+                hideControlsTimer = undefined;
+            }
+        };
+
+        const isFocusWithinFullscreenControls = () => {
+            const focusedElement =
+                document.querySelector(":focus-visible") ??
+                document.querySelector(":focus");
+            return (
+                focusedElement instanceof Node &&
+                !!mediaControlsContainerElement?.contains(focusedElement)
+            );
+        };
+
+        const scheduleFullscreenControlsAutoHide = () => {
+            if (!document.fullscreenElement) {
+                clearFullscreenControlsTimer();
+                return;
             }
 
-            // Hide controls after inactivity
+            clearFullscreenControlsTimer();
             hideControlsTimer = setTimeout(() => {
+                if (!document.fullscreenElement) {
+                    hideControlsTimer = undefined;
+                    return;
+                }
+
+                if (isFocusWithinFullscreenControls()) {
+                    scheduleFullscreenControlsAutoHide();
+                    return;
+                }
+
                 pswp.element?.classList.remove("pswp--controls-visible");
                 hideControlsTimer = undefined;
             }, 3000);
         };
+
+        const handleFullscreenControlsActivity = () => {
+            if (!document.fullscreenElement) {
+                clearFullscreenControlsTimer();
+                return;
+            }
+
+            pswp.element?.classList.add("pswp--controls-visible");
+            scheduleFullscreenControlsAutoHide();
+        };
+
+        /**
+         * Show video controls on mouse movement, hide after inactivity.
+         */
+        const handleMouseMoveInFullscreen = () =>
+            handleFullscreenControlsActivity();
 
         const _updateVideoControlsAndPlayback = (itemData: ItemData) => {
             const container = mediaControlsContainerElement;
@@ -1882,6 +1926,10 @@ export class FileViewerPhotoSwipe {
             // Even though we ignore shift, Caps lock might still be on.
             const lkey = e.key.toLowerCase();
 
+            if (pswp.element?.classList.contains("pswp--video-fullscreen")) {
+                handleFullscreenControlsActivity();
+            }
+
             if (isUIAutoHidden && lkey == "h") {
                 handleViewerActivity();
                 pswpEvent.preventDefault();
@@ -2067,9 +2115,7 @@ export class FileViewerPhotoSwipe {
                 "mousemove",
                 handleMouseMoveInFullscreen,
             );
-            if (hideControlsTimer) {
-                clearTimeout(hideControlsTimer);
-            }
+            clearFullscreenControlsTimer();
             clearIdleAutoHideState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -1755,11 +1755,25 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
+        // Returns true if a keyboard focus is present on any of the actions
+        // controls which is going to be hidden.
+        const isFocusVisibledOnAutoHideableUIControl = () => {
+            const fv = document.querySelector(":focus-visible");
+            return (
+                fv instanceof HTMLElement &&
+                !!fv.closest(".pswp__top-bar, .pswp__bottom-right-controls")
+            );
+        };
+
+        // The gradient on the top and bottom will only hide if it's on a
+        // desktop or web interface with a proper hover-capable pointer.
         const shouldAutoHideViewerUI =
             typeof window != "undefined" &&
             "matchMedia" in window &&
             window.matchMedia("(hover: hover) and (pointer: fine)").matches;
 
+        // Timer for controling the inactivity. On each mouse movement
+        // this timer is cleared by the handleIdleMouse.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
         const clearIdleTimer = () => {
@@ -1769,13 +1783,24 @@ export class FileViewerPhotoSwipe {
             }
         };
 
+        // This function is trigged on each mouse movement,
+        // we have added a eventListener mousedown for the same.
         const handleIdleMouseMove = () => {
+            // Checking if any of the controls have mouse focus.
             if (!shouldAutoHideViewerUI) return;
 
+            // Clearning the timer and removing the idle class,
+            // If it was already on a idle state.
             clearIdleTimer();
             pswp.element?.classList.remove("pswp--idle");
+
+            // Setting the timer to add the idle class after 2000ms
             idleTimer = setTimeout(() => {
-                pswp.element?.classList.add("pswp--idle");
+                // Keep the controls visible while keyboard focus is still on
+                // one of the auto-hidden bars.
+                if (!isFocusVisibledOnAutoHideableUIControl()) {
+                    pswp.element?.classList.add("pswp--idle");
+                }
                 idleTimer = undefined;
             }, 2000);
         };

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -837,6 +837,7 @@ export class FileViewerPhotoSwipe {
                     handleMouseMoveInFullscreen,
                 );
             }
+            handleViewerActivity();
         };
 
         /**
@@ -1771,9 +1772,12 @@ export class FileViewerPhotoSwipe {
             typeof window != "undefined" &&
             "matchMedia" in window &&
             window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+        const isIdleAutoHideEnabled = () =>
+            shouldAutoHideViewerUI &&
+            !!document.fullscreenElement &&
+            !pswp.element?.classList.contains("pswp--video-fullscreen");
 
-        // Timer for controling the inactivity. On each mouse movement
-        // this timer is cleared by the handleIdleMouse.
+        // Timer for controlling inactivity. User activity clears and resets it.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
         const clearIdleTimer = () => {
@@ -1782,23 +1786,31 @@ export class FileViewerPhotoSwipe {
                 idleTimer = undefined;
             }
         };
-
-        // This function is trigged on each mouse movement,
-        // we have added a eventListener mousedown for the same.
-        const handleIdleMouseMove = () => {
-            // Checking if any of the controls have mouse focus.
-            if (!shouldAutoHideViewerUI) return;
-
-            // Clearning the timer and removing the idle class,
-            // If it was already on a idle state.
+        const clearIdleState = () => {
             clearIdleTimer();
             pswp.element?.classList.remove("pswp--idle");
+        };
+
+        // Any user activity should bring the viewer back out of the idle state.
+        const handleViewerActivity = () => {
+            // Idle auto-hide is only enabled for the fullscreen viewer UI.
+            if (!isIdleAutoHideEnabled()) {
+                clearIdleState();
+                return;
+            }
+
+            // Clearing the timer and removing the idle class,
+            // if it was already in an idle state.
+            clearIdleState();
 
             // Setting the timer to add the idle class after 2000ms
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
                 // one of the auto-hidden bars.
-                if (!isFocusVisibledOnAutoHideableUIControl()) {
+                if (
+                    isIdleAutoHideEnabled() &&
+                    !isFocusVisibledOnAutoHideableUIControl()
+                ) {
                     pswp.element?.classList.add("pswp--idle");
                 }
                 idleTimer = undefined;
@@ -1820,6 +1832,8 @@ export class FileViewerPhotoSwipe {
         const handleHelp = () => delegate.performKeyAction("help");
 
         pswp.on("keydown", (pswpEvent) => {
+            handleViewerActivity();
+
             // Ignore keyboard events when one of our sub-dialogs are open.
             if (delegate.shouldIgnoreKeyboardEvent()) {
                 pswpEvent.preventDefault();
@@ -1977,12 +1991,14 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
-            pswp.element!.addEventListener("mousemove", handleIdleMouseMove);
+            pswp.element!.addEventListener("mousedown", handleViewerActivity);
+            pswp.element!.addEventListener("mousemove", handleViewerActivity);
+            pswp.element!.addEventListener("wheel", handleViewerActivity);
             document.addEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
             );
-            handleIdleMouseMove();
+            handleViewerActivity();
         });
 
         // The PhotoSwipe dialog has being closed and the animations have
@@ -1992,7 +2008,9 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
-            pswp.element?.removeEventListener("mousemove", handleIdleMouseMove);
+            pswp.element?.removeEventListener("mousedown", handleViewerActivity);
+            pswp.element?.removeEventListener("mousemove", handleViewerActivity);
+            pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
@@ -2004,7 +2022,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
-            clearIdleTimer();
+            clearIdleState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -1755,6 +1755,31 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
+        const shouldAutoHideViewerUI =
+            typeof window != "undefined" &&
+            "matchMedia" in window &&
+            window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+        let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+        const clearIdleTimer = () => {
+            if (idleTimer) {
+                clearTimeout(idleTimer);
+                idleTimer = undefined;
+            }
+        };
+
+        const handleIdleMouseMove = () => {
+            if (!shouldAutoHideViewerUI) return;
+
+            clearIdleTimer();
+            pswp.element?.classList.remove("pswp--idle");
+            idleTimer = setTimeout(() => {
+                pswp.element?.classList.add("pswp--idle");
+                idleTimer = undefined;
+            }, 2000);
+        };
+
         // Some actions routed via the delegate
 
         const handleDelete = () => delegate.performKeyAction("delete");
@@ -1927,10 +1952,12 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
+            pswp.element!.addEventListener("mousemove", handleIdleMouseMove);
             document.addEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
             );
+            handleIdleMouseMove();
         });
 
         // The PhotoSwipe dialog has being closed and the animations have
@@ -1940,6 +1967,7 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
+            pswp.element?.removeEventListener("mousemove", handleIdleMouseMove);
             document.removeEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
@@ -1951,6 +1979,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
+            clearIdleTimer();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -860,7 +860,7 @@ export class FileViewerPhotoSwipe {
             hideControlsTimer = setTimeout(() => {
                 pswp.element?.classList.remove("pswp--controls-visible");
                 hideControlsTimer = undefined;
-            }, 2000);
+            }, 3000);
         };
 
         const _updateVideoControlsAndPlayback = (itemData: ItemData) => {
@@ -1803,7 +1803,7 @@ export class FileViewerPhotoSwipe {
             // if it was already in an idle state.
             clearIdleState();
 
-            // Setting the timer to add the idle class after 2000ms
+            // Setting the timer to add the idle class after 3000ms
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
                 // one of the auto-hidden bars.
@@ -1814,7 +1814,7 @@ export class FileViewerPhotoSwipe {
                     pswp.element?.classList.add("pswp--idle");
                 }
                 idleTimer = undefined;
-            }, 2000);
+            }, 3000);
         };
 
         // Some actions routed via the delegate

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -1556,6 +1556,7 @@ export class FileViewerPhotoSwipe {
                 appendTo: "root",
                 html: bottomRightControlsHTML(),
                 onInit: (element, pswp) => {
+                    element.classList.add("pswp__hide-on-close");
                     const captionEl =
                         element.querySelector<HTMLElement>(".pswp__caption")!;
                     // Get the action buttons container.
@@ -1734,8 +1735,11 @@ export class FileViewerPhotoSwipe {
 
         // Toggle controls infrastructure
 
-        const handleToggleUIControls = () =>
-            pswp.element!.classList.toggle("pswp--ui-visible");
+        const areUIControlsVisible = () =>
+            pswp.element?.classList.contains("pswp--ui-visible") ?? false;
+        const setUIControlsVisible = (visible: boolean) => {
+            pswp.element?.classList.toggle("pswp--ui-visible", visible);
+        };
 
         // Return true if the current keyboard focus is on any of the UI
         // controls (e.g. as a result of user tabbing through them).
@@ -1779,6 +1783,7 @@ export class FileViewerPhotoSwipe {
 
         // Timer for controlling inactivity. User activity clears and resets it.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
+        let isUIAutoHidden = false;
 
         const clearIdleTimer = () => {
             if (idleTimer) {
@@ -1786,35 +1791,68 @@ export class FileViewerPhotoSwipe {
                 idleTimer = undefined;
             }
         };
-        const clearIdleState = () => {
+        const clearIdleAutoHideState = () => {
             clearIdleTimer();
-            pswp.element?.classList.remove("pswp--idle");
+            isUIAutoHidden = false;
+        };
+        const scheduleUIControlsAutoHide = () => {
+            if (!isIdleAutoHideEnabled() || !areUIControlsVisible()) return;
+
+            clearIdleTimer();
+            idleTimer = setTimeout(() => {
+                // Keep the controls visible while keyboard focus is still on
+                // one of the auto-hidden bars.
+                if (
+                    isIdleAutoHideEnabled() &&
+                    areUIControlsVisible() &&
+                    !isFocusVisibledOnAutoHideableUIControl()
+                ) {
+                    setUIControlsVisible(false);
+                    isUIAutoHidden = true;
+                }
+                idleTimer = undefined;
+            }, 3000);
         };
 
         // Any user activity should bring the viewer back out of the idle state.
         const handleViewerActivity = () => {
             // Idle auto-hide is only enabled for the fullscreen viewer UI.
             if (!isIdleAutoHideEnabled()) {
-                clearIdleState();
+                clearIdleTimer();
+                if (isUIAutoHidden) {
+                    setUIControlsVisible(true);
+                    isUIAutoHidden = false;
+                }
                 return;
             }
 
-            // Clearing the timer and removing the idle class,
-            // if it was already in an idle state.
-            clearIdleState();
+            if (isUIAutoHidden) {
+                setUIControlsVisible(true);
+                isUIAutoHidden = false;
+            }
 
-            // Setting the timer to add the idle class after 3000ms
-            idleTimer = setTimeout(() => {
-                // Keep the controls visible while keyboard focus is still on
-                // one of the auto-hidden bars.
-                if (
-                    isIdleAutoHideEnabled() &&
-                    !isFocusVisibledOnAutoHideableUIControl()
-                ) {
-                    pswp.element?.classList.add("pswp--idle");
-                }
-                idleTimer = undefined;
-            }, 3000);
+            if (areUIControlsVisible()) {
+                scheduleUIControlsAutoHide();
+            } else {
+                clearIdleTimer();
+            }
+        };
+        const handleViewerClick = (e: MouseEvent) => {
+            if (isIdleAutoHideEnabled() && isUIAutoHidden) {
+                handleViewerActivity();
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return;
+            }
+
+            handleViewerActivity();
+        };
+
+        const handleToggleUIControls = () => {
+            const willBeVisible = !areUIControlsVisible();
+            clearIdleAutoHideState();
+            setUIControlsVisible(willBeVisible);
+            if (willBeVisible) scheduleUIControlsAutoHide();
         };
 
         // Some actions routed via the delegate
@@ -1832,8 +1870,6 @@ export class FileViewerPhotoSwipe {
         const handleHelp = () => delegate.performKeyAction("help");
 
         pswp.on("keydown", (pswpEvent) => {
-            handleViewerActivity();
-
             // Ignore keyboard events when one of our sub-dialogs are open.
             if (delegate.shouldIgnoreKeyboardEvent()) {
                 pswpEvent.preventDefault();
@@ -1845,6 +1881,14 @@ export class FileViewerPhotoSwipe {
             const key = e.key;
             // Even though we ignore shift, Caps lock might still be on.
             const lkey = e.key.toLowerCase();
+
+            if (isUIAutoHidden && lkey == "h") {
+                handleViewerActivity();
+                pswpEvent.preventDefault();
+                return;
+            }
+
+            handleViewerActivity();
 
             // When one of the controls on the screen has a visible focus
             // indicator, we want the Escape key to blur its focus instead of
@@ -1991,7 +2035,9 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
-            pswp.element!.addEventListener("mousedown", handleViewerActivity);
+            pswp.element!.addEventListener("click", handleViewerClick, {
+                capture: true,
+            });
             pswp.element!.addEventListener("mousemove", handleViewerActivity);
             pswp.element!.addEventListener("wheel", handleViewerActivity);
             document.addEventListener(
@@ -2008,7 +2054,9 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
-            pswp.element?.removeEventListener("mousedown", handleViewerActivity);
+            pswp.element?.removeEventListener("click", handleViewerClick, {
+                capture: true,
+            });
             pswp.element?.removeEventListener("mousemove", handleViewerActivity);
             pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
@@ -2022,7 +2070,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
-            clearIdleState();
+            clearIdleAutoHideState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -1600,7 +1600,6 @@ export class FileViewerPhotoSwipe {
                 appendTo: "root",
                 html: bottomRightControlsHTML(),
                 onInit: (element, pswp) => {
-                    element.classList.add("pswp__hide-on-close");
                     const captionEl =
                         element.querySelector<HTMLElement>(".pswp__caption")!;
                     // Get the action buttons container.

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -2104,7 +2104,10 @@ export class FileViewerPhotoSwipe {
             pswp.element?.removeEventListener("click", handleViewerClick, {
                 capture: true,
             });
-            pswp.element?.removeEventListener("mousemove", handleViewerActivity);
+            pswp.element?.removeEventListener(
+                "mousemove",
+                handleViewerActivity,
+            );
             pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
                 "fullscreenchange",

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -1803,13 +1803,15 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
-        // Returns true if a keyboard focus is present on any of the actions
-        // controls which is going to be hidden.
+        // Returns true if keyboard focus is present on any action control that
+        // is going to be hidden.
         const isFocusVisibledOnAutoHideableUIControl = () => {
             const fv = document.querySelector(":focus-visible");
             return (
                 fv instanceof HTMLElement &&
-                !!fv.closest(".pswp__top-bar, .pswp__bottom-right-controls")
+                !!fv.closest(
+                    ".pswp__top-bar, .pswp__bottom-right-controls, .pswp__button--arrow",
+                )
             );
         };
 
@@ -1844,7 +1846,7 @@ export class FileViewerPhotoSwipe {
             clearIdleTimer();
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
-                // one of the auto-hidden bars.
+                // one of the auto-hidden controls.
                 if (
                     isIdleAutoHideEnabled() &&
                     areUIControlsVisible() &&

--- a/web/apps/embed/src/styles/photoswipe.css
+++ b/web/apps/embed/src/styles/photoswipe.css
@@ -486,8 +486,7 @@ body:has(
 }
 
 /* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__top-bar:focus-within,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls:focus-within {
     opacity: 1;

--- a/web/apps/embed/src/styles/photoswipe.css
+++ b/web/apps/embed/src/styles/photoswipe.css
@@ -46,11 +46,11 @@
    As a workaround, repeat the CSS, but with a higher specificity by including
    the button selector */
 
-.pswp .pswp__hide-on-close button {
+.pswp .pswp__hide-on-close * {
     pointer-events: none;
 }
 
-.pswp--ui-visible .pswp__hide-on-close button {
+.pswp--ui-visible .pswp__hide-on-close * {
     pointer-events: auto;
 }
 
@@ -475,24 +475,6 @@ body:has(
     align-items: flex-end;
     gap: 12px;
     transition: opacity 0.3s ease;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls {
-    opacity: 0;
-    pointer-events: none;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-:fullscreen
-    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__top-bar:focus-within,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls:focus-within {
-    opacity: 1;
-    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/embed/src/styles/photoswipe.css
+++ b/web/apps/embed/src/styles/photoswipe.css
@@ -477,11 +477,21 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
+/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
+}
+
+/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__top-bar:focus-within,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls:focus-within {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/embed/src/styles/photoswipe.css
+++ b/web/apps/embed/src/styles/photoswipe.css
@@ -9,6 +9,7 @@
    entire amount. See also: [Note: Customize the desktop title bar] */
 .pswp-ente .pswp__top-bar {
     top: calc(env(titlebar-area-height, 0px) * 0.4);
+    transition: opacity 0.3s ease;
 }
 
 @media (width >= 450px) {
@@ -473,6 +474,14 @@ body:has(
     flex-direction: column-reverse;
     align-items: flex-end;
     gap: 12px;
+    transition: opacity 0.3s ease;
+}
+
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls {
+    opacity: 0;
+    pointer-events: none;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/embed/src/styles/photoswipe.css
+++ b/web/apps/embed/src/styles/photoswipe.css
@@ -477,17 +477,19 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
-/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
 }
 
-/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+:fullscreen
+    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__top-bar:focus-within,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls:focus-within {
     opacity: 1;
     pointer-events: auto;

--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -499,8 +499,7 @@ body:has(
 }
 
 /* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__top-bar:focus-within,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls:focus-within {
     opacity: 1;

--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -9,6 +9,7 @@
    entire amount. See also: [Note: Customize the desktop title bar] */
 .pswp-ente .pswp__top-bar {
     top: calc(env(titlebar-area-height, 0px) * 0.4);
+    transition: opacity 0.3s ease;
 }
 
 @media (width >= 450px) {
@@ -486,6 +487,14 @@ body:has(
     flex-direction: column-reverse;
     align-items: flex-end;
     gap: 12px;
+    transition: opacity 0.3s ease;
+}
+
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls {
+    opacity: 0;
+    pointer-events: none;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -48,11 +48,11 @@
    As a workaround, repeat the CSS, but with a higher specificity by including
    the button selector */
 
-.pswp .pswp__hide-on-close button {
+.pswp .pswp__hide-on-close * {
     pointer-events: none;
 }
 
-.pswp--ui-visible .pswp__hide-on-close button {
+.pswp--ui-visible .pswp__hide-on-close * {
     pointer-events: auto;
 }
 
@@ -488,24 +488,6 @@ body:has(
     align-items: flex-end;
     gap: 12px;
     transition: opacity 0.3s ease;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls {
-    opacity: 0;
-    pointer-events: none;
-}
-
-/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-:fullscreen
-    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__top-bar:focus-within,
-:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
-    .pswp__bottom-right-controls:focus-within {
-    opacity: 1;
-    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -490,17 +490,19 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
-/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, hide the top bar and bottom-right controls */
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
 }
 
-/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar:focus-within,
-.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+/* When the viewer is idle in fullscreen, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+:fullscreen
+    .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__top-bar:focus-within,
+:fullscreen .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls:focus-within {
     opacity: 1;
     pointer-events: auto;

--- a/web/apps/photos/src/styles/photoswipe.css
+++ b/web/apps/photos/src/styles/photoswipe.css
@@ -490,11 +490,21 @@ body:has(
     transition: opacity 0.3s ease;
 }
 
+/* When the viewer is idle, and not in video fullscreen, hide the top bar and bottom-right controls */
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen) .pswp__top-bar,
 .pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
     .pswp__bottom-right-controls {
     opacity: 0;
     pointer-events: none;
+}
+
+/* When the viewer is idle, and not in video fullscreen, show the top bar and bottom-right controls if the user tabs into one of those controls */
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__top-bar:focus-within,
+.pswp-ente.pswp--idle:not(.pswp--video-fullscreen)
+    .pswp__bottom-right-controls:focus-within {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 /* Black gradient overlay at the bottom */

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -807,6 +807,7 @@ export class FileViewerPhotoSwipe {
                     "mousemove",
                     handleMouseMoveInFullscreen,
                 );
+                handleFullscreenControlsActivity();
             }
         };
 
@@ -822,6 +823,11 @@ export class FileViewerPhotoSwipe {
                     "mousemove",
                     handleMouseMoveInFullscreen,
                 );
+                clearFullscreenControlsTimer();
+            } else if (
+                pswp.element?.classList.contains("pswp--video-fullscreen")
+            ) {
+                handleFullscreenControlsActivity();
             }
             handleViewerActivity();
         };
@@ -831,23 +837,61 @@ export class FileViewerPhotoSwipe {
          */
         let hideControlsTimer: ReturnType<typeof setTimeout> | undefined;
 
-        /**
-         * Show video controls on mouse movement, hide after inactivity.
-         */
-        const handleMouseMoveInFullscreen = () => {
-            pswp.element?.classList.add("pswp--controls-visible");
-
-            // Clear any pending hide timer
+        const clearFullscreenControlsTimer = () => {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
+                hideControlsTimer = undefined;
+            }
+        };
+
+        const isFocusWithinFullscreenControls = () => {
+            const focusedElement =
+                document.querySelector(":focus-visible") ??
+                document.querySelector(":focus");
+            return (
+                focusedElement instanceof Node &&
+                !!mediaControlsContainerElement?.contains(focusedElement)
+            );
+        };
+
+        const scheduleFullscreenControlsAutoHide = () => {
+            if (!document.fullscreenElement) {
+                clearFullscreenControlsTimer();
+                return;
             }
 
-            // Hide controls after inactivity
+            clearFullscreenControlsTimer();
             hideControlsTimer = setTimeout(() => {
+                if (!document.fullscreenElement) {
+                    hideControlsTimer = undefined;
+                    return;
+                }
+
+                if (isFocusWithinFullscreenControls()) {
+                    scheduleFullscreenControlsAutoHide();
+                    return;
+                }
+
                 pswp.element?.classList.remove("pswp--controls-visible");
                 hideControlsTimer = undefined;
             }, 3000);
         };
+
+        const handleFullscreenControlsActivity = () => {
+            if (!document.fullscreenElement) {
+                clearFullscreenControlsTimer();
+                return;
+            }
+
+            pswp.element?.classList.add("pswp--controls-visible");
+            scheduleFullscreenControlsAutoHide();
+        };
+
+        /**
+         * Show video controls on mouse movement, hide after inactivity.
+         */
+        const handleMouseMoveInFullscreen = () =>
+            handleFullscreenControlsActivity();
 
         const _updateVideoControlsAndPlayback = (itemData: ItemData) => {
             const container = mediaControlsContainerElement;
@@ -1851,6 +1895,10 @@ export class FileViewerPhotoSwipe {
             // Even though we ignore shift, Caps lock might still be on.
             const lkey = e.key.toLowerCase();
 
+            if (pswp.element?.classList.contains("pswp--video-fullscreen")) {
+                handleFullscreenControlsActivity();
+            }
+
             if (isUIAutoHidden && lkey == "h") {
                 handleViewerActivity();
                 pswpEvent.preventDefault();
@@ -2036,9 +2084,7 @@ export class FileViewerPhotoSwipe {
                 "mousemove",
                 handleMouseMoveInFullscreen,
             );
-            if (hideControlsTimer) {
-                clearTimeout(hideControlsTimer);
-            }
+            clearFullscreenControlsTimer();
             clearIdleAutoHideState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -1724,11 +1724,25 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
+        // Returns true if a keyboard focus is present on any of the actions
+        // controls which is going to be hidden.
+        const isFocusVisibledOnAutoHideableUIControl = () => {
+            const fv = document.querySelector(":focus-visible");
+            return (
+                fv instanceof HTMLElement &&
+                !!fv.closest(".pswp__top-bar, .pswp__bottom-right-controls")
+            );
+        };
+
+        // The gradient on the top and bottom will only hide if it's on a
+        // desktop or web interface with a proper hover-capable pointer.
         const shouldAutoHideViewerUI =
             typeof window != "undefined" &&
             "matchMedia" in window &&
             window.matchMedia("(hover: hover) and (pointer: fine)").matches;
 
+        // Timer for controling the inactivity. On each mouse movement
+        // this timer is cleared by the handleIdleMouse.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
         const clearIdleTimer = () => {
@@ -1738,13 +1752,24 @@ export class FileViewerPhotoSwipe {
             }
         };
 
+        // This function is trigged on each mouse movement,
+        // we have added a eventListener mousedown for the same.
         const handleIdleMouseMove = () => {
+            // Checking if any of the controls have mouse focus.
             if (!shouldAutoHideViewerUI) return;
 
+            // Clearning the timer and removing the idle class,
+            // If it was already on a idle state.
             clearIdleTimer();
             pswp.element?.classList.remove("pswp--idle");
+
+            // Setting the timer to add the idle class after 2000ms
             idleTimer = setTimeout(() => {
-                pswp.element?.classList.add("pswp--idle");
+                // Keep the controls visible while keyboard focus is still on
+                // one of the auto-hidden bars.
+                if (!isFocusVisibledOnAutoHideableUIControl()) {
+                    pswp.element?.classList.add("pswp--idle");
+                }
                 idleTimer = undefined;
             }, 2000);
         };

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -1529,6 +1529,7 @@ export class FileViewerPhotoSwipe {
                 appendTo: "root",
                 html: bottomRightControlsHTML(),
                 onInit: (element, pswp) => {
+                    element.classList.add("pswp__hide-on-close");
                     const captionEl =
                         element.querySelector<HTMLElement>(".pswp__caption")!;
                     // Get the action buttons container.
@@ -1703,8 +1704,11 @@ export class FileViewerPhotoSwipe {
 
         // Toggle controls infrastructure
 
-        const handleToggleUIControls = () =>
-            pswp.element!.classList.toggle("pswp--ui-visible");
+        const areUIControlsVisible = () =>
+            pswp.element?.classList.contains("pswp--ui-visible") ?? false;
+        const setUIControlsVisible = (visible: boolean) => {
+            pswp.element?.classList.toggle("pswp--ui-visible", visible);
+        };
 
         // Return true if the current keyboard focus is on any of the UI
         // controls (e.g. as a result of user tabbing through them).
@@ -1748,6 +1752,7 @@ export class FileViewerPhotoSwipe {
 
         // Timer for controlling inactivity. User activity clears and resets it.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
+        let isUIAutoHidden = false;
 
         const clearIdleTimer = () => {
             if (idleTimer) {
@@ -1755,35 +1760,68 @@ export class FileViewerPhotoSwipe {
                 idleTimer = undefined;
             }
         };
-        const clearIdleState = () => {
+        const clearIdleAutoHideState = () => {
             clearIdleTimer();
-            pswp.element?.classList.remove("pswp--idle");
+            isUIAutoHidden = false;
+        };
+        const scheduleUIControlsAutoHide = () => {
+            if (!isIdleAutoHideEnabled() || !areUIControlsVisible()) return;
+
+            clearIdleTimer();
+            idleTimer = setTimeout(() => {
+                // Keep the controls visible while keyboard focus is still on
+                // one of the auto-hidden bars.
+                if (
+                    isIdleAutoHideEnabled() &&
+                    areUIControlsVisible() &&
+                    !isFocusVisibledOnAutoHideableUIControl()
+                ) {
+                    setUIControlsVisible(false);
+                    isUIAutoHidden = true;
+                }
+                idleTimer = undefined;
+            }, 3000);
         };
 
         // Any user activity should bring the viewer back out of the idle state.
         const handleViewerActivity = () => {
             // Idle auto-hide is only enabled for the fullscreen viewer UI.
             if (!isIdleAutoHideEnabled()) {
-                clearIdleState();
+                clearIdleTimer();
+                if (isUIAutoHidden) {
+                    setUIControlsVisible(true);
+                    isUIAutoHidden = false;
+                }
                 return;
             }
 
-            // Clearing the timer and removing the idle class,
-            // if it was already in an idle state.
-            clearIdleState();
+            if (isUIAutoHidden) {
+                setUIControlsVisible(true);
+                isUIAutoHidden = false;
+            }
 
-            // Setting the timer to add the idle class after 3000ms
-            idleTimer = setTimeout(() => {
-                // Keep the controls visible while keyboard focus is still on
-                // one of the auto-hidden bars.
-                if (
-                    isIdleAutoHideEnabled() &&
-                    !isFocusVisibledOnAutoHideableUIControl()
-                ) {
-                    pswp.element?.classList.add("pswp--idle");
-                }
-                idleTimer = undefined;
-            }, 3000);
+            if (areUIControlsVisible()) {
+                scheduleUIControlsAutoHide();
+            } else {
+                clearIdleTimer();
+            }
+        };
+        const handleViewerClick = (e: MouseEvent) => {
+            if (isIdleAutoHideEnabled() && isUIAutoHidden) {
+                handleViewerActivity();
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return;
+            }
+
+            handleViewerActivity();
+        };
+
+        const handleToggleUIControls = () => {
+            const willBeVisible = !areUIControlsVisible();
+            clearIdleAutoHideState();
+            setUIControlsVisible(willBeVisible);
+            if (willBeVisible) scheduleUIControlsAutoHide();
         };
 
         // Some actions routed via the delegate
@@ -1801,8 +1839,6 @@ export class FileViewerPhotoSwipe {
         const handleHelp = () => delegate.performKeyAction("help");
 
         pswp.on("keydown", (pswpEvent) => {
-            handleViewerActivity();
-
             // Ignore keyboard events when one of our sub-dialogs are open.
             if (delegate.shouldIgnoreKeyboardEvent()) {
                 pswpEvent.preventDefault();
@@ -1814,6 +1850,14 @@ export class FileViewerPhotoSwipe {
             const key = e.key;
             // Even though we ignore shift, Caps lock might still be on.
             const lkey = e.key.toLowerCase();
+
+            if (isUIAutoHidden && lkey == "h") {
+                handleViewerActivity();
+                pswpEvent.preventDefault();
+                return;
+            }
+
+            handleViewerActivity();
 
             // When one of the controls on the screen has a visible focus
             // indicator, we want the Escape key to blur its focus instead of
@@ -1960,7 +2004,9 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
-            pswp.element!.addEventListener("mousedown", handleViewerActivity);
+            pswp.element!.addEventListener("click", handleViewerClick, {
+                capture: true,
+            });
             pswp.element!.addEventListener("mousemove", handleViewerActivity);
             pswp.element!.addEventListener("wheel", handleViewerActivity);
             document.addEventListener(
@@ -1977,7 +2023,9 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
-            pswp.element?.removeEventListener("mousedown", handleViewerActivity);
+            pswp.element?.removeEventListener("click", handleViewerClick, {
+                capture: true,
+            });
             pswp.element?.removeEventListener("mousemove", handleViewerActivity);
             pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
@@ -1991,7 +2039,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
-            clearIdleState();
+            clearIdleAutoHideState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -1772,13 +1772,15 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
-        // Returns true if a keyboard focus is present on any of the actions
-        // controls which is going to be hidden.
+        // Returns true if keyboard focus is present on any action control that
+        // is going to be hidden.
         const isFocusVisibledOnAutoHideableUIControl = () => {
             const fv = document.querySelector(":focus-visible");
             return (
                 fv instanceof HTMLElement &&
-                !!fv.closest(".pswp__top-bar, .pswp__bottom-right-controls")
+                !!fv.closest(
+                    ".pswp__top-bar, .pswp__bottom-right-controls, .pswp__button--arrow",
+                )
             );
         };
 
@@ -1813,7 +1815,7 @@ export class FileViewerPhotoSwipe {
             clearIdleTimer();
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
-                // one of the auto-hidden bars.
+                // one of the auto-hidden controls.
                 if (
                     isIdleAutoHideEnabled() &&
                     areUIControlsVisible() &&

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -2073,7 +2073,10 @@ export class FileViewerPhotoSwipe {
             pswp.element?.removeEventListener("click", handleViewerClick, {
                 capture: true,
             });
-            pswp.element?.removeEventListener("mousemove", handleViewerActivity);
+            pswp.element?.removeEventListener(
+                "mousemove",
+                handleViewerActivity,
+            );
             pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
                 "fullscreenchange",

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -823,6 +823,7 @@ export class FileViewerPhotoSwipe {
                     handleMouseMoveInFullscreen,
                 );
             }
+            handleViewerActivity();
         };
 
         /**
@@ -1740,9 +1741,12 @@ export class FileViewerPhotoSwipe {
             typeof window != "undefined" &&
             "matchMedia" in window &&
             window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+        const isIdleAutoHideEnabled = () =>
+            shouldAutoHideViewerUI &&
+            !!document.fullscreenElement &&
+            !pswp.element?.classList.contains("pswp--video-fullscreen");
 
-        // Timer for controling the inactivity. On each mouse movement
-        // this timer is cleared by the handleIdleMouse.
+        // Timer for controlling inactivity. User activity clears and resets it.
         let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
         const clearIdleTimer = () => {
@@ -1751,23 +1755,31 @@ export class FileViewerPhotoSwipe {
                 idleTimer = undefined;
             }
         };
-
-        // This function is trigged on each mouse movement,
-        // we have added a eventListener mousedown for the same.
-        const handleIdleMouseMove = () => {
-            // Checking if any of the controls have mouse focus.
-            if (!shouldAutoHideViewerUI) return;
-
-            // Clearning the timer and removing the idle class,
-            // If it was already on a idle state.
+        const clearIdleState = () => {
             clearIdleTimer();
             pswp.element?.classList.remove("pswp--idle");
+        };
+
+        // Any user activity should bring the viewer back out of the idle state.
+        const handleViewerActivity = () => {
+            // Idle auto-hide is only enabled for the fullscreen viewer UI.
+            if (!isIdleAutoHideEnabled()) {
+                clearIdleState();
+                return;
+            }
+
+            // Clearing the timer and removing the idle class,
+            // if it was already in an idle state.
+            clearIdleState();
 
             // Setting the timer to add the idle class after 2000ms
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
                 // one of the auto-hidden bars.
-                if (!isFocusVisibledOnAutoHideableUIControl()) {
+                if (
+                    isIdleAutoHideEnabled() &&
+                    !isFocusVisibledOnAutoHideableUIControl()
+                ) {
                     pswp.element?.classList.add("pswp--idle");
                 }
                 idleTimer = undefined;
@@ -1789,6 +1801,8 @@ export class FileViewerPhotoSwipe {
         const handleHelp = () => delegate.performKeyAction("help");
 
         pswp.on("keydown", (pswpEvent) => {
+            handleViewerActivity();
+
             // Ignore keyboard events when one of our sub-dialogs are open.
             if (delegate.shouldIgnoreKeyboardEvent()) {
                 pswpEvent.preventDefault();
@@ -1946,12 +1960,14 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
-            pswp.element!.addEventListener("mousemove", handleIdleMouseMove);
+            pswp.element!.addEventListener("mousedown", handleViewerActivity);
+            pswp.element!.addEventListener("mousemove", handleViewerActivity);
+            pswp.element!.addEventListener("wheel", handleViewerActivity);
             document.addEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
             );
-            handleIdleMouseMove();
+            handleViewerActivity();
         });
 
         // The PhotoSwipe dialog has being closed and the animations have
@@ -1961,7 +1977,9 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
-            pswp.element?.removeEventListener("mousemove", handleIdleMouseMove);
+            pswp.element?.removeEventListener("mousedown", handleViewerActivity);
+            pswp.element?.removeEventListener("mousemove", handleViewerActivity);
+            pswp.element?.removeEventListener("wheel", handleViewerActivity);
             document.removeEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
@@ -1973,7 +1991,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
-            clearIdleTimer();
+            clearIdleState();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -1573,7 +1573,6 @@ export class FileViewerPhotoSwipe {
                 appendTo: "root",
                 html: bottomRightControlsHTML(),
                 onInit: (element, pswp) => {
-                    element.classList.add("pswp__hide-on-close");
                     const captionEl =
                         element.querySelector<HTMLElement>(".pswp__caption")!;
                     // Get the action buttons container.

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -846,7 +846,7 @@ export class FileViewerPhotoSwipe {
             hideControlsTimer = setTimeout(() => {
                 pswp.element?.classList.remove("pswp--controls-visible");
                 hideControlsTimer = undefined;
-            }, 2000);
+            }, 3000);
         };
 
         const _updateVideoControlsAndPlayback = (itemData: ItemData) => {
@@ -1772,7 +1772,7 @@ export class FileViewerPhotoSwipe {
             // if it was already in an idle state.
             clearIdleState();
 
-            // Setting the timer to add the idle class after 2000ms
+            // Setting the timer to add the idle class after 3000ms
             idleTimer = setTimeout(() => {
                 // Keep the controls visible while keyboard focus is still on
                 // one of the auto-hidden bars.
@@ -1783,7 +1783,7 @@ export class FileViewerPhotoSwipe {
                     pswp.element?.classList.add("pswp--idle");
                 }
                 idleTimer = undefined;
-            }, 2000);
+            }, 3000);
         };
 
         // Some actions routed via the delegate

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -1724,6 +1724,31 @@ export class FileViewerPhotoSwipe {
             return false;
         };
 
+        const shouldAutoHideViewerUI =
+            typeof window != "undefined" &&
+            "matchMedia" in window &&
+            window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+        let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+        const clearIdleTimer = () => {
+            if (idleTimer) {
+                clearTimeout(idleTimer);
+                idleTimer = undefined;
+            }
+        };
+
+        const handleIdleMouseMove = () => {
+            if (!shouldAutoHideViewerUI) return;
+
+            clearIdleTimer();
+            pswp.element?.classList.remove("pswp--idle");
+            idleTimer = setTimeout(() => {
+                pswp.element?.classList.add("pswp--idle");
+                idleTimer = undefined;
+            }, 2000);
+        };
+
         // Some actions routed via the delegate
 
         const handleDelete = () => delegate.performKeyAction("delete");
@@ -1896,10 +1921,12 @@ export class FileViewerPhotoSwipe {
 
         pswp.on("initialLayout", () => {
             pswp.element!.addEventListener("mousedown", blurMediaChromeFocus);
+            pswp.element!.addEventListener("mousemove", handleIdleMouseMove);
             document.addEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
             );
+            handleIdleMouseMove();
         });
 
         // The PhotoSwipe dialog has being closed and the animations have
@@ -1909,6 +1936,7 @@ export class FileViewerPhotoSwipe {
                 "mousedown",
                 blurMediaChromeFocus,
             );
+            pswp.element?.removeEventListener("mousemove", handleIdleMouseMove);
             document.removeEventListener(
                 "fullscreenchange",
                 handleFullscreenChange,
@@ -1920,6 +1948,7 @@ export class FileViewerPhotoSwipe {
             if (hideControlsTimer) {
                 clearTimeout(hideControlsTimer);
             }
+            clearIdleTimer();
             fileViewerDidClose();
             // Let our parent know that we have been closed.
             onClose();


### PR DESCRIPTION
## Description

In the FileViewer, the top and bottom gradients and controls can obscure parts of an image, especially in fullscreen or when the image fills the viewport leaving no clickable area on the sides to hide them.

This PR fixes the issue by fading out the controls and gradients after 2 seconds of inactivity. They reappear on the next mouse movement.
