### PR TITLE
Support adaptive HTTP/2 transport in Photos

### DIFF
--- a/mobile/apps/photos/ios/Podfile
+++ b/mobile/apps/photos/ios/Podfile
@@ -53,23 +53,4 @@ post_install do |installer|
 
   end
 
-  # Temporary Flutter 3.32.8 arm64-simulator workaround.
-  # Remove once the app is on Flutter 3.38+ and these frameworks load normally.
-  installer.aggregate_targets.each do |aggregate_target|
-    aggregate_target.user_project.native_targets.each do |target|
-      next unless target.name == 'Runner'
-
-      force_link_flags = [
-        '$(inherited)',
-        '-Wl,-needed_framework,cupertino_http',
-        '-Wl,-needed_framework,objective_c',
-      ]
-
-      target.build_configurations.each do |config|
-        config.build_settings['OTHER_LDFLAGS[sdk=iphonesimulator*]'] = force_link_flags
-      end
-    end
-
-    aggregate_target.user_project.save
-  end
 end

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -11,9 +11,6 @@ PODS:
     - Flutter
   - connectivity_plus (0.0.1):
     - Flutter
-  - cupertino_http (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - dart_ui_isolate (0.0.1):
     - Flutter
   - device_info_plus (0.0.1):
@@ -170,8 +167,6 @@ PODS:
     - Flutter
   - native_video_player (4.0.0):
     - Flutter
-  - objective_c (0.0.1):
-    - Flutter
   - onnxruntime (0.0.1):
     - Flutter
     - onnxruntime-objc (= 1.18.0)
@@ -272,7 +267,6 @@ DEPENDENCIES:
   - battery_info (from `.symlinks/plugins/battery_info/ios`)
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
-  - cupertino_http (from `.symlinks/plugins/cupertino_http/darwin`)
   - dart_ui_isolate (from `.symlinks/plugins/dart_ui_isolate/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - ente_photos_rust (from `.symlinks/plugins/ente_photos_rust/ios`)
@@ -308,7 +302,6 @@ DEPENDENCIES:
   - move_to_background (from `.symlinks/plugins/move_to_background/ios`)
   - native_video_editor (from `.symlinks/plugins/native_video_editor/ios`)
   - native_video_player (from `.symlinks/plugins/native_video_player/ios`)
-  - objective_c (from `.symlinks/plugins/objective_c/ios`)
   - onnxruntime (from `.symlinks/plugins/onnxruntime/ios`)
   - open_mail_app (from `.symlinks/plugins/open_mail_app/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -369,8 +362,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/camera_avfoundation/ios"
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
-  cupertino_http:
-    :path: ".symlinks/plugins/cupertino_http/darwin"
   dart_ui_isolate:
     :path: ".symlinks/plugins/dart_ui_isolate/ios"
   device_info_plus:
@@ -441,8 +432,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/native_video_editor/ios"
   native_video_player:
     :path: ".symlinks/plugins/native_video_player/ios"
-  objective_c:
-    :path: ".symlinks/plugins/objective_c/ios"
   onnxruntime:
     :path: ".symlinks/plugins/onnxruntime/ios"
   open_mail_app:
@@ -497,7 +486,6 @@ SPEC CHECKSUMS:
   battery_info: 83f3aae7be2fccefab1d2bf06b8aa96f11c8bcdd
   camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   dart_ui_isolate: 46f6714abe6891313267153ef6f9748d8ecfcab1
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   ente_photos_rust: 79732f3ba67df7b0fb22089627afb80d692c2b2d
@@ -544,7 +532,6 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   native_video_editor: 7f6e3d37acdae585f6c273b1e2be6ca6d6bb461e
   native_video_player: 6809dec117e8997161dbfb42a6f90d6df71a504d
-  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
   onnxruntime: f9b296392c96c42882be020a59dbeac6310d81b2
   onnxruntime-c: a909204639a1f035f575127ac406f781ac797c9c
   onnxruntime-objc: b6fab0f1787aa6f7190c2013f03037df4718bd8b
@@ -577,6 +564,6 @@ SPEC CHECKSUMS:
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: 1c99c7c32f840e3e08127181dd09d4755dbe2090
+PODFILE CHECKSUM: a0ca58908e52cf6c3fe2f16f5b193ce82a62fa3b
 
 COCOAPODS: 1.16.2

--- a/mobile/apps/photos/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/apps/photos/ios/Runner.xcodeproj/project.pbxproj
@@ -634,7 +634,6 @@
 				"${BUILT_PRODUCTS_DIR}/battery_info/battery_info.framework",
 				"${BUILT_PRODUCTS_DIR}/camera_avfoundation/camera_avfoundation.framework",
 				"${BUILT_PRODUCTS_DIR}/connectivity_plus/connectivity_plus.framework",
-				"${BUILT_PRODUCTS_DIR}/cupertino_http/cupertino_http.framework",
 				"${BUILT_PRODUCTS_DIR}/dart_ui_isolate/dart_ui_isolate.framework",
 				"${BUILT_PRODUCTS_DIR}/device_info_plus/device_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/ente_photos_rust/ente_photos_rust.framework",
@@ -668,7 +667,6 @@
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 				"${BUILT_PRODUCTS_DIR}/native_video_editor/native_video_editor.framework",
 				"${BUILT_PRODUCTS_DIR}/native_video_player/native_video_player.framework",
-				"${BUILT_PRODUCTS_DIR}/objective_c/objective_c.framework",
 				"${BUILT_PRODUCTS_DIR}/open_mail_app/open_mail_app.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
@@ -738,7 +736,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/battery_info.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/camera_avfoundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/connectivity_plus.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/cupertino_http.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/dart_ui_isolate.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ente_photos_rust.framework",
@@ -772,7 +769,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/native_video_editor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/native_video_player.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/objective_c.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/open_mail_app.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
@@ -1043,11 +1039,6 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.11;
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"-Wl,-needed_framework,cupertino_http",
-					"-Wl,-needed_framework,objective_c",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.frame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1350,11 +1341,6 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.11;
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"-Wl,-needed_framework,cupertino_http",
-					"-Wl,-needed_framework,objective_c",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.frame.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1398,11 +1384,6 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 0.0.11;
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"$(inherited)",
-					"-Wl,-needed_framework,cupertino_http",
-					"-Wl,-needed_framework,objective_c",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.frame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -2,7 +2,6 @@ import "dart:async";
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import "package:native_dio_adapter/native_dio_adapter.dart";
 import 'package:package_info_plus/package_info_plus.dart';
 import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
@@ -40,13 +39,6 @@ class NetworkClient {
         },
       ),
     );
-
-    // Only use NativeAdapter on iOS. On Android, Cronet (used by NativeAdapter)
-    // doesn't work in background tasks on Android 15, causing CronetException
-    // during background sync. Use default adapter on Android instead.
-    if (Platform.isIOS) {
-      _enteDio.httpClientAdapter = NativeAdapter();
-    }
 
     _setupInterceptors(endpoint);
 

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -1,7 +1,11 @@
 import "dart:async";
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:dio_http2_adapter/dio_http2_adapter.dart';
+import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
@@ -10,17 +14,19 @@ import "package:photos/events/endpoint_updated_event.dart";
 import "package:ua_client_hints/ua_client_hints.dart";
 
 class NetworkClient {
+  final _logger = Logger("NetworkClient");
   late Dio _dio;
   late Dio _enteDio;
   StreamSubscription<EndpointUpdatedEvent>? _endpointUpdatedSubscription;
   static const kConnectTimeout = 15;
+  static const _connectTimeout = Duration(seconds: kConnectTimeout);
 
   Future<void> init(PackageInfo packageInfo) async {
     final String ua = await userAgent();
     final endpoint = Configuration.instance.getHttpEndpoint();
     _dio = Dio(
       BaseOptions(
-        connectTimeout: const Duration(seconds: kConnectTimeout),
+        connectTimeout: _connectTimeout,
         headers: {
           HttpHeaders.userAgentHeader: ua,
           'X-Client-Version': packageInfo.version,
@@ -31,7 +37,7 @@ class NetworkClient {
     _enteDio = Dio(
       BaseOptions(
         baseUrl: endpoint,
-        connectTimeout: const Duration(seconds: kConnectTimeout),
+        connectTimeout: _connectTimeout,
         headers: {
           HttpHeaders.userAgentHeader: ua,
           'X-Client-Version': packageInfo.version,
@@ -39,6 +45,9 @@ class NetworkClient {
         },
       ),
     );
+
+    _dio.httpClientAdapter = _newAdaptiveHttpClientAdapter(_connectTimeout);
+    _enteDio.httpClientAdapter = _newAdaptiveHttpClientAdapter(_connectTimeout);
 
     _setupInterceptors(endpoint);
 
@@ -58,6 +67,33 @@ class NetworkClient {
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));
   }
 
+  HttpClientAdapter _newAdaptiveHttpClientAdapter(Duration connectTimeout) {
+    final fallbackAdapter = IOHttpClientAdapter();
+    final http2Adapter = Http2Adapter(
+      ConnectionManager(
+        handshakeTimout: connectTimeout,
+      ),
+      fallbackAdapter: fallbackAdapter,
+      onNotSupported: (options, requestStream, cancelFuture, exception) {
+        _logger.info(
+          "HTTP/2 not supported for ${options.method} "
+          "${_uriOrigin(options.uri)}; falling back to IO adapter",
+        );
+        return fallbackAdapter.fetch(options, requestStream, cancelFuture);
+      },
+    );
+    return _AdaptiveHttpClientAdapter(
+      http2Adapter: http2Adapter,
+      fallbackAdapter: fallbackAdapter,
+      logger: _logger,
+    );
+  }
+
+  String _uriOrigin(Uri uri) {
+    final port = uri.hasPort ? ":${uri.port}" : "";
+    return "${uri.scheme}://${uri.host}$port";
+  }
+
   NetworkClient._privateConstructor();
 
   static NetworkClient instance = NetworkClient._privateConstructor();
@@ -65,4 +101,103 @@ class NetworkClient {
   Dio getDio() => _dio;
 
   Dio get enteDio => _enteDio;
+}
+
+class _AdaptiveHttpClientAdapter implements HttpClientAdapter {
+  _AdaptiveHttpClientAdapter({
+    required HttpClientAdapter http2Adapter,
+    required HttpClientAdapter fallbackAdapter,
+    required Logger logger,
+  })  : _http2Adapter = http2Adapter,
+        _fallbackAdapter = fallbackAdapter,
+        _logger = logger;
+
+  final HttpClientAdapter _http2Adapter;
+  final HttpClientAdapter _fallbackAdapter;
+  final Logger _logger;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    if (options.uri.scheme != "https") {
+      return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
+    }
+    // Keep explicit body send-timeout behavior on Dio's IO adapter. The app
+    // does not set this globally, but per-request timeouts should not inherit
+    // dio_http2_adapter's stream-close behavior after a timed-out body stream.
+    if (_hasRequestBodySendTimeout(options, requestStream)) {
+      return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
+    }
+    // Keep cancellable body streams on Dio's IO adapter. dio_http2_adapter closes
+    // the HTTP/2 outgoing stream on cancellation, which can race with active file
+    // streams and surface stream-close errors instead of a clean Dio cancellation.
+    if (_hasCancellableRequestBody(requestStream, cancelFuture)) {
+      return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
+    }
+
+    return _http2Adapter.fetch(options, requestStream, cancelFuture).catchError(
+      (Object e, StackTrace s) {
+        if (e is TimeoutException) {
+          throw DioException.connectionTimeout(
+            requestOptions: options,
+            timeout: options.connectTimeout ?? Duration.zero,
+            error: e,
+          );
+        }
+        if (_isFallbackHandshakeError(e)) {
+          _logger.info(
+            "HTTP/2 TLS negotiation failed for ${options.method} "
+            "${_uriOrigin(options.uri)}; falling back to IO adapter",
+          );
+          return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
+        }
+        Error.throwWithStackTrace(e, s);
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {
+    _http2Adapter.close(force: force);
+    _fallbackAdapter.close(force: force);
+  }
+
+  bool _isFallbackHandshakeError(Object e) {
+    if (e is HandshakeException) {
+      return _isNoApplicationProtocolError(e);
+    }
+    if (e is DioException && e.error is HandshakeException) {
+      return _isNoApplicationProtocolError(e.error! as HandshakeException);
+    }
+    return false;
+  }
+
+  bool _isNoApplicationProtocolError(HandshakeException e) {
+    final message = "${e.message} $e".toLowerCase();
+    return message.contains("no_application_protocol") ||
+        message.contains("no application protocol");
+  }
+
+  bool _hasRequestBodySendTimeout(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+  ) {
+    final sendTimeout = options.sendTimeout ?? Duration.zero;
+    return requestStream != null && sendTimeout > Duration.zero;
+  }
+
+  bool _hasCancellableRequestBody(
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    return requestStream != null && cancelFuture != null;
+  }
+
+  String _uriOrigin(Uri uri) {
+    final port = uri.hasPort ? ":${uri.port}" : "";
+    return "${uri.scheme}://${uri.host}$port";
+  }
 }

--- a/mobile/apps/photos/plugins/ente_cast/pubspec.lock
+++ b/mobile/apps/photos/plugins/ente_cast/pubspec.lock
@@ -38,10 +38,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -132,6 +132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   multicast_dns:
     dependency: transitive
     description:

--- a/mobile/apps/photos/plugins/ente_cast/pubspec.yaml
+++ b/mobile/apps/photos/plugins/ente_cast/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
       url: https://github.com/guyluz11/flutter_cast.git
       ref: af6378574352884beab6cddec462c7fdfc9a8c35
   collection: 1.19.1
-  dio: 5.8.0+1
+  dio: 5.9.2
   flutter:
     sdk: flutter
   shared_preferences: 2.5.3

--- a/mobile/apps/photos/plugins/ente_feature_flag/pubspec.lock
+++ b/mobile/apps/photos/plugins/ente_feature_flag/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.2"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -107,6 +107,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:

--- a/mobile/apps/photos/plugins/ente_feature_flag/pubspec.yaml
+++ b/mobile/apps/photos/plugins/ente_feature_flag/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   collection: 1.19.1
-  dio: 5.8.0+1
+  dio: 5.9.2
   flutter:
     sdk: flutter
   shared_preferences: 2.5.3

--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -459,14 +459,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
-  cupertino_http:
-    dependency: transitive
-    description:
-      name: cupertino_http
-      sha256: "8fb9e2c36d0732d9d96abd76683406b57e78a2514e27c962e0c603dbe6f2e3f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -1879,14 +1871,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  native_dio_adapter:
-    dependency: "direct main"
-    description:
-      name: native_dio_adapter
-      sha256: "7420bc9517b2abe09810199a19924617b45690a44ecfb0616ac9babc11875c03"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   native_video_editor:
     dependency: "direct main"
     description:
@@ -1926,14 +1910,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "9f034ba1eeca53ddb339bc8f4813cb07336a849cd735559b60cdc068ecce2dc7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.1.0"
   octo_image:
     dependency: transitive
     description:

--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -527,10 +527,18 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0+1"
+    version: "5.9.2"
+  dio_http2_adapter:
+    dependency: "direct main"
+    description:
+      name: dio_http2_adapter
+      sha256: "79f3d69b155b92a786c8734bd11860390b986210d4e07cbb6a5c8c806a7187b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -1330,6 +1338,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http2:
+    dependency: transitive
+    description:
+      name: http2
+      sha256: "382d3aefc5bd6dc68c6b892d7664f29b5beb3251611ae946a98d35158a82bbfa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   http_client_helper:
     dependency: transitive
     description:

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -185,7 +185,6 @@ dependencies:
       url: https://github.com/ente-io/move_to_background.git
       ref: 0cdfeed654d79636eff0c57110f3f6ad5801ba2f
   nanoid: 1.0.0
-  native_dio_adapter: 1.4.0
   native_video_editor:
     path: ../../packages/native_video_editor
   native_video_player: 4.0.0

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -48,7 +48,8 @@ dependencies:
   dart_ui_isolate: 1.1.1
   defer_pointer: 0.0.2
   device_info_plus: 11.3.0
-  dio: 5.8.0+1
+  dio: 5.9.2
+  dio_http2_adapter: 2.7.0
   dots_indicator: 4.0.1
   dotted_border: 2.1.0
   dropdown_button2: 2.3.9

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Add HTTP/2 support with HTTP/1.1 fallback for Photos API requests
 - Amrithesh: Improve zoomed OCR selection UX in the photo viewer
 - Neeraj: Fix dedupe cleanup progress percentage display
 - Neeraj: Fix Added by visibility in file details


### PR DESCRIPTION
## Summary
- Remove the Photos native Dio adapter and stale iOS pod/linker references.
- Add an adaptive Dio HTTP/2 adapter for Photos network clients with IO fallback for HTTP/1.1, plain HTTP, ALPN negotiation failures, and cancellable body streams.
- Pin Dio to 5.9.2, add dio_http2_adapter, update plugin lockfiles, and document the internal change.

## Testing
- dart format lib/core/network/network.dart
- ruby mobile/scripts/check_frozen_pubspecs.rb mobile
- flutter analyze lib/core/network/network.dart
- flutter analyze
- git diff --check
- iOS simulator Debug xcodebuild passed; otool verified cupertino_http/objective_c are no longer linked.