### PR TITLE
Add pet clustering Rust modules

### DIFF
--- a/mobile/apps/photos/rust/src/api/ml_indexing_api.rs
+++ b/mobile/apps/photos/rust/src/api/ml_indexing_api.rs
@@ -1,8 +1,15 @@
+use std::collections::HashMap;
+
 use ente_media_inspector::ml::{
     indexing as shared_indexing,
+    pet::{
+        cluster::{self, ClusterConfig, PetClusterIndexInput, PetClusterInput, Species},
+        cluster_v2,
+    },
     runtime::{ExecutionProviderPolicy, MlRuntimeConfig, ModelPaths},
     types as shared_types,
 };
+use ente_media_inspector::vector_db::VectorDB;
 
 #[derive(Clone, Debug)]
 pub struct RustExecutionProviderPolicy {
@@ -331,5 +338,643 @@ fn to_api_pet_body_result(result: shared_types::PetBodyResult) -> RustPetBodyRes
             .into_iter()
             .map(|v| v as f64)
             .collect(),
+    }
+}
+
+// -- Pet Clustering API --
+
+/// A single pet face/body entry for clustering, passed from Dart.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterInput {
+    pub pet_face_id: String,
+    /// L2-normalized face embedding. Empty if no face detected.
+    pub face_embedding: Vec<f64>,
+    /// L2-normalized body embedding. Empty if no body detected.
+    pub body_embedding: Vec<f64>,
+    /// 0 = dog, 1 = cat.
+    pub species: u8,
+    pub file_id: i64,
+}
+
+/// Result entry: one pet_face_id mapped to a cluster.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterEntry {
+    pub pet_face_id: String,
+    pub cluster_id: String,
+}
+
+/// Cluster summary: centroid + count.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterSummary {
+    pub cluster_id: String,
+    pub centroid: Vec<f64>,
+    pub count: i32,
+}
+
+/// Cluster exemplars: multiple diverse real embeddings per cluster.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterExemplarSummary {
+    pub cluster_id: String,
+    /// Multiple L2-normalized exemplar embeddings (real faces, not averaged).
+    pub exemplars: Vec<Vec<f64>>,
+    pub count: i32,
+}
+
+/// Existing cluster exemplars passed from Dart for incremental matching.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterExemplarInput {
+    pub cluster_id: String,
+    pub exemplars: Vec<Vec<f64>>,
+}
+
+/// Full clustering result returned to Dart.
+#[derive(Clone, Debug)]
+pub struct RustPetClusterResult {
+    pub assignments: Vec<RustPetClusterEntry>,
+    pub summaries: Vec<RustPetClusterSummary>,
+    /// Exemplar summaries for multi-exemplar incremental matching.
+    pub exemplar_summaries: Vec<RustPetClusterExemplarSummary>,
+    pub n_unclustered: i32,
+}
+
+/// Run batch pet clustering on all provided inputs.
+pub fn run_pet_clustering_rust(
+    inputs: Vec<RustPetClusterInput>,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+
+    let cluster_inputs: Vec<PetClusterInput> = inputs
+        .into_iter()
+        .map(|i| PetClusterInput {
+            pet_face_id: i.pet_face_id,
+            face_embedding: i.face_embedding.into_iter().map(|v| v as f32).collect(),
+            body_embedding: i.body_embedding.into_iter().map(|v| v as f32).collect(),
+            species: i.species,
+            file_id: i.file_id,
+        })
+        .collect();
+
+    let result = cluster::run_pet_clustering(&cluster_inputs, &config);
+
+    Ok(to_api_cluster_result(result))
+}
+
+/// Run incremental pet clustering: assign new inputs to existing clusters,
+/// then cluster remainder among themselves.
+pub fn run_pet_clustering_incremental_rust(
+    new_inputs: Vec<RustPetClusterInput>,
+    existing_face_centroids: Vec<RustPetClusterSummary>,
+    existing_body_centroids: Vec<RustPetClusterSummary>,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+
+    let cluster_inputs: Vec<PetClusterInput> = new_inputs
+        .into_iter()
+        .map(|i| PetClusterInput {
+            pet_face_id: i.pet_face_id,
+            face_embedding: i.face_embedding.into_iter().map(|v| v as f32).collect(),
+            body_embedding: i.body_embedding.into_iter().map(|v| v as f32).collect(),
+            species: i.species,
+            file_id: i.file_id,
+        })
+        .collect();
+
+    let face_centroids: HashMap<String, Vec<f32>> = existing_face_centroids
+        .into_iter()
+        .map(|s| {
+            (
+                s.cluster_id,
+                s.centroid.into_iter().map(|v| v as f32).collect(),
+            )
+        })
+        .collect();
+
+    let _body_centroids: HashMap<String, Vec<f32>> = existing_body_centroids
+        .into_iter()
+        .map(|s| {
+            (
+                s.cluster_id,
+                s.centroid.into_iter().map(|v| v as f32).collect(),
+            )
+        })
+        .collect();
+
+    let result = cluster::run_pet_clustering_incremental(&cluster_inputs, &face_centroids, &config);
+
+    Ok(to_api_cluster_result(result))
+}
+
+/// Run incremental pet clustering using multi-exemplar matching.
+///
+/// Instead of comparing against a single centroid, compares new faces against
+/// multiple real exemplar embeddings per cluster for better accuracy.
+pub fn run_pet_clustering_incremental_exemplars_rust(
+    new_inputs: Vec<RustPetClusterInput>,
+    existing_exemplars: Vec<RustPetClusterExemplarInput>,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+
+    let cluster_inputs: Vec<PetClusterInput> = new_inputs
+        .into_iter()
+        .map(|i| PetClusterInput {
+            pet_face_id: i.pet_face_id,
+            face_embedding: i.face_embedding.into_iter().map(|v| v as f32).collect(),
+            body_embedding: i.body_embedding.into_iter().map(|v| v as f32).collect(),
+            species: i.species,
+            file_id: i.file_id,
+        })
+        .collect();
+
+    let exemplars: HashMap<String, Vec<Vec<f32>>> = existing_exemplars
+        .into_iter()
+        .map(|e| {
+            (
+                e.cluster_id,
+                e.exemplars
+                    .into_iter()
+                    .map(|ex| ex.into_iter().map(|v| v as f32).collect())
+                    .collect(),
+            )
+        })
+        .collect();
+
+    let result = cluster::run_pet_clustering_incremental_with_exemplars(
+        &cluster_inputs,
+        &exemplars,
+        &config,
+    );
+
+    Ok(to_api_cluster_result(result))
+}
+
+fn to_api_cluster_result(result: cluster::PetClusterResult) -> RustPetClusterResult {
+    let cluster::PetClusterResult {
+        face_to_cluster,
+        cluster_counts,
+        cluster_centroids,
+        cluster_exemplars,
+        n_unclustered,
+    } = result;
+
+    let assignments: Vec<RustPetClusterEntry> = face_to_cluster
+        .into_iter()
+        .map(|(face_id, cluster_id)| RustPetClusterEntry {
+            pet_face_id: face_id,
+            cluster_id,
+        })
+        .collect();
+
+    let summaries: Vec<RustPetClusterSummary> = cluster_centroids
+        .into_iter()
+        .map(|(cluster_id, centroid)| {
+            let count = cluster_counts.get(&cluster_id).copied().unwrap_or(0) as i32;
+            RustPetClusterSummary {
+                cluster_id,
+                centroid: centroid.into_iter().map(|v| v as f64).collect(),
+                count,
+            }
+        })
+        .collect();
+
+    let exemplar_summaries: Vec<RustPetClusterExemplarSummary> = cluster_exemplars
+        .into_iter()
+        .map(|(cluster_id, exemplars)| {
+            let count = cluster_counts.get(&cluster_id).copied().unwrap_or(0) as i32;
+            RustPetClusterExemplarSummary {
+                cluster_id,
+                exemplars: exemplars
+                    .into_iter()
+                    .map(|ex| ex.into_iter().map(|v| v as f64).collect())
+                    .collect(),
+                count,
+            }
+        })
+        .collect();
+
+    RustPetClusterResult {
+        assignments,
+        summaries,
+        exemplar_summaries,
+        n_unclustered: n_unclustered as i32,
+    }
+}
+
+fn to_api_cluster_result_v2(result: cluster::PetClusterResult) -> RustPetClusterResult {
+    let cluster::PetClusterResult {
+        face_to_cluster,
+        cluster_counts,
+        cluster_centroids: _,
+        cluster_exemplars,
+        n_unclustered,
+    } = result;
+
+    let assignments: Vec<RustPetClusterEntry> = face_to_cluster
+        .into_iter()
+        .map(|(face_id, cluster_id)| RustPetClusterEntry {
+            pet_face_id: face_id,
+            cluster_id,
+        })
+        .collect();
+
+    let summaries: Vec<RustPetClusterSummary> = cluster_counts
+        .iter()
+        .map(|(cluster_id, count)| RustPetClusterSummary {
+            cluster_id: cluster_id.clone(),
+            centroid: Vec::new(),
+            count: *count as i32,
+        })
+        .collect();
+
+    let exemplar_summaries: Vec<RustPetClusterExemplarSummary> = cluster_exemplars
+        .into_iter()
+        .map(|(cluster_id, exemplars)| {
+            let count = cluster_counts.get(&cluster_id).copied().unwrap_or(0) as i32;
+            RustPetClusterExemplarSummary {
+                cluster_id,
+                exemplars: exemplars
+                    .into_iter()
+                    .map(|ex| ex.into_iter().map(|v| v as f64).collect())
+                    .collect(),
+                count,
+            }
+        })
+        .collect();
+
+    RustPetClusterResult {
+        assignments,
+        summaries,
+        exemplar_summaries,
+        n_unclustered: n_unclustered as i32,
+    }
+}
+
+// -- Pet Clustering with direct usearch access --
+
+/// Lightweight face metadata passed from Dart (no embeddings).
+#[derive(Clone, Debug)]
+pub struct RustPetFaceMeta {
+    pub pet_face_id: String,
+    /// Integer key in the usearch index.
+    pub vector_id: i64,
+    pub species: u8,
+    pub file_id: i64,
+    /// Existing cluster ID, or empty string if unclustered.
+    pub cluster_id: String,
+}
+
+/// Run batch pet clustering by reading embeddings directly from usearch.
+///
+/// Dart passes only lightweight metadata + the path to the usearch index file.
+/// Rust opens the index, bulk-reads embeddings, clusters, and returns
+/// assignments — no embedding round-trip through FFI.
+pub fn run_pet_clustering_from_index(
+    faces: Vec<RustPetFaceMeta>,
+    face_index_path: String,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+    let dim = 128; // pet face embedding dimension
+
+    let vdb = VectorDB::new(&face_index_path, dim)
+        .map_err(|e| format!("Failed to open face index: {e}"))?;
+
+    let inputs: Vec<PetClusterIndexInput> = faces
+        .iter()
+        .map(|face| PetClusterIndexInput {
+            pet_face_id: face.pet_face_id.clone(),
+            vector_id: face.vector_id as u64,
+            species: face.species,
+            file_id: face.file_id,
+        })
+        .collect();
+
+    if inputs.len() < 2 {
+        return Ok(RustPetClusterResult {
+            assignments: Vec::new(),
+            summaries: Vec::new(),
+            exemplar_summaries: Vec::new(),
+            n_unclustered: inputs.len() as i32,
+        });
+    }
+
+    println!("Pet clustering V2 active: NN first pass + exemplar HAC second pass");
+    let result = cluster_v2::run_pet_clustering_from_vdb_v2(&inputs, &vdb, &config)?;
+    Ok(to_api_cluster_result_v2(result))
+}
+
+/// Run incremental pet clustering by reading embeddings directly from usearch.
+///
+/// Only unclustered faces are clustered against existing centroids.
+/// Centroids are read from a separate usearch index.
+pub fn run_pet_clustering_incremental_from_index(
+    new_faces: Vec<RustPetFaceMeta>,
+    face_index_path: String,
+    centroid_index_path: String,
+    // cluster_id -> vector_id in the centroid index
+    centroid_mappings: Vec<RustCentroidMapping>,
+    // cluster_id -> face count (unused for now, reserved for weighted merge)
+    _centroid_counts: Vec<RustCentroidCount>,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+    let dim = 128;
+
+    let vdb = VectorDB::new(&face_index_path, dim)
+        .map_err(|e| format!("Failed to open face index: {e}"))?;
+
+    let mut inputs = Vec::with_capacity(new_faces.len());
+    for face in &new_faces {
+        let emb = match vdb.get_vector(face.vector_id as u64) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        inputs.push(PetClusterInput {
+            pet_face_id: face.pet_face_id.clone(),
+            face_embedding: emb,
+            body_embedding: Vec::new(),
+            species: face.species,
+            file_id: face.file_id,
+        });
+    }
+
+    if inputs.is_empty() {
+        return Ok(RustPetClusterResult {
+            assignments: Vec::new(),
+            summaries: Vec::new(),
+            exemplar_summaries: Vec::new(),
+            n_unclustered: 0,
+        });
+    }
+
+    // Load existing centroids from centroid index
+    let face_centroids: HashMap<String, Vec<f32>> = if !centroid_mappings.is_empty() {
+        let centroid_vdb = VectorDB::new(&centroid_index_path, dim)
+            .map_err(|e| format!("Failed to open centroid index: {e}"))?;
+
+        let mut centroids = HashMap::new();
+        for mapping in &centroid_mappings {
+            if let Ok(emb) = centroid_vdb.get_vector(mapping.vector_id as u64) {
+                centroids.insert(mapping.cluster_id.clone(), emb);
+            }
+        }
+        centroids
+    } else {
+        HashMap::new()
+    };
+
+    let result = cluster::run_pet_clustering_incremental(&inputs, &face_centroids, &config);
+
+    Ok(to_api_cluster_result(result))
+}
+
+/// Mapping from cluster ID to its vector ID in the centroid usearch index.
+#[derive(Clone, Debug)]
+pub struct RustCentroidMapping {
+    pub cluster_id: String,
+    pub vector_id: i64,
+}
+
+/// Cluster ID with its face count (for incremental clustering).
+#[derive(Clone, Debug)]
+pub struct RustCentroidCount {
+    pub cluster_id: String,
+    pub count: i32,
+}
+
+/// Exemplar embeddings for a cluster, used for incremental matching.
+#[derive(Clone, Debug)]
+pub struct RustClusterExemplars {
+    pub cluster_id: String,
+    /// Multiple real face embeddings (not averaged), f64 for Dart compatibility.
+    pub exemplars: Vec<Vec<f64>>,
+}
+
+/// Run incremental pet clustering using multi-exemplar matching.
+///
+/// Instead of comparing new faces against a single centroid per cluster,
+/// compares against multiple diverse real face embeddings (exemplars).
+/// Gives F1=0.96 vs centroid's F1=0.86.
+pub fn run_pet_clustering_incremental_exemplars_from_index(
+    new_faces: Vec<RustPetFaceMeta>,
+    face_index_path: String,
+    cluster_exemplars: Vec<RustClusterExemplars>,
+    species: u8,
+) -> Result<RustPetClusterResult, String> {
+    let config = ClusterConfig::for_species(Species::from_u8(species));
+    let dim = 128;
+
+    let vdb = VectorDB::new(&face_index_path, dim)
+        .map_err(|e| format!("Failed to open face index: {e}"))?;
+
+    let mut inputs = Vec::with_capacity(new_faces.len());
+    for face in &new_faces {
+        let emb = match vdb.get_vector(face.vector_id as u64) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        inputs.push(PetClusterInput {
+            pet_face_id: face.pet_face_id.clone(),
+            face_embedding: emb,
+            body_embedding: Vec::new(),
+            species: face.species,
+            file_id: face.file_id,
+        });
+    }
+
+    if inputs.is_empty() {
+        return Ok(RustPetClusterResult {
+            assignments: Vec::new(),
+            summaries: Vec::new(),
+            exemplar_summaries: Vec::new(),
+            n_unclustered: 0,
+        });
+    }
+
+    // Convert exemplars from f64 to f32
+    let existing_exemplars: HashMap<String, Vec<Vec<f32>>> = cluster_exemplars
+        .into_iter()
+        .map(|ce| {
+            let exs: Vec<Vec<f32>> = ce
+                .exemplars
+                .into_iter()
+                .map(|e| e.into_iter().map(|v| v as f32).collect())
+                .collect();
+            (ce.cluster_id, exs)
+        })
+        .collect();
+
+    let result = cluster::run_pet_clustering_incremental_with_exemplars(
+        &inputs,
+        &existing_exemplars,
+        &config,
+    );
+
+    Ok(to_api_cluster_result(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn normalize(values: &[f32]) -> Vec<f32> {
+        let norm = values.iter().map(|value| value * value).sum::<f32>().sqrt();
+        values.iter().map(|value| value / norm).collect()
+    }
+
+    fn unique_test_index_path(name: &str) -> String {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "ente-pet-tests-{name}-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        path_to_string(dir.join("pet_faces.usearch"))
+    }
+
+    fn path_to_string(path: PathBuf) -> String {
+        path.to_str().expect("path string").to_string()
+    }
+
+    fn build_test_face_index(vectors: &[Vec<f32>], species: u8) -> (String, Vec<RustPetFaceMeta>) {
+        let index_path = unique_test_index_path("face-index");
+        let mut vdb = VectorDB::new(&index_path, vectors[0].len()).expect("vector db");
+        let keys: Vec<u64> = (0..vectors.len()).map(|idx| idx as u64 + 1).collect();
+        vdb.bulk_add_vectors(keys.clone(), vectors)
+            .expect("bulk add vectors");
+        let faces = keys
+            .into_iter()
+            .enumerate()
+            .map(|(idx, key)| RustPetFaceMeta {
+                pet_face_id: format!("pet_face_{idx}"),
+                vector_id: key as i64,
+                species,
+                file_id: idx as i64,
+                cluster_id: String::new(),
+            })
+            .collect();
+        (index_path, faces)
+    }
+
+    fn build_rust_inputs(vectors: &[Vec<f32>], species: u8) -> Vec<RustPetClusterInput> {
+        vectors
+            .iter()
+            .enumerate()
+            .map(|(idx, vector)| RustPetClusterInput {
+                pet_face_id: format!("pet_face_{idx}"),
+                face_embedding: vector.iter().copied().map(f64::from).collect(),
+                body_embedding: Vec::new(),
+                species,
+                file_id: idx as i64,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn v2_batch_api_returns_empty_centroid_vectors_with_matching_summary_counts() {
+        let vectors = vec![
+            normalize(&[1.0, 0.0, 0.0, 0.0]),
+            normalize(&[0.99, 0.04, 0.0, 0.0]),
+            normalize(&[0.0, 1.0, 0.0, 0.0]),
+            normalize(&[0.02, 0.99, 0.0, 0.0]),
+        ];
+        let (index_path, faces) = build_test_face_index(&vectors, 0);
+
+        let result = run_pet_clustering_from_index(faces, index_path, 0).expect("v2 batch");
+
+        assert_eq!(result.assignments.len(), 4);
+        assert_eq!(result.summaries.len(), 2);
+        assert_eq!(result.exemplar_summaries.len(), 2);
+        assert!(
+            result
+                .summaries
+                .iter()
+                .all(|summary| summary.centroid.is_empty())
+        );
+    }
+
+    #[test]
+    fn legacy_batch_api_still_returns_populated_centroids() {
+        let vectors = vec![
+            normalize(&[1.0, 0.0, 0.0, 0.0]),
+            normalize(&[0.99, 0.04, 0.0, 0.0]),
+            normalize(&[0.0, 1.0, 0.0, 0.0]),
+            normalize(&[0.02, 0.99, 0.0, 0.0]),
+        ];
+        let inputs = build_rust_inputs(&vectors, 0);
+
+        let result = run_pet_clustering_rust(inputs, 0).expect("legacy batch");
+
+        assert_eq!(result.summaries.len(), 2);
+        assert!(
+            result
+                .summaries
+                .iter()
+                .all(|summary| !summary.centroid.is_empty())
+        );
+    }
+
+    #[test]
+    fn legacy_incremental_api_still_returns_populated_centroids() {
+        let existing = vec![
+            RustPetClusterSummary {
+                cluster_id: "cluster_a".to_string(),
+                centroid: normalize(&[1.0, 0.0, 0.0, 0.0])
+                    .into_iter()
+                    .map(f64::from)
+                    .collect(),
+                count: 2,
+            },
+            RustPetClusterSummary {
+                cluster_id: "cluster_b".to_string(),
+                centroid: normalize(&[0.0, 1.0, 0.0, 0.0])
+                    .into_iter()
+                    .map(f64::from)
+                    .collect(),
+                count: 2,
+            },
+        ];
+        let new_inputs = vec![
+            RustPetClusterInput {
+                pet_face_id: "new_a".to_string(),
+                face_embedding: normalize(&[0.98, 0.05, 0.0, 0.0])
+                    .into_iter()
+                    .map(f64::from)
+                    .collect(),
+                body_embedding: Vec::new(),
+                species: 0,
+                file_id: 1,
+            },
+            RustPetClusterInput {
+                pet_face_id: "new_b".to_string(),
+                face_embedding: normalize(&[0.03, 0.99, 0.0, 0.0])
+                    .into_iter()
+                    .map(f64::from)
+                    .collect(),
+                body_embedding: Vec::new(),
+                species: 0,
+                file_id: 2,
+            },
+        ];
+
+        let result = run_pet_clustering_incremental_rust(new_inputs, existing, Vec::new(), 0)
+            .expect("legacy incremental");
+
+        assert_eq!(result.assignments.len(), 2);
+        assert_eq!(result.summaries.len(), 2);
+        assert!(
+            result
+                .summaries
+                .iter()
+                .all(|summary| !summary.centroid.is_empty())
+        );
     }
 }

--- a/rust/photos/src/ml/pet/cluster.rs
+++ b/rust/photos/src/ml/pet/cluster.rs
@@ -1,0 +1,1744 @@
+//! Pet clustering engine — face-based agglomerative clustering.
+//!
+//! Clusters pet face embeddings using average-linkage agglomerative
+//! clustering with species-specific distance thresholds.
+//!
+//! All embeddings are assumed L2-normalized (cosine distance = 1 − dot).
+
+use crate::vector_db::VectorDB;
+use std::collections::{HashMap, HashSet};
+
+unsafe extern "C" {
+    fn simsimd_dot_f32(a: *const f32, b: *const f32, n: u64, d: *mut f64);
+}
+
+pub(crate) fn simsimd_dot_product(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let mut score = 0.0_f64;
+    unsafe {
+        simsimd_dot_f32(a.as_ptr(), b.as_ptr(), a.len() as u64, &mut score);
+    }
+    score as f32
+}
+
+pub(crate) fn simsimd_cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    1.0 - simsimd_dot_product(a, b)
+}
+
+// ── Species-specific configuration ──────────────────────────────────────
+
+/// Species identifier for threshold lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Species {
+    Dog = 0,
+    Cat = 1,
+}
+
+impl Species {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Species::Dog,
+            _ => Species::Cat,
+        }
+    }
+}
+
+/// Clustering thresholds per species.
+#[derive(Clone, Debug)]
+pub struct ClusterConfig {
+    pub species: Species,
+    /// Minimum number of faces to form a cluster.
+    pub min_cluster_size: usize,
+    /// Distance threshold for agglomerative clustering (average linkage).
+    /// Lower = tighter clusters, higher = more permissive merging.
+    pub agglomerative_threshold: f32,
+    /// Maximum number of exemplar embeddings to store per cluster.
+    /// Used for multi-exemplar incremental matching.
+    pub max_exemplars: usize,
+}
+
+impl ClusterConfig {
+    pub fn dog() -> Self {
+        Self {
+            species: Species::Dog,
+            min_cluster_size: 2,
+            agglomerative_threshold: 0.45,
+            max_exemplars: 5,
+        }
+    }
+
+    pub fn cat() -> Self {
+        Self {
+            species: Species::Cat,
+            min_cluster_size: 2,
+            agglomerative_threshold: 0.75,
+            max_exemplars: 5,
+        }
+    }
+
+    pub fn for_species(species: Species) -> Self {
+        match species {
+            Species::Dog => Self::dog(),
+            Species::Cat => Self::cat(),
+        }
+    }
+
+    fn exemplar_energy_margin(&self) -> f32 {
+        0.02
+    }
+
+    fn cluster_assignment_margin(&self) -> f32 {
+        0.03
+    }
+
+    fn greedy_face_threshold(&self) -> f32 {
+        match self.species {
+            Species::Dog => 0.32,
+            Species::Cat => 0.52,
+        }
+    }
+
+    fn greedy_body_threshold(&self) -> f32 {
+        match self.species {
+            Species::Dog => 0.30,
+            Species::Cat => 0.40,
+        }
+    }
+
+    fn greedy_combined_threshold(&self) -> f32 {
+        match self.species {
+            Species::Dog => 0.30,
+            Species::Cat => 0.46,
+        }
+    }
+
+    fn body_distance_weight(&self) -> (f32, f32) {
+        (0.75, 0.25)
+    }
+
+    fn hac_sample_size(&self) -> usize {
+        128
+    }
+}
+
+// ── Input / Output types ────────────────────────────────────────────────
+
+/// One image's data for clustering. Index-aligned across the batch.
+#[derive(Clone, Debug)]
+pub struct PetClusterInput {
+    /// Unique ID for this pet face (from indexing). Used as the key in results.
+    pub pet_face_id: String,
+    /// L2-normalized face embedding (128-d). Empty vec if no face.
+    pub face_embedding: Vec<f32>,
+    /// L2-normalized body embedding. Empty vec if no body.
+    pub body_embedding: Vec<f32>,
+    /// 0 = dog, 1 = cat.
+    pub species: u8,
+    /// File ID that this detection belongs to.
+    pub file_id: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PetClusterIndexInput {
+    pub pet_face_id: String,
+    pub vector_id: u64,
+    pub species: u8,
+    pub file_id: i64,
+}
+
+impl PetClusterInput {
+    pub fn face_only(
+        pet_face_id: String,
+        face_embedding: Vec<f32>,
+        species: u8,
+        file_id: i64,
+    ) -> Self {
+        Self {
+            pet_face_id,
+            face_embedding,
+            body_embedding: Vec::new(),
+            species,
+            file_id,
+        }
+    }
+
+    pub fn has_face(&self) -> bool {
+        !self.face_embedding.is_empty()
+    }
+
+    pub fn has_body(&self) -> bool {
+        !self.body_embedding.is_empty()
+    }
+}
+
+/// Result of clustering: maps each pet_face_id to a cluster_id string.
+#[derive(Clone, Debug, Default)]
+pub struct PetClusterResult {
+    /// pet_face_id → cluster_id (UUID-style string).
+    pub face_to_cluster: HashMap<String, String>,
+    /// cluster_id → centroid face embedding (L2-normalized).
+    pub cluster_centroids: HashMap<String, Vec<f32>>,
+    /// cluster_id → diverse exemplar embeddings (real faces, not averaged).
+    /// Used for multi-exemplar incremental matching.
+    pub cluster_exemplars: HashMap<String, Vec<Vec<f32>>>,
+    /// cluster_id → member count.
+    pub cluster_counts: HashMap<String, usize>,
+    /// Number of inputs that remained unclustered.
+    pub n_unclustered: usize,
+}
+
+// ── Core clustering engine ──────────────────────────────────────────────
+
+/// Run face-only pet clustering (agglomerative average linkage).
+///
+/// This is the main entry point called from the API layer.
+pub fn run_pet_clustering(inputs: &[PetClusterInput], config: &ClusterConfig) -> PetClusterResult {
+    let n = inputs.len();
+    if n == 0 {
+        return PetClusterResult::default();
+    }
+
+    let has_face: Vec<bool> = inputs.iter().map(|i| i.has_face()).collect();
+
+    // Face-based agglomerative clustering
+    let mut labels = phase1_face_cluster(inputs, &has_face, config);
+    renumber_labels(&mut labels);
+
+    build_result(inputs, &labels, &has_face, config)
+}
+
+pub fn run_pet_clustering_from_vdb(
+    inputs: &[PetClusterIndexInput],
+    vdb: &VectorDB,
+    config: &ClusterConfig,
+) -> Result<PetClusterResult, String> {
+    if inputs.is_empty() {
+        return Ok(PetClusterResult::default());
+    }
+
+    let allowed_keys: Vec<u64> = inputs.iter().map(|i| i.vector_id).collect();
+    let mut key_to_position = HashMap::with_capacity(inputs.len());
+    for (idx, input) in inputs.iter().enumerate() {
+        key_to_position.insert(input.vector_id, idx);
+    }
+
+    let mut vector_cache: HashMap<u64, Vec<f32>> = HashMap::with_capacity(inputs.len());
+    let mut materialized_inputs = Vec::with_capacity(inputs.len());
+    let mut clusters: Vec<GreedyCluster> = Vec::new();
+    let mut assigned_cluster: Vec<Option<usize>> = vec![None; inputs.len()];
+
+    for (idx, input) in inputs.iter().enumerate() {
+        let face_embedding = get_cached_vector(vdb, input.vector_id, &mut vector_cache)?;
+        let observation = PetClusterInput {
+            pet_face_id: input.pet_face_id.clone(),
+            face_embedding: face_embedding.clone(),
+            body_embedding: Vec::new(),
+            species: input.species,
+            file_id: input.file_id,
+        };
+        materialized_inputs.push(observation.clone());
+
+        let (neighbor_keys, _) = vdb.approx_filtered_search_vectors_within_distance(
+            &face_embedding,
+            &allowed_keys,
+            32,
+            config.greedy_face_threshold(),
+        )?;
+
+        let mut candidate_clusters: Vec<usize> = Vec::new();
+        for key in neighbor_keys {
+            if key == input.vector_id {
+                continue;
+            }
+            let Some(&neighbor_idx) = key_to_position.get(&key) else {
+                continue;
+            };
+            if neighbor_idx >= idx {
+                continue;
+            }
+            if let Some(cluster_idx) = assigned_cluster[neighbor_idx]
+                && !candidate_clusters.contains(&cluster_idx)
+            {
+                candidate_clusters.push(cluster_idx);
+            }
+        }
+
+        let mut best_idx = None;
+        let mut best_dist = f32::INFINITY;
+        let mut second_best_dist = f32::INFINITY;
+        for &cluster_idx in &candidate_clusters {
+            let dist = greedy_cluster_distance(&observation, &clusters[cluster_idx], config);
+            if dist < best_dist {
+                second_best_dist = best_dist;
+                best_dist = dist;
+                best_idx = Some(cluster_idx);
+            } else if dist < second_best_dist {
+                second_best_dist = dist;
+            }
+        }
+
+        let has_clear_winner = candidate_clusters.len() <= 1
+            || (second_best_dist - best_dist) > config.cluster_assignment_margin();
+        let cluster_idx = if best_dist.is_finite() && has_clear_winner {
+            if let Some(cluster_idx) = best_idx {
+                clusters[cluster_idx].add_member(idx, &observation);
+                cluster_idx
+            } else {
+                let cluster_idx = clusters.len();
+                clusters.push(GreedyCluster::new(idx, &observation));
+                cluster_idx
+            }
+        } else {
+            let cluster_idx = clusters.len();
+            clusters.push(GreedyCluster::new(idx, &observation));
+            cluster_idx
+        };
+        assigned_cluster[idx] = Some(cluster_idx);
+    }
+
+    median_linkage_merge(&mut clusters, &materialized_inputs, config);
+
+    let mut labels = vec![-1i32; materialized_inputs.len()];
+    for (cluster_idx, cluster) in clusters.iter().enumerate() {
+        if cluster.members.len() < config.min_cluster_size {
+            continue;
+        }
+        for &member_idx in &cluster.members {
+            labels[member_idx] = cluster_idx as i32;
+        }
+    }
+    renumber_labels(&mut labels);
+
+    let has_face = vec![true; materialized_inputs.len()];
+    Ok(build_result(
+        &materialized_inputs,
+        &labels,
+        &has_face,
+        config,
+    ))
+}
+
+/// Run incremental face-only clustering: assign new inputs to existing
+/// face clusters by centroid similarity, then cluster the remainder.
+///
+/// Uses a relaxed threshold for centroid matching (centroid is an average
+/// that doesn't represent any individual face perfectly, so it needs more
+/// slack than pairwise comparisons in batch mode).
+pub fn run_pet_clustering_incremental(
+    new_inputs: &[PetClusterInput],
+    existing_centroids_face: &HashMap<String, Vec<f32>>,
+    config: &ClusterConfig,
+) -> PetClusterResult {
+    let n = new_inputs.len();
+    if n == 0 {
+        return PetClusterResult::default();
+    }
+
+    let mut labels = vec![-1i32; n];
+    let mut cluster_name_map: HashMap<i32, String> = HashMap::new();
+
+    // Step 1: Try to assign each new face to the closest existing cluster.
+    // Use a relaxed threshold: centroids are averages that drift from
+    // individual members, so we allow 15% more distance than batch mode.
+    let centroid_threshold = config.agglomerative_threshold * 1.15;
+    let min_sim = 1.0 - centroid_threshold;
+
+    for (i, inp) in new_inputs.iter().enumerate() {
+        if !inp.has_face() {
+            continue;
+        }
+
+        let mut best_sim = -1.0f32;
+        let mut second_best_sim = -1.0f32;
+        let mut best_id: Option<&String> = None;
+
+        for (cluster_id, centroid) in existing_centroids_face {
+            let sim = simsimd_dot_product(&inp.face_embedding, centroid);
+            if sim > best_sim {
+                second_best_sim = best_sim;
+                best_sim = sim;
+                best_id = Some(cluster_id);
+            } else if sim > second_best_sim {
+                second_best_sim = sim;
+            }
+        }
+
+        // Assign if:
+        // 1. Distance to best centroid is below relaxed threshold
+        // 2. Best is clearly better than second-best (margin > 0.05)
+        //    to avoid ambiguous assignments
+        let has_clear_winner =
+            existing_centroids_face.len() <= 1 || (best_sim - second_best_sim) > 0.05;
+
+        if best_sim > min_sim
+            && has_clear_winner
+            && let Some(cid) = best_id
+        {
+            let numeric = cluster_name_map
+                .iter()
+                .find(|(_, v)| *v == cid)
+                .map(|(k, _)| *k)
+                .unwrap_or_else(|| {
+                    let new_label = cluster_name_map.len() as i32;
+                    cluster_name_map.insert(new_label, cid.clone());
+                    new_label
+                });
+            labels[i] = numeric;
+        }
+    }
+
+    // Step 2: Cluster unassigned among themselves
+    let unassigned: Vec<usize> = labels
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| **l == -1)
+        .map(|(i, _)| i)
+        .collect();
+
+    if unassigned.len() >= config.min_cluster_size {
+        let sub_inputs: Vec<PetClusterInput> =
+            unassigned.iter().map(|&i| new_inputs[i].clone()).collect();
+        let sub_result = run_pet_clustering(&sub_inputs, config);
+
+        let mut next_label = cluster_name_map.keys().copied().max().unwrap_or(-1) + 1;
+        for (sub_idx, &global_idx) in unassigned.iter().enumerate() {
+            let pet_face_id = &sub_inputs[sub_idx].pet_face_id;
+            if let Some(cluster_id) = sub_result.face_to_cluster.get(pet_face_id) {
+                let numeric = cluster_name_map
+                    .iter()
+                    .find(|(_, v)| *v == cluster_id)
+                    .map(|(k, _)| *k)
+                    .unwrap_or_else(|| {
+                        let label = next_label;
+                        next_label += 1;
+                        cluster_name_map.insert(label, cluster_id.clone());
+                        label
+                    });
+                labels[global_idx] = numeric;
+            }
+        }
+    }
+
+    // Build final result
+    let mut result = PetClusterResult::default();
+    for (i, inp) in new_inputs.iter().enumerate() {
+        if labels[i] >= 0 {
+            if let Some(cluster_id) = cluster_name_map.get(&labels[i]) {
+                result
+                    .face_to_cluster
+                    .insert(inp.pet_face_id.clone(), cluster_id.clone());
+                *result.cluster_counts.entry(cluster_id.clone()).or_insert(0) += 1;
+            }
+        } else {
+            result.n_unclustered += 1;
+        }
+    }
+
+    // Recompute face centroids
+    for cluster_id in result.cluster_counts.keys() {
+        let face_embs: Vec<&Vec<f32>> = new_inputs
+            .iter()
+            .filter(|inp| {
+                result
+                    .face_to_cluster
+                    .get(&inp.pet_face_id)
+                    .map(|c| c == cluster_id)
+                    .unwrap_or(false)
+                    && inp.has_face()
+            })
+            .map(|inp| &inp.face_embedding)
+            .collect();
+
+        if !face_embs.is_empty() {
+            let centroid = mean_centroid(&face_embs, face_embs[0].len());
+            result
+                .cluster_centroids
+                .insert(cluster_id.clone(), centroid);
+        }
+    }
+
+    result
+}
+
+/// Run incremental clustering using multi-exemplar matching.
+///
+/// Instead of comparing new faces against a single mean centroid per cluster,
+/// this compares against multiple real exemplar embeddings. A face matches a
+/// cluster if it is similar enough to ANY exemplar in that cluster.
+///
+/// Benefits over centroid matching:
+/// - No "centroid drift" — exemplars are real embeddings that don't degrade.
+/// - Captures cluster shape (e.g., front vs. profile views of the same pet).
+/// - No need for the 1.15× threshold relaxation hack.
+pub fn run_pet_clustering_incremental_with_exemplars(
+    new_inputs: &[PetClusterInput],
+    existing_exemplars: &HashMap<String, Vec<Vec<f32>>>,
+    config: &ClusterConfig,
+) -> PetClusterResult {
+    let n = new_inputs.len();
+    if n == 0 {
+        return PetClusterResult::default();
+    }
+
+    let mut labels = vec![-1i32; n];
+    let mut cluster_name_map: HashMap<i32, String> = HashMap::new();
+
+    // Step 1: Match each new face against all exemplars of each cluster.
+    // No threshold relaxation needed — we're comparing against real faces.
+    let min_sim = 1.0 - config.agglomerative_threshold;
+
+    for (i, inp) in new_inputs.iter().enumerate() {
+        if !inp.has_face() {
+            continue;
+        }
+
+        let mut best_sim = f32::NEG_INFINITY;
+        let mut second_best_sim = f32::NEG_INFINITY;
+        let mut best_id: Option<&String> = None;
+
+        let mut best_energy = f32::NEG_INFINITY;
+        let mut second_best_energy = f32::NEG_INFINITY;
+
+        for (cluster_id, exemplars) in existing_exemplars {
+            let (cluster_sim, cluster_energy) =
+                exemplar_cluster_score(&inp.face_embedding, exemplars, min_sim);
+
+            if cluster_energy > best_energy
+                || (cluster_energy == best_energy && cluster_sim > best_sim)
+            {
+                second_best_energy = best_energy;
+                second_best_sim = best_sim;
+                best_energy = cluster_energy;
+                best_sim = cluster_sim;
+                best_id = Some(cluster_id);
+            } else if cluster_energy > second_best_energy
+                || (cluster_energy == second_best_energy && cluster_sim > second_best_sim)
+            {
+                second_best_energy = cluster_energy;
+                second_best_sim = cluster_sim;
+            }
+        }
+
+        // Apple-like "gallery assignment": use multiple exemplars as votes.
+        // A cluster wins if it has the strongest exemplar support ("energy"),
+        // while still requiring at least one exemplar to exceed the hard match
+        // threshold so we do not force low-confidence assignments.
+        let has_clear_winner = existing_exemplars.len() <= 1
+            || (best_energy - second_best_energy) > config.exemplar_energy_margin()
+            || (best_sim - second_best_sim) > 0.05;
+
+        if best_sim > min_sim
+            && best_energy.is_finite()
+            && best_energy > 0.0
+            && has_clear_winner
+            && let Some(cid) = best_id
+        {
+            let numeric = cluster_name_map
+                .iter()
+                .find(|(_, v)| *v == cid)
+                .map(|(k, _)| *k)
+                .unwrap_or_else(|| {
+                    let new_label = cluster_name_map.len() as i32;
+                    cluster_name_map.insert(new_label, cid.clone());
+                    new_label
+                });
+            labels[i] = numeric;
+        }
+    }
+
+    // Step 2: Cluster unassigned among themselves
+    let unassigned: Vec<usize> = labels
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| **l == -1)
+        .map(|(i, _)| i)
+        .collect();
+
+    if unassigned.len() >= config.min_cluster_size {
+        let sub_inputs: Vec<PetClusterInput> =
+            unassigned.iter().map(|&i| new_inputs[i].clone()).collect();
+        let sub_result = run_pet_clustering(&sub_inputs, config);
+
+        let mut next_label = cluster_name_map.keys().copied().max().unwrap_or(-1) + 1;
+        for (sub_idx, &global_idx) in unassigned.iter().enumerate() {
+            let pet_face_id = &sub_inputs[sub_idx].pet_face_id;
+            if let Some(cluster_id) = sub_result.face_to_cluster.get(pet_face_id) {
+                let numeric = cluster_name_map
+                    .iter()
+                    .find(|(_, v)| *v == cluster_id)
+                    .map(|(k, _)| *k)
+                    .unwrap_or_else(|| {
+                        let label = next_label;
+                        next_label += 1;
+                        cluster_name_map.insert(label, cluster_id.clone());
+                        label
+                    });
+                labels[global_idx] = numeric;
+            }
+        }
+    }
+
+    // Build final result
+    let face_dim = new_inputs
+        .iter()
+        .find(|i| i.has_face())
+        .map(|i| i.face_embedding.len())
+        .unwrap_or(128);
+
+    let mut result = PetClusterResult::default();
+    for (i, inp) in new_inputs.iter().enumerate() {
+        if labels[i] >= 0 {
+            if let Some(cluster_id) = cluster_name_map.get(&labels[i]) {
+                result
+                    .face_to_cluster
+                    .insert(inp.pet_face_id.clone(), cluster_id.clone());
+                *result.cluster_counts.entry(cluster_id.clone()).or_insert(0) += 1;
+            }
+        } else {
+            result.n_unclustered += 1;
+        }
+    }
+
+    // Compute centroids and exemplars from the new faces in each cluster
+    for cluster_id in result.cluster_counts.keys() {
+        let face_embs: Vec<&Vec<f32>> = new_inputs
+            .iter()
+            .filter(|inp| {
+                result
+                    .face_to_cluster
+                    .get(&inp.pet_face_id)
+                    .map(|c| c == cluster_id)
+                    .unwrap_or(false)
+                    && inp.has_face()
+            })
+            .map(|inp| &inp.face_embedding)
+            .collect();
+
+        if !face_embs.is_empty() {
+            result
+                .cluster_centroids
+                .insert(cluster_id.clone(), mean_centroid(&face_embs, face_dim));
+            result.cluster_exemplars.insert(
+                cluster_id.clone(),
+                select_exemplars(&face_embs, config.max_exemplars, face_dim),
+            );
+        }
+    }
+
+    result
+}
+
+// ── Phase 1: Conservative greedy micro-clusters + HAC merge ─────────────
+
+/// Build conservative micro-clusters, then grow them with face-only HAC.
+fn phase1_face_cluster(
+    inputs: &[PetClusterInput],
+    has_face: &[bool],
+    config: &ClusterConfig,
+) -> Vec<i32> {
+    let n = inputs.len();
+    let mut labels = vec![-1i32; n];
+
+    let face_indices: Vec<usize> = has_face
+        .iter()
+        .enumerate()
+        .filter(|(_, h)| **h)
+        .map(|(i, _)| i)
+        .collect();
+
+    if face_indices.len() < 2 {
+        return labels;
+    }
+
+    let nf = face_indices.len();
+
+    // Guard against excessive memory usage: n^2 * 4 bytes.
+    // 5000^2 * 4 = ~100MB, which is the upper bound for mobile devices.
+    if nf > 5000 {
+        return labels;
+    }
+
+    let mut clusters = greedy_microclusters(inputs, &face_indices, config);
+    if clusters.is_empty() {
+        return labels;
+    }
+
+    median_linkage_merge(&mut clusters, inputs, config);
+
+    for (cluster_idx, cluster) in clusters.iter().enumerate() {
+        if cluster.members.len() < config.min_cluster_size {
+            continue;
+        }
+        for &global_idx in &cluster.members {
+            labels[global_idx] = cluster_idx as i32;
+        }
+    }
+
+    labels
+}
+
+fn greedy_microclusters(
+    inputs: &[PetClusterInput],
+    face_indices: &[usize],
+    config: &ClusterConfig,
+) -> Vec<GreedyCluster> {
+    let mut clusters: Vec<GreedyCluster> = Vec::new();
+
+    for &global_idx in face_indices {
+        let observation = &inputs[global_idx];
+        let mut best_idx = None;
+        let mut best_dist = f32::INFINITY;
+        let mut second_best_dist = f32::INFINITY;
+
+        for (cluster_idx, cluster) in clusters.iter().enumerate() {
+            let dist = greedy_cluster_distance(observation, cluster, config);
+            if dist < best_dist {
+                second_best_dist = best_dist;
+                best_dist = dist;
+                best_idx = Some(cluster_idx);
+            } else if dist < second_best_dist {
+                second_best_dist = dist;
+            }
+        }
+
+        let has_clear_winner = clusters.len() <= 1
+            || (second_best_dist - best_dist) > config.cluster_assignment_margin();
+        if best_dist.is_finite()
+            && has_clear_winner
+            && let Some(cluster_idx) = best_idx
+        {
+            clusters[cluster_idx].add_member(global_idx, observation);
+        } else {
+            clusters.push(GreedyCluster::new(global_idx, observation));
+        }
+    }
+
+    clusters
+}
+
+fn greedy_cluster_distance(
+    observation: &PetClusterInput,
+    cluster: &GreedyCluster,
+    config: &ClusterConfig,
+) -> f32 {
+    let face_dist = if observation.has_face() && cluster.face_count > 0 {
+        simsimd_cosine_distance(&observation.face_embedding, &cluster.face_centroid)
+    } else {
+        f32::INFINITY
+    };
+
+    let body_dist = if observation.has_body() && cluster.body_count > 0 {
+        simsimd_cosine_distance(&observation.body_embedding, &cluster.body_centroid)
+    } else {
+        f32::INFINITY
+    };
+
+    if face_dist.is_finite() {
+        if body_dist.is_finite() && body_dist <= config.greedy_body_threshold() {
+            let (alpha, beta) = config.body_distance_weight();
+            let combined = alpha * face_dist + beta * body_dist;
+            if combined <= config.greedy_combined_threshold() {
+                return face_dist.min(combined);
+            }
+        }
+        if face_dist <= config.greedy_face_threshold() {
+            face_dist
+        } else {
+            f32::INFINITY
+        }
+    } else if body_dist <= config.greedy_body_threshold() {
+        body_dist
+    } else {
+        f32::INFINITY
+    }
+}
+
+fn median_linkage_merge(
+    clusters: &mut Vec<GreedyCluster>,
+    inputs: &[PetClusterInput],
+    config: &ClusterConfig,
+) {
+    loop {
+        let mut best_pair = None;
+        let mut best_dist = f32::INFINITY;
+
+        for i in 0..clusters.len() {
+            for j in (i + 1)..clusters.len() {
+                let dist = sampled_median_face_distance(&clusters[i], &clusters[j], inputs, config);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_pair = Some((i, j));
+                }
+            }
+        }
+
+        let Some((left, right)) = best_pair else {
+            break;
+        };
+        if best_dist > config.agglomerative_threshold {
+            break;
+        }
+
+        let other = clusters.remove(right);
+        clusters[left].merge(other);
+    }
+}
+
+fn sampled_median_face_distance(
+    left: &GreedyCluster,
+    right: &GreedyCluster,
+    inputs: &[PetClusterInput],
+    config: &ClusterConfig,
+) -> f32 {
+    let total_pairs = left.members.len() * right.members.len();
+    if total_pairs == 0 {
+        return f32::INFINITY;
+    }
+
+    let mut distances = Vec::with_capacity(total_pairs.min(config.hac_sample_size()));
+    if total_pairs <= config.hac_sample_size() {
+        for &li in &left.members {
+            for &ri in &right.members {
+                distances.push(face_distance(
+                    &inputs[li].face_embedding,
+                    &inputs[ri].face_embedding,
+                ));
+            }
+        }
+    } else {
+        let sample_size = config.hac_sample_size();
+        let mut state =
+            ((left.members[0] as u64) << 32) ^ (right.members[0] as u64) ^ (total_pairs as u64);
+        for _ in 0..sample_size {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let li = left.members[(state as usize) % left.members.len()];
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let ri = right.members[(state as usize) % right.members.len()];
+            distances.push(face_distance(
+                &inputs[li].face_embedding,
+                &inputs[ri].face_embedding,
+            ));
+        }
+    }
+
+    distances.sort_by(|a, b| a.total_cmp(b));
+    distances[distances.len() / 2]
+}
+
+fn face_distance(left: &[f32], right: &[f32]) -> f32 {
+    simsimd_cosine_distance(left, right)
+}
+
+fn get_cached_vector(
+    vdb: &VectorDB,
+    key: u64,
+    cache: &mut HashMap<u64, Vec<f32>>,
+) -> Result<Vec<f32>, String> {
+    if let Some(vector) = cache.get(&key) {
+        return Ok(vector.clone());
+    }
+
+    let vector = vdb.get_vector(key)?;
+    cache.insert(key, vector.clone());
+    Ok(vector)
+}
+
+fn exemplar_cluster_score(
+    face_embedding: &[f32],
+    exemplars: &[Vec<f32>],
+    min_sim: f32,
+) -> (f32, f32) {
+    let mut similarities: Vec<f32> = exemplars
+        .iter()
+        .map(|ex| simsimd_dot_product(face_embedding, ex))
+        .collect();
+    if similarities.is_empty() {
+        return (f32::NEG_INFINITY, f32::NEG_INFINITY);
+    }
+
+    similarities.sort_by(|a, b| b.total_cmp(a));
+    let best_sim = similarities[0];
+    let energy = similarities
+        .iter()
+        .take(3)
+        .map(|sim| (sim - min_sim).max(0.0))
+        .sum();
+
+    (best_sim, energy)
+}
+
+struct GreedyCluster {
+    members: Vec<usize>,
+    face_count: usize,
+    body_count: usize,
+    face_centroid: Vec<f32>,
+    body_centroid: Vec<f32>,
+}
+
+impl GreedyCluster {
+    fn new(first_idx: usize, observation: &PetClusterInput) -> Self {
+        Self {
+            members: vec![first_idx],
+            face_count: usize::from(observation.has_face()),
+            body_count: usize::from(observation.has_body()),
+            face_centroid: observation.face_embedding.clone(),
+            body_centroid: observation.body_embedding.clone(),
+        }
+    }
+
+    fn add_member(&mut self, idx: usize, observation: &PetClusterInput) {
+        self.members.push(idx);
+        if observation.has_face() {
+            if self.face_count == 0 {
+                self.face_centroid = observation.face_embedding.clone();
+            } else {
+                update_running_mean(
+                    &mut self.face_centroid,
+                    &observation.face_embedding,
+                    self.face_count,
+                );
+            }
+            self.face_count += 1;
+        }
+        if observation.has_body() {
+            if self.body_count == 0 {
+                self.body_centroid = observation.body_embedding.clone();
+            } else {
+                update_running_mean(
+                    &mut self.body_centroid,
+                    &observation.body_embedding,
+                    self.body_count,
+                );
+            }
+            self.body_count += 1;
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.members.extend(other.members);
+        if other.face_count > 0 {
+            if self.face_count == 0 {
+                self.face_centroid = other.face_centroid;
+                self.face_count = other.face_count;
+            } else {
+                merge_running_means(
+                    &mut self.face_centroid,
+                    self.face_count,
+                    &other.face_centroid,
+                    other.face_count,
+                );
+                self.face_count += other.face_count;
+            }
+        }
+        if other.body_count > 0 {
+            if self.body_count == 0 {
+                self.body_centroid = other.body_centroid;
+                self.body_count = other.body_count;
+            } else {
+                merge_running_means(
+                    &mut self.body_centroid,
+                    self.body_count,
+                    &other.body_centroid,
+                    other.body_count,
+                );
+                self.body_count += other.body_count;
+            }
+        }
+    }
+}
+
+fn update_running_mean(mean: &mut [f32], sample: &[f32], previous_count: usize) {
+    let prev = previous_count as f32;
+    let next = prev + 1.0;
+    for (m, s) in mean.iter_mut().zip(sample.iter()) {
+        *m = ((*m * prev) + *s) / next;
+    }
+}
+
+fn merge_running_means(
+    mean: &mut [f32],
+    left_count: usize,
+    other_mean: &[f32],
+    right_count: usize,
+) {
+    let left = left_count as f32;
+    let right = right_count as f32;
+    let total = left + right;
+    for (m, o) in mean.iter_mut().zip(other_mean.iter()) {
+        *m = ((*m * left) + (*o * right)) / total;
+    }
+}
+
+fn l2_norm(v: &[f32]) -> f32 {
+    simsimd_dot_product(v, v).sqrt()
+}
+
+fn normalize(v: &mut [f32]) {
+    let norm = l2_norm(v);
+    if norm > 1e-8 {
+        for value in v.iter_mut() {
+            *value /= norm;
+        }
+    }
+}
+
+pub(crate) fn select_exemplars(embs: &[&Vec<f32>], k: usize, dim: usize) -> Vec<Vec<f32>> {
+    let n = embs.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= k {
+        return embs.iter().map(|embedding| (*embedding).clone()).collect();
+    }
+
+    let centroid = mean_centroid(embs, dim);
+    let mut selected: Vec<usize> = Vec::with_capacity(k);
+
+    let first = (0..n)
+        .max_by(|&left, &right| {
+            simsimd_dot_product(embs[left], &centroid)
+                .partial_cmp(&simsimd_dot_product(embs[right], &centroid))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .unwrap();
+    selected.push(first);
+
+    while selected.len() < k {
+        let best = (0..n)
+            .filter(|idx| !selected.contains(idx))
+            .min_by(|&left, &right| {
+                let max_sim_left = selected
+                    .iter()
+                    .map(|&selected_idx| simsimd_dot_product(embs[left], embs[selected_idx]))
+                    .fold(f32::NEG_INFINITY, f32::max);
+                let max_sim_right = selected
+                    .iter()
+                    .map(|&selected_idx| simsimd_dot_product(embs[right], embs[selected_idx]))
+                    .fold(f32::NEG_INFINITY, f32::max);
+                max_sim_left
+                    .partial_cmp(&max_sim_right)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .unwrap();
+        selected.push(best);
+    }
+
+    selected.iter().map(|&idx| embs[idx].clone()).collect()
+}
+
+pub(crate) fn mean_centroid(embs: &[&Vec<f32>], dim: usize) -> Vec<f32> {
+    if embs.is_empty() {
+        return vec![0.0; dim];
+    }
+
+    let mut centroid = vec![0.0f32; dim];
+    for embedding in embs {
+        for (idx, &value) in embedding.iter().enumerate() {
+            if idx < dim {
+                centroid[idx] += value;
+            }
+        }
+    }
+
+    let count = embs.len() as f32;
+    for value in &mut centroid {
+        *value /= count;
+    }
+    normalize(&mut centroid);
+    centroid
+}
+
+pub(crate) fn unique_cluster_ids(labels: &[i32]) -> Vec<i32> {
+    let mut ids: Vec<i32> = labels
+        .iter()
+        .copied()
+        .filter(|&label| label >= 0)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+pub(crate) fn renumber_labels(labels: &mut [i32]) {
+    let unique = unique_cluster_ids(labels);
+    let mapping: HashMap<i32, i32> = unique
+        .iter()
+        .enumerate()
+        .map(|(new, &old)| (old, new as i32))
+        .collect();
+    for label in labels.iter_mut() {
+        if *label >= 0
+            && let Some(&new) = mapping.get(label)
+        {
+            *label = new;
+        }
+    }
+}
+
+fn build_result(
+    inputs: &[PetClusterInput],
+    labels: &[i32],
+    has_face: &[bool],
+    config: &ClusterConfig,
+) -> PetClusterResult {
+    let mut result = PetClusterResult::default();
+
+    // Generate cluster ID strings (UUID-like from hash for determinism)
+    let unique = unique_cluster_ids(labels);
+    let cluster_id_map: HashMap<i32, String> = unique
+        .iter()
+        .map(|&c| {
+            // Create a deterministic cluster ID from the first member's pet_face_id
+            let first_member = labels
+                .iter()
+                .enumerate()
+                .find(|(_, l)| **l == c)
+                .map(|(i, _)| i)
+                .unwrap();
+            let id = format!("pet_cluster_{}", inputs[first_member].pet_face_id);
+            (c, id)
+        })
+        .collect();
+
+    // Map each input to its cluster
+    for (i, inp) in inputs.iter().enumerate() {
+        if labels[i] >= 0 {
+            if let Some(cluster_id) = cluster_id_map.get(&labels[i]) {
+                result
+                    .face_to_cluster
+                    .insert(inp.pet_face_id.clone(), cluster_id.clone());
+                *result.cluster_counts.entry(cluster_id.clone()).or_insert(0) += 1;
+            }
+        } else {
+            result.n_unclustered += 1;
+        }
+    }
+
+    // Compute centroids and exemplars for each cluster
+    let face_dim = inputs
+        .iter()
+        .find(|i| i.has_face())
+        .map(|i| i.face_embedding.len())
+        .unwrap_or(128);
+
+    for (&numeric, cluster_id) in &cluster_id_map {
+        let face_embs: Vec<&Vec<f32>> = labels
+            .iter()
+            .enumerate()
+            .filter(|(i, l)| **l == numeric && has_face[*i])
+            .map(|(i, _)| &inputs[i].face_embedding)
+            .collect();
+        if !face_embs.is_empty() {
+            result
+                .cluster_centroids
+                .insert(cluster_id.clone(), mean_centroid(&face_embs, face_dim));
+            result.cluster_exemplars.insert(
+                cluster_id.clone(),
+                select_exemplars(&face_embs, config.max_exemplars, face_dim),
+            );
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_input(face_id: &str, face: Vec<f32>, species: u8) -> PetClusterInput {
+        PetClusterInput {
+            pet_face_id: face_id.to_string(),
+            face_embedding: face,
+            body_embedding: Vec::new(),
+            species,
+            file_id: 0,
+        }
+    }
+
+    /// Make a face embedding clustered around a base direction.
+    fn make_face(base_dim: usize, noise_seed: u32) -> Vec<f32> {
+        let mut v = vec![0.0f32; 128];
+        v[base_dim] = 1.0;
+        for k in 0..10u32 {
+            let dim = (noise_seed.wrapping_mul(7).wrapping_add(k * 13 + 3) % 128) as usize;
+            let t = (noise_seed as f32 * 0.618 + k as f32 * 1.377).sin();
+            v[dim] += t * 0.35;
+        }
+        normalized(v)
+    }
+
+    #[allow(dead_code)]
+    fn perturb(base: &[f32], dim: usize, amount: f32) -> Vec<f32> {
+        let mut v = base.to_vec();
+        let idx = dim % v.len();
+        v[idx] += amount;
+        normalized(v)
+    }
+
+    fn normalized(mut v: Vec<f32>) -> Vec<f32> {
+        let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if n > 0.0 {
+            for x in v.iter_mut() {
+                *x /= n;
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let config = ClusterConfig::dog();
+        let result = run_pet_clustering(&[], &config);
+        assert_eq!(result.n_unclustered, 0);
+        assert!(result.face_to_cluster.is_empty());
+    }
+
+    #[test]
+    fn test_single_input() {
+        let config = ClusterConfig::dog();
+        let inputs = vec![make_input("face_1", normalized(vec![1.0; 128]), 0)];
+        let result = run_pet_clustering(&inputs, &config);
+        // Single input can't form a cluster
+        assert_eq!(result.n_unclustered, 1);
+    }
+
+    #[test]
+    fn test_two_similar_faces_cluster() {
+        let config = ClusterConfig::dog();
+        // HDBSCAN needs density contrast — provide 2 groups
+        let mut inputs: Vec<_> = (0..5)
+            .map(|i| make_input(&format!("a{}", i), make_face(0, i), 0))
+            .collect();
+        // Second group so HDBSCAN sees density contrast
+        for i in 0..5 {
+            inputs.push(make_input(&format!("b{}", i), make_face(64, i + 100), 0));
+        }
+
+        let result = run_pet_clustering(&inputs, &config);
+        let c0 = result.face_to_cluster.get("a0");
+        assert!(c0.is_some(), "a0 should be clustered");
+        for i in 1..5 {
+            assert_eq!(
+                c0,
+                result.face_to_cluster.get(&format!("a{}", i)),
+                "a{} should be in same cluster as a0",
+                i
+            );
+        }
+        // Groups should be separate
+        assert_ne!(
+            result.face_to_cluster.get("a0"),
+            result.face_to_cluster.get("b0"),
+            "Group A and B should be separate"
+        );
+    }
+
+    #[test]
+    fn test_two_groups_separate() {
+        let config = ClusterConfig::dog();
+
+        // Group A: 3 nearly-identical faces along dimension 0
+        let base_a = {
+            let mut v = vec![0.0f32; 128];
+            v[0] = 1.0;
+            v
+        };
+        // Group B: 3 nearly-identical faces along dimension 64
+        let base_b = {
+            let mut v = vec![0.0f32; 128];
+            v[64] = 1.0;
+            v
+        };
+
+        let perturb = |base: &Vec<f32>, dim: usize, amt: f32| {
+            let mut v = base.clone();
+            v[dim] += amt;
+            normalized(v)
+        };
+
+        let inputs = vec![
+            make_input("a1", base_a.clone(), 0),
+            make_input("a2", perturb(&base_a, 1, 0.02), 0),
+            make_input("a3", perturb(&base_a, 2, 0.02), 0),
+            make_input("b1", base_b.clone(), 0),
+            make_input("b2", perturb(&base_b, 65, 0.02), 0),
+            make_input("b3", perturb(&base_b, 66, 0.02), 0),
+        ];
+        let result = run_pet_clustering(&inputs, &config);
+
+        let ca1 = result.face_to_cluster.get("a1");
+        let ca2 = result.face_to_cluster.get("a2");
+        let ca3 = result.face_to_cluster.get("a3");
+        let cb1 = result.face_to_cluster.get("b1");
+        let cb2 = result.face_to_cluster.get("b2");
+        let cb3 = result.face_to_cluster.get("b3");
+        assert_eq!(ca1, ca2, "a1 and a2 should be in same cluster");
+        assert_eq!(ca1, ca3, "a1 and a3 should be in same cluster");
+        assert_eq!(cb1, cb2, "b1 and b2 should be in same cluster");
+        assert_eq!(cb1, cb3, "b1 and b3 should be in same cluster");
+        assert_ne!(
+            ca1, cb1,
+            "group a and group b should be in different clusters"
+        );
+    }
+
+    /// Simulate the real app flow:
+    /// ONE:   Batch cluster initial faces → creates clusters + centroids
+    /// TWO:   New faces arrive → incremental assigns to existing clusters
+    /// THREE: More faces arrive → incremental assigns again
+    #[test]
+    fn test_incremental_one_two_three() {
+        let config = ClusterConfig::dog();
+
+        // ── ONE: Initial batch of 10 faces (2 dogs, 5 each) ──
+        let mut batch_inputs = Vec::new();
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("dogA_{}", i), make_face(0, i), 0));
+        }
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(
+                &format!("dogB_{}", i),
+                make_face(64, i + 100),
+                0,
+            ));
+        }
+
+        let batch_result = run_pet_clustering(&batch_inputs, &config);
+
+        // Verify batch: 2 clusters, 0 unclustered
+        let ca = batch_result.face_to_cluster.get("dogA_0");
+        let cb = batch_result.face_to_cluster.get("dogB_0");
+        assert!(ca.is_some(), "ONE: dogA_0 should be clustered");
+        assert!(cb.is_some(), "ONE: dogB_0 should be clustered");
+        assert_ne!(ca, cb, "ONE: dog A and dog B should be separate clusters");
+
+        // All A's in same cluster
+        for i in 1..5 {
+            assert_eq!(
+                ca,
+                batch_result.face_to_cluster.get(&format!("dogA_{}", i)),
+                "ONE: dogA_{} should be in same cluster as dogA_0",
+                i
+            );
+        }
+        // All B's in same cluster
+        for i in 1..5 {
+            assert_eq!(
+                cb,
+                batch_result.face_to_cluster.get(&format!("dogB_{}", i)),
+                "ONE: dogB_{} should be in same cluster as dogB_0",
+                i
+            );
+        }
+
+        let cluster_a_id = ca.unwrap().clone();
+        let cluster_b_id = cb.unwrap().clone();
+
+        println!(
+            "ONE: {} clusters, {} unclustered, A={}, B={}",
+            batch_result.cluster_counts.len(),
+            batch_result.n_unclustered,
+            cluster_a_id,
+            cluster_b_id
+        );
+
+        // Extract centroids (simulating what Dart stores in VDB)
+        let centroids = batch_result.cluster_centroids.clone();
+        assert!(
+            centroids.contains_key(&cluster_a_id),
+            "ONE: centroid for cluster A should exist"
+        );
+        assert!(
+            centroids.contains_key(&cluster_b_id),
+            "ONE: centroid for cluster B should exist"
+        );
+
+        // ── TWO: 4 new faces arrive (2 for each dog) ──
+        let new_faces_two = vec![
+            make_input("dogA_new1", make_face(0, 50), 0),
+            make_input("dogA_new2", make_face(0, 51), 0),
+            make_input("dogB_new1", make_face(64, 150), 0),
+            make_input("dogB_new2", make_face(64, 151), 0),
+        ];
+
+        let incr_result_two = run_pet_clustering_incremental(&new_faces_two, &centroids, &config);
+
+        println!(
+            "TWO: {} assigned, {} unclustered, clusters={:?}",
+            incr_result_two.face_to_cluster.len(),
+            incr_result_two.n_unclustered,
+            incr_result_two.cluster_counts
+        );
+
+        // dogA new faces should go to cluster A
+        let ca_new1 = incr_result_two.face_to_cluster.get("dogA_new1");
+        let ca_new2 = incr_result_two.face_to_cluster.get("dogA_new2");
+        assert_eq!(
+            ca_new1,
+            Some(&cluster_a_id),
+            "TWO: dogA_new1 should be assigned to cluster A"
+        );
+        assert_eq!(
+            ca_new2,
+            Some(&cluster_a_id),
+            "TWO: dogA_new2 should be assigned to cluster A"
+        );
+
+        // dogB new faces should go to cluster B
+        let cb_new1 = incr_result_two.face_to_cluster.get("dogB_new1");
+        let cb_new2 = incr_result_two.face_to_cluster.get("dogB_new2");
+        assert_eq!(
+            cb_new1,
+            Some(&cluster_b_id),
+            "TWO: dogB_new1 should be assigned to cluster B"
+        );
+        assert_eq!(
+            cb_new2,
+            Some(&cluster_b_id),
+            "TWO: dogB_new2 should be assigned to cluster B"
+        );
+
+        assert_eq!(
+            incr_result_two.n_unclustered, 0,
+            "TWO: all new faces should be assigned"
+        );
+
+        // ── THREE: 3 more faces (2 dog A, 1 completely new dog C) ──
+        let new_faces_three = vec![
+            make_input("dogA_new3", make_face(0, 52), 0),
+            make_input("dogA_new4", make_face(0, 53), 0),
+            // Dog C: new identity, dim 32 (not matching A or B)
+            make_input("dogC_0", make_face(32, 200), 0),
+        ];
+
+        let incr_result_three =
+            run_pet_clustering_incremental(&new_faces_three, &centroids, &config);
+
+        println!(
+            "THREE: {} assigned, {} unclustered, clusters={:?}",
+            incr_result_three.face_to_cluster.len(),
+            incr_result_three.n_unclustered,
+            incr_result_three.cluster_counts
+        );
+
+        // Dog A faces should still go to cluster A
+        assert_eq!(
+            incr_result_three.face_to_cluster.get("dogA_new3"),
+            Some(&cluster_a_id),
+            "THREE: dogA_new3 should be assigned to cluster A"
+        );
+        assert_eq!(
+            incr_result_three.face_to_cluster.get("dogA_new4"),
+            Some(&cluster_a_id),
+            "THREE: dogA_new4 should be assigned to cluster A"
+        );
+
+        // Dog C should NOT be assigned to A or B (it's a new identity)
+        let cc = incr_result_three.face_to_cluster.get("dogC_0");
+        if let Some(cid) = cc {
+            assert_ne!(cid, &cluster_a_id, "THREE: dogC should not be in cluster A");
+            assert_ne!(cid, &cluster_b_id, "THREE: dogC should not be in cluster B");
+            println!("THREE: dogC_0 created new cluster {}", cid);
+        } else {
+            println!("THREE: dogC_0 stayed unclustered (only 1 face, expected)");
+        }
+    }
+
+    /// Test incremental with a face that's borderline between two clusters.
+    /// The margin check should prevent ambiguous assignment.
+    #[test]
+    fn test_incremental_ambiguous_face_stays_unassigned() {
+        let config = ClusterConfig::dog();
+
+        // Batch: 2 clusters
+        let mut batch_inputs = Vec::new();
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("a{}", i), make_face(0, i), 0));
+        }
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("b{}", i), make_face(64, i + 100), 0));
+        }
+
+        let batch_result = run_pet_clustering(&batch_inputs, &config);
+        let centroids = batch_result.cluster_centroids.clone();
+
+        // Create a face that's equidistant from both centroids
+        // (halfway between dim 0 and dim 64)
+        let mut ambiguous = vec![0.0f32; 128];
+        ambiguous[0] = 1.0;
+        ambiguous[64] = 1.0;
+        let ambiguous = normalized(ambiguous);
+
+        let new_faces = vec![make_input("ambiguous", ambiguous, 0)];
+
+        let result = run_pet_clustering_incremental(&new_faces, &centroids, &config);
+
+        println!(
+            "AMBIGUOUS: assigned={:?}, unclustered={}",
+            result.face_to_cluster.get("ambiguous"),
+            result.n_unclustered
+        );
+
+        // Should either be unassigned or in its own new cluster — NOT in A or B
+        let cluster_a = batch_result.face_to_cluster.get("a0").unwrap();
+        let cluster_b = batch_result.face_to_cluster.get("b0").unwrap();
+
+        if let Some(assigned) = result.face_to_cluster.get("ambiguous") {
+            assert_ne!(
+                assigned, cluster_a,
+                "Ambiguous face should not be forced into cluster A"
+            );
+            assert_ne!(
+                assigned, cluster_b,
+                "Ambiguous face should not be forced into cluster B"
+            );
+        }
+    }
+
+    /// Test incremental handles faceless (body-only) inputs.
+    #[test]
+    fn test_incremental_faceless_stays_unassigned() {
+        let config = ClusterConfig::dog();
+
+        // Batch: 2 clusters
+        let mut batch_inputs = Vec::new();
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("a{}", i), make_face(0, i), 0));
+        }
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("b{}", i), make_face(64, i + 100), 0));
+        }
+
+        let batch_result = run_pet_clustering(&batch_inputs, &config);
+        let centroids = batch_result.cluster_centroids.clone();
+
+        // Faceless input — can't match against face centroids
+        let new_faces = vec![make_input("no_face", vec![], 0)];
+
+        let result = run_pet_clustering_incremental(&new_faces, &centroids, &config);
+
+        assert_eq!(
+            result.n_unclustered, 1,
+            "Faceless input should be unclustered in incremental mode"
+        );
+    }
+
+    /// Exemplar-based incremental: same ONE→TWO→THREE flow but using
+    /// multi-exemplar matching instead of centroid matching.
+    #[test]
+    fn test_incremental_exemplars_one_two_three() {
+        let config = ClusterConfig::dog();
+
+        // ── ONE: Batch cluster 10 faces (2 dogs, 5 each) ──
+        let mut batch_inputs = Vec::new();
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(&format!("dogA_{}", i), make_face(0, i), 0));
+        }
+        for i in 0..5u32 {
+            batch_inputs.push(make_input(
+                &format!("dogB_{}", i),
+                make_face(64, i + 100),
+                0,
+            ));
+        }
+
+        let batch_result = run_pet_clustering(&batch_inputs, &config);
+
+        let ca = batch_result.face_to_cluster.get("dogA_0");
+        let cb = batch_result.face_to_cluster.get("dogB_0");
+        assert!(ca.is_some());
+        assert!(cb.is_some());
+        assert_ne!(ca, cb);
+
+        let cluster_a_id = ca.unwrap().clone();
+        let cluster_b_id = cb.unwrap().clone();
+
+        // Verify exemplars were computed
+        let exemplars = batch_result.cluster_exemplars.clone();
+        assert!(
+            exemplars.contains_key(&cluster_a_id),
+            "ONE: exemplars for cluster A should exist"
+        );
+        assert!(
+            exemplars.contains_key(&cluster_b_id),
+            "ONE: exemplars for cluster B should exist"
+        );
+        assert!(
+            exemplars[&cluster_a_id].len() <= config.max_exemplars,
+            "ONE: exemplar count should not exceed max_exemplars"
+        );
+
+        println!(
+            "ONE (exemplars): A has {} exemplars, B has {} exemplars",
+            exemplars[&cluster_a_id].len(),
+            exemplars[&cluster_b_id].len()
+        );
+
+        // ── TWO: 4 new faces, using exemplar matching ──
+        let new_faces_two = vec![
+            make_input("dogA_new1", make_face(0, 50), 0),
+            make_input("dogA_new2", make_face(0, 51), 0),
+            make_input("dogB_new1", make_face(64, 150), 0),
+            make_input("dogB_new2", make_face(64, 151), 0),
+        ];
+
+        let incr_result_two =
+            run_pet_clustering_incremental_with_exemplars(&new_faces_two, &exemplars, &config);
+
+        println!(
+            "TWO (exemplars): {} assigned, {} unclustered",
+            incr_result_two.face_to_cluster.len(),
+            incr_result_two.n_unclustered,
+        );
+
+        assert_eq!(
+            incr_result_two.face_to_cluster.get("dogA_new1"),
+            Some(&cluster_a_id),
+            "TWO: dogA_new1 should be assigned to cluster A"
+        );
+        assert_eq!(
+            incr_result_two.face_to_cluster.get("dogA_new2"),
+            Some(&cluster_a_id),
+            "TWO: dogA_new2 should be assigned to cluster A"
+        );
+        assert_eq!(
+            incr_result_two.face_to_cluster.get("dogB_new1"),
+            Some(&cluster_b_id),
+            "TWO: dogB_new1 should be assigned to cluster B"
+        );
+        assert_eq!(
+            incr_result_two.face_to_cluster.get("dogB_new2"),
+            Some(&cluster_b_id),
+            "TWO: dogB_new2 should be assigned to cluster B"
+        );
+        assert_eq!(incr_result_two.n_unclustered, 0);
+
+        // ── THREE: 3 more faces (2 dog A, 1 new dog C) ──
+        let new_faces_three = vec![
+            make_input("dogA_new3", make_face(0, 52), 0),
+            make_input("dogA_new4", make_face(0, 53), 0),
+            make_input("dogC_0", make_face(32, 200), 0),
+        ];
+
+        let incr_result_three =
+            run_pet_clustering_incremental_with_exemplars(&new_faces_three, &exemplars, &config);
+
+        println!(
+            "THREE (exemplars): {} assigned, {} unclustered",
+            incr_result_three.face_to_cluster.len(),
+            incr_result_three.n_unclustered,
+        );
+
+        assert_eq!(
+            incr_result_three.face_to_cluster.get("dogA_new3"),
+            Some(&cluster_a_id),
+            "THREE: dogA_new3 should be assigned to cluster A"
+        );
+        assert_eq!(
+            incr_result_three.face_to_cluster.get("dogA_new4"),
+            Some(&cluster_a_id),
+            "THREE: dogA_new4 should be assigned to cluster A"
+        );
+
+        // Dog C should NOT be in cluster A or B
+        let cc = incr_result_three.face_to_cluster.get("dogC_0");
+        if let Some(cid) = cc {
+            assert_ne!(cid, &cluster_a_id);
+            assert_ne!(cid, &cluster_b_id);
+            println!("THREE (exemplars): dogC_0 created new cluster {}", cid);
+        } else {
+            println!("THREE (exemplars): dogC_0 stayed unclustered (only 1 face)");
+        }
+    }
+
+    /// Verify that batch clustering produces exemplars for all clusters.
+    #[test]
+    fn test_batch_produces_exemplars() {
+        let config = ClusterConfig::dog();
+
+        let mut inputs = Vec::new();
+        for i in 0..8u32 {
+            inputs.push(make_input(&format!("a{}", i), make_face(0, i), 0));
+        }
+        for i in 0..8u32 {
+            inputs.push(make_input(&format!("b{}", i), make_face(64, i + 100), 0));
+        }
+
+        let result = run_pet_clustering(&inputs, &config);
+
+        // Every cluster with a centroid should also have exemplars
+        for cid in result.cluster_centroids.keys() {
+            assert!(
+                result.cluster_exemplars.contains_key(cid),
+                "Cluster {} should have exemplars",
+                cid
+            );
+            let exs = &result.cluster_exemplars[cid];
+            assert!(!exs.is_empty(), "Exemplars should not be empty");
+            assert!(
+                exs.len() <= config.max_exemplars,
+                "Should not exceed max_exemplars"
+            );
+            // Each exemplar should be 128-d
+            for ex in exs {
+                assert_eq!(ex.len(), 128);
+            }
+        }
+    }
+
+    #[test]
+    fn test_two_stage_batch_merges_microclusters_back_together() {
+        let config = ClusterConfig::dog();
+
+        let a_left = normalized({
+            let mut v = vec![0.0f32; 128];
+            v[0] = 1.0;
+            v[1] = 0.65;
+            v
+        });
+        let a_right = normalized({
+            let mut v = vec![0.0f32; 128];
+            v[0] = 1.0;
+            v[2] = 0.65;
+            v
+        });
+        let b_left = normalized({
+            let mut v = vec![0.0f32; 128];
+            v[64] = 1.0;
+            v[65] = 0.65;
+            v
+        });
+        let b_right = normalized({
+            let mut v = vec![0.0f32; 128];
+            v[64] = 1.0;
+            v[66] = 0.65;
+            v
+        });
+
+        let inputs = vec![
+            make_input("a_left_0", a_left.clone(), 0),
+            make_input("a_left_1", perturb(&a_left, 3, 0.03), 0),
+            make_input("a_right_0", a_right.clone(), 0),
+            make_input("a_right_1", perturb(&a_right, 4, 0.03), 0),
+            make_input("b_left_0", b_left.clone(), 0),
+            make_input("b_left_1", perturb(&b_left, 67, 0.03), 0),
+            make_input("b_right_0", b_right.clone(), 0),
+            make_input("b_right_1", perturb(&b_right, 68, 0.03), 0),
+        ];
+
+        let result = run_pet_clustering(&inputs, &config);
+
+        let a_cluster = result.face_to_cluster.get("a_left_0").unwrap();
+        let b_cluster = result.face_to_cluster.get("b_left_0").unwrap();
+
+        assert_eq!(a_cluster, result.face_to_cluster.get("a_right_0").unwrap());
+        assert_eq!(a_cluster, result.face_to_cluster.get("a_right_1").unwrap());
+        assert_eq!(b_cluster, result.face_to_cluster.get("b_right_0").unwrap());
+        assert_eq!(b_cluster, result.face_to_cluster.get("b_right_1").unwrap());
+        assert_ne!(a_cluster, b_cluster);
+        assert_eq!(result.cluster_counts[a_cluster], 4);
+        assert_eq!(result.cluster_counts[b_cluster], 4);
+    }
+}

--- a/rust/photos/src/ml/pet/cluster_v2.rs
+++ b/rust/photos/src/ml/pet/cluster_v2.rs
@@ -1,0 +1,620 @@
+//! Pet clustering V2.
+//!
+//! This module keeps the current production-facing types from `cluster.rs`,
+//! but implements a new two-pass clustering strategy inspired by the Apple
+//! Photos writeup:
+//!
+//! 1. A conservative greedy first pass builds small micro-clusters by
+//!    querying `VectorDB` for nearby candidates and assigning by nearest
+//!    already-seen neighbor cluster.
+//! 2. A second pass uses face-only exemplar HAC to merge those micro-clusters
+//!    across broader boundaries.
+//!
+//! This module intentionally exposes only the direct-`VectorDB` flow for the
+//! first pass. It is optimized for face embeddings only.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::ml::pet::cluster::{
+    ClusterConfig, PetClusterIndexInput, PetClusterResult, renumber_labels, select_exemplars,
+    simsimd_cosine_distance, unique_cluster_ids,
+};
+use crate::vector_db::VectorDB;
+
+/// Run V2 clustering while using `VectorDB` directly in the first pass to
+/// fetch candidate neighbors for each observation.
+pub fn run_pet_clustering_from_vdb_v2(
+    inputs: &[PetClusterIndexInput],
+    vdb: &VectorDB,
+    config: &ClusterConfig,
+) -> Result<PetClusterResult, String> {
+    run_pet_clustering_from_vdb_v2_with_stats(inputs, vdb, config).map(|(result, _)| result)
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(not(test), allow(dead_code))]
+struct V2TimingStats {
+    first_pass: Duration,
+    second_pass: Duration,
+}
+
+fn run_pet_clustering_from_vdb_v2_with_stats(
+    inputs: &[PetClusterIndexInput],
+    vdb: &VectorDB,
+    config: &ClusterConfig,
+) -> Result<(PetClusterResult, V2TimingStats), String> {
+    if inputs.is_empty() {
+        return Ok((PetClusterResult::default(), V2TimingStats::default()));
+    }
+
+    let mut key_to_position = HashMap::with_capacity(inputs.len());
+    for (idx, input) in inputs.iter().enumerate() {
+        key_to_position.insert(input.vector_id, idx);
+    }
+
+    let mut vector_cache: HashMap<u64, Vec<f32>> = HashMap::with_capacity(inputs.len());
+    let mut materialized_inputs = Vec::with_capacity(inputs.len());
+    let mut clusters: Vec<GreedyMicroCluster> = Vec::new();
+    let mut assigned_cluster: Vec<Option<usize>> = vec![None; inputs.len()];
+
+    let first_pass_start = Instant::now();
+    for (idx, input) in inputs.iter().enumerate() {
+        let face_embedding = get_cached_vector(vdb, input.vector_id, &mut vector_cache)?;
+        let observation = FaceObservation {
+            pet_face_id: input.pet_face_id.clone(),
+            face_embedding,
+        };
+        materialized_inputs.push(observation.clone());
+
+        let (neighbor_keys, neighbor_distances) =
+            vdb.search_vectors(&observation.face_embedding, 10, false)?;
+
+        let mut candidate_clusters: Vec<(usize, f32)> = Vec::new();
+        for (key, distance) in neighbor_keys
+            .into_iter()
+            .zip(neighbor_distances.into_iter())
+        {
+            if key == input.vector_id {
+                continue;
+            }
+            if !distance.is_finite() || distance > greedy_face_threshold(config) {
+                continue;
+            }
+            let Some(&neighbor_idx) = key_to_position.get(&key) else {
+                continue;
+            };
+            if neighbor_idx >= idx {
+                continue;
+            }
+            if let Some(cluster_idx) = assigned_cluster[neighbor_idx] {
+                if let Some((_, best_dist)) = candidate_clusters
+                    .iter_mut()
+                    .find(|(existing_cluster, _)| *existing_cluster == cluster_idx)
+                {
+                    *best_dist = best_dist.min(distance);
+                } else {
+                    candidate_clusters.push((cluster_idx, distance));
+                }
+            }
+        }
+
+        let cluster_idx = assign_to_greedy_cluster(idx, &candidate_clusters, &mut clusters, config);
+        assigned_cluster[idx] = Some(cluster_idx);
+    }
+    let first_pass_time = first_pass_start.elapsed();
+
+    let second_pass_start = Instant::now();
+    exemplar_hac_merge_v2(&mut clusters, &materialized_inputs, config);
+    let second_pass_time = second_pass_start.elapsed();
+
+    let mut labels = vec![-1i32; materialized_inputs.len()];
+    for (cluster_idx, cluster) in clusters.iter().enumerate() {
+        if cluster.members.len() < config.min_cluster_size {
+            continue;
+        }
+        for &member_idx in &cluster.members {
+            labels[member_idx] = cluster_idx as i32;
+        }
+    }
+    renumber_labels(&mut labels);
+
+    let has_face = vec![true; materialized_inputs.len()];
+    Ok((
+        build_result_v2(&materialized_inputs, &labels, &has_face, config),
+        V2TimingStats {
+            first_pass: first_pass_time,
+            second_pass: second_pass_time,
+        },
+    ))
+}
+
+fn assign_to_greedy_cluster(
+    idx: usize,
+    candidate_clusters: &[(usize, f32)],
+    clusters: &mut Vec<GreedyMicroCluster>,
+    config: &ClusterConfig,
+) -> usize {
+    let mut best_idx = None;
+    let mut best_dist = f32::INFINITY;
+    let mut second_best_dist = f32::INFINITY;
+
+    for &(cluster_idx, dist) in candidate_clusters {
+        if dist < best_dist {
+            second_best_dist = best_dist;
+            best_dist = dist;
+            best_idx = Some(cluster_idx);
+        } else if dist < second_best_dist {
+            second_best_dist = dist;
+        }
+    }
+
+    let has_clear_winner = candidate_clusters.len() <= 1
+        || (second_best_dist - best_dist) > cluster_assignment_margin(config);
+    if best_dist.is_finite()
+        && best_dist <= greedy_face_threshold(config)
+        && has_clear_winner
+        && let Some(cluster_idx) = best_idx
+    {
+        clusters[cluster_idx].add_member(idx, config.max_exemplars);
+        cluster_idx
+    } else {
+        let cluster_idx = clusters.len();
+        clusters.push(GreedyMicroCluster::new(idx, config.max_exemplars));
+        cluster_idx
+    }
+}
+
+fn exemplar_hac_merge_v2(
+    clusters: &mut Vec<GreedyMicroCluster>,
+    inputs: &[FaceObservation],
+    config: &ClusterConfig,
+) {
+    loop {
+        let mut best_pair = None;
+        let mut best_dist = f32::INFINITY;
+
+        for left in 0..clusters.len() {
+            for right in (left + 1)..clusters.len() {
+                let dist = exemplar_cluster_distance_v2(&clusters[left], &clusters[right], inputs);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_pair = Some((left, right));
+                }
+            }
+        }
+
+        let Some((left, right)) = best_pair else {
+            break;
+        };
+        if best_dist > config.agglomerative_threshold {
+            break;
+        }
+
+        let other = clusters.remove(right);
+        clusters[left].merge(other, config.max_exemplars);
+    }
+}
+
+fn exemplar_cluster_distance_v2(
+    left: &GreedyMicroCluster,
+    right: &GreedyMicroCluster,
+    inputs: &[FaceObservation],
+) -> f32 {
+    if left.exemplar_member_indices.is_empty() || right.exemplar_member_indices.is_empty() {
+        return f32::INFINITY;
+    }
+
+    let mut distances = Vec::with_capacity(
+        left.exemplar_member_indices.len() * right.exemplar_member_indices.len(),
+    );
+    for &li in &left.exemplar_member_indices {
+        for &ri in &right.exemplar_member_indices {
+            distances.push(face_distance_v2(
+                &inputs[li].face_embedding,
+                &inputs[ri].face_embedding,
+            ));
+        }
+    }
+    if distances.is_empty() {
+        return f32::INFINITY;
+    }
+
+    distances.sort_by(|a, b| a.total_cmp(b));
+    if distances.len() == 1 {
+        distances[0]
+    } else {
+        (distances[0] + distances[1]) / 2.0
+    }
+}
+
+fn face_distance_v2(left: &[f32], right: &[f32]) -> f32 {
+    simsimd_cosine_distance(left, right)
+}
+
+fn get_cached_vector(
+    vdb: &VectorDB,
+    key: u64,
+    cache: &mut HashMap<u64, Vec<f32>>,
+) -> Result<Vec<f32>, String> {
+    if let Some(vector) = cache.get(&key) {
+        return Ok(vector.clone());
+    }
+    let vector = vdb.get_vector(key)?;
+    cache.insert(key, vector.clone());
+    Ok(vector)
+}
+
+fn build_result_v2(
+    inputs: &[FaceObservation],
+    labels: &[i32],
+    has_face: &[bool],
+    config: &ClusterConfig,
+) -> PetClusterResult {
+    let mut result = PetClusterResult::default();
+
+    let unique = unique_cluster_ids(labels);
+    let cluster_id_map: HashMap<i32, String> = unique
+        .iter()
+        .map(|&cluster| {
+            let first_member = labels
+                .iter()
+                .enumerate()
+                .find(|(_, label)| **label == cluster)
+                .map(|(idx, _)| idx)
+                .unwrap();
+            let cluster_id = format!("pet_cluster_{}", inputs[first_member].pet_face_id);
+            (cluster, cluster_id)
+        })
+        .collect();
+
+    for (idx, input) in inputs.iter().enumerate() {
+        if labels[idx] >= 0 {
+            if let Some(cluster_id) = cluster_id_map.get(&labels[idx]) {
+                result
+                    .face_to_cluster
+                    .insert(input.pet_face_id.clone(), cluster_id.clone());
+                *result.cluster_counts.entry(cluster_id.clone()).or_insert(0) += 1;
+            }
+        } else {
+            result.n_unclustered += 1;
+        }
+    }
+
+    let face_dim = inputs
+        .iter()
+        .find(|input| !input.face_embedding.is_empty())
+        .map(|input| input.face_embedding.len())
+        .unwrap_or(128);
+
+    for (&cluster_label, cluster_id) in &cluster_id_map {
+        let face_embs: Vec<&Vec<f32>> = labels
+            .iter()
+            .enumerate()
+            .filter(|(idx, label)| **label == cluster_label && has_face[*idx])
+            .map(|(idx, _)| &inputs[idx].face_embedding)
+            .collect();
+        if !face_embs.is_empty() {
+            result.cluster_exemplars.insert(
+                cluster_id.clone(),
+                select_exemplars(&face_embs, config.max_exemplars, face_dim),
+            );
+        }
+    }
+
+    result
+}
+
+#[derive(Clone)]
+struct FaceObservation {
+    pet_face_id: String,
+    face_embedding: Vec<f32>,
+}
+
+struct GreedyMicroCluster {
+    members: Vec<usize>,
+    exemplar_member_indices: Vec<usize>,
+}
+
+impl GreedyMicroCluster {
+    fn new(first_idx: usize, max_exemplars: usize) -> Self {
+        let members = vec![first_idx];
+        Self {
+            exemplar_member_indices: deterministic_exemplar_sample(&members, max_exemplars),
+            members,
+        }
+    }
+
+    fn add_member(&mut self, idx: usize, max_exemplars: usize) {
+        self.members.push(idx);
+        self.refresh_exemplars(max_exemplars);
+    }
+
+    fn merge(&mut self, other: Self, max_exemplars: usize) {
+        self.members.extend(other.members);
+        self.refresh_exemplars(max_exemplars);
+    }
+
+    fn refresh_exemplars(&mut self, max_exemplars: usize) {
+        self.exemplar_member_indices = deterministic_exemplar_sample(&self.members, max_exemplars);
+    }
+}
+
+fn deterministic_exemplar_sample(members: &[usize], max_exemplars: usize) -> Vec<usize> {
+    if max_exemplars == 0 || members.is_empty() {
+        return Vec::new();
+    }
+    if members.len() <= max_exemplars {
+        let mut all_members = members.to_vec();
+        all_members.sort_unstable();
+        return all_members;
+    }
+
+    let mut sample = members.to_vec();
+    let mut state = exemplar_seed(members);
+    for i in 0..max_exemplars {
+        let remaining = sample.len() - i;
+        let swap_idx = i + ((next_prng_u64(&mut state) as usize) % remaining);
+        sample.swap(i, swap_idx);
+    }
+    sample.truncate(max_exemplars);
+    sample.sort_unstable();
+    sample
+}
+
+fn exemplar_seed(members: &[usize]) -> u64 {
+    let mut sorted = members.to_vec();
+    sorted.sort_unstable();
+    let mut state = 0x9E37_79B9_7F4A_7C15u64;
+    for &member in &sorted {
+        let mixed = (member as u64).wrapping_add(0x517C_C1B7_2722_0A95u64);
+        state ^= mixed
+            .wrapping_add(0x9E37_79B9_7F4A_7C15u64)
+            .wrapping_add(state << 6)
+            .wrapping_add(state >> 2);
+    }
+    state
+}
+
+fn next_prng_u64(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *state
+}
+
+fn greedy_face_threshold(config: &ClusterConfig) -> f32 {
+    match config.species {
+        crate::ml::pet::cluster::Species::Dog => 0.32,
+        crate::ml::pet::cluster::Species::Cat => 0.52,
+    }
+}
+
+fn cluster_assignment_margin(_config: &ClusterConfig) -> f32 {
+    0.03
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::ml::pet::cluster::{self, Species};
+
+    fn normalize(values: &[f32]) -> Vec<f32> {
+        let norm = values.iter().map(|value| value * value).sum::<f32>().sqrt();
+        values.iter().map(|value| value / norm).collect()
+    }
+
+    fn test_config() -> ClusterConfig {
+        ClusterConfig::for_species(Species::Dog)
+    }
+
+    fn build_test_vdb(
+        vectors: Vec<Vec<f32>>,
+        species: Species,
+    ) -> (tempfile::TempDir, VectorDB, Vec<PetClusterIndexInput>) {
+        let dir = tempdir().expect("tempdir");
+        let index_path = dir.path().join("pet_faces.usearch");
+        let index_path = index_path.to_str().expect("index path").to_string();
+        let mut vdb = VectorDB::new(&index_path, vectors[0].len()).expect("vector db");
+        let keys: Vec<u64> = (0..vectors.len()).map(|idx| idx as u64 + 1).collect();
+        vdb.bulk_add_vectors(keys.clone(), &vectors)
+            .expect("bulk add vectors");
+        let inputs = keys
+            .into_iter()
+            .enumerate()
+            .map(|(idx, key)| PetClusterIndexInput {
+                pet_face_id: format!("pet_face_{idx}"),
+                vector_id: key,
+                species: species as u8,
+                file_id: idx as i64,
+            })
+            .collect();
+        (dir, vdb, inputs)
+    }
+
+    fn face(id: usize, embedding: Vec<f32>) -> FaceObservation {
+        FaceObservation {
+            pet_face_id: format!("face_{id}"),
+            face_embedding: embedding,
+        }
+    }
+
+    fn synthetic_embeddings(
+        clusters: usize,
+        members_per_cluster: usize,
+        dimensions: usize,
+    ) -> Vec<Vec<f32>> {
+        let mut vectors = Vec::with_capacity(clusters * members_per_cluster);
+        for cluster_idx in 0..clusters {
+            let mut base = vec![0.0; dimensions];
+            base[cluster_idx % dimensions] = 1.0;
+            if dimensions > 1 {
+                base[(cluster_idx * 7 + 3) % dimensions] = 0.25;
+            }
+            let base = normalize(&base);
+            for member_idx in 0..members_per_cluster {
+                let mut sample = base.clone();
+                let mut state = exemplar_seed(&[cluster_idx, member_idx, dimensions]);
+                for value in &mut sample {
+                    let noise =
+                        ((next_prng_u64(&mut state) >> 40) as f32 / (1u32 << 24) as f32) - 0.5;
+                    *value += noise * 0.02;
+                }
+                vectors.push(normalize(&sample));
+            }
+        }
+        vectors
+    }
+
+    #[test]
+    fn nearest_neighbor_first_pass_clusters_obvious_same_dog_faces() {
+        let vectors = vec![
+            normalize(&[1.0, 0.0, 0.0, 0.0]),
+            normalize(&[0.0, 1.0, 0.0, 0.0]),
+            normalize(&[0.99, 0.04, 0.0, 0.0]),
+            normalize(&[0.02, 0.99, 0.0, 0.0]),
+        ];
+        let (_dir, vdb, inputs) = build_test_vdb(vectors, Species::Dog);
+
+        let (result, _stats) =
+            run_pet_clustering_from_vdb_v2_with_stats(&inputs, &vdb, &test_config())
+                .expect("v2 clustering");
+
+        assert_eq!(result.n_unclustered, 0);
+        assert_eq!(result.cluster_counts.len(), 2);
+        assert_eq!(
+            result.face_to_cluster["pet_face_0"],
+            result.face_to_cluster["pet_face_2"]
+        );
+        assert_eq!(
+            result.face_to_cluster["pet_face_1"],
+            result.face_to_cluster["pet_face_3"]
+        );
+        assert_ne!(
+            result.face_to_cluster["pet_face_0"],
+            result.face_to_cluster["pet_face_1"]
+        );
+    }
+
+    #[test]
+    fn ambiguous_nearest_neighbor_margin_stays_split() {
+        let config = test_config();
+        let mut clusters = vec![
+            GreedyMicroCluster::new(0, config.max_exemplars),
+            GreedyMicroCluster::new(1, config.max_exemplars),
+        ];
+
+        let assigned = assign_to_greedy_cluster(2, &[(0, 0.10), (1, 0.09)], &mut clusters, &config);
+
+        assert_eq!(assigned, 2);
+        assert_eq!(clusters.len(), 3);
+        assert_eq!(clusters[2].members, vec![2]);
+    }
+
+    #[test]
+    fn second_pass_merges_split_same_dog_micro_clusters() {
+        let config = test_config();
+        let inputs = vec![
+            face(0, normalize(&[1.0, 0.0, 0.0])),
+            face(1, normalize(&[0.99, 0.03, 0.0])),
+            face(2, normalize(&[0.98, 0.05, 0.0])),
+            face(3, normalize(&[0.97, 0.07, 0.0])),
+        ];
+        let mut clusters = vec![
+            GreedyMicroCluster::new(0, config.max_exemplars),
+            GreedyMicroCluster::new(2, config.max_exemplars),
+        ];
+        clusters[0].add_member(1, config.max_exemplars);
+        clusters[1].add_member(3, config.max_exemplars);
+
+        exemplar_hac_merge_v2(&mut clusters, &inputs, &config);
+
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].members.len(), 4);
+    }
+
+    #[test]
+    fn second_pass_rejects_different_dogs_when_only_one_pair_is_close() {
+        let config = test_config();
+        let inputs = vec![
+            face(0, normalize(&[1.0, 0.0, 0.0])),
+            face(1, normalize(&[1.0, 0.0, 0.0])),
+            face(2, normalize(&[0.0, 1.0, 0.0])),
+        ];
+        let mut clusters = vec![
+            GreedyMicroCluster::new(0, config.max_exemplars),
+            GreedyMicroCluster::new(1, config.max_exemplars),
+        ];
+        clusters[1].add_member(2, config.max_exemplars);
+
+        let pair_score = exemplar_cluster_distance_v2(&clusters[0], &clusters[1], &inputs);
+        exemplar_hac_merge_v2(&mut clusters, &inputs, &config);
+
+        assert!(pair_score > config.agglomerative_threshold);
+        assert_eq!(clusters.len(), 2);
+    }
+
+    #[test]
+    fn deterministic_exemplar_sampling_is_stable() {
+        let members = vec![9, 2, 7, 5, 1, 4, 3];
+
+        let first = deterministic_exemplar_sample(&members, 5);
+        let second = deterministic_exemplar_sample(&members, 5);
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 5);
+    }
+
+    #[test]
+    fn build_result_v2_returns_exemplars_without_centroids() {
+        let config = test_config();
+        let inputs = vec![
+            face(0, normalize(&[1.0, 0.0, 0.0])),
+            face(1, normalize(&[0.99, 0.03, 0.0])),
+            face(2, normalize(&[0.0, 1.0, 0.0])),
+            face(3, normalize(&[0.02, 0.99, 0.0])),
+        ];
+        let labels = vec![0, 0, 1, 1];
+        let has_face = vec![true; inputs.len()];
+
+        let result = build_result_v2(&inputs, &labels, &has_face, &config);
+
+        assert!(result.cluster_centroids.is_empty());
+        assert_eq!(result.cluster_counts.len(), 2);
+        assert_eq!(result.cluster_exemplars.len(), 2);
+        assert_eq!(result.face_to_cluster.len(), 4);
+    }
+
+    #[test]
+    #[ignore]
+    fn benchmark_v2_against_current_app_path_on_seeded_synthetic_embeddings() {
+        let config = test_config();
+        let vectors = synthetic_embeddings(20, 50, 128);
+        let (_dir, vdb, inputs) = build_test_vdb(vectors, Species::Dog);
+
+        let baseline_start = Instant::now();
+        let baseline =
+            cluster::run_pet_clustering_from_vdb(&inputs, &vdb, &config).expect("baseline");
+        let baseline_total = baseline_start.elapsed();
+
+        let (v2, stats) =
+            run_pet_clustering_from_vdb_v2_with_stats(&inputs, &vdb, &config).expect("v2");
+        let v2_total = stats.first_pass + stats.second_pass;
+
+        println!(
+            "baseline_total_ms={} baseline_assigned={} baseline_unclustered={} v2_first_pass_ms={} v2_second_pass_ms={} v2_total_ms={} v2_assigned={} v2_unclustered={}",
+            baseline_total.as_millis(),
+            baseline.face_to_cluster.len(),
+            baseline.n_unclustered,
+            stats.first_pass.as_millis(),
+            stats.second_pass.as_millis(),
+            v2_total.as_millis(),
+            v2.face_to_cluster.len(),
+            v2.n_unclustered,
+        );
+    }
+}

--- a/rust/photos/src/ml/pet/mod.rs
+++ b/rust/photos/src/ml/pet/mod.rs
@@ -1,4 +1,6 @@
 pub mod align;
+pub mod cluster;
+pub mod cluster_v2;
 pub mod detect;
 pub mod embed;
 pub mod preprocess;


### PR DESCRIPTION
## Summary
- add the Rust pet clustering module to the shared photos crate
- add the V2 pet clustering path and wire the mobile Rust API entrypoints to it
- export the pet clustering module from the pet ML package

## Verification
- cargo fmt --all --check (rust/photos)
- cargo test ml::pet::cluster_v2 -- --nocapture (rust/photos)
- cargo clippy --all-targets -- -D warnings (rust/photos)
- cargo test api::ml_indexing_api::tests -- --nocapture (mobile/apps/photos/rust)
- cargo clippy --all-targets -- -D warnings (mobile/apps/photos/rust)

## Notes
- mobile/apps/photos/rust cargo fmt --all --check still fails on pre-existing formatting in usearch_api.rs on main, so that file was intentionally left out of this PR