### PR TITLE
docs: update Locker sharing and offline help

### DIFF
--- a/docs/docs/locker/faq/sharing.md
+++ b/docs/docs/locker/faq/sharing.md
@@ -22,15 +22,22 @@ Your family member will receive the shared collection in their Locker app.
 
 ### Can I share with non-Ente users? {#locker-share-non-users}
 
-Yes, using public links for individual items. Create a public link that can be
-opened in any web browser:
+Yes, using public links for individual items or collections. Create a public
+link that can be opened in any web browser:
+
+### For an item
 
 1. Long press on the item
 2. Tap the share button
 3. Tap **Share link**
 4. Copy and share the link
 
-Note: Collections cannot be shared via public links - only with other Ente users.
+### For a collection
+
+1. Open the collection
+2. Tap the share button
+3. Tap **Share link**
+4. Copy and share the link
 
 Learn more about [Public links](/locker/features/sharing/public-links).
 

--- a/docs/docs/locker/faq/troubleshooting.md
+++ b/docs/docs/locker/faq/troubleshooting.md
@@ -121,11 +121,13 @@ Logs help us diagnose issues but contain no personal data.
 
 ### Can I use Locker offline? {#locker-offline}
 
-Locker requires an internet connection to function. You cannot view or create
-items while offline.
+Yes, for items you choose to keep locally on your device.
 
-If you need access to critical information during travel or in areas with poor
-connectivity, consider keeping physical copies of essential documents.
+Locker now supports keeping specific items available offline so you can open
+them without an internet connection after they have been downloaded.
+
+You still need internet access for syncing changes, fetching items that are not
+already stored locally, and creating or refreshing shared links.
 
 ## Related Features
 

--- a/docs/docs/locker/features/sharing/index.md
+++ b/docs/docs/locker/features/sharing/index.md
@@ -18,6 +18,14 @@ notifications and can access shared collections from their Locker app.
 Learn more about
 [Sharing collections with users](/locker/features/sharing/share-with-users).
 
+### Share collections via public links
+
+You can also create public links for collections so anyone with the link can
+open them in a browser, even without an Ente account.
+
+Use collection links when you want to share a group of items without requiring
+recipients to sign in.
+
 ### Share items via public links
 
 Create shareable links for individual items that anyone can access in a web
@@ -38,13 +46,13 @@ Learn more about [Ente Paste](/locker/features/sharing/ente-paste).
 
 | Content     | Share with Ente users | Share via public link | Share via Ente Paste |
 | ----------- | --------------------- | --------------------- | -------------------- |
-| Collections | Yes                   | No                    | No                   |
+| Collections | Yes                   | Yes                   | No                   |
 | Items       | No                    | Yes                   | No                   |
 | Text        | No                    | No                    | Yes                  |
 
 To share with other Ente users, organize items into a collection and share the
-collection. To share individual items with anyone (including non-Ente users),
-create a public link.
+collection. To share items or collections with anyone (including non-Ente
+users), create a public link.
 
 ## Security considerations
 
@@ -56,7 +64,8 @@ specifically for their account. Only they can decrypt and view the content.
 ### Public links
 
 Public links embed the decryption key in the URL. Anyone with the link can view
-the content. Delete links when no longer needed.
+the content. Locker supports public links for both individual items and
+collections. Delete links when no longer needed.
 
 ## Related FAQs
 

--- a/docs/docs/locker/features/sharing/public-links.md
+++ b/docs/docs/locker/features/sharing/public-links.md
@@ -41,7 +41,16 @@ When you create a public link:
 
 ## Deleting a link
 
+### For an item
+
 1. Long press on the item
+2. Tap the share button
+3. Tap **Delete link**
+4. Confirm deletion
+
+### For a collection
+
+1. Open the collection
 2. Tap the share button
 3. Tap **Delete link**
 4. Confirm deletion

--- a/docs/docs/locker/features/sharing/public-links.md
+++ b/docs/docs/locker/features/sharing/public-links.md
@@ -1,15 +1,20 @@
 ---
 title: Public Links
-description: Create secure, shareable links for documents
+description: Create secure, shareable links for documents and collections
 ---
 
 # Public Links
 
-Public links let you share individual items with anyone, even if they don't have
-an Ente account. Recipients can view the content in their web browser.
+Public links let you share individual items or whole collections with anyone,
+even if they don't have an Ente account. Recipients can view the content in
+their web browser.
 
-This is the way to share individual items with others. To share collections, use
-[Share with Ente users](/locker/features/sharing/share-with-users) instead.
+Use public links when you want browser-based sharing without requiring the
+recipient to sign in.
+
+If you want to share a collection privately with another Ente user inside the
+app, use [Share with Ente users](/locker/features/sharing/share-with-users)
+instead.
 
 ## How it works
 
@@ -22,7 +27,15 @@ When you create a public link:
 
 ## Creating a public link
 
+### For an item
+
 1. Long press on the item you want to share
+2. Tap the share button
+3. Tap **Share link**
+
+### For a collection
+
+1. Open the collection you want to share
 2. Tap the share button
 3. Tap **Share link**
 
@@ -45,8 +58,8 @@ The link will immediately stop working.
 
 Public links open in a web browser. The viewer can:
 
-- View the shared content
-- Access on any device with a browser
+- View the shared item or collection
+- Access it on any device with a browser
 
 No Ente app or account is required.
 

--- a/docs/docs/locker/index.md
+++ b/docs/docs/locker/index.md
@@ -52,8 +52,8 @@ making it easy to categorize information in ways that work for you.
 
 ### Secure sharing
 
-Share collections with other Ente users, or create public links for individual
-items that anyone can view in a browser.
+Share collections with other Ente users, or create public links for
+individual items and collections that anyone can view in a browser.
 
 ### Open source
 


### PR DESCRIPTION
## Summary
- update Locker sharing docs to cover public links for both items and collections
- fix the sharing FAQ and overview pages so they no longer say collections can't be shared via public links
- update the offline FAQ to explain that locally kept items remain available without internet, with syncing and link actions still requiring connectivity
