### PR TITLE
[mob][locker] Fix Locker file opening and offline cache cleanup

### DIFF
--- a/mobile/apps/locker/lib/events/opened_settings_event.dart
+++ b/mobile/apps/locker/lib/events/opened_settings_event.dart
@@ -1,0 +1,3 @@
+import "package:ente_events/models/event.dart";
+
+class OpenedSettingsEvent extends Event {}

--- a/mobile/apps/locker/lib/events/user_details_refresh_event.dart
+++ b/mobile/apps/locker/lib/events/user_details_refresh_event.dart
@@ -6,5 +6,4 @@ import "package:ente_events/models/event.dart";
 /// - File uploads complete (PDF/text files or info items)
 /// - Files are moved to trash
 /// - Files are restored from trash
-/// - Settings drawer is opened
 class UserDetailsRefreshEvent extends Event {}

--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -99,6 +99,10 @@
       }
     }
   },
+  "noAppToOpenFileDownloadInstead": "No app is available to preview this file. You can download it and open it with another app.",
+  "@noAppToOpenFileDownloadInstead": {
+    "description": "Message shown when Android cannot find an app to open or preview a file"
+  },
   "minutesAgo": "{minutes}m ago",
   "@minutesAgo": {
     "description": "Time format for minutes ago",

--- a/mobile/apps/locker/lib/l10n/app_localizations.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations.dart
@@ -342,6 +342,12 @@ abstract class AppLocalizations {
   /// **'Could not open item: {error}'**
   String couldNotOpenFile(String error);
 
+  /// Message shown when Android cannot find an app to open or preview a file
+  ///
+  /// In en, this message translates to:
+  /// **'No app is available to preview this file. You can download it and open it with another app.'**
+  String get noAppToOpenFileDownloadInstead;
+
   /// Time format for minutes ago
   ///
   /// In en, this message translates to:

--- a/mobile/apps/locker/lib/l10n/app_localizations_en.dart
+++ b/mobile/apps/locker/lib/l10n/app_localizations_en.dart
@@ -154,6 +154,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get noAppToOpenFileDownloadInstead =>
+      'No app is available to preview this file. You can download it and open it with another app.';
+
+  @override
   String minutesAgo(int minutes) {
     return '${minutes}m ago';
   }

--- a/mobile/apps/locker/lib/services/configuration.dart
+++ b/mobile/apps/locker/lib/services/configuration.dart
@@ -19,8 +19,7 @@ class Configuration extends BaseConfiguration {
   Future<void> logout({bool autoLogout = false}) async {
     CollectionService.instance.clearCache();
     FavoritesService.instance.clearCache();
-
-    await super.logout(autoLogout: autoLogout);
     await clearAllOfflineFileCopies();
+    await super.logout(autoLogout: autoLogout);
   }
 }

--- a/mobile/apps/locker/lib/services/files/download/file_downloader.dart
+++ b/mobile/apps/locker/lib/services/files/download/file_downloader.dart
@@ -29,13 +29,13 @@ Future<File> ensureEncryptedOfflineCopy(
   ProgressCallback? progressCallback,
 }) async {
   final existingFile = await getCurrentOfflineEncryptedCopy(file);
+  final String logPrefix = 'File-${file.uploadedFileID}:';
   if (existingFile != null) {
     final existingSize = await existingFile.length();
     progressCallback?.call(existingSize, existingSize);
     return existingFile;
   }
 
-  final String logPrefix = 'File-${file.uploadedFileID}:';
   final String tempDir = Configuration.instance.getTempDirectory();
   final String tempEncryptedFilePath =
       "$tempDir${file.uploadedFileID}.encrypted";
@@ -96,7 +96,6 @@ Future<File> ensureEncryptedOfflineCopy(
 
     await encryptedFile.copy(finalEncryptedFilePath);
     await encryptedFile.delete();
-    _logger.info('$logPrefix persisted encrypted offline copy');
     return finalEncryptedFile;
   } catch (e, s) {
     _logger.severe(
@@ -228,7 +227,6 @@ Future<File?> downloadAndDecrypt(
     if (shouldUseCache && await decryptedFile.exists()) {
       final decryptedSize = await decryptedFile.length();
       if (decryptedSize > 0) {
-        _logger.info('$logPrefix using cached decrypted file');
         progressCallback?.call(decryptedSize, decryptedSize);
         return decryptedFile;
       } else {
@@ -246,7 +244,6 @@ Future<File?> downloadAndDecrypt(
           usingCachedEncryptedFile = true;
           encryptedFilePath = cachedEncryptedFilePath;
           encryptedFile = cachedEncryptedFile;
-          _logger.info('$logPrefix using cached encrypted file');
         } else {
           await cachedEncryptedFile.delete();
         }
@@ -320,11 +317,14 @@ Future<File?> downloadAndDecrypt(
         fileKey,
       );
       fakeProgress?.stop();
-      _logger
-          .info('$logPrefix decryption completed (ID ${file.uploadedFileID})');
     } catch (e, s) {
       fakeProgress?.stop();
       _logger.severe("Critical: $logPrefix failed to decrypt", e, s);
+      try {
+        if (await decryptedFile.exists()) {
+          await decryptedFile.delete();
+        }
+      } catch (_) {}
       if (downloadedFreshEncryptedFile) {
         try {
           await encryptedFile.delete();

--- a/mobile/apps/locker/lib/services/files/offline/offline_file_storage.dart
+++ b/mobile/apps/locker/lib/services/files/offline/offline_file_storage.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 const _offlineEncryptedDirName = 'offline_documents';
+const _openHandoffDirName = 'open_handoff';
 final _logger = Logger('OfflineFileStorage');
 
 String _safeExtension(String fileName) {
@@ -21,10 +22,40 @@ String getCachedEncryptedFilePath(EnteFile file) {
   return "$cacheDir${file.uploadedFileID}.encrypted";
 }
 
+String getPreferredFileExtension(
+  EnteFile? file, {
+  String? fallbackPath,
+  String? fallbackName,
+}) {
+  final titleExtension = _safeExtension(file?.title ?? '');
+  if (titleExtension.isNotEmpty) {
+    return titleExtension;
+  }
+
+  final nameExtension = _safeExtension(fallbackName ?? file?.displayName ?? '');
+  if (nameExtension.isNotEmpty) {
+    return nameExtension;
+  }
+
+  final pathExtension = _safeExtension(fallbackPath ?? '');
+  if (pathExtension.isNotEmpty) {
+    return pathExtension;
+  }
+
+  return '';
+}
+
 String getCachedDecryptedFilePath(EnteFile file) {
   final String cacheDir = Configuration.instance.getCacheDirectory();
-  final String extension = _safeExtension(file.displayName);
+  final String extension = getPreferredFileExtension(file);
   return "$cacheDir${file.uploadedFileID}.decrypted$extension";
+}
+
+String getOpenHandoffDirectoryPath() {
+  return p.join(
+    Configuration.instance.getCacheDirectory(),
+    _openHandoffDirName,
+  );
 }
 
 Future<Directory> _getOfflineEncryptedDirectory() async {
@@ -74,68 +105,32 @@ Future<void> removeOfflineFileCopiesFromDisk(
     ' (removeWorkingCopies=$removeWorkingCopies)',
   );
 
-  await _deleteFilesFromDirectory(await _getOfflineEncryptedDirectory(), (
-    baseName,
-  ) {
-    final fileId = _parseEncryptedFileId(baseName);
-    return fileId != null && ids.contains(fileId);
-  });
+  await _deleteOfflineEncryptedCopies(ids);
 
   if (!removeWorkingCopies) {
     return;
   }
 
   await _deleteCachedFileCopies(ids);
+  await _deleteOpenHandoffCopies(ids);
 }
 
 Future<void> clearAllOfflineFileCopies() async {
   _logger.info('Clearing all offline file copies');
-  await _deleteFilesFromDirectory(
-    await _getOfflineEncryptedDirectory(),
-    (_) => true,
-  );
-
-  final cacheDirectory = Directory(Configuration.instance.getCacheDirectory());
-  await _deleteFilesFromDirectory(cacheDirectory, _isOfflineWorkingCopyBaseName);
+  await _deleteOfflineEncryptedCopies();
+  await _deleteCachedFileCopies(null);
+  await _deleteOpenHandoffCopies();
 }
 
-Future<void> cleanupOfflineWorkingFiles({
+Future<void> cleanupStaleOfflineFileCopies({
   Duration olderThan = Duration.zero,
 }) async {
-  _logger.fine('Cleaning offline working files older than $olderThan');
-  final directory = Directory(Configuration.instance.getCacheDirectory());
-  if (!await directory.exists()) {
-    return;
-  }
-
-  final now = DateTime.now();
-  await for (final entity in directory.list(followLinks: false)) {
-    if (entity is! File) {
-      continue;
-    }
-
-    final baseName = p.basename(entity.path);
-    if (!_isOfflineWorkingCopyBaseName(baseName)) {
-      continue;
-    }
-
-    try {
-      if (olderThan > Duration.zero) {
-        final stat = await entity.stat();
-        if (now.difference(stat.modified) < olderThan) {
-          continue;
-        }
-      }
-      await entity.delete();
-    } catch (e, s) {
-      _logger.warning('Failed to delete cached offline working file', e, s);
-    }
-  }
-}
-
-bool _isOfflineWorkingCopyBaseName(String baseName) {
-  return _parseEncryptedFileId(baseName) != null ||
-      _parseCachedDecryptedFileId(baseName) != null;
+  _logger.fine('Cleaning stale offline file copies older than $olderThan');
+  await _deleteCachedFileCopies(
+    null,
+    olderThan: olderThan,
+  );
+  await _cleanupStaleOpenHandoffCopies(olderThan: olderThan);
 }
 
 int? _parseEncryptedFileId(String baseName) {
@@ -147,34 +142,121 @@ int? _parseEncryptedFileId(String baseName) {
 }
 
 int? _parseCachedDecryptedFileId(String baseName) {
-  final match = RegExp(r'^(\d+)\.decrypted').firstMatch(baseName);
+  final match = RegExp(r'^(\d+)\.decrypted(?:\.[^.]+)?$').firstMatch(baseName);
   if (match == null) {
     return null;
   }
   return int.tryParse(match.group(1)!);
 }
 
-Future<void> _deleteCachedFileCopies(Set<int> ids) async {
-  final cacheDirectory = Directory(Configuration.instance.getCacheDirectory());
-  await _deleteFilesFromDirectory(cacheDirectory, (baseName) {
-    final encryptedId = _parseEncryptedFileId(baseName);
-    if (encryptedId != null && ids.contains(encryptedId)) {
-      return true;
-    }
-
-    final decryptedId = _parseCachedDecryptedFileId(baseName);
-    return decryptedId != null && ids.contains(decryptedId);
-  });
+int? _parseCachedFileId(String baseName) {
+  return _parseEncryptedFileId(baseName) ??
+      _parseCachedDecryptedFileId(baseName);
 }
 
-Future<void> _deleteFilesFromDirectory(
-  Directory directory,
-  bool Function(String baseName) shouldDelete,
-) async {
+Future<void> _deleteOfflineEncryptedCopies([
+  Set<int>? ids,
+]) async {
+  final directory = await _getOfflineEncryptedDirectory();
+  await _deleteMatchingFiles(
+    directory,
+    shouldDelete: (baseName) {
+      if (ids == null) {
+        return true;
+      }
+
+      final fileId = _parseEncryptedFileId(baseName);
+      return fileId != null && ids.contains(fileId);
+    },
+  );
+}
+
+Future<void> _deleteCachedFileCopies(
+  Set<int>? ids, {
+  Duration olderThan = Duration.zero,
+}) async {
+  // The cache directory is shared; only Locker's ID-keyed working files belong here.
+  final cacheDirectory = Directory(Configuration.instance.getCacheDirectory());
+  await _deleteMatchingFiles(
+    cacheDirectory,
+    shouldDelete: (baseName) {
+      final fileId = _parseCachedFileId(baseName);
+      return fileId != null && (ids == null || ids.contains(fileId));
+    },
+    olderThan: olderThan,
+  );
+}
+
+Future<void> _deleteOpenHandoffCopies([
+  Set<int>? ids,
+]) async {
+  final handoffDirectory = Directory(getOpenHandoffDirectoryPath());
+  if (!await handoffDirectory.exists()) {
+    return;
+  }
+
+  if (ids == null) {
+    await _deleteImmediateChildren(handoffDirectory, shouldDelete: (_) => true);
+    return;
+  }
+
+  await _deleteImmediateChildren(
+    handoffDirectory,
+    shouldDelete: (entity) {
+      if (entity is! Directory) {
+        return false;
+      }
+      final fileId = int.tryParse(p.basename(entity.path));
+      return fileId != null && ids.contains(fileId);
+    },
+  );
+}
+
+Future<void> _cleanupStaleOpenHandoffCopies({
+  Duration olderThan = Duration.zero,
+}) async {
+  final handoffDirectory = Directory(getOpenHandoffDirectoryPath());
+  if (!await handoffDirectory.exists()) {
+    return;
+  }
+
+  final now = DateTime.now();
+  await for (final fileIdEntity in handoffDirectory.list(followLinks: false)) {
+    // Handoffs are open_handoff/<fileId>/<timestamp>/<display-name>.
+    // Age the timestamp entries, not the long-lived fileId parent.
+    if (fileIdEntity is! Directory) {
+      await _deleteIfEligible(
+        fileIdEntity,
+        now: now,
+        olderThan: olderThan,
+      );
+      continue;
+    }
+
+    await for (final handoffEntity in fileIdEntity.list(followLinks: false)) {
+      await _deleteIfEligible(
+        handoffEntity,
+        now: now,
+        olderThan: olderThan,
+      );
+    }
+
+    if (await _isDirectoryEmpty(fileIdEntity)) {
+      await _deleteEntity(fileIdEntity);
+    }
+  }
+}
+
+Future<void> _deleteMatchingFiles(
+  Directory directory, {
+  required bool Function(String baseName) shouldDelete,
+  Duration olderThan = Duration.zero,
+}) async {
   if (!await directory.exists()) {
     return;
   }
 
+  final now = DateTime.now();
   await for (final entity in directory.list(followLinks: false)) {
     if (entity is! File) {
       continue;
@@ -185,10 +267,83 @@ Future<void> _deleteFilesFromDirectory(
       continue;
     }
 
-    try {
-      await entity.delete();
-    } catch (e, s) {
-      _logger.warning('Failed to delete offline file copy ${entity.path}', e, s);
+    await _deleteIfEligible(
+      entity,
+      now: now,
+      olderThan: olderThan,
+    );
+  }
+}
+
+Future<void> _deleteImmediateChildren(
+  Directory directory, {
+  required bool Function(FileSystemEntity entity) shouldDelete,
+  Duration olderThan = Duration.zero,
+}) async {
+  if (!await directory.exists()) {
+    return;
+  }
+
+  final now = DateTime.now();
+  await for (final entity in directory.list(followLinks: false)) {
+    if (!shouldDelete(entity)) {
+      continue;
     }
+
+    await _deleteIfEligible(
+      entity,
+      now: now,
+      olderThan: olderThan,
+    );
+  }
+}
+
+Future<bool> _isDirectoryEmpty(Directory directory) async {
+  try {
+    await for (final _ in directory.list(followLinks: false)) {
+      return false;
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<bool> _isEligibleForDeletion(
+  FileSystemEntity entity, {
+  required DateTime now,
+  required Duration olderThan,
+}) async {
+  if (olderThan <= Duration.zero) {
+    return true;
+  }
+
+  try {
+    final stat = await entity.stat();
+    return now.difference(stat.modified) >= olderThan;
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<void> _deleteIfEligible(
+  FileSystemEntity entity, {
+  required DateTime now,
+  required Duration olderThan,
+}) async {
+  if (await _isEligibleForDeletion(
+    entity,
+    now: now,
+    olderThan: olderThan,
+  )) {
+    await _deleteEntity(entity);
+  }
+}
+
+Future<void> _deleteEntity(FileSystemEntity entity) async {
+  try {
+    await entity.delete(recursive: entity is Directory);
+  } catch (e, s) {
+    _logger.warning('Failed to delete file copy ${entity.path}', e, s);
   }
 }

--- a/mobile/apps/locker/lib/services/files/offline/offline_files_service.dart
+++ b/mobile/apps/locker/lib/services/files/offline/offline_files_service.dart
@@ -27,8 +27,8 @@ class OfflineFilesService {
   final Logger _logger = Logger('OfflineFilesService');
 
   Future<void> init() async {
-    _logger.fine('Cleaning up stale offline working files');
-    await cleanupOfflineWorkingFiles(
+    _logger.fine('Cleaning up stale offline file copies');
+    await cleanupStaleOfflineFileCopies(
       olderThan: _cachedFileCleanupAge,
     );
   }
@@ -74,7 +74,9 @@ class OfflineFilesService {
     final total = eligibleFiles.length;
     final dialog = createProgressDialog(
       context,
-      total == 1 ? context.l10n.savingOffline : '${context.l10n.savingOffline} 0/$total',
+      total == 1
+          ? context.l10n.savingOffline
+          : '${context.l10n.savingOffline} 0/$total',
       isDismissible: false,
     );
 

--- a/mobile/apps/locker/lib/states/user_details_state.dart
+++ b/mobile/apps/locker/lib/states/user_details_state.dart
@@ -4,6 +4,7 @@ import "package:ente_accounts/models/user_details.dart";
 import "package:ente_accounts/services/user_service.dart";
 import "package:ente_events/event_bus.dart";
 import "package:flutter/material.dart";
+import "package:locker/events/opened_settings_event.dart";
 import "package:locker/events/user_details_refresh_event.dart";
 
 class UserDetailsStateWidget extends StatefulWidget {
@@ -20,6 +21,7 @@ class UserDetailsStateWidget extends StatefulWidget {
 
 class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
   late UserDetails? _userDetails;
+  late StreamSubscription<OpenedSettingsEvent> _openedSettingsEventSubscription;
   late StreamSubscription<UserDetailsRefreshEvent>
       _userDetailsRefreshEventSubscription;
   bool _isCached = true;
@@ -27,6 +29,10 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
   @override
   void initState() {
     _userDetails = UserService.instance.getCachedUserDetails();
+    _openedSettingsEventSubscription =
+        Bus.instance.on<OpenedSettingsEvent>().listen((event) {
+      _fetchUserDetails();
+    });
     _userDetailsRefreshEventSubscription =
         Bus.instance.on<UserDetailsRefreshEvent>().listen((event) {
       _fetchUserDetails();
@@ -36,6 +42,7 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
 
   @override
   void dispose() {
+    _openedSettingsEventSubscription.cancel();
     _userDetailsRefreshEventSubscription.cancel();
     super.dispose();
   }
@@ -78,8 +85,7 @@ class InheritedUserDetails extends InheritedWidget {
 
   @override
   bool updateShouldNotify(covariant InheritedUserDetails oldWidget) {
-    return (userDetails?.usage != oldWidget.userDetails?.usage) ||
-        (userDetails?.fileCount != oldWidget.userDetails?.fileCount) ||
+    return (userDetails != oldWidget.userDetails) ||
         (isCached != oldWidget.isCached);
   }
 }

--- a/mobile/apps/locker/lib/states/user_details_state.dart
+++ b/mobile/apps/locker/lib/states/user_details_state.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:ente_accounts/models/user_details.dart";
 import "package:ente_accounts/services/user_service.dart";
 import "package:ente_events/event_bus.dart";
+import "package:ente_events/models/user_details_changed_event.dart";
 import "package:flutter/material.dart";
 import "package:locker/events/opened_settings_event.dart";
 import "package:locker/events/user_details_refresh_event.dart";
@@ -22,6 +23,8 @@ class UserDetailsStateWidget extends StatefulWidget {
 class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
   late UserDetails? _userDetails;
   late StreamSubscription<OpenedSettingsEvent> _openedSettingsEventSubscription;
+  late StreamSubscription<UserDetailsChangedEvent>
+      _userDetailsChangedSubscription;
   late StreamSubscription<UserDetailsRefreshEvent>
       _userDetailsRefreshEventSubscription;
   bool _isCached = true;
@@ -33,6 +36,10 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
         Bus.instance.on<OpenedSettingsEvent>().listen((event) {
       _fetchUserDetails();
     });
+    _userDetailsChangedSubscription =
+        Bus.instance.on<UserDetailsChangedEvent>().listen((event) {
+      _refreshFromCache();
+    });
     _userDetailsRefreshEventSubscription =
         Bus.instance.on<UserDetailsRefreshEvent>().listen((event) {
       _fetchUserDetails();
@@ -43,6 +50,7 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
   @override
   void dispose() {
     _openedSettingsEventSubscription.cancel();
+    _userDetailsChangedSubscription.cancel();
     _userDetailsRefreshEventSubscription.cancel();
     super.dispose();
   }
@@ -61,6 +69,14 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
       shouldCache: true,
     );
     _isCached = false;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _refreshFromCache() {
+    _userDetails = UserService.instance.getCachedUserDetails();
+    _isCached = true;
     if (mounted) {
       setState(() {});
     }

--- a/mobile/apps/locker/lib/states/user_details_state.dart
+++ b/mobile/apps/locker/lib/states/user_details_state.dart
@@ -76,7 +76,6 @@ class UserDetailsStateWidgetState extends State<UserDetailsStateWidget> {
 
   void _refreshFromCache() {
     _userDetails = UserService.instance.getCachedUserDetails();
-    _isCached = true;
     if (mounted) {
       setState(() {});
     }

--- a/mobile/apps/locker/lib/ui/drawer/drawer_page.dart
+++ b/mobile/apps/locker/lib/ui/drawer/drawer_page.dart
@@ -1,11 +1,8 @@
-import "package:ente_accounts/services/user_service.dart";
-import "package:ente_events/event_bus.dart";
 import "package:ente_sharing/verify_identity_dialog.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:ente_ui/theme/colors.dart";
 import "package:ente_ui/theme/ente_theme.dart";
 import "package:flutter/material.dart";
-import "package:locker/events/user_details_refresh_event.dart";
 import "package:locker/services/configuration.dart";
 import "package:locker/ui/components/legacy_collections_trash_widget.dart";
 import "package:locker/ui/components/usage_card_widget.dart";
@@ -24,12 +21,6 @@ class DrawerPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Bus.instance.fire(UserDetailsRefreshEvent());
-
-    final hasLoggedIn = Configuration.instance.hasConfiguredAccount();
-    if (hasLoggedIn) {
-      UserService.instance.getUserDetailsV2().ignore();
-    }
     final enteColorScheme = getEnteColorScheme(context);
     return Scaffold(
       backgroundColor: enteColorScheme.backgroundBase,

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -14,6 +14,7 @@ import "package:flutter_svg/flutter_svg.dart";
 import "package:hugeicons/hugeicons.dart";
 import 'package:listen_sharing_intent/listen_sharing_intent.dart';
 import 'package:locker/events/collections_updated_event.dart';
+import 'package:locker/events/opened_settings_event.dart';
 import 'package:locker/l10n/l10n.dart';
 import 'package:locker/models/selected_files.dart';
 import 'package:locker/services/collections/collections_service.dart';
@@ -653,7 +654,12 @@ class _HomePageState extends UploaderPageState<HomePage>
                   child: _settingsPage,
                 ),
                 drawerEnableOpenDragGesture: true,
-                onDrawerChanged: (isOpened) => _isSettingsOpen = isOpened,
+                onDrawerChanged: (isOpened) {
+                  _isSettingsOpen = isOpened;
+                  if (isOpened) {
+                    Bus.instance.fire(OpenedSettingsEvent());
+                  }
+                },
                 appBar: CustomLockerAppBar(
                   scaffoldKey: scaffoldKey,
                   isSearchActive: isSearchActive,

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -34,22 +34,27 @@ class FileUtil {
       return _openInfoFile(context, file);
     }
 
-    if (file.localPath != null) {
-      final localFile = File(file.localPath!);
-      if (await localFile.exists()) {
-        await _launchFile(context, localFile, displayName: file.displayName);
-        return;
-      }
+    if (file.uploadedFileID == null) {
+      await showGenericErrorBottomSheet(
+        context: context,
+        error: Exception(context.l10n.errorOpeningFile),
+      );
+      return;
     }
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));
     if (await cachedDecryptedFile.exists()) {
-      await _launchFile(
-        context,
-        cachedDecryptedFile,
-        displayName: file.displayName,
-      );
-      return;
+      final cachedSize = await cachedDecryptedFile.length();
+      if (cachedSize > 0) {
+        await _launchFile(
+          context,
+          cachedDecryptedFile,
+          displayName: file.displayName,
+          lockerFile: file,
+        );
+        return;
+      }
+      await cachedDecryptedFile.delete();
     }
 
     final dialog = createProgressDialog(
@@ -64,9 +69,7 @@ class FileUtil {
       void progressCallback(int downloaded, int total) {
         if (total > 0 && downloaded >= 0) {
           final percentage = ((downloaded / total) * 100).clamp(0, 100).round();
-          dialog.update(
-            message: context.l10n.downloadingProgress(percentage),
-          );
+          dialog.update(message: context.l10n.downloadingProgress(percentage));
         } else {
           dialog.update(message: context.l10n.downloading);
         }
@@ -85,6 +88,7 @@ class FileUtil {
           context,
           decryptedFile,
           displayName: file.displayName,
+          lockerFile: file,
         );
       } else {
         await showAlertBottomSheet(
@@ -104,17 +108,11 @@ class FileUtil {
       }
     } catch (e) {
       await dialog.hide();
-      await showGenericErrorBottomSheet(
-        context: context,
-        error: e,
-      );
+      await showGenericErrorBottomSheet(context: context, error: e);
     }
   }
 
-  static Future<bool> downloadFile(
-    BuildContext context,
-    EnteFile file,
-  ) {
+  static Future<bool> downloadFile(BuildContext context, EnteFile file) {
     return _downloadFiles(context, [file]);
   }
 
@@ -157,8 +155,9 @@ class FileUtil {
 
         // Skip info items for now; they are meant to be viewed in-app.
         if (InfoFileService.instance.isInfoFile(file)) {
-          _logger
-              .fine('Skipping info file download (ID: ${file.uploadedFileID})');
+          _logger.fine(
+            'Skipping info file download (ID: ${file.uploadedFileID})',
+          );
           if (!hasShownInfoSkipToast) {
             hasShownInfoSkipToast = true;
             showToast(
@@ -205,15 +204,9 @@ class FileUtil {
       _logger.severe('Failed to save files', e, s);
       if (context.mounted) {
         if (e is UnsupportedError) {
-          showToast(
-            context,
-            'This file type is not supported for download',
-          );
+          showToast(context, 'This file type is not supported for download');
         } else {
-          showToast(
-            context,
-            context.l10n.failedToDownloadOrDecrypt,
-          );
+          showToast(context, context.l10n.failedToDownloadOrDecrypt);
         }
       }
       return false;
@@ -369,10 +362,7 @@ class FileUtil {
       Widget page;
       switch (infoItem.type) {
         case InfoType.note:
-          page = PersonalNotePage(
-            mode: InfoPageMode.view,
-            existingFile: file,
-          );
+          page = PersonalNotePage(mode: InfoPageMode.view, existingFile: file);
           break;
         case InfoType.accountCredential:
           page = AccountCredentialsPage(
@@ -394,14 +384,11 @@ class FileUtil {
           break;
       }
 
-      await Navigator.of(context).push(
-        MaterialPageRoute(builder: (context) => page),
-      );
+      await Navigator.of(
+        context,
+      ).push(MaterialPageRoute(builder: (context) => page));
     } catch (e) {
-      await showGenericErrorBottomSheet(
-        context: context,
-        error: e,
-      );
+      await showGenericErrorBottomSheet(context: context, error: e);
     }
   }
 
@@ -409,30 +396,152 @@ class FileUtil {
     BuildContext context,
     File file, {
     String? displayName,
+    EnteFile? lockerFile,
   }) async {
     File fileToOpen = file;
 
     try {
-      if (displayName != null && displayName.isNotEmpty) {
-        try {
-          final sanitizedName = _sanitizeFileName(p.basename(displayName));
-          final launchPath = p.join(file.parent.path, sanitizedName);
-          await file.copy(launchPath);
-          fileToOpen = File(launchPath);
-        } catch (e) {
-          _logger.warning("Failed to create display-name copy: $e");
-        }
+      fileToOpen = await _prepareOpenFile(
+        file,
+        displayName: displayName,
+        lockerFile: lockerFile,
+      );
+
+      if (!await fileToOpen.exists() || await fileToOpen.length() == 0) {
+        throw Exception("File is missing or empty");
       }
 
       final result = await OpenFile.open(fileToOpen.path);
       if (result.type != ResultType.done) {
-        throw Exception(result.message);
+        if (context.mounted) {
+          await _showOpenFileError(
+            context,
+            resultType: result.type,
+            error: result.message,
+            lockerFile: lockerFile,
+          );
+        }
       }
     } catch (e) {
-      await showGenericErrorBottomSheet(
-        context: context,
-        error: e,
-      );
+      if (context.mounted) {
+        await _showOpenFileError(
+          context,
+          error: e.toString(),
+          lockerFile: lockerFile,
+        );
+      }
     }
+  }
+
+  static Future<File> _prepareOpenFile(
+    File file, {
+    required String? displayName,
+    required EnteFile? lockerFile,
+  }) async {
+    final contentExtension = getPreferredFileExtension(
+      lockerFile,
+      fallbackPath: file.path,
+      fallbackName: displayName,
+    );
+
+    final launchName = _openHandoffFileName(
+      displayName: displayName,
+      lockerFile: lockerFile,
+      contentExtension: contentExtension,
+    );
+    final fileDirectoryName = lockerFile?.uploadedFileID?.toString() ??
+        file.path.hashCode.toUnsigned(32).toRadixString(16);
+    final launchDir = Directory(
+      p.join(
+        getOpenHandoffDirectoryPath(),
+        fileDirectoryName,
+        DateTime.now().microsecondsSinceEpoch.toString(),
+      ),
+    );
+
+    try {
+      await launchDir.create(recursive: true);
+      final launchPath = p.join(launchDir.path, launchName);
+      return await file.copy(launchPath);
+    } catch (_) {
+      throw Exception("Failed to prepare file for opening");
+    }
+  }
+
+  @visibleForTesting
+  static Future<File> prepareOpenFileForTest(
+    File file, {
+    required String? displayName,
+    required EnteFile? lockerFile,
+  }) {
+    return _prepareOpenFile(
+      file,
+      displayName: displayName,
+      lockerFile: lockerFile,
+    );
+  }
+
+  static String _openHandoffFileName({
+    required String? displayName,
+    required EnteFile? lockerFile,
+    required String contentExtension,
+  }) {
+    final rawName = displayName != null && displayName.trim().isNotEmpty
+        ? displayName
+        : lockerFile?.uploadedFileID != null
+            ? "file-${lockerFile!.uploadedFileID}"
+            : "file";
+    final sanitizedName = _sanitizeFileName(p.basename(rawName));
+    final sanitizedExtension = p.extension(sanitizedName);
+    if (contentExtension.isEmpty ||
+        sanitizedExtension.toLowerCase() == contentExtension.toLowerCase()) {
+      return sanitizedName;
+    }
+    return "${_baseNameWithoutExtension(sanitizedName)}$contentExtension";
+  }
+
+  static Future<void> _showOpenFileError(
+    BuildContext context, {
+    required String error,
+    ResultType? resultType,
+    EnteFile? lockerFile,
+  }) async {
+    await showAlertBottomSheet(
+      context,
+      title: context.l10n.oops,
+      message: _openFileErrorMessage(
+        context,
+        error,
+        resultType: resultType,
+      ),
+      assetPath: "assets/warning-grey.png",
+      buttons: [
+        GradientButton(
+          text: context.l10n.download,
+          onTap: () async {
+            Navigator.of(context).pop();
+            await downloadFile(context, lockerFile!);
+          },
+        ),
+      ],
+    );
+  }
+
+  static String _openFileErrorMessage(
+    BuildContext context,
+    String error, {
+    ResultType? resultType,
+  }) {
+    if (resultType == ResultType.noAppToOpen) {
+      return context.l10n.noAppToOpenFileDownloadInstead;
+    }
+
+    final cleaned = error
+        .replaceFirst(RegExp(r"^Exception:\s*"), "")
+        .replaceAll("。", ".")
+        .trim();
+    return context.l10n.couldNotOpenFile(
+      cleaned.isEmpty ? context.l10n.noAppToOpenFileDownloadInstead : cleaned,
+    );
   }
 }

--- a/mobile/apps/locker/pubspec.yaml
+++ b/mobile/apps/locker/pubspec.yaml
@@ -1,7 +1,7 @@
 name: locker
 description: "Ente Locker – Safe space for your important documents"
 publish_to: "none"
-version: 1.0.2+99
+version: 1.0.3+102
 environment:
   sdk: ">=3.0.0 <4.0.0"
 

--- a/mobile/apps/locker/test/services/files/download/file_downloader_test.dart
+++ b/mobile/apps/locker/test/services/files/download/file_downloader_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/files/download/file_downloader.dart'
+    as file_downloader;
+import 'package:locker/services/files/offline/offline_file_storage.dart';
+import 'package:locker/services/files/sync/models/file.dart';
+import 'package:path/path.dart' as p;
+
+import '../../../test_utils/configuration_test_util.dart';
+
+void main() {
+  EnteFile lockerFile({
+    required int uploadedFileID,
+    required String title,
+    String? localPath,
+  }) {
+    return EnteFile()
+      ..uploadedFileID = uploadedFileID
+      ..title = title
+      ..localPath = localPath;
+  }
+
+  Future<File> writeFile(String path, String contents) async {
+    final file = File(path);
+    await file.parent.create(recursive: true);
+    return file.writeAsString(contents);
+  }
+
+  group('file_downloader openFile cache identity', () {
+    late Directory root;
+
+    setUp(() async {
+      root = await setupLockerConfigurationForTest('file_downloader');
+    });
+
+    tearDown(() async {
+      clearLockerConfigurationTestHandlers();
+      if (await root.exists()) {
+        await root.delete(recursive: true);
+      }
+    });
+
+    test('returns ID-keyed cached decrypted copy and ignores localPath',
+        () async {
+      final staleLocalPath = await writeFile(
+        p.join(root.path, 'old-local-copy.pdf'),
+        'stale local bytes',
+      );
+      final file = lockerFile(
+        uploadedFileID: 901,
+        title: 'statement.pdf',
+        localPath: staleLocalPath.path,
+      );
+      final cachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(file),
+        'current cached bytes',
+      );
+
+      final opened = await file_downloader.openFile(file, Uint8List(32));
+
+      expect(opened, isNotNull);
+      expect(opened!.path, cachedDecrypted.path);
+      expect(await opened.readAsString(), 'current cached bytes');
+      expect(await staleLocalPath.readAsString(), 'stale local bytes');
+    });
+
+    test('isolates cached decrypted files by uploaded file ID', () async {
+      final sharedLocalPath = await writeFile(
+        p.join(root.path, 'shared-local.pdf'),
+        'stale shared local bytes',
+      );
+      final firstFile = lockerFile(
+        uploadedFileID: 902,
+        title: 'same-name.pdf',
+        localPath: sharedLocalPath.path,
+      );
+      final secondFile = lockerFile(
+        uploadedFileID: 903,
+        title: 'same-name.pdf',
+        localPath: sharedLocalPath.path,
+      );
+      final firstCached = await writeFile(
+        getCachedDecryptedFilePath(firstFile),
+        'first cached bytes',
+      );
+      final secondCached = await writeFile(
+        getCachedDecryptedFilePath(secondFile),
+        'second cached bytes',
+      );
+
+      final firstOpened = await file_downloader.openFile(
+        firstFile,
+        Uint8List(32),
+      );
+      final secondOpened = await file_downloader.openFile(
+        secondFile,
+        Uint8List(32),
+      );
+
+      expect(firstOpened, isNotNull);
+      expect(secondOpened, isNotNull);
+      expect(firstOpened!.path, firstCached.path);
+      expect(secondOpened!.path, secondCached.path);
+      expect(await firstOpened.readAsString(), 'first cached bytes');
+      expect(await secondOpened.readAsString(), 'second cached bytes');
+      expect(firstOpened.path, isNot(secondOpened.path));
+      expect(await sharedLocalPath.readAsString(), 'stale shared local bytes');
+    });
+  });
+}

--- a/mobile/apps/locker/test/services/files/offline/offline_file_storage_test.dart
+++ b/mobile/apps/locker/test/services/files/offline/offline_file_storage_test.dart
@@ -1,0 +1,326 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/configuration.dart';
+import 'package:locker/services/files/offline/offline_file_storage.dart';
+import 'package:locker/services/files/sync/models/file.dart';
+import 'package:path/path.dart' as p;
+
+import '../../../test_utils/configuration_test_util.dart';
+
+void main() {
+  EnteFile lockerFile(
+    int uploadedFileID, {
+    String title = 'document.pdf',
+  }) {
+    return EnteFile()
+      ..uploadedFileID = uploadedFileID
+      ..title = title;
+  }
+
+  Future<File> writeFile(String path, String contents) async {
+    final file = File(path);
+    await file.parent.create(recursive: true);
+    return file.writeAsString(contents);
+  }
+
+  Future<Directory> createHandoff(
+    int uploadedFileID,
+    String timestamp, {
+    String fileName = 'document.pdf',
+  }) async {
+    final directory = Directory(
+      p.join(
+        getOpenHandoffDirectoryPath(),
+        uploadedFileID.toString(),
+        timestamp,
+      ),
+    );
+    await directory.create(recursive: true);
+    await writeFile(p.join(directory.path, fileName), timestamp);
+    return directory;
+  }
+
+  Future<void> makeOld(File file) async {
+    await file.setLastModified(
+      DateTime.now().subtract(const Duration(minutes: 5)),
+    );
+  }
+
+  group('OfflineFileStorage', () {
+    late Directory root;
+
+    setUp(() async {
+      root = await setupLockerConfigurationForTest('offline_storage');
+    });
+
+    tearDown(() async {
+      clearLockerConfigurationTestHandlers();
+      if (await root.exists()) {
+        await root.delete(recursive: true);
+      }
+    });
+
+    test('removes only the selected file ID from owned storage', () async {
+      final firstFile = lockerFile(123, title: 'first.pdf');
+      final secondFile = lockerFile(456, title: 'second.png');
+      final firstOffline = await writeFile(
+        await getOfflineEncryptedFilePath(firstFile),
+        'offline 123',
+      );
+      final secondOffline = await writeFile(
+        await getOfflineEncryptedFilePath(secondFile),
+        'offline 456',
+      );
+      final malformedOffline = await writeFile(
+        p.join(firstOffline.parent.path, 'not-a-file-id.encrypted'),
+        'malformed',
+      );
+      final firstCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(firstFile),
+        'cached encrypted 123',
+      );
+      final firstCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(firstFile),
+        'cached decrypted 123',
+      );
+      final malformedCachedDecrypted = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), '123.decrypted_bak'),
+        'malformed decrypted',
+      );
+      final secondCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(secondFile),
+        'cached encrypted 456',
+      );
+      final secondCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(secondFile),
+        'cached decrypted 456',
+      );
+      final firstHandoff = await createHandoff(123, '100');
+      final secondHandoff = await createHandoff(456, '100');
+      final nonIdHandoff = Directory(
+        p.join(getOpenHandoffDirectoryPath(), 'not-an-id', '100'),
+      );
+      await nonIdHandoff.create(recursive: true);
+      final unrelatedCacheFile = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), 'keep.me'),
+        'unrelated',
+      );
+
+      await removeOfflineFileCopiesFromDisk([123]);
+
+      expect(await firstOffline.exists(), isFalse);
+      expect(await firstCachedEncrypted.exists(), isFalse);
+      expect(await firstCachedDecrypted.exists(), isFalse);
+      expect(await firstHandoff.exists(), isFalse);
+      expect(await malformedCachedDecrypted.exists(), isTrue);
+      expect(await secondOffline.exists(), isTrue);
+      expect(await secondCachedEncrypted.exists(), isTrue);
+      expect(await secondCachedDecrypted.exists(), isTrue);
+      expect(await secondHandoff.exists(), isTrue);
+      expect(await malformedOffline.exists(), isTrue);
+      expect(await nonIdHandoff.exists(), isTrue);
+      expect(await unrelatedCacheFile.exists(), isTrue);
+    });
+
+    test('can remove offline encrypted blobs while preserving working copies',
+        () async {
+      final file = lockerFile(123, title: 'document.pdf');
+      final offline = await writeFile(
+        await getOfflineEncryptedFilePath(file),
+        'offline 123',
+      );
+      final cachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(file),
+        'cached encrypted 123',
+      );
+      final cachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(file),
+        'cached decrypted 123',
+      );
+      final handoff = await createHandoff(123, '100');
+
+      await removeOfflineFileCopiesFromDisk(
+        [123],
+        removeWorkingCopies: false,
+      );
+
+      expect(await offline.exists(), isFalse);
+      expect(await cachedEncrypted.exists(), isTrue);
+      expect(await cachedDecrypted.exists(), isTrue);
+      expect(await handoff.exists(), isTrue);
+    });
+
+    test('clears owned offline cache while preserving unrelated cache files',
+        () async {
+      final firstFile = lockerFile(123, title: 'first.pdf');
+      final secondFile = lockerFile(456, title: 'second.png');
+      final firstOffline = await writeFile(
+        await getOfflineEncryptedFilePath(firstFile),
+        'offline 123',
+      );
+      final secondOffline = await writeFile(
+        await getOfflineEncryptedFilePath(secondFile),
+        'offline 456',
+      );
+      final malformedOffline = await writeFile(
+        p.join(firstOffline.parent.path, 'not-a-file-id.encrypted'),
+        'malformed offline',
+      );
+      final firstCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(firstFile),
+        'cached encrypted 123',
+      );
+      final firstCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(firstFile),
+        'cached decrypted 123',
+      );
+      final secondCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(secondFile),
+        'cached encrypted 456',
+      );
+      final secondCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(secondFile),
+        'cached decrypted 456',
+      );
+      final firstHandoff = await createHandoff(123, '100');
+      final secondHandoff = await createHandoff(456, '100');
+      final nonIdHandoff = Directory(
+        p.join(getOpenHandoffDirectoryPath(), 'not-an-id', '100'),
+      );
+      await nonIdHandoff.create(recursive: true);
+      await writeFile(p.join(nonIdHandoff.path, 'document.pdf'), 'non id');
+      final rootHandoffFile = await writeFile(
+        p.join(getOpenHandoffDirectoryPath(), 'root-handoff.tmp'),
+        'root handoff',
+      );
+      final unrelatedCacheFile = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), 'keep.me'),
+        'unrelated',
+      );
+
+      await clearAllOfflineFileCopies();
+
+      expect(await firstOffline.exists(), isFalse);
+      expect(await secondOffline.exists(), isFalse);
+      expect(await malformedOffline.exists(), isFalse);
+      expect(await firstCachedEncrypted.exists(), isFalse);
+      expect(await firstCachedDecrypted.exists(), isFalse);
+      expect(await secondCachedEncrypted.exists(), isFalse);
+      expect(await secondCachedDecrypted.exists(), isFalse);
+      expect(await firstHandoff.exists(), isFalse);
+      expect(await secondHandoff.exists(), isFalse);
+      expect(await nonIdHandoff.exists(), isFalse);
+      expect(await rootHandoffFile.exists(), isFalse);
+      expect(await unrelatedCacheFile.exists(), isTrue);
+    });
+
+    test('stale cache cleanup is age gated and ID pattern scoped', () async {
+      final oldFile = lockerFile(123, title: 'old.pdf');
+      final freshFile = lockerFile(456, title: 'fresh.pdf');
+      final oldOfflineEncrypted = await writeFile(
+        await getOfflineEncryptedFilePath(oldFile),
+        'offline source',
+      );
+      final oldCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(oldFile),
+        'old encrypted',
+      );
+      final oldCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(oldFile),
+        'old decrypted',
+      );
+      final freshCachedEncrypted = await writeFile(
+        getCachedEncryptedFilePath(freshFile),
+        'fresh encrypted',
+      );
+      final freshCachedDecrypted = await writeFile(
+        getCachedDecryptedFilePath(freshFile),
+        'fresh decrypted',
+      );
+      final staleUnrelatedCacheFile = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), 'keep.me'),
+        'unrelated',
+      );
+      final staleMalformedCacheFile = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), '123.encrypted.bak'),
+        'malformed',
+      );
+      final staleMalformedDecryptedCacheFile = await writeFile(
+        p.join(Configuration.instance.getCacheDirectory(), '123.decrypted_bak'),
+        'malformed decrypted',
+      );
+      await makeOld(oldOfflineEncrypted);
+      await makeOld(oldCachedEncrypted);
+      await makeOld(oldCachedDecrypted);
+      await makeOld(staleUnrelatedCacheFile);
+      await makeOld(staleMalformedCacheFile);
+      await makeOld(staleMalformedDecryptedCacheFile);
+
+      await cleanupStaleOfflineFileCopies(
+        olderThan: const Duration(minutes: 1),
+      );
+
+      expect(await oldOfflineEncrypted.exists(), isTrue);
+      expect(await oldCachedEncrypted.exists(), isFalse);
+      expect(await oldCachedDecrypted.exists(), isFalse);
+      expect(await freshCachedEncrypted.exists(), isTrue);
+      expect(await freshCachedDecrypted.exists(), isTrue);
+      expect(await staleUnrelatedCacheFile.exists(), isTrue);
+      expect(await staleMalformedCacheFile.exists(), isTrue);
+      expect(await staleMalformedDecryptedCacheFile.exists(), isTrue);
+    });
+
+    test('ages timestamp children instead of file ID parent', () async {
+      final cacheDirectory = Configuration.instance.getCacheDirectory();
+      final oldHandoff = Directory(
+        p.join(cacheDirectory, 'open_handoff', '123', '100'),
+      );
+      final freshHandoff = Directory(
+        p.join(cacheDirectory, 'open_handoff', '123', '200'),
+      );
+      final staleOnlyHandoff = Directory(
+        p.join(cacheDirectory, 'open_handoff', '456', '100'),
+      );
+      final unrelatedCacheFile = File(p.join(cacheDirectory, 'keep.me'));
+      await oldHandoff.create(recursive: true);
+      await staleOnlyHandoff.create(recursive: true);
+      await File(p.join(oldHandoff.path, 'document.pdf')).writeAsString('old');
+      await File(p.join(staleOnlyHandoff.path, 'document.pdf'))
+          .writeAsString('stale');
+      final staleRootHandoffFile = await writeFile(
+        p.join(cacheDirectory, 'open_handoff', 'stale-root.tmp'),
+        'stale root',
+      );
+      await unrelatedCacheFile.writeAsString('unrelated');
+
+      await Future<void>.delayed(const Duration(seconds: 2));
+      await freshHandoff.create(recursive: true);
+      await File(p.join(freshHandoff.path, 'document.pdf'))
+          .writeAsString('fresh');
+      final freshRootHandoffFile = await writeFile(
+        p.join(cacheDirectory, 'open_handoff', 'fresh-root.tmp'),
+        'fresh root',
+      );
+
+      await cleanupStaleOfflineFileCopies(
+        olderThan: const Duration(seconds: 1),
+      );
+
+      expect(await oldHandoff.exists(), isFalse);
+      expect(await freshHandoff.exists(), isTrue);
+      expect(await staleRootHandoffFile.exists(), isFalse);
+      expect(await freshRootHandoffFile.exists(), isTrue);
+      expect(
+        await Directory(p.join(cacheDirectory, 'open_handoff', '123')).exists(),
+        isTrue,
+      );
+      expect(await staleOnlyHandoff.exists(), isFalse);
+      expect(
+        await Directory(p.join(cacheDirectory, 'open_handoff', '456')).exists(),
+        isFalse,
+      );
+      expect(await unrelatedCacheFile.exists(), isTrue);
+    });
+  });
+}

--- a/mobile/apps/locker/test/test_utils/configuration_test_util.dart
+++ b/mobile/apps/locker/test/test_utils/configuration_test_util.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/configuration.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+const _secureStorageChannel =
+    MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+Future<Directory> setupLockerConfigurationForTest(String name) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final root = await Directory.systemTemp.createTemp('locker_${name}_');
+  final tempDirectory = Directory('${root.path}/temp_root');
+  final supportDirectory = Directory('${root.path}/support');
+  await tempDirectory.create(recursive: true);
+  await supportDirectory.create(recursive: true);
+
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_pathProviderChannel, (call) async {
+    switch (call.method) {
+      case 'getTemporaryDirectory':
+        return tempDirectory.path;
+      case 'getApplicationSupportDirectory':
+        return supportDirectory.path;
+      default:
+        return root.path;
+    }
+  });
+
+  final secureStorage = <String, String>{};
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_secureStorageChannel, (call) async {
+    final arguments = (call.arguments as Map?) ?? {};
+    final key = arguments['key'] as String?;
+    switch (call.method) {
+      case 'read':
+        return secureStorage[key];
+      case 'write':
+        if (key != null) {
+          secureStorage[key] = arguments['value'] as String;
+        }
+        return null;
+      case 'delete':
+        if (key != null) {
+          secureStorage.remove(key);
+        }
+        return null;
+      case 'deleteAll':
+        secureStorage.clear();
+        return null;
+      case 'containsKey':
+        return key != null && secureStorage.containsKey(key);
+      case 'readAll':
+        return secureStorage;
+      default:
+        return null;
+    }
+  });
+
+  SharedPreferences.setMockInitialValues({});
+  await Configuration.instance.init([]);
+
+  return root;
+}
+
+void clearLockerConfigurationTestHandlers() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_pathProviderChannel, null);
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_secureStorageChannel, null);
+}

--- a/mobile/apps/locker/test/utils/file_util_test.dart
+++ b/mobile/apps/locker/test/utils/file_util_test.dart
@@ -1,0 +1,299 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/configuration.dart';
+import 'package:locker/services/files/offline/offline_file_storage.dart';
+import 'package:locker/services/files/sync/models/file.dart';
+import 'package:locker/utils/file_util.dart';
+import 'package:path/path.dart' as p;
+
+import '../test_utils/configuration_test_util.dart';
+
+void main() {
+  EnteFile lockerFile({
+    required int uploadedFileID,
+    required String title,
+    String? localPath,
+  }) {
+    return EnteFile()
+      ..uploadedFileID = uploadedFileID
+      ..title = title
+      ..localPath = localPath;
+  }
+
+  String cacheRelativePath(File file) {
+    return p.relative(
+      file.path,
+      from: Configuration.instance.getCacheDirectory(),
+    );
+  }
+
+  group('FileUtil handoff preparation', () {
+    late Directory root;
+
+    setUp(() async {
+      root = await setupLockerConfigurationForTest('file_util');
+    });
+
+    tearDown(() async {
+      clearLockerConfigurationTestHandlers();
+      if (await root.exists()) {
+        await root.delete(recursive: true);
+      }
+    });
+
+    test('creates a fresh open_handoff copy using uploaded file ID', () async {
+      final source = File(p.join(root.path, 'source.bin'));
+      await source.writeAsString('current file bytes');
+      final file = lockerFile(uploadedFileID: 123, title: 'original.pdf');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: null,
+        lockerFile: file,
+      );
+
+      expect(handoffFile.path, isNot(source.path));
+      expect(await handoffFile.readAsString(), 'current file bytes');
+      expect(await source.exists(), isTrue);
+      expect(
+        cacheRelativePath(handoffFile),
+        startsWith(p.join('open_handoff', '123')),
+      );
+      expect(p.basename(handoffFile.path), 'file-123.pdf');
+    });
+
+    test('uses UI display name with metadata-derived extension', () async {
+      final source = File(p.join(root.path, 'source.bin'));
+      await source.writeAsString('renamed file bytes');
+      final file = lockerFile(uploadedFileID: 456, title: 'passport.png');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Front side',
+        lockerFile: file,
+      );
+
+      expect(p.basename(handoffFile.path), 'Front side.png');
+      expect(await handoffFile.readAsString(), 'renamed file bytes');
+      expect(
+        cacheRelativePath(handoffFile),
+        startsWith(p.join('open_handoff', '456')),
+      );
+    });
+
+    test('creates distinct handoff paths for repeated same-file opens',
+        () async {
+      final source = File(p.join(root.path, 'source.bin'));
+      await source.writeAsString('first version');
+      final file = lockerFile(uploadedFileID: 234, title: 'invoice.pdf');
+
+      final firstHandoff = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Invoice',
+        lockerFile: file,
+      );
+
+      await source.writeAsString('second version');
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+
+      final secondHandoff = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Invoice',
+        lockerFile: file,
+      );
+
+      expect(secondHandoff.path, isNot(firstHandoff.path));
+      expect(
+        p.dirname(secondHandoff.path),
+        isNot(p.dirname(firstHandoff.path)),
+      );
+      expect(p.basename(firstHandoff.path), 'Invoice.pdf');
+      expect(p.basename(secondHandoff.path), 'Invoice.pdf');
+      expect(await firstHandoff.readAsString(), 'first version');
+      expect(await secondHandoff.readAsString(), 'second version');
+      expect(await source.readAsString(), 'second version');
+    });
+
+    test('ignores stale localPath when preparing the open handoff', () async {
+      final source = File(p.join(root.path, 'current-cache.bin'));
+      final staleLocalPath = File(p.join(root.path, 'old-local-copy.docx'));
+      await source.writeAsString('current cache bytes');
+      await staleLocalPath.writeAsString('stale local bytes');
+      final file = lockerFile(
+        uploadedFileID: 321,
+        title: 'locker-copy.pdf',
+        localPath: staleLocalPath.path,
+      );
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: null,
+        lockerFile: file,
+      );
+
+      expect(await handoffFile.readAsString(), 'current cache bytes');
+      expect(await staleLocalPath.readAsString(), 'stale local bytes');
+      expect(cacheRelativePath(handoffFile), startsWith('open_handoff'));
+      expect(
+        cacheRelativePath(handoffFile),
+        startsWith(p.join('open_handoff', '321')),
+      );
+      expect(p.basename(handoffFile.path), 'file-321.pdf');
+      expect(handoffFile.path, isNot(staleLocalPath.path));
+    });
+
+    test('partitions handoff copies by uploaded file ID, not source path',
+        () async {
+      final source = File(p.join(root.path, 'shared-source.bin'));
+      final staleLocalPath = File(p.join(root.path, 'same-stale-local.txt'));
+      await source.writeAsString('shared source bytes');
+      await staleLocalPath.writeAsString('shared stale bytes');
+      final firstFile = lockerFile(
+        uploadedFileID: 111,
+        title: 'first.pdf',
+        localPath: staleLocalPath.path,
+      );
+      final secondFile = lockerFile(
+        uploadedFileID: 222,
+        title: 'second.pdf',
+        localPath: staleLocalPath.path,
+      );
+
+      final firstHandoff = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Document',
+        lockerFile: firstFile,
+      );
+      final secondHandoff = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Document',
+        lockerFile: secondFile,
+      );
+
+      expect(
+        cacheRelativePath(firstHandoff),
+        startsWith(p.join('open_handoff', '111')),
+      );
+      expect(
+        cacheRelativePath(secondHandoff),
+        startsWith(p.join('open_handoff', '222')),
+      );
+      expect(await firstHandoff.readAsString(), 'shared source bytes');
+      expect(await secondHandoff.readAsString(), 'shared source bytes');
+      expect(await staleLocalPath.readAsString(), 'shared stale bytes');
+    });
+
+    test('replaces stale display extension with Locker metadata extension',
+        () async {
+      final source = File(p.join(root.path, 'front.tmp'));
+      await source.writeAsString('front bytes');
+      final file = lockerFile(uploadedFileID: 654, title: 'passport.png');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Front side.jpg',
+        lockerFile: file,
+      );
+
+      expect(p.basename(handoffFile.path), 'Front side.png');
+      expect(await handoffFile.readAsString(), 'front bytes');
+    });
+
+    test('keeps display extension when it already matches metadata extension',
+        () async {
+      final source = File(p.join(root.path, 'invoice.tmp'));
+      await source.writeAsString('invoice bytes');
+      final file = lockerFile(uploadedFileID: 655, title: 'invoice.pdf');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Invoice.PDF',
+        lockerFile: file,
+      );
+
+      expect(p.basename(handoffFile.path), 'Invoice.PDF');
+      expect(await handoffFile.readAsString(), 'invoice bytes');
+    });
+
+    test('falls back to source extension when metadata has no extension',
+        () async {
+      final source = File(p.join(root.path, 'current-cache.bin'));
+      await source.writeAsString('source extension bytes');
+      final file = lockerFile(uploadedFileID: 656, title: 'untitled');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Visible name',
+        lockerFile: file,
+      );
+
+      expect(p.basename(handoffFile.path), 'Visible name.bin');
+      expect(await handoffFile.readAsString(), 'source extension bytes');
+    });
+
+    test('falls back to display extension when metadata and source lack one',
+        () async {
+      final source = File(p.join(root.path, 'current-cache'));
+      await source.writeAsString('display extension bytes');
+      final file = lockerFile(uploadedFileID: 657, title: 'untitled');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Visible name.pdf',
+        lockerFile: file,
+      );
+
+      expect(p.basename(handoffFile.path), 'Visible name.pdf');
+      expect(await handoffFile.readAsString(), 'display extension bytes');
+    });
+
+    test('does not use internal decrypted cache suffix as handoff extension',
+        () async {
+      final file = lockerFile(uploadedFileID: 658, title: 'untitled');
+      final source = File(getCachedDecryptedFilePath(file));
+      await source.writeAsString('cached decrypted bytes');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'Visible name.pdf',
+        lockerFile: file,
+      );
+
+      expect(p.basename(source.path), '658.decrypted');
+      expect(p.basename(handoffFile.path), 'Visible name.pdf');
+      expect(await handoffFile.readAsString(), 'cached decrypted bytes');
+    });
+
+    test('sanitizes display names before creating the handoff copy', () async {
+      final source = File(p.join(root.path, 'source.bin'));
+      await source.writeAsString('safe bytes');
+      final file = lockerFile(uploadedFileID: 987, title: 'document.pdf');
+
+      final handoffFile = await FileUtil.prepareOpenFileForTest(
+        source,
+        displayName: 'bad:*?"<>|name',
+        lockerFile: file,
+      );
+
+      final launchName = p.basename(handoffFile.path);
+      expect(launchName, endsWith('.pdf'));
+      expect(launchName, isNot(contains(RegExp(r'[\\/:*?"<>|]'))));
+      expect(await handoffFile.readAsString(), 'safe bytes');
+    });
+
+    test('fails closed when handoff copy cannot be created', () async {
+      final missingSource = File(p.join(root.path, 'missing.pdf'));
+      final file = lockerFile(uploadedFileID: 789, title: 'missing.pdf');
+
+      await expectLater(
+        FileUtil.prepareOpenFileForTest(
+          missingSource,
+          displayName: 'Missing',
+          lockerFile: file,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -469,12 +469,13 @@ class UserService {
       await dialog.hide();
       if (response.statusCode == 200) {
         Widget page;
-        final String passkeySessionID = response.data["passkeySessionID"];
-        final String accountsUrl = response.data["accountsUrl"] ?? kAccountsUrl;
-        String twoFASessionID = response.data["twoFactorSessionID"];
+        final responseData = response.data;
+        final String passkeySessionID = responseData["passkeySessionID"] ?? "";
+        final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
+        String twoFASessionID = responseData["twoFactorSessionID"] ?? "";
         if (twoFASessionID.isEmpty &&
-            response.data["twoFactorSessionIDV2"] != null) {
-          twoFASessionID = response.data["twoFactorSessionIDV2"];
+            responseData["twoFactorSessionIDV2"] != null) {
+          twoFASessionID = responseData["twoFactorSessionIDV2"];
         }
         if (passkeySessionID.isNotEmpty) {
           page = PasskeyPage(
@@ -798,12 +799,13 @@ class UserService {
     );
     if (response.statusCode == 200) {
       Widget? page;
-      final String passkeySessionID = response.data["passkeySessionID"];
-      final String accountsUrl = response.data["accountsUrl"] ?? kAccountsUrl;
-      String twoFASessionID = response.data["twoFactorSessionID"];
+      final responseData = response.data;
+      final String passkeySessionID = responseData["passkeySessionID"] ?? "";
+      final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
+      String twoFASessionID = responseData["twoFactorSessionID"] ?? "";
       if (twoFASessionID.isEmpty &&
-          response.data["twoFactorSessionIDV2"] != null) {
-        twoFASessionID = response.data["twoFactorSessionIDV2"];
+          responseData["twoFactorSessionIDV2"] != null) {
+        twoFASessionID = responseData["twoFactorSessionIDV2"];
       }
       _config.setVolatilePassword(userPassword);
       if (passkeySessionID.isNotEmpty) {


### PR DESCRIPTION
## Description
Locker was mixing stale file paths with Locker file identity, causing wrong/stale opens, fragile offline behavior, and unsafe cache cleanup.

Fix: Make file opening ID-first, hand off fresh external-open copies, scope cleanup to Locker-owned files, and harden logout/user-details refresh races. 
This PR fixes Locker file opening by treating uploadedFileID as the source of truth instead of stale localPath metadata.

## Changes included:

- Ignore stale localPath for synced Locker file opens.
- Require uploadedFileID for synced-file open flow.
- Create fresh open_handoff/fileId/timestamp/name copies before opening files externally.
- Preserve visible filenames/extensions using Locker metadata.
- Fail closed instead of handing external apps internal cache/decrypted source paths.
- Keep offline encrypted blobs safe when offline open/decrypt fails.
- Scope cleanup to:
    - offline encrypted blobs
    - ID-keyed cached encrypted/decrypted files
    - open_handoff
    - Clear Locker-owned offline/cache/handoff files before logout teardown.

## Tests
- Add tests for file opening, handoff behavior, offline storage cleanup, and cache identity.


