### PR TITLE
[server] Reduce Stripe invoice paid alert noise

### DIFF
--- a/server/pkg/controller/stripe.go
+++ b/server/pkg/controller/stripe.go
@@ -333,7 +333,9 @@ func (c *StripeController) handleInvoicePaid(event stripe.Event, country ente.St
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// See: Ignore webhooks received before user has been created
-			c.notifyIgnoredPaidStripeWebhook(event.Type, country, stripeSubscriptionID, invoice.Customer.ID)
+			if invoice.BillingReason != stripe.InvoiceBillingReasonSubscriptionCreate {
+				c.notifyIgnoredPaidStripeWebhook(event.Type, country, stripeSubscriptionID, invoice.Customer.ID)
+			}
 			log.Warn("Webhook is reporting an event for un-verified subscription stripeSubscriptionID:", stripeSubscriptionID)
 			return ente.StripeEventLog{}, nil
 		}


### PR DESCRIPTION
Suppress Discord alerts for unknown initial Stripe subscription invoices; keep alerts for later paid invoices.

Tested: `cd server && go test ./...`