### PR TITLE
[web] Add extra auth web issuer legacy period parsing

### DIFF
--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -193,6 +193,10 @@ const parseIssuer = (url: URL, path: string): string => {
     let issuer = url.searchParams.get("issuer");
     if (issuer) {
         // This is to handle bug in old versions of Ente Auth app.
+        const periodIndex = issuer.indexOf("period=");
+        if (periodIndex >= 0) {
+            issuer = issuer.substring(0, periodIndex);
+        }
         if (issuer.endsWith("period")) {
             issuer = issuer.substring(0, issuer.length - 6);
         }

--- a/web/apps/auth/src/services/code.ts
+++ b/web/apps/auth/src/services/code.ts
@@ -193,9 +193,12 @@ const parseIssuer = (url: URL, path: string): string => {
     let issuer = url.searchParams.get("issuer");
     if (issuer) {
         // This is to handle bug in old versions of Ente Auth app.
-        const periodIndex = issuer.indexOf("period=");
-        if (periodIndex >= 0) {
-            issuer = issuer.substring(0, periodIndex);
+        const periodSuffixIndex = issuer.search(/&?period=\d+$/);
+        if (
+            periodSuffixIndex > 0 &&
+            !/\s/.test(issuer.charAt(periodSuffixIndex - 1))
+        ) {
+            issuer = issuer.substring(0, periodSuffixIndex);
         }
         if (issuer.endsWith("period")) {
             issuer = issuer.substring(0, issuer.length - 6);


### PR DESCRIPTION
Pre-v3.1.8 Ente Auth built otpauth:// URIs without URI-encoding the issuer, so issuers containing URL-unsafe characters produced malformed query strings where `period=N` folded into the issuer value. The root cause was fixed in 75c3bc1c84 (Sep 2024).

Web has carried a mitigation since the viewer's first commit (4faa05a465, Mar 2023), but it only stripped a trailing literal `period` — i.e. `issuer=Xperiod`. Some exports instead surface as `issuer=Xperiod=30` (different URL parsers react differently to the malformed input), which the old check missed. Handle that second shape too.
