### PR TITLE
[mob][photos] Use video copy for likes/comments on videos in feed

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -2851,6 +2851,10 @@
   "@likedYourVideo": {
     "description": "Social notification action text shown after a person's name, for example 'John liked your video'. Make sure the translation reads naturally with a name before it, and do not capitalize the first letter."
   },
+  "likedAVideo": "liked a video",
+  "@likedAVideo": {
+    "description": "Social action text shown after a person's name, for example 'John liked a video'. Make sure the translation reads naturally with a name before it, and do not capitalize the first letter."
+  },
   "commentedOnYourPhoto": "commented on your photo",
   "@commentedOnYourPhoto": {
     "description": "Social notification action text shown after a person's name, for example 'John commented on your photo'. Make sure the translation reads naturally with a name before it, and do not capitalize the first letter."

--- a/mobile/apps/photos/lib/models/social/feed_data_provider.dart
+++ b/mobile/apps/photos/lib/models/social/feed_data_provider.dart
@@ -6,6 +6,7 @@ import "package:photos/db/social_db.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
+import "package:photos/models/file/file_type.dart";
 import "package:photos/models/social/comment.dart";
 import "package:photos/models/social/feed_item.dart";
 import "package:photos/models/social/reaction.dart";
@@ -294,6 +295,8 @@ class FeedDataProvider {
         createdAt: reactions.first.createdAt,
         isOwnedByCurrentUser:
             fileID != null && filesByID[fileID]?.ownerID == userID,
+        isVideo: fileID != null &&
+            filesByID[fileID]?.fileType == FileType.video,
       );
     }).toList();
   }
@@ -340,6 +343,8 @@ class FeedDataProvider {
         createdAt: comments.first.createdAt,
         isOwnedByCurrentUser:
             fileID != null && filesByID[fileID]?.ownerID == userID,
+        isVideo: fileID != null &&
+            filesByID[fileID]?.fileType == FileType.video,
       );
     }).toList();
   }

--- a/mobile/apps/photos/lib/models/social/feed_item.dart
+++ b/mobile/apps/photos/lib/models/social/feed_item.dart
@@ -58,6 +58,11 @@ class FeedItem {
   /// Populated for [FeedItemType.sharedPhoto] and [FeedItemType.sharedCollection].
   final String? collectionName;
 
+  /// Whether the target file is a video.
+  /// Only meaningful for types whose copy varies by photo vs video
+  /// ([FeedItemType.photoLike] and [FeedItemType.comment]).
+  final bool isVideo;
+
   const FeedItem({
     required this.type,
     required this.collectionID,
@@ -69,6 +74,7 @@ class FeedItem {
     required this.isOwnedByCurrentUser,
     this.sharedFileIDs,
     this.collectionName,
+    this.isVideo = false,
   });
 
   /// Number of users who performed this action.
@@ -126,6 +132,7 @@ class FeedItem {
     bool? isOwnedByCurrentUser,
     List<int>? sharedFileIDs,
     String? collectionName,
+    bool? isVideo,
   }) {
     return FeedItem(
       type: type ?? this.type,
@@ -138,6 +145,7 @@ class FeedItem {
       isOwnedByCurrentUser: isOwnedByCurrentUser ?? this.isOwnedByCurrentUser,
       sharedFileIDs: sharedFileIDs ?? this.sharedFileIDs,
       collectionName: collectionName ?? this.collectionName,
+      isVideo: isVideo ?? this.isVideo,
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/social/widgets/feed_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/feed_item_widget.dart
@@ -617,12 +617,16 @@ class _FeedTextContent extends StatelessWidget {
     switch (feedItem.type) {
       case FeedItemType.photoLike:
         return TextSpan(
-          text: isOwn ? l10n.likedYourPhoto : l10n.likedAPhoto,
+          text: feedItem.isVideo
+              ? (isOwn ? l10n.likedYourVideo : l10n.likedAVideo)
+              : (isOwn ? l10n.likedYourPhoto : l10n.likedAPhoto),
           style: baseStyle,
         );
       case FeedItemType.comment:
         return TextSpan(
-          text: isOwn ? l10n.commentedOnYourPhoto : l10n.commentedOnAPhoto,
+          text: feedItem.isVideo
+              ? (isOwn ? l10n.commentedOnYourVideo : l10n.commentedOnAVideo)
+              : (isOwn ? l10n.commentedOnYourPhoto : l10n.commentedOnAPhoto),
           style: baseStyle,
         );
       case FeedItemType.reply:

--- a/mobile/apps/photos/lib/ui/social/widgets/feed_preview_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/feed_preview_item_widget.dart
@@ -321,12 +321,16 @@ class _PreviewTextContent extends StatelessWidget {
     switch (feedItem.type) {
       case FeedItemType.photoLike:
         return TextSpan(
-          text: isOwn ? l10n.likedYourPhoto : l10n.likedAPhoto,
+          text: feedItem.isVideo
+              ? (isOwn ? l10n.likedYourVideo : l10n.likedAVideo)
+              : (isOwn ? l10n.likedYourPhoto : l10n.likedAPhoto),
           style: baseStyle,
         );
       case FeedItemType.comment:
         return TextSpan(
-          text: isOwn ? l10n.commentedOnYourPhoto : l10n.commentedOnAPhoto,
+          text: feedItem.isVideo
+              ? (isOwn ? l10n.commentedOnYourVideo : l10n.commentedOnAVideo)
+              : (isOwn ? l10n.commentedOnYourPhoto : l10n.commentedOnAPhoto),
           style: baseStyle,
         );
       case FeedItemType.reply:


### PR DESCRIPTION
## Summary

Feed items previously rendered "liked your photo" and "commented on your photo" even when the target file was a video. Adds an `isVideo` flag to `FeedItem` (populated from `filesByID[fileID].fileType` in the aggregator) and uses it in the `photoLike` and `comment` arms of both `feed_item_widget.dart` and `feed_preview_item_widget.dart`.

The push-notification path (`social_notification_coordinator.dart`) was already correct and is unchanged.


