### PR TITLE
Fix resumable downloads through signed redirects

### DIFF
--- a/mobile/apps/photos/lib/module/download/manager.dart
+++ b/mobile/apps/photos/lib/module/download/manager.dart
@@ -286,7 +286,11 @@ class DownloadManager {
           'but got $actualSize bytes',
         );
         existingChunks[i] = false;
-        // await chunkFile.delete(); // Remove corrupted chunk
+        try {
+          await chunkFile.delete();
+        } catch (e) {
+          _logger.warning('Failed to delete corrupted chunk ${i + 1}', e);
+        }
       }
     }
 

--- a/mobile/apps/photos/lib/module/download/manager.dart
+++ b/mobile/apps/photos/lib/module/download/manager.dart
@@ -322,15 +322,13 @@ class DownloadManager {
         ? task.totalBytes - 1
         : (startByte + downloadChunkSize) - 1;
     _logger.info('Downloading chunk ${chunkIndex + 1}/$totalChunks');
+    final downloadUrl = await _resolveDownloadRedirect(task.id, cancelToken);
     await _dio.download(
-      FileUrl.getUrl(task.id, FileUrlType.directDownload),
+      downloadUrl,
       chunkPath,
-      queryParameters: {
-        "token": Configuration.instance.getToken(),
-      },
       options: Options(
         headers: {
-          "Range": "bytes=$startByte-$endByte",
+          HttpHeaders.rangeHeader: "bytes=$startByte-$endByte",
         },
       ),
       cancelToken: cancelToken,
@@ -347,6 +345,36 @@ class DownloadManager {
       bytesDownloaded: (chunkIndex) * downloadChunkSize + chunkFileSize,
     );
     _updateTask(task);
+  }
+
+  Future<String> _resolveDownloadRedirect(
+    int fileID,
+    CancelToken cancelToken,
+  ) async {
+    final response = await _dio.get<void>(
+      FileUrl.getUrl(fileID, FileUrlType.directDownload),
+      options: Options(
+        followRedirects: false,
+        receiveDataWhenStatusError: false,
+        headers: {
+          "X-Auth-Token": Configuration.instance.getToken(),
+        },
+        validateStatus: (status) {
+          return status != null &&
+              status >= HttpStatus.multipleChoices &&
+              status < HttpStatus.badRequest;
+        },
+      ),
+      cancelToken: cancelToken,
+    );
+    final location = response.headers.value(HttpHeaders.locationHeader);
+    if (location == null || location.isEmpty) {
+      throw StateError(
+        'Missing redirect location for file $fileID '
+        '(status ${response.statusCode})',
+      );
+    }
+    return location;
   }
 
   Future<String> _combineChunks(String basePath, int totalChunks) async {

--- a/mobile/apps/photos/lib/module/download/manager.dart
+++ b/mobile/apps/photos/lib/module/download/manager.dart
@@ -206,6 +206,7 @@ class DownloadManager {
       _logger.info(
         'Resuming download for ${task.filename} (${task.bytesDownloaded}/${task.totalBytes} bytes)',
       );
+      String? downloadUrl;
       for (int i = 0; i < totalChunks; i++) {
         if (existingChunks[i]) {
           continue;
@@ -214,7 +215,15 @@ class DownloadManager {
           _logger.info('Download cancelled for ${task.filename}');
           break;
         }
-        await _downloadChunk(task, basePath, i, totalChunks, cancelToken);
+        downloadUrl ??= await _resolveDownloadRedirect(task.id, cancelToken);
+        await _downloadChunk(
+          task,
+          basePath,
+          i,
+          totalChunks,
+          cancelToken,
+          downloadUrl,
+        );
         existingChunks[i] = true;
       }
 
@@ -319,6 +328,7 @@ class DownloadManager {
     int chunkIndex,
     int totalChunks,
     CancelToken cancelToken,
+    String downloadUrl,
   ) async {
     final chunkPath = _getChunkPath(basePath, chunkIndex + 1);
     final startByte = chunkIndex * downloadChunkSize;
@@ -326,7 +336,6 @@ class DownloadManager {
         ? task.totalBytes - 1
         : (startByte + downloadChunkSize) - 1;
     _logger.info('Downloading chunk ${chunkIndex + 1}/$totalChunks');
-    final downloadUrl = await _resolveDownloadRedirect(task.id, cancelToken);
     await _dio.download(
       downloadUrl,
       chunkPath,


### PR DESCRIPTION
## Summary
- resolve the Museum download redirect before issuing ranged chunk requests
- reuse the signed object URL for all missing chunks in one download attempt
- delete invalid partial chunk files before retrying them

## Validation
- flutter analyze
- git diff --check upstream/main...HEAD