### PR TITLE
[server] Add upload eligibility endpoint

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -569,6 +569,7 @@ func main() {
 		FileUrlCtrl:  fileLinkCtrl,
 	}
 	pasteHandler := &api.PasteHandler{Controller: pasteCtrl}
+	privateAPI.GET("/files/upload-eligibility", fileHandler.ValidateUploadEligibility)
 	privateAPI.GET("/files/upload-urls", fileHandler.GetUploadURLs)
 	privateAPI.GET("/files/multipart-upload-urls", fileHandler.GetMultipartUploadURLs)
 	privateAPI.POST("/files/upload-url", fileHandler.GetUploadURLV2)

--- a/server/pkg/api/file.go
+++ b/server/pkg/api/file.go
@@ -150,6 +150,17 @@ func (h *FileHandler) GetUploadURLs(c *gin.Context) {
 	})
 }
 
+// ValidateUploadEligibility verifies that the user can upload without minting upload URLs.
+func (h *FileHandler) ValidateUploadEligibility(c *gin.Context) {
+	enteApp := auth.GetApp(c)
+	userID := auth.GetUserID(c.Request.Header)
+	if err := h.Controller.ValidateUploadEligibility(c, userID, enteApp); err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	c.Status(http.StatusOK)
+}
+
 // GetUploadURLV2 returns a single upload URL that enforces checksum + content-length headers
 func (h *FileHandler) GetUploadURLV2(c *gin.Context) {
 	enteApp := auth.GetApp(c)

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -347,6 +347,14 @@ func (c *FileController) GetUploadURLs(ctx context.Context, userID int64, count 
 	return urls, nil
 }
 
+// ValidateUploadEligibility checks if a user is allowed to upload without minting upload URLs.
+func (c *FileController) ValidateUploadEligibility(ctx context.Context, userID int64, app ente.App) error {
+	if err := c.UsageCtrl.CanUploadFile(ctx, userID, nil, app); err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	return nil
+}
+
 // GetUploadURLWithMetadata returns a single presigned URL that enforces checksum & length
 func (c *FileController) GetUploadURLWithMetadata(ctx context.Context, userID int64, req ente.UploadURLRequest, app ente.App) (ente.UploadURL, error) {
 	if req.ContentLength <= 0 {


### PR DESCRIPTION
## Summary
- Add a private `/files/upload-eligibility` endpoint.
- Reuse the existing upload eligibility check without minting pre-signed upload URLs.

## Validation
- `git diff --check`
- `go test ./pkg/api ./cmd/museum`
