### PR TITLE
[mob][auth] Exclude x86 libs from F-Droid APK

### DIFF
--- a/mobile/apps/auth/android/app/build.gradle
+++ b/mobile/apps/auth/android/app/build.gradle
@@ -66,7 +66,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a"
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86_64"
         }
     }
 

--- a/mobile/apps/auth/android/app/build.gradle
+++ b/mobile/apps/auth/android/app/build.gradle
@@ -65,6 +65,9 @@ android {
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a"
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Fixes #10194 by adding Auth Android ABI filters to exclude x86/x86_64 native libraries from F-Droid APKs.