### PR TITLE
[mobile] Share language display names

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/language_picker.dart
+++ b/mobile/apps/auth/lib/ui/settings/language_picker.dart
@@ -6,6 +6,7 @@ import 'package:ente_auth/ui/components/menu_item_widget.dart';
 import 'package:ente_auth/ui/components/separators.dart';
 import 'package:ente_auth/ui/components/title_bar_title_widget.dart';
 import 'package:ente_auth/ui/components/title_bar_widget.dart';
+import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -48,8 +49,9 @@ class LanguageSelectorPage extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           ClipRRect(
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(8)),
+                            borderRadius: const BorderRadius.all(
+                              Radius.circular(8),
+                            ),
                             child: ItemsWidget(
                               supportedLocales,
                               onLocaleChanged,
@@ -105,9 +107,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
   Widget build(BuildContext context) {
     items.clear();
     for (Locale locale in widget.supportedLocales) {
-      items.add(
-        _menuItemForPicker(locale),
-      );
+      items.add(_menuItemForPicker(locale));
     }
     items = addSeparators(
       items,
@@ -116,101 +116,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
         bgColor: getEnteColorScheme(context).fillFaint,
       ),
     );
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: items,
-    );
-  }
-
-  String _getLanguageName(Locale locale) {
-    switch (locale.languageCode) {
-      case 'ar':
-        return 'العربية';
-      case 'ca':
-        return 'Català';
-      case 'cs':
-        return 'Čeština';
-      case 'en':
-        return 'English';
-      case 'bg':
-        return 'Български';
-      case 'el':
-        return 'Ελληνικά';
-      case 'es':
-        switch (locale.countryCode) {
-          case 'ES':
-            return 'Español (España)';
-          default:
-            return 'Español';
-        }
-      case 'fr':
-        return 'Français';
-      case 'de':
-        return 'Deutsch';
-      case 'he':
-        return 'עברית';
-      case 'hu':
-        return 'Magyar';
-      case 'id':
-        return 'Bahasa Indonesia';
-      case 'it':
-        return 'Italiano';
-      case 'lt':
-        return 'Lietuvių';
-      case 'nl':
-        return 'Nederlands';
-      case 'no':
-        return 'Norsk';
-      case 'pl':
-        return 'Polski';
-      case 'pt':
-        switch (locale.countryCode) {
-          case 'BR':
-            return 'Português (Brasil)';
-          default:
-            return 'Português';
-        }
-      case 'ro':
-        return 'Română';
-      case 'ru':
-        return 'Русский';
-      case 'sl':
-        return 'Slovenščina';
-      case 'sk':
-        return 'Slovenčina';
-      case 'tr':
-        return 'Türkçe';
-      case 'uk':
-        return 'Українська';
-      case 'vi':
-        return 'Tiếng Việt';
-      case 'fi':
-        return 'Suomi';
-      case 'zh':
-        if (locale.countryCode == 'TW') {
-          return '中文 (台灣)';
-        } else if (locale.countryCode == 'HK') {
-          return '中文 (香港)';
-        } else if (locale.countryCode == 'CN') {
-          return '中文 (中国)';
-        }
-        switch (locale.scriptCode) {
-          case 'Hans':
-            return '中文 (简体)';
-          case 'Hant':
-            return '中文 (繁體)';
-          default:
-            return '中文';
-        }
-      case 'ja':
-        return '日本語';
-      case 'ko':
-        return '한국어';
-      case 'fa':
-        return 'فارسی';
-      default:
-        return locale.languageCode;
-    }
+    return Column(mainAxisSize: MainAxisSize.min, children: items);
   }
 
   Widget _menuItemForPicker(Locale locale) {
@@ -218,7 +124,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
       key: ValueKey(locale.toString()),
       menuItemColor: getEnteColorScheme(context).fillFaint,
       captionedTextWidget: CaptionedTextWidget(
-        title: _getLanguageName(locale) + (kDebugMode ? ' ($locale)' : ''),
+        title: getLocaleDisplayName(locale) + (kDebugMode ? ' ($locale)' : ''),
       ),
       trailingIcon: currentLocale == locale ? Icons.check : null,
       alignCaptionedTextToLeft: true,

--- a/mobile/apps/locker/lib/ui/settings/language_selector_page.dart
+++ b/mobile/apps/locker/lib/ui/settings/language_selector_page.dart
@@ -1,3 +1,4 @@
+import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_ui/components/captioned_text_widget.dart";
 import "package:ente_ui/components/divider_widget.dart";
 import "package:ente_ui/components/menu_item_widget.dart";
@@ -103,47 +104,7 @@ class _LanguageItemsWidgetState extends State<_LanguageItemsWidget> {
         bgColor: getEnteColorScheme(context).fillFaint,
       ),
     );
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: items,
-    );
-  }
-
-  String _getLanguageName(Locale locale) {
-    switch (locale.languageCode) {
-      case 'cs':
-        return 'Čeština';
-      case 'de':
-        return 'Deutsch';
-      case 'en':
-        return 'English';
-      case 'es':
-        return 'Español';
-      case 'fr':
-        return 'Français';
-      case 'it':
-        return 'Italiano';
-      case 'ja':
-        return '日本語';
-      case 'nl':
-        return 'Nederlands';
-      case 'pl':
-        return 'Polski';
-      case 'pt':
-        return 'Português';
-      case 'ro':
-        return 'Română';
-      case 'ru':
-        return 'Русский';
-      case 'tr':
-        return 'Türkçe';
-      case 'uk':
-        return 'Українська';
-      case 'vi':
-        return 'Tiếng Việt';
-      default:
-        return locale.languageCode;
-    }
+    return Column(mainAxisSize: MainAxisSize.min, children: items);
   }
 
   Widget _menuItemForPicker(Locale locale) {
@@ -151,7 +112,7 @@ class _LanguageItemsWidgetState extends State<_LanguageItemsWidget> {
       key: ValueKey(locale.toString()),
       menuItemColor: getEnteColorScheme(context).fillFaint,
       captionedTextWidget: CaptionedTextWidget(
-        title: _getLanguageName(locale) + (kDebugMode ? ' ($locale)' : ''),
+        title: getLocaleDisplayName(locale) + (kDebugMode ? ' ($locale)' : ''),
       ),
       trailingIcon: currentLocale == locale ? Icons.check : null,
       alignCaptionedTextToLeft: true,

--- a/mobile/apps/photos/lib/ui/settings/language_picker.dart
+++ b/mobile/apps/photos/lib/ui/settings/language_picker.dart
@@ -1,3 +1,4 @@
+import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:photos/l10n/l10n.dart";
@@ -126,63 +127,12 @@ class _ItemsWidgetState extends State<ItemsWidget> {
     );
   }
 
-  String _getLanguageName(Locale locale) {
-    switch (locale.languageCode) {
-      case 'ca':
-        return 'Català';
-      case 'cs':
-        return 'Čeština';
-      case 'en':
-        return 'English';
-      case 'es':
-        return 'Español';
-      case 'fr':
-        return 'Français';
-      case 'de':
-        return 'Deutsch';
-      case 'it':
-        return 'Italiano';
-      case 'ja':
-        return '日本語';
-      case 'nl':
-        return 'Nederlands';
-      case 'no':
-        return 'Norsk';
-      case 'pl':
-        return 'Polski';
-      case 'pt':
-        if (locale.countryCode == 'BR') {
-          return 'Português (Brasil)';
-        } else if (locale.countryCode == 'PT') {
-          return 'Português (Portugal)';
-        }
-        return 'Português';
-      case 'ro':
-        return 'Română';
-      case 'ru':
-        return 'Русский';
-      case 'tr':
-        return 'Türkçe';
-      case 'zh':
-        if (locale.countryCode == 'CN') {
-          return '中文 (简体)';
-        }
-        return '中文';
-      case 'uk':
-        return 'Українська';
-      case 'vi':
-        return 'Tiếng Việt';
-      default:
-        return locale.languageCode;
-    }
-  }
-
   Widget _menuItemForPicker(Locale locale) {
     return MenuItemWidget(
       key: ValueKey(locale.toString()),
       menuItemColor: getEnteColorScheme(context).fillFaint,
       captionedTextWidget: CaptionedTextWidget(
-        title: _getLanguageName(locale) + (kDebugMode ? ' ($locale)' : ''),
+        title: getLocaleDisplayName(locale) + (kDebugMode ? ' ($locale)' : ''),
       ),
       trailingIcon: currentLocale == locale ? Icons.check : null,
       alignCaptionedTextToLeft: true,

--- a/mobile/packages/ente_pure_utils/lib/ente_pure_utils.dart
+++ b/mobile/packages/ente_pure_utils/lib/ente_pure_utils.dart
@@ -8,6 +8,7 @@ export 'src/extensions/input_formatter.dart';
 export 'src/extensions/list.dart';
 export 'src/extensions/string.dart';
 export 'src/fake_progress.dart';
+export 'src/locale_display_name.dart';
 export 'src/navigation_util.dart';
 export 'src/parse_util.dart';
 export 'src/platform_detector.dart';

--- a/mobile/packages/ente_pure_utils/lib/src/locale_display_name.dart
+++ b/mobile/packages/ente_pure_utils/lib/src/locale_display_name.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/widgets.dart';
+
+String getLocaleDisplayName(Locale locale) {
+  switch (locale.languageCode) {
+    case 'ca':
+      return 'Català';
+    case 'cs':
+      return 'Čeština';
+    case 'ar':
+      return 'العربية';
+    case 'bg':
+      return 'Български';
+    case 'de':
+      return 'Deutsch';
+    case 'el':
+      return 'Ελληνικά';
+    case 'en':
+      return 'English';
+    case 'es':
+      switch (locale.countryCode) {
+        case 'ES':
+          return 'Español (España)';
+        default:
+          return 'Español';
+      }
+    case 'fa':
+      return 'فارسی';
+    case 'fi':
+      return 'Suomi';
+    case 'fr':
+      return 'Français';
+    case 'he':
+      return 'עברית';
+    case 'hu':
+      return 'Magyar';
+    case 'id':
+      return 'Bahasa Indonesia';
+    case 'it':
+      return 'Italiano';
+    case 'ja':
+      return '日本語';
+    case 'ko':
+      return '한국어';
+    case 'lt':
+      return 'Lietuvių';
+    case 'nl':
+      return 'Nederlands';
+    case 'no':
+      return 'Norsk';
+    case 'pl':
+      return 'Polski';
+    case 'pt':
+      if (locale.countryCode == 'BR') {
+        return 'Português (Brasil)';
+      } else if (locale.countryCode == 'PT') {
+        return 'Português (Portugal)';
+      }
+      return 'Português';
+    case 'ro':
+      return 'Română';
+    case 'ru':
+      return 'Русский';
+    case 'sk':
+      return 'Slovenčina';
+    case 'sl':
+      return 'Slovenščina';
+    case 'tr':
+      return 'Türkçe';
+    case 'zh':
+      if (locale.countryCode == 'TW') {
+        return '中文 (台灣)';
+      } else if (locale.countryCode == 'HK') {
+        return '中文 (香港)';
+      } else if (locale.countryCode == 'CN') {
+        return '中文 (中国)';
+      }
+      switch (locale.scriptCode) {
+        case 'Hans':
+          return '中文 (简体)';
+        case 'Hant':
+          return '中文 (繁體)';
+        default:
+          return '中文';
+      }
+    case 'uk':
+      return 'Українська';
+    case 'vi':
+      return 'Tiếng Việt';
+    default:
+      return locale.languageCode;
+  }
+}

--- a/mobile/packages/ente_pure_utils/test/locale_display_name_test.dart
+++ b/mobile/packages/ente_pure_utils/test/locale_display_name_test.dart
@@ -1,0 +1,48 @@
+import 'package:ente_pure_utils/ente_pure_utils.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('getLocaleDisplayName', () {
+    test('labels Chinese variants by region', () {
+      expect(getLocaleDisplayName(const Locale('zh', 'CN')), '中文 (中国)');
+      expect(getLocaleDisplayName(const Locale('zh', 'TW')), '中文 (台灣)');
+      expect(getLocaleDisplayName(const Locale('zh', 'HK')), '中文 (香港)');
+    });
+
+    test('labels Chinese variants by script', () {
+      expect(
+        getLocaleDisplayName(
+          const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'),
+        ),
+        '中文 (简体)',
+      );
+      expect(
+        getLocaleDisplayName(
+          const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+        ),
+        '中文 (繁體)',
+      );
+    });
+
+    test('keeps auth language selector labels', () {
+      expect(getLocaleDisplayName(const Locale('ar')), 'العربية');
+      expect(getLocaleDisplayName(const Locale('bg')), 'Български');
+      expect(
+        getLocaleDisplayName(const Locale('es', 'ES')),
+        'Español (España)',
+      );
+      expect(getLocaleDisplayName(const Locale('fa')), 'فارسی');
+      expect(getLocaleDisplayName(const Locale('fi')), 'Suomi');
+      expect(getLocaleDisplayName(const Locale('he')), 'עברית');
+      expect(getLocaleDisplayName(const Locale('id')), 'Bahasa Indonesia');
+      expect(getLocaleDisplayName(const Locale('ko')), '한국어');
+      expect(
+        getLocaleDisplayName(const Locale('pt', 'BR')),
+        'Português (Brasil)',
+      );
+      expect(getLocaleDisplayName(const Locale('sk')), 'Slovenčina');
+      expect(getLocaleDisplayName(const Locale('sl')), 'Slovenščina');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Move language display-name mapping into `ente_pure_utils` so Photos, Auth, and Locker share one implementation.
- Preserve Auth's existing language labels, including region/script-specific Chinese labels.
- Use the shared helper from each app's language selector.

## Validation

- `flutter test test/locale_display_name_test.dart` in `mobile/packages/ente_pure_utils`
- `flutter analyze` in `mobile/packages/ente_pure_utils`
- `flutter analyze lib/ui/settings/language_picker.dart` in `mobile/apps/photos`
- `flutter analyze lib/ui/settings/language_picker.dart` in `mobile/apps/auth`
- `flutter analyze lib/ui/settings/language_selector_page.dart` in `mobile/apps/locker`
