### PR TITLE
Add mobile v1.3.24 and v1.3.28 to photos changelog

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -21,6 +21,15 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Better people list experience (bigger view with search)
 - Various bug fixes (map view tiles, etc)
 
+## v1.3.28 (mobile) - Mar 2026
+
+- Fix app getting stuck on splash screen
+- Bug fixes and performance improvements
+
+## v1.3.24 (mobile) - Mar 2026
+
+- Fix app getting stuck on splash screen
+
 ## v1.3.22 (mobile) - Mar 2026
 
 - Gallery mode to use Ente Photos without an account


### PR DESCRIPTION
## Summary

Comparing the [Ente Photos changelog](https://ente.com/help/photos/changelog) against the [GitHub releases](https://github.com/ente-io/ente/releases), two mobile releases published after `photos-v1.3.16` were missing from the docs:

- [`photos-v1.3.24`](https://github.com/ente-io/ente/releases/tag/photos-v1.3.24) (Mar 17, 2026)
- [`photos-v1.3.28`](https://github.com/ente-io/ente/releases/tag/photos-v1.3.28) (Mar 26, 2026)

Both are bug-fix releases. Entries have been inserted between `v1.7.22` (desktop) and `v1.3.22` (mobile) to preserve the reverse-chronological ordering of `docs/docs/photos/changelog.md`.

## Test plan

- [ ] Verify the new entries render correctly on the docs site
- [ ] Confirm reverse-chronological ordering is preserved