### PR TITLE
 Support Rust OTP signup completion

### DIFF
--- a/rust/accounts/src/flow.rs
+++ b/rust/accounts/src/flow.rs
@@ -304,6 +304,30 @@ where
             .await
     }
 
+    /// Create a new account after the caller has already sent and collected a signup OTP.
+    pub async fn create_account_with_otp(
+        &mut self,
+        params: CreateAccountParams,
+        otp: &str,
+    ) -> Result<AuthenticatedAccount> {
+        crypto::init()?;
+
+        let email = params.email;
+        let password = params.password;
+        let verification = self
+            .client
+            .verify_email(&email, otp, params.source.as_deref())
+            .await?;
+
+        self.finish_verified_signup(
+            email,
+            password,
+            verification,
+            KeyDerivationStrength::Sensitive,
+        )
+        .await
+    }
+
     /// Login to an existing account.
     pub async fn login(&mut self, params: LoginParams) -> Result<AuthenticatedAccount> {
         crypto::init()?;
@@ -643,6 +667,17 @@ where
             .verify_email_otp(&email, OtpPurpose::Signup, params.source.as_deref())
             .await?;
 
+        self.finish_verified_signup(email, password, verification, key_derivation_strength)
+            .await
+    }
+
+    async fn finish_verified_signup(
+        &self,
+        email: String,
+        password: Zeroizing<String>,
+        verification: AuthResponse,
+        key_derivation_strength: KeyDerivationStrength,
+    ) -> Result<AuthenticatedAccount> {
         let token = verification.token.clone().ok_or_else(|| {
             Error::AuthenticationFailed("Signup verification did not return a session token".into())
         })?;

--- a/rust/core/src/http.rs
+++ b/rust/core/src/http.rs
@@ -265,6 +265,7 @@ pub struct HttpClient {
     base_url: String,
     base_origin: Option<Url>,
     auth_token: RwLock<Option<Zeroizing<String>>>,
+    #[cfg(not(target_arch = "wasm32"))]
     user_agent: Option<String>,
     client_package: Option<String>,
     client_version: Option<String>,
@@ -322,6 +323,7 @@ impl HttpClient {
             base_url,
             base_origin,
             auth_token: RwLock::new(config.auth_token.map(Zeroizing::new)),
+            #[cfg(not(target_arch = "wasm32"))]
             user_agent: config.user_agent,
             client_package: config.client_package,
             client_version: config.client_version,


### PR DESCRIPTION
## Summary
- add a Rust account signup entry point for callers that already collected the signup OTP
- share verified-signup completion between the interactive and caller-provided OTP flows
- keep the core HTTP user agent field off wasm builds

## Scope
- rust/accounts/src/flow.rs
- rust/core/src/http.rs

## Validation
- cargo fmt --manifest-path rust/core/Cargo.toml --check
- cargo fmt --manifest-path rust/accounts/Cargo.toml --check
- cargo test --manifest-path rust/core/Cargo.toml
- cargo test --manifest-path rust/accounts/Cargo.toml
- cargo check --manifest-path rust/core/Cargo.toml --target wasm32-unknown-unknown
- cargo check --manifest-path rust/accounts/Cargo.toml --target wasm32-unknown-unknown