### PR TITLE
[mobile][auth] Fix auth desktop review link

### DIFF
--- a/mobile/apps/auth/lib/services/update_service.dart
+++ b/mobile/apps/auth/lib/services/update_service.dart
@@ -97,9 +97,9 @@ class UpdateService {
 
   // getRateDetails returns details about the place
   Tuple2<String, String> getRateDetails() {
-    // Note: in auth, currently we don't have a way to identify if the
-    // app was installed from play store, f-droid or github based on pkg name
     if (Platform.isAndroid) {
+      // Note: in auth, currently we don't have a way to identify if the
+      // app was installed from play store, f-droid or github based on pkg name
       if (flavor == "playstore") {
         return const Tuple2(
           "Play Store",
@@ -111,9 +111,15 @@ class UpdateService {
         "https://alternativeto.net/software/ente-authenticator/about/",
       );
     }
+    if (Platform.isIOS) {
+      return const Tuple2(
+        "App Store",
+        "https://apps.apple.com/in/app/ente-photos/id6444121398",
+      );
+    }
     return const Tuple2(
-      "App Store",
-      "https://apps.apple.com/in/app/ente-photos/id6444121398",
+      "AlternativeTo",
+      "https://alternativeto.net/software/ente-authenticator/about/",
     );
   }
 

--- a/mobile/apps/auth/lib/ui/components/banner_widget.dart
+++ b/mobile/apps/auth/lib/ui/components/banner_widget.dart
@@ -1,7 +1,6 @@
 import 'package:dotted_border/dotted_border.dart';
 import 'package:ente_auth/services/update_service.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
-import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:styled_text/tags/styled_text_tag.dart';
 import 'package:styled_text/widgets/styled_text.dart';
@@ -43,13 +42,7 @@ class BannerWidget extends StatelessWidget {
 
     switch (type) {
       case BannerType.rateUs:
-        if (PlatformDetector.isMobile()) {
-          url = Uri.parse(rateUrl);
-        } else if (PlatformDetector.isDesktop()) {
-          url = Uri.parse(
-            "https://play.google.com/store/apps/details?id=io.ente.auth",
-          );
-        }
+        url = Uri.parse(rateUrl);
         imagePath = "assets/rate_us.png";
         dashColor = const Color.fromRGBO(255, 191, 12, 1);
         boxShadow = [

--- a/mobile/apps/auth/lib/ui/settings/notification_banner_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/notification_banner_widget.dart
@@ -1,10 +1,9 @@
-import 'dart:io';
-
 import 'package:ente_accounts/models/user_details.dart';
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/services/preference_service.dart';
+import 'package:ente_auth/services/update_service.dart';
 import 'package:ente_auth/ui/components/banner_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -21,6 +20,8 @@ class NotificationBannerWidget extends StatelessWidget {
         .difference(DateTime.fromMillisecondsSinceEpoch(appInstallTime))
         .inDays;
     final l10n = context.l10n;
+    final ratePlace = UpdateService.instance.getRateDetails().item1;
+    final rateSubText = l10n.rateUsOnStore(ratePlace);
 
     if (Configuration.instance.hasConfiguredAccount()) {
       return FutureBuilder<UserDetails>(
@@ -37,9 +38,7 @@ class NotificationBannerWidget extends StatelessWidget {
                 [
                   BannerWidget(
                     text: l10n.tellUsWhatYouThink,
-                    subText: Platform.isIOS
-                        ? l10n.dropReviewiOS
-                        : l10n.dropReviewAndroid,
+                    subText: rateSubText,
                     type: BannerType.rateUs,
                   ),
                   sectionSpacing,
@@ -88,8 +87,7 @@ class NotificationBannerWidget extends StatelessWidget {
           [
             BannerWidget(
               text: l10n.tellUsWhatYouThink,
-              subText:
-                  Platform.isIOS ? l10n.dropReviewiOS : l10n.dropReviewAndroid,
+              subText: rateSubText,
               type: BannerType.rateUs,
             ),
             sectionSpacing,


### PR DESCRIPTION
## Summary
- route the Ente Auth desktop review CTA to AlternativeTo instead of Google Play
- reuse the resolved review destination for the banner copy so desktop text matches the link

## Root Cause
`BannerWidget` hardcoded a Play Store URL for desktop, and `NotificationBannerWidget` defaulted every non-iOS platform to Play Store review copy.

## Validation
- reviewed the touched desktop/mobile review CTA paths
- `flutter analyze` is currently blocked in this worktree by missing generated localization/assets files unrelated to this patch

Closes #5018
