### PR TITLE
[ensu][desktop] Gemma 4

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,6 +1,11 @@
 [alias]
 codegen = ["run", "-p", "codegen", "--"]
 
+[env]
+# Some targets, like armv7 Android, have no enabled target features, so Cargo
+# otherwise omits CARGO_CFG_TARGET_FEATURE. llama-cpp-sys-2 expects it to exist.
+CARGO_CFG_TARGET_FEATURE = ""
+
 [target.'cfg(target_arch = "aarch64")']
 rustflags = ["--cfg", "chacha20_force_neon"]
 
@@ -10,8 +15,7 @@ rustflags = ["--cfg", "chacha20_force_neon"]
 rustflags = ["--cfg", "chacha20_force_neon", "-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.armv7-linux-androideabi]
-# llama-cpp-sys-2 expects Cargo to provide CARGO_CFG_TARGET_FEATURE; armv7 Android has none by default.
-rustflags = ["--cfg", "target_feature=\"\"", "-C", "link-arg=-Wl,-z,max-page-size=16384"]
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.x86_64-linux-android]
 rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -10,7 +10,8 @@ rustflags = ["--cfg", "chacha20_force_neon"]
 rustflags = ["--cfg", "chacha20_force_neon", "-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.armv7-linux-androideabi]
-rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+# llama-cpp-sys-2 expects Cargo to provide CARGO_CFG_TARGET_FEATURE; armv7 Android has none by default.
+rustflags = ["--cfg", "target_feature=\"\"", "-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.x86_64-linux-android]
 rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]

--- a/rust/apps/ensu/src-tauri/Cargo.lock
+++ b/rust/apps/ensu/src-tauri/Cargo.lock
@@ -1185,11 +1185,13 @@ dependencies = [
  "ente-core",
  "inference_rs",
  "keyring",
+ "libc",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/apps/ensu/src-tauri/Cargo.lock
+++ b/rust/apps/ensu/src-tauri/Cargo.lock
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2675,9 +2675,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2947ab625c59d1fdf42e61f538c3fa66f43de2f78316971920873f359483d1d8"
+checksum = "b2e7a3cc3ed741aa3d5e6e3ff1d84d5ab7ba13bf15c857be06a5d11517767616"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2689,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a529006bf16af70c7485ba957820dc2bc9467d75697e97970c81d2da73c76f"
+checksum = "0a2efa5c5675f4e2170c52c4418f71907d39b1e3931fd7566f8382cf9e166282"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/apps/ensu/src-tauri/Cargo.toml
+++ b/rust/apps/ensu/src-tauri/Cargo.toml
@@ -18,6 +18,12 @@ inference_rs = { path = "../../../ensu/inference" }
 uuid = { version = "1", features = ["v4"] }
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_System_SystemInformation"] }
+
 [features]
 custom-protocol = ["tauri/custom-protocol"]
 updater = ["tauri/updater"]

--- a/rust/apps/ensu/src-tauri/src/commands.rs
+++ b/rust/apps/ensu/src-tauri/src/commands.rs
@@ -3,8 +3,6 @@ use std::fs;
 use std::io::{Read, Write};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
-use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -190,30 +188,38 @@ fn default_llm_threads() -> i32 {
     i32::try_from(threads).unwrap_or(1)
 }
 
-#[cfg(target_os = "macos")]
-fn macos_total_memory_bytes() -> Option<u64> {
-    for candidate in ["/usr/sbin/sysctl", "/sbin/sysctl", "sysctl"] {
-        let output = match Command::new(candidate).args(["-n", "hw.memsize"]).output() {
-            Ok(output) => output,
-            Err(_) => continue,
-        };
-
-        if !output.status.success() {
-            continue;
-        }
-
-        if let Ok(text) = String::from_utf8(output.stdout) {
-            if let Ok(bytes) = text.trim().parse::<u64>() {
-                return Some(bytes);
-            }
-        }
+#[cfg(unix)]
+fn total_memory_bytes() -> Option<u64> {
+    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if pages <= 0 || page_size <= 0 {
+        return None;
     }
 
-    None
+    u64::try_from(pages)
+        .ok()?
+        .checked_mul(u64::try_from(page_size).ok()?)
 }
 
-#[cfg(not(target_os = "macos"))]
-fn macos_total_memory_bytes() -> Option<u64> {
+#[cfg(target_os = "windows")]
+fn total_memory_bytes() -> Option<u64> {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+
+    let mut status = MEMORYSTATUSEX {
+        dwLength: std::mem::size_of::<MEMORYSTATUSEX>() as u32,
+        ..Default::default()
+    };
+
+    let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+    if ok == 0 {
+        None
+    } else {
+        Some(status.ullTotalPhys)
+    }
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+fn total_memory_bytes() -> Option<u64> {
     None
 }
 
@@ -1560,7 +1566,7 @@ impl llm::EventSink for LlmEventSink {
 pub fn system_info() -> SystemInfo {
     SystemInfo {
         platform: std::env::consts::OS.to_string(),
-        total_memory_bytes: macos_total_memory_bytes(),
+        total_memory_bytes: total_memory_bytes(),
     }
 }
 

--- a/rust/ensu/inference/Cargo.lock
+++ b/rust/ensu/inference/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2947ab625c59d1fdf42e61f538c3fa66f43de2f78316971920873f359483d1d8"
+checksum = "b2e7a3cc3ed741aa3d5e6e3ff1d84d5ab7ba13bf15c857be06a5d11517767616"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a529006bf16af70c7485ba957820dc2bc9467d75697e97970c81d2da73c76f"
+checksum = "0a2efa5c5675f4e2170c52c4418f71907d39b1e3931fd7566f8382cf9e166282"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/ensu/inference/Cargo.toml
+++ b/rust/ensu/inference/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1"
 #
 # "mtmd" is used on all platforms for enabling multimodal support.
 [target.'cfg(target_os = "macos")'.dependencies]
-llama-cpp-2 = { version = "=0.1.138", default-features = false, features = ["mtmd"] }
+llama-cpp-2 = { version = "=0.1.144", default-features = false, features = ["mtmd"] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-llama-cpp-2 = { version = "=0.1.138", features = ["mtmd"] }
+llama-cpp-2 = { version = "=0.1.144", features = ["mtmd"] }

--- a/rust/ensu/inference/src/defaults.rs
+++ b/rust/ensu/inference/src/defaults.rs
@@ -82,9 +82,21 @@ fn qwen_4b_q4km() -> EnsuModelPreset {
     }
 }
 
+fn gemma_4_e4b_q4km() -> EnsuModelPreset {
+    EnsuModelPreset {
+        id: "gemma-4-e4b-q4km".to_string(),
+        title: "Gemma 4 E4B (Q4_K_M)".to_string(),
+        url: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf?download=true".to_string(),
+        mmproj_url: Some(
+            "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+                .to_string(),
+        ),
+    }
+}
+
 pub fn ensu_defaults() -> EnsuDefaults {
     let mobile_default_model = lfm_vl_1_6b();
-    let desktop_default_model = qwen_4b_q4km();
+    let desktop_default_model = gemma_4_e4b_q4km();
 
     EnsuDefaults {
         mobile_system_prompt_body: MOBILE_SYSTEM_PROMPT_BODY.to_string(),
@@ -94,6 +106,12 @@ pub fn ensu_defaults() -> EnsuDefaults {
         mobile_default_model,
         mobile_model_presets: vec![lfm_1_2b(), qwen_0_8b(), qwen_2b_q8()],
         desktop_default_model,
-        desktop_model_presets: vec![lfm_vl_1_6b(), lfm_1_2b(), qwen_0_8b(), qwen_2b_q8()],
+        desktop_model_presets: vec![
+            qwen_4b_q4km(),
+            lfm_vl_1_6b(),
+            lfm_1_2b(),
+            qwen_0_8b(),
+            qwen_2b_q8(),
+        ],
     }
 }

--- a/rust/uniffi/ensu/inference/Cargo.lock
+++ b/rust/uniffi/ensu/inference/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -390,9 +390,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2947ab625c59d1fdf42e61f538c3fa66f43de2f78316971920873f359483d1d8"
+checksum = "b2e7a3cc3ed741aa3d5e6e3ff1d84d5ab7ba13bf15c857be06a5d11517767616"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.138"
+version = "0.1.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a529006bf16af70c7485ba957820dc2bc9467d75697e97970c81d2da73c76f"
+checksum = "0a2efa5c5675f4e2170c52c4418f71907d39b1e3931fd7566f8382cf9e166282"
 dependencies = [
  "bindgen",
  "cc",

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -14,7 +14,7 @@ const DEFAULT_TAURI_CONTEXT_SIZE = 12000;
 const DEFAULT_GENERATION_MAX_TOKENS = 8_192;
 const OVERFLOW_SAFETY_TOKENS = 256;
 const MIN_GGUF_BYTES = 1024 * 1024; // 1MB
-const MIN_HIGH_RAM_MAC_BYTES = 16 * 1024 * 1024 * 1024;
+const MIN_DESKTOP_DEFAULT_MEMORY_BYTES = 16 * 1024 * 1024 * 1024;
 
 // These fallback values must stay in sync with rust/ensu/inference/src/defaults.rs.
 // When running inside Tauri, resolveDefaultModelForDevice() overwrites them with
@@ -448,12 +448,8 @@ export class LlmProvider {
             const platform = info.platform?.toLowerCase();
             const totalMemoryBytes = info.totalMemoryBytes ?? 0;
 
-            const isMacPlatform =
-                platform === "macos" ||
-                platform === "darwin" ||
-                platform === "mac";
             this.useDesktopRustDefaults =
-                isMacPlatform && totalMemoryBytes >= MIN_HIGH_RAM_MAC_BYTES;
+                totalMemoryBytes >= MIN_DESKTOP_DEFAULT_MEMORY_BYTES;
 
             if (this.useDesktopRustDefaults) {
                 this.defaultModel = DESKTOP_DEFAULT_MODEL;

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -31,14 +31,14 @@ export const DEFAULT_MODEL: ModelInfo = {
 };
 
 const DESKTOP_DEFAULT_MODEL: ModelInfo = {
-    id: "qwen-4b-q4km",
-    name: "Qwen 3.5 4B (Q4_K_M)",
-    url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true",
+    id: "gemma-4-e4b-q4km",
+    name: "Gemma 4 E4B (Q4_K_M)",
+    url: "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf?download=true",
     mmprojUrl:
-        "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf",
-    sizeBytes: 2_740_937_888,
-    mmprojSizeBytes: 672_423_616,
-    sizeHuman: "3.63 GB",
+        "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf",
+    sizeBytes: 4_977_169_088,
+    mmprojSizeBytes: 990_372_800,
+    sizeHuman: "5.97 GB",
 };
 
 interface TauriEnsuModelPreset {
@@ -83,6 +83,11 @@ export const FALLBACK_MOBILE_MODEL_PRESETS: ResolvedModelPreset[] = [
 ];
 
 export const FALLBACK_DESKTOP_MODEL_PRESETS: ResolvedModelPreset[] = [
+    {
+        name: "Qwen 3.5 4B (Q4_K_M)",
+        url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true",
+        mmproj: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf",
+    },
     {
         name: "LFM 2.5 VL 1.6B (Q4_0)",
         url: "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/LFM2.5-VL-1.6B-Q4_0.gguf?download=true",


### PR DESCRIPTION
- Upgrade `llama-cpp-2` from `0.1.138` to `0.1.144`
- Update the Rust desktop default model to Gemma 4 E4B Q4_K_M
- Update the web fallback desktop default metadata to match Gemma 4 E4B, including model/mmproj size fields
- Keep the previous Qwen 3.5 4B Q4_K_M desktop default available as a desktop preset
- Refresh the affected Rust lockfiles