### PR TITLE
[mobile] Update photos changelog for v1.3.36

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -7,6 +7,15 @@ description: Release notes of recent updates to Ente Photos mobile and desktop a
 
 A short summary list of changes to the Ente Photos mobile and desktop apps. For a more descriptive list with screenshots and blog post links, see the [news](https://ente.com/news).
 
+## v1.3.36 (mobile) - Apr 2026
+
+- Memories improvements
+- View other family members
+- Better OCR selection
+- Fix dedupe cleanup progress percentage display
+- Fix app going blank on iOS after deleting all empty albums
+- Home gallery bug fixes
+
 ## v1.3.32 (mobile) - Apr 2026
 
 - Memory Lane


### PR DESCRIPTION
## Summary
- add the `v1.3.36` Ente Photos mobile entry to the help-site changelog
- summarize the GitHub release notes in the same short bullet format used on the existing page

## Why
- keep `https://ente.com/help/photos/changelog` in sync with the latest mobile release notes

## Impact
- help-site readers can see the latest `v1.3.36` mobile changes from the changelog page
- no product code or behavior changes

## Validation
- reviewed the live help page structure and `origin/main` version of `docs/docs/photos/changelog.md`
- compared the inserted summary against the `photos-v1.3.36` GitHub release notes
- ran `git diff --check`
