### PR TITLE
docs: document file content hash format in architecture overview

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -97,6 +97,12 @@ unencrypted.
 - Each `collectionKey` is then encrypted with your `masterKey`.
 - All of the above mentioned encrypted data is then pushed to the server for
   storage.
+- Before encryption, the client also computes a content hash of the original
+  file using `BLAKE2b-512` (libsodium's `crypto_generichash`, 64-byte output)
+  and stores it base64-encoded in the file's (encrypted) metadata as a `hash`
+  field. This lets clients verify integrity of decrypted content end-to-end
+  without involving the server, and supports content-based deduplication
+  during re-uploads.
 
 <img src="assets/file-encryption.svg" class="architecture-svg" title="File
 encryption" />


### PR DESCRIPTION
The architecture overview describes how files are encrypted and how keys flow, but doesn't mention that the client also computes a BLAKE2b-512 content hash of each file's plaintext and stores it in the encrypted metadata.

This detail is documented in `mobile/native/darwin/Packages/EnteCrypto/CRYPTO_SPEC.md` under "Hash Verification System" but is easy to miss when reading the architecture overview — particularly for anyone integrating against the API or building a third-party client.

Adds one bullet to the Upload section noting:
- Algorithm: BLAKE2b-512 via `crypto_generichash`
- Encoding: base64
- Storage: file's encrypted metadata, `hash` field
- Purpose: client-side integrity verification + content-based dedup

Confirmed against `CRYPTO_SPEC.md` and against decrypted metadata samples.