### PR TITLE
[server] Remove inactive account deletion Discord alert

### DIFF
--- a/server/pkg/controller/user/inactive_user_orchestrator.go
+++ b/server/pkg/controller/user/inactive_user_orchestrator.go
@@ -467,12 +467,6 @@ func (c *InactiveUserOrchestrator) processCandidate(candidate repo.UserInactivit
 		"deletion_date": deletionDate,
 	}).Info("Sent inactive user email")
 
-	if config.IsFinal {
-		c.DiscordController.NotifyAdminAction(
-			fmt.Sprintf("Inactive user %d (%s) reached 13 months inactivity and account deletion was initiated",
-				user.ID, user.Email))
-	}
-
 	return stage, true, false, false, nil
 }
 


### PR DESCRIPTION
## Summary
- Remove the per-user Discord admin alert emitted after inactive accounts reach the final deletion stage.
- Keep the automated deletion flow, final email, notification history update, and run summary behavior unchanged.

## Testing
- `go test ./pkg/controller/user`
- `git diff --check`