### PR TITLE
Allow collaborators to upload directly to shared albums

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -1889,32 +1889,10 @@ class CollectionsService {
       }
 
       if (filesToCopy.isNotEmpty) {
-        final dstCollection = _collectionIDToCollections[dstCollectionID];
-        final currentUserID = _config.getUserID()!;
-        final shouldCopyViaUncategorized = dstCollection != null &&
-            !dstCollection.isOwner(currentUserID) &&
-            dstCollection.canAdd(currentUserID);
-
-        final int copyDestinationCollectionID;
-        if (shouldCopyViaUncategorized) {
-          final uncategorizedCollection =
-              await CollectionsService.instance.getUncategorizedCollection();
-          copyDestinationCollectionID = uncategorizedCollection.id;
-        } else {
-          copyDestinationCollectionID = dstCollectionID;
-        }
-
-        final copiedFiles = await _copyFilesToCollection(
+        await _copyFilesToCollection(
           filesToCopy,
-          dstCollectionID: copyDestinationCollectionID,
+          dstCollectionID: dstCollectionID,
         );
-
-        if (shouldCopyViaUncategorized) {
-          await _addToCollection(
-            dstCollectionID,
-            copiedFiles,
-          );
-        }
       }
     }
   }

--- a/server/ente/file.go
+++ b/server/ente/file.go
@@ -165,6 +165,11 @@ type UploadURL struct {
 type UploadURLRequest struct {
 	ContentLength int64  `json:"contentLength" binding:"required"`
 	ContentMD5    string `json:"contentMD5" binding:"required"`
+	// CollectionID, when non-zero, scopes the quota check to the album owner
+	// instead of the actor. The actor must have CanAdd on this collection.
+	// Optional for backwards compatibility — clients that omit it (or pass 0)
+	// get the legacy actor-quota behavior.
+	CollectionID int64 `json:"collectionID,omitempty"`
 }
 
 // MultipartUploadURLs represents the part upload url for a specific object
@@ -179,6 +184,9 @@ type MultipartUploadURLRequest struct {
 	ContentLength int64    `json:"contentLength" binding:"required"`
 	PartLength    int64    `json:"partLength" binding:"required"`
 	PartMD5s      []string `json:"partMd5s" binding:"required"`
+	// CollectionID, when non-zero, scopes the quota check to the album owner
+	// instead of the actor. See UploadURLRequest.CollectionID.
+	CollectionID int64 `json:"collectionID,omitempty"`
 }
 
 type ObjectType string

--- a/server/migrations/121_add_added_by_user_id_cf.down.sql
+++ b/server/migrations/121_add_added_by_user_id_cf.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collection_files
+    DROP COLUMN IF EXISTS added_by_user_id;

--- a/server/migrations/121_add_added_by_user_id_cf.up.sql
+++ b/server/migrations/121_add_added_by_user_id_cf.up.sql
@@ -1,0 +1,6 @@
+-- Track who actually added each row in collection_files. NULL means
+-- "added by collection owner" (legacy rows). For collaborator-uploaded
+-- files this records the collaborator's user_id while file.owner_id stays
+-- with the album owner.
+ALTER TABLE collection_files
+    ADD COLUMN IF NOT EXISTS added_by_user_id BIGINT;

--- a/server/pkg/api/file.go
+++ b/server/pkg/api/file.go
@@ -140,7 +140,8 @@ func (h *FileHandler) GetUploadURLs(c *gin.Context) {
 
 	userID := auth.GetUserID(c.Request.Header)
 	count, _ := strconv.Atoi(c.Query("count"))
-	urls, err := h.Controller.GetUploadURLs(c, userID, count, enteApp, false)
+	collectionID, _ := strconv.ParseInt(c.Query("collectionID"), 10, 64)
+	urls, err := h.Controller.GetUploadURLs(c, userID, count, enteApp, false, collectionID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -184,7 +185,8 @@ func (h *FileHandler) GetMultipartUploadURLs(c *gin.Context) {
 
 	userID := auth.GetUserID(c.Request.Header)
 	count, _ := strconv.Atoi(c.Query("count"))
-	urls, err := h.Controller.GetMultipartUploadURLs(c, userID, count, enteApp)
+	collectionID, _ := strconv.ParseInt(c.Query("collectionID"), 10, 64)
+	urls, err := h.Controller.GetMultipartUploadURLs(c, userID, count, enteApp, collectionID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/api/public_collection.go
+++ b/server/pkg/api/public_collection.go
@@ -133,7 +133,7 @@ func (h *PublicCollectionHandler) GetUploadUrls(c *gin.Context) {
 	}
 	userID := collection.Owner.ID
 	count, _ := strconv.Atoi(c.Query("count"))
-	urls, err := h.FileCtrl.GetUploadURLs(c, userID, count, enteApp, false)
+	urls, err := h.FileCtrl.GetUploadURLs(c, userID, count, enteApp, false, 0)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -175,7 +175,7 @@ func (h *PublicCollectionHandler) GetMultipartUploadURLs(c *gin.Context) {
 	}
 	userID := collection.Owner.ID
 	count, _ := strconv.Atoi(c.Query("count"))
-	urls, err := h.FileCtrl.GetMultipartUploadURLs(c, userID, count, enteApp)
+	urls, err := h.FileCtrl.GetMultipartUploadURLs(c, userID, count, enteApp, 0)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/controller/collections/file_action.go
+++ b/server/pkg/controller/collections/file_action.go
@@ -163,13 +163,17 @@ func (c *CollectionController) MoveFiles(ctx *gin.Context, req ente.MoveFilesReq
 
 // RemoveFilesV3 enforces all removal rules for shared collections:
 //  1. accessCtrl must confirm the actor participates in the collection;
-//  2. collaborators/viewers may only remove the files they added themselves;
-//  3. the collection owner may remove files added by others but never their own;
-//  4. admins can remove anyone's files, but a collection owner's files are only
-//     queued for removal (REMOVE action + pending collection_action entry) so
-//     the owner can act on them;
-//  5. once the validations pass, non-owner files are deleted immediately via
-//     CollectionRepo.RemoveFilesV3.
+//  2. collaborators/viewers may only remove files they themselves added
+//     (added_by_user_id == actor) — note this is decoupled from file
+//     ownership: a collaborator-uploaded file is owned by the album owner
+//     but added_by remains the collaborator;
+//  3. the collection owner may remove files added by others but never the
+//     ones they added themselves (those go through Trash);
+//  4. admins can remove anyone's files; files originally added by the
+//     collection owner are queued for removal (REMOVE action + pending
+//     collection_action entry) so the owner can act on them;
+//  5. once the validations pass, non-owner-uploaded files are detached
+//     immediately via CollectionRepo.RemoveFilesV3.
 func (c *CollectionController) RemoveFilesV3(ctx *gin.Context, actorUserID int64, req ente.RemoveFilesV3Request) error {
 	accessResp, err := c.AccessCtrl.GetCollection(ctx, &access.GetCollectionParams{
 		CollectionID: req.CollectionID,
@@ -192,49 +196,56 @@ func (c *CollectionController) RemoveFilesV3(ctx *gin.Context, actorUserID int64
 	}
 	req.FileIDs = fileIDsToRemove
 
-	// Partition fileIDs by owner
-	ownerToFilesMap, err := c.FileRepo.GetOwnerToFileIDsMap(ctx, req.FileIDs)
+	// Partition fileIDs by uploader (added_by_user_id, with NULL fallback to f_owner_id).
+	addedByMap, err := c.CollectionRepo.GetAddedByMapForCollection(ctx, req.CollectionID, req.FileIDs)
 	if err != nil {
-		return stacktrace.Propagate(err, "failed to get owner to fileIDs map")
+		return stacktrace.Propagate(err, "failed to get added_by map")
 	}
-	if err := c.isRemoveAllowed(ctx, actorUserID, collectionOwnerID, role, ownerToFilesMap); err != nil {
-		return stacktrace.Propagate(err, "file removal check failed for others")
-	}
-	filesOwnedByCollectionOwner := ownerToFilesMap[collectionOwnerID]
-
-	// Files owned by others (excluding owner)
-	ownerFilesSet := make(map[int64]struct{}, len(filesOwnedByCollectionOwner))
-	for _, fid := range filesOwnedByCollectionOwner {
-		ownerFilesSet[fid] = struct{}{}
-	}
-	others := make([]int64, 0, len(req.FileIDs)-len(filesOwnedByCollectionOwner))
+	ownerUploaded := make([]int64, 0)
+	otherUploaded := make([]int64, 0)
+	actorUploaded := make([]int64, 0)
 	for _, fid := range req.FileIDs {
-		if _, found := ownerFilesSet[fid]; !found {
-			others = append(others, fid)
+		addedBy, ok := addedByMap[fid]
+		if !ok {
+			return stacktrace.NewError(fmt.Sprintf("missing added_by for file %d in collection %d", fid, req.CollectionID))
+		}
+		switch addedBy {
+		case actorUserID:
+			actorUploaded = append(actorUploaded, fid)
+		case collectionOwnerID:
+			ownerUploaded = append(ownerUploaded, fid)
+		default:
+			otherUploaded = append(otherUploaded, fid)
 		}
 	}
+	if err := c.isRemoveAllowedByUploader(actorUserID, collectionOwnerID, role, actorUploaded, ownerUploaded, otherUploaded); err != nil {
+		return stacktrace.Propagate(err, "file removal check failed")
+	}
 
-	// If admin is trying to remove owner's files
-	if len(filesOwnedByCollectionOwner) > 0 {
+	// ADMIN suggesting removal of owner-uploaded files: queue suggest-action
+	// rather than detach immediately.
+	if len(ownerUploaded) > 0 {
 		if role != nil && *role == ente.ADMIN && actorUserID != collectionOwnerID {
-			// Populate collection_files with action for owner's files
-			if err := c.CollectionRepo.SuggestAction(ctx, req.CollectionID, actorUserID, filesOwnedByCollectionOwner, ente.ActionRemove); err != nil {
+			if err := c.CollectionRepo.SuggestAction(ctx, req.CollectionID, actorUserID, ownerUploaded, ente.ActionRemove); err != nil {
 				return stacktrace.Propagate(err, "failed to set remove action for owner's files")
 			}
-			if err := c.CollectionActionsRepo.CreateBulk(ctx, collectionOwnerID, actorUserID, req.CollectionID, filesOwnedByCollectionOwner, nil, ente.ActionRemove, true); err != nil {
+			if err := c.CollectionActionsRepo.CreateBulk(ctx, collectionOwnerID, actorUserID, req.CollectionID, ownerUploaded, nil, ente.ActionRemove, true); err != nil {
 				return stacktrace.Propagate(err, "failed to create collection action REMOVE")
 			}
 		} else {
-			// unless client is buggy, we should never reach here.
-			return stacktrace.NewError(fmt.Sprintf("actor %d with role %s is not allowed to remove files owned by collectionOwner %d", actorUserID, *role, collectionOwnerID))
+			// Should be unreachable when isRemoveAllowedByUploader passed.
+			return stacktrace.NewError(fmt.Sprintf("actor %d with role %v is not allowed to remove files added by collection owner %d", actorUserID, role, collectionOwnerID))
 		}
 	}
-	// Remove files owned by others if allowed
-	if len(others) > 0 {
-		if err := c.CollectionRepo.RemoveFilesV3(ctx, req.CollectionID, collectionOwnerID, others); err != nil {
+
+	// Files added by actor (collaborator/admin removing their own contributions)
+	// or by other non-owner participants (owner/admin removing them) are
+	// detached immediately.
+	immediate := append(actorUploaded, otherUploaded...)
+	if len(immediate) > 0 {
+		if err := c.CollectionRepo.RemoveFilesV3(ctx, req.CollectionID, collectionOwnerID, immediate); err != nil {
 			return stacktrace.Propagate(err, "failed to remove files")
 		}
-
 	}
 	return nil
 }
@@ -292,37 +303,38 @@ func (c *CollectionController) SuggestDeleteInSharedCollection(ctx *gin.Context,
 	return nil
 }
 
-// isRemoveAllowed verifies that given set of files can be removed from the collection or not
-func (c *CollectionController) isRemoveAllowed(ctx *gin.Context,
+// isRemoveAllowedByUploader checks the partition built from added_by_user_id:
+//   - actorUploaded — files the actor added themselves
+//   - ownerUploaded — files the collection owner added (only when actor != owner)
+//   - otherUploaded — files added by some third participant (not actor, not owner)
+//
+// Rules:
+//   - The collection owner cannot remove their own contributions via this
+//     path — they must use Trash, which deletes the file globally.
+//   - ADMIN can remove anything. Owner-uploaded files are routed through a
+//     suggest-action queue by the caller, but pass the permission check here.
+//   - The collection owner can remove anything they did not upload.
+//   - COLLABORATOR / VIEWER can only remove files they themselves added.
+func (c *CollectionController) isRemoveAllowedByUploader(
 	actorUserID int64,
 	collectionOwnerID int64,
 	role *ente.CollectionParticipantRole,
-	ownerToFilesMap map[int64][]int64) error {
+	actorUploaded []int64,
+	ownerUploaded []int64,
+	otherUploaded []int64) error {
 
-	// verify that none of the file belongs to the collection owner
-	if _, ok := ownerToFilesMap[collectionOwnerID]; ok {
-		if collectionOwnerID == actorUserID {
-			return stacktrace.Propagate(ente.NewBadRequestWithMessage("can not remove files owned collection owner, admins can perform remove suggestion"), "")
-		} else if role == nil || *role != ente.ADMIN {
-			return stacktrace.Propagate(ente.NewBadRequestWithMessage("can not remove files owned by album owner"), fmt.Sprintf("role %s", *role))
-		}
+	if actorUserID == collectionOwnerID && len(actorUploaded) > 0 {
+		return stacktrace.Propagate(ente.NewBadRequestWithMessage("can not remove files added by collection owner via remove; use trash"), "")
 	}
-	// allow collection owner to remove files added by others
-	if collectionOwnerID == actorUserID {
-		return nil
-	}
-	// allow admins to remove files added by anyone else.
 	if role != nil && *role == ente.ADMIN {
 		return nil
 	}
-	// for collaborators and viewers, they should be only removing files added by themselfs.
-	// verify that user is only trying to remove files owned by them
-	if len(ownerToFilesMap) > 1 {
-		return stacktrace.Propagate(ente.ErrPermissionDenied, "can not remove files owned by others")
+	if actorUserID == collectionOwnerID {
+		return nil
 	}
-	// verify that user is only trying to remove files owned by them
-	if _, ok := ownerToFilesMap[actorUserID]; !ok {
-		return stacktrace.Propagate(ente.ErrPermissionDenied, "can not remove files owned by others")
+	// COLLABORATOR / VIEWER: only files they added themselves.
+	if len(ownerUploaded) > 0 || len(otherUploaded) > 0 {
+		return stacktrace.Propagate(ente.ErrPermissionDenied, "can not remove files added by others")
 	}
 	return nil
 }
@@ -336,14 +348,19 @@ func (c *CollectionController) IsCopyAllowed(ctx *gin.Context, actorUserID int64
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to verify srcCollection access")
 	}
-	// verify that dstCollectionID is owned by actorUserID
+	// Verify that the actor has CanAdd on the destination collection. Mirrors
+	// the loosening applied to POST /files: a collaborator may copy into a
+	// shared album whose owner pays the storage. file ownership and quota
+	// are pinned to the album owner inside FileController.Create.
 	dstCollection, err := c.AccessCtrl.GetCollection(ctx, &access.GetCollectionParams{
 		CollectionID: req.DstCollection,
 		ActorUserID:  actorUserID,
-		VerifyOwner:  true,
 	})
 	if err != nil {
-		return stacktrace.Propagate(err, "failed to ownership of the dstCollection access")
+		return stacktrace.Propagate(err, "failed to verify dstCollection access")
+	}
+	if !dstCollection.Role.CanAdd() {
+		return stacktrace.Propagate(ente.ErrPermissionDenied, fmt.Sprintf("user %d cannot add files to dst collection %d", actorUserID, req.DstCollection))
 	}
 	if srcCollection.Collection.App != dstCollection.Collection.App {
 		return stacktrace.Propagate(ente.ErrInvalidApp, fmt.Sprintf("copy across app not supported %s to %s", srcCollection.Collection.App, dstCollection.Collection.App))

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -98,28 +98,33 @@ func (c *FileController) validateFileCreateOrUpdateReq(userID int64, file ente.F
 	if file.UpdationTime == 0 {
 		return stacktrace.Propagate(ente.ErrBadRequest, "UpdationTime is required")
 	}
-	if isCreateFileReq {
-		collection, err := c.CollectionRepo.Get(file.CollectionID)
-		if err != nil {
-			return stacktrace.Propagate(err, "")
-		}
-		if ente.App(collection.App) != app {
-			return stacktrace.Propagate(ente.ErrInvalidApp, fmt.Sprintf("ctx app is different from collection app=%s collectionApp=%s", app, collection.App))
-		}
-		// Verify that user owns the collection.
-		// Warning: Do not remove this check
-		if collection.Owner.ID != userID {
-			return stacktrace.Propagate(ente.ErrPermissionDenied, "collection doesn't belong to user")
-		}
-		if collection.IsDeleted {
-			return stacktrace.Propagate(ente.ErrCollectionDeleted, "collection has been deleted")
-		}
-		if file.OwnerID != userID {
-			return stacktrace.Propagate(ente.ErrPermissionDenied, "file ownerID doesn't match with userID")
-		}
-	}
-
+	// Note: per-collection access checks happen in validateCreateAccess for
+	// create requests, and via FileRepo.GetOwnerID in Update. We deliberately
+	// no longer enforce file.OwnerID == userID on create; the album owner is
+	// resolved server-side and pinned onto the file (see Create).
 	return nil
+}
+
+// validateCreateAccess confirms the actor has CanAdd role on the destination
+// collection and returns the album-owner ID. Files uploaded to a shared album
+// are owned by the album owner (who pays storage). The actor's identity is
+// preserved separately on the collection_files row via added_by_user_id.
+func (c *FileController) validateCreateAccess(ctx *gin.Context, actorUserID int64, collectionID int64, app ente.App) (int64, error) {
+	resp, err := c.AccessCtrl.GetCollection(ctx, &access.GetCollectionParams{
+		CollectionID:   collectionID,
+		ActorUserID:    actorUserID,
+		IncludeDeleted: false,
+	})
+	if err != nil {
+		return 0, stacktrace.Propagate(err, "")
+	}
+	if ente.App(resp.Collection.App) != app {
+		return 0, stacktrace.Propagate(ente.ErrInvalidApp, fmt.Sprintf("ctx app=%s collectionApp=%s", app, resp.Collection.App))
+	}
+	if !resp.Role.CanAdd() {
+		return 0, stacktrace.Propagate(ente.ErrPermissionDenied, fmt.Sprintf("user %d with role %v can not add files to collection %d", actorUserID, resp.Role, collectionID))
+	}
+	return resp.Collection.Owner.ID, nil
 }
 
 type sizeResult struct {
@@ -143,6 +148,14 @@ func (c *FileController) Create(ctx *gin.Context, userID int64, file ente.File, 
 	if err != nil {
 		return file, stacktrace.Propagate(err, "")
 	}
+	collectionOwnerID, err := c.validateCreateAccess(ctx, userID, file.CollectionID, app)
+	if err != nil {
+		return file, stacktrace.Propagate(err, "")
+	}
+	// Pin file ownership to the album owner regardless of what the client sent.
+	// For collaborator uploads this re-attributes the file to the album owner;
+	// the actor (userID) is preserved separately as added_by_user_id.
+	file.OwnerID = collectionOwnerID
 	// Receive results from both operations
 	fileResult := <-fileChan
 	thumbResult := <-thumbChan
@@ -176,7 +189,10 @@ func (c *FileController) Create(ctx *gin.Context, userID int64, file ente.File, 
 	}
 	file.Thumbnail.Size = thumbnailSize
 	var totalUploadSize = fileSize + thumbnailSize
-	err = c.UsageCtrl.CanUploadFile(ctx, userID, &totalUploadSize, app)
+	// Quota is charged to the album owner (= file.OwnerID), not the actor. A
+	// collaborator at 100% quota can still upload to a shared album whose
+	// owner has space.
+	err = c.UsageCtrl.CanUploadFile(ctx, collectionOwnerID, &totalUploadSize, app)
 	if err != nil {
 		return file, stacktrace.Propagate(err, "")
 	}
@@ -188,7 +204,7 @@ func (c *FileController) Create(ctx *gin.Context, userID int64, file ente.File, 
 
 	// all iz well
 	var usage int64
-	file, usage, err = c.FileRepo.Create(file, fileSize, thumbnailSize, fileSize+thumbnailSize, userID, app)
+	file, usage, err = c.FileRepo.Create(file, fileSize, thumbnailSize, fileSize+thumbnailSize, collectionOwnerID, userID, app)
 	if err != nil {
 		if err == ente.ErrDuplicateFileObjectFound || err == ente.ErrDuplicateThumbnailObjectFound {
 			var existing ente.File

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -336,9 +336,39 @@ func (c *FileController) Update(ctx context.Context, userID int64, file ente.Fil
 	return response, nil
 }
 
+// resolveQuotaOwner returns the user_id whose quota the upload should be
+// charged to. When collectionID is non-zero, the actor must have CanAdd on
+// the destination and quota is charged to the album owner. When 0, fall back
+// to the actor — used by the public-link upload path and by clients that
+// haven't been updated to pass collectionID.
+func (c *FileController) resolveQuotaOwner(ctx *gin.Context, actorUserID int64, collectionID int64, app ente.App) (int64, error) {
+	if collectionID == 0 {
+		return actorUserID, nil
+	}
+	resp, err := c.AccessCtrl.GetCollection(ctx, &access.GetCollectionParams{
+		CollectionID:   collectionID,
+		ActorUserID:    actorUserID,
+		IncludeDeleted: false,
+	})
+	if err != nil {
+		return 0, stacktrace.Propagate(err, "")
+	}
+	if ente.App(resp.Collection.App) != app {
+		return 0, stacktrace.Propagate(ente.ErrInvalidApp, fmt.Sprintf("ctx app=%s collectionApp=%s", app, resp.Collection.App))
+	}
+	if !resp.Role.CanAdd() {
+		return 0, stacktrace.Propagate(ente.ErrPermissionDenied, fmt.Sprintf("user %d cannot upload to collection %d", actorUserID, collectionID))
+	}
+	return resp.Collection.Owner.ID, nil
+}
+
 // GetUploadURLs returns a bunch of presigned URLs for uploading files
-func (c *FileController) GetUploadURLs(ctx context.Context, userID int64, count int, app ente.App, ignoreLimit bool) ([]ente.UploadURL, error) {
-	err := c.UsageCtrl.CanUploadFile(ctx, userID, nil, app)
+func (c *FileController) GetUploadURLs(ctx *gin.Context, userID int64, count int, app ente.App, ignoreLimit bool, collectionID int64) ([]ente.UploadURL, error) {
+	quotaUserID, err := c.resolveQuotaOwner(ctx, userID, collectionID, app)
+	if err != nil {
+		return []ente.UploadURL{}, stacktrace.Propagate(err, "")
+	}
+	err = c.UsageCtrl.CanUploadFile(ctx, quotaUserID, nil, app)
 	if err != nil {
 		return []ente.UploadURL{}, stacktrace.Propagate(err, "")
 	}
@@ -372,7 +402,7 @@ func (c *FileController) ValidateUploadEligibility(ctx context.Context, userID i
 }
 
 // GetUploadURLWithMetadata returns a single presigned URL that enforces checksum & length
-func (c *FileController) GetUploadURLWithMetadata(ctx context.Context, userID int64, req ente.UploadURLRequest, app ente.App) (ente.UploadURL, error) {
+func (c *FileController) GetUploadURLWithMetadata(ctx *gin.Context, userID int64, req ente.UploadURLRequest, app ente.App) (ente.UploadURL, error) {
 	if req.ContentLength <= 0 {
 		return ente.UploadURL{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength must be greater than 0")
 	}
@@ -383,7 +413,11 @@ func (c *FileController) GetUploadURLWithMetadata(ctx context.Context, userID in
 	if err != nil {
 		return ente.UploadURL{}, err
 	}
-	if err := c.UsageCtrl.CanUploadFile(ctx, userID, &req.ContentLength, app); err != nil {
+	quotaUserID, err := c.resolveQuotaOwner(ctx, userID, req.CollectionID, app)
+	if err != nil {
+		return ente.UploadURL{}, stacktrace.Propagate(err, "")
+	}
+	if err := c.UsageCtrl.CanUploadFile(ctx, quotaUserID, &req.ContentLength, app); err != nil {
 		return ente.UploadURL{}, stacktrace.Propagate(err, "")
 	}
 	s3Client := c.S3Config.GetHotS3Client()
@@ -1084,11 +1118,15 @@ func (c *FileController) getObjectURL(s3Client *s3.S3, dc string, bucket *string
 }
 
 // GetMultipartUploadURLs return collections of url to upload the parts of the files
-func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int64, count int, app ente.App) (ente.MultipartUploadURLs, error) {
+func (c *FileController) GetMultipartUploadURLs(ctx *gin.Context, userID int64, count int, app ente.App, collectionID int64) (ente.MultipartUploadURLs, error) {
 	if count <= 0 || count > maxMultipartPartCount {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "multipart upload cannot exceed %d parts", maxMultipartPartCount)
 	}
-	err := c.UsageCtrl.CanUploadFile(ctx, userID, nil, app)
+	quotaUserID, err := c.resolveQuotaOwner(ctx, userID, collectionID, app)
+	if err != nil {
+		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
+	}
+	err = c.UsageCtrl.CanUploadFile(ctx, quotaUserID, nil, app)
 	if err != nil {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
 	}
@@ -1132,7 +1170,7 @@ func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int6
 }
 
 // GetMultipartUploadURLWithMetadata enforces content length & per-part checksum requirements
-func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, userID int64, req ente.MultipartUploadURLRequest, app ente.App) (ente.MultipartUploadURLs, error) {
+func (c *FileController) GetMultipartUploadURLWithMetadata(ctx *gin.Context, userID int64, req ente.MultipartUploadURLRequest, app ente.App) (ente.MultipartUploadURLs, error) {
 	if req.ContentLength <= 0 {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength must be greater than 0")
 	}
@@ -1161,7 +1199,11 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 		normalizedChecksums[i] = normalized
 	}
 	partLengths := computePartLengths(req.ContentLength, req.PartLength, partCount)
-	if err := c.UsageCtrl.CanUploadFile(ctx, userID, nil, app); err != nil {
+	quotaUserID, err := c.resolveQuotaOwner(ctx, userID, req.CollectionID, app)
+	if err != nil {
+		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
+	}
+	if err := c.UsageCtrl.CanUploadFile(ctx, quotaUserID, nil, app); err != nil {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
 	}
 	s3Client := c.S3Config.GetHotS3Client()

--- a/server/pkg/controller/file_copy/file_copy.go
+++ b/server/pkg/controller/file_copy/file_copy.go
@@ -93,7 +93,7 @@ func (fc *FileCopyController) CopyFiles(c *gin.Context, req ente.CopyFileSyncReq
 
 	// request the uploadUrls using existing method. This is to ensure that orphan objects are automatically cleaned up
 	// todo:(neeraj) optimize this method by removing the need for getting a signed url for each object
-	uploadUrls, err := fc.FileController.GetUploadURLs(c, userID, len(s3ObjectsToCopy), app, true)
+	uploadUrls, err := fc.FileController.GetUploadURLs(c, userID, len(s3ObjectsToCopy), app, true, req.DstCollection)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -712,17 +712,29 @@ func (repo *CollectionRepository) RestoreFiles(ctx context.Context, userID int64
 	return tx.Commit()
 }
 
-// RemoveFilesV3 just remove the entries from the collection. This method assume that collection owner is
-// different from the file owners
+// RemoveFilesV3 just removes the entries from the collection. The defensive
+// guard ensures we never silently delete files that the collection owner
+// originally added — those have to flow through the suggest-action queue
+// instead. After the collaborator-upload work, file ownership is decoupled
+// from authorship (a collaborator-uploaded file is owned by the album owner
+// but its added_by_user_id stays with the collaborator), so we authorize on
+// added_by_user_id (with f_owner_id fallback for legacy NULL rows).
 func (repo *CollectionRepository) RemoveFilesV3(context context.Context, collectionID int64, collectionOwnerID int64, fileIDs []int64) error {
 	updationTime := time.Microseconds()
-	ownerToFileIDs, err := repo.FileRepo.GetOwnerToFileIDsMap(context, fileIDs)
+	rows, err := repo.DB.QueryContext(context,
+		`SELECT file_id FROM collection_files
+		  WHERE collection_id = $1 AND file_id = ANY($2)
+		    AND COALESCE(added_by_user_id, f_owner_id) = $3`,
+		collectionID, pq.Array(fileIDs), collectionOwnerID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	// verify that none of the file belongs to the collection owner
-	if _, ok := ownerToFileIDs[collectionOwnerID]; ok {
-		return errors.New("can not remove files owned by album owner")
+	defer rows.Close()
+	if rows.Next() {
+		return errors.New("can not remove files added by album owner")
+	}
+	if err := rows.Err(); err != nil {
+		return stacktrace.Propagate(err, "")
 	}
 
 	// check if there are files owned by collection owner

--- a/server/pkg/repo/collection_files.go
+++ b/server/pkg/repo/collection_files.go
@@ -110,6 +110,37 @@ func (repo *CollectionRepository) VerifyAllFileIDsExistsInCollection(ctx context
 	return nil
 }
 
+// GetAddedByMapForCollection returns a map of fileID -> effective uploader.
+// added_by_user_id is preferred; for legacy rows where it is NULL we fall
+// back to f_owner_id (which used to equal the uploader before the
+// collaborator-upload work decoupled file ownership from authorship).
+func (repo *CollectionRepository) GetAddedByMapForCollection(ctx context.Context, cID int64, fileIDs []int64) (map[int64]int64, error) {
+	result := make(map[int64]int64, len(fileIDs))
+	if len(fileIDs) == 0 {
+		return result, nil
+	}
+	rows, err := repo.DB.QueryContext(ctx,
+		`SELECT file_id, COALESCE(added_by_user_id, f_owner_id)
+		   FROM collection_files
+		  WHERE collection_id = $1 AND file_id = ANY ($2)`,
+		cID, pq.Array(fileIDs))
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var fileID, addedBy int64
+		if err := rows.Scan(&fileID, &addedBy); err != nil {
+			return nil, stacktrace.Propagate(err, "")
+		}
+		result[fileID] = addedBy
+	}
+	if err := rows.Err(); err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	return result, nil
+}
+
 // FilterActiveFileIDsInCollection returns the fileIDs still active in the collection
 // (not deleted and not marked for owner removal).
 // If any fileID was never in the collection, it returns an error.

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -29,13 +29,18 @@ type FileRepository struct {
 	UsageRepo         *UsageRepository
 }
 
-// Create creates an entry in the database for the given file
+// Create creates an entry in the database for the given file. file.OwnerID
+// must already equal collectionOwnerID — the controller is responsible for
+// pinning the file's owner to the album owner before this point. The actor
+// who actually performed the upload (which may differ from the album owner
+// for collaborator uploads) is recorded as added_by_user_id.
 func (repo *FileRepository) Create(
 	file ente.File,
 	fileSize int64,
 	thumbnailSize int64,
 	usageDiff int64,
 	collectionOwnerID int64,
+	addedByUserID int64,
 	app ente.App,
 ) (ente.File, int64, error) {
 	hotDC := repo.S3Config.GetHotDataCenter()
@@ -65,9 +70,9 @@ func (repo *FileRepository) Create(
 	}
 	file.ID = fileID
 	_, err = tx.ExecContext(ctx, `INSERT INTO collection_files
-			(collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
-			VALUES($1, $2, $3, $4, $5, $6, $7, $8)`, file.CollectionID, file.ID,
-		file.EncryptedKey, file.KeyDecryptionNonce, false, file.UpdationTime, file.OwnerID, collectionOwnerID)
+			(collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id, added_by_user_id)
+			VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`, file.CollectionID, file.ID,
+		file.EncryptedKey, file.KeyDecryptionNonce, false, file.UpdationTime, file.OwnerID, collectionOwnerID, addedByUserID)
 	if err != nil {
 		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")

--- a/web/packages/gallery/services/upload/remote.ts
+++ b/web/packages/gallery/services/upload/remote.ts
@@ -43,12 +43,19 @@ const ObjectUploadURLResponse = z.object({ urls: ObjectUploadURL.array() });
  * the S3 bucket. Each URL also has an associated "object key" with which remote
  * will refer to the uploaded object after it has been uploaded.
  */
-export const fetchUploadURLs = async (countHint: number) => {
+export const fetchUploadURLs = async (
+    countHint: number,
+    collectionID?: number,
+) => {
     const count = Math.min(50, countHint * 2);
-    const res = await fetch(
-        await apiURL("/files/upload-urls", { count, ts: Date.now() }),
-        { headers: await authenticatedRequestHeaders() },
-    );
+    const params: Record<string, string | number | boolean> = {
+        count,
+        ts: Date.now(),
+    };
+    if (collectionID) params.collectionID = collectionID;
+    const res = await fetch(await apiURL("/files/upload-urls", params), {
+        headers: await authenticatedRequestHeaders(),
+    });
     ensureOk(res);
     return ObjectUploadURLResponse.parse(await res.json()).urls;
 };
@@ -56,18 +63,31 @@ export const fetchUploadURLs = async (countHint: number) => {
 export const fetchUploadURLWithMetadata = async ({
     contentLength,
     contentMd5,
+    collectionID,
 }: {
     contentLength: number;
     contentMd5: string;
+    /**
+     * Optional. When set, the server scopes the upload-quota check to the
+     * album owner of this collection (the actor must have CanAdd). Lets
+     * collaborators upload to shared albums even when their own account is
+     * at quota.
+     */
+    collectionID?: number;
 }) => {
     const headers = new Headers(await authenticatedRequestHeaders());
     headers.set("Content-Type", "application/json");
+    const body: Record<string, unknown> = {
+        contentLength,
+        contentMD5: contentMd5,
+    };
+    if (collectionID) body.collectionID = collectionID;
     const res = await fetch(
         await apiURL("/files/upload-url", { ts: Date.now() }),
         {
             method: "POST",
             headers,
-            body: JSON.stringify({ contentLength, contentMD5: contentMd5 }),
+            body: JSON.stringify(body),
         },
     );
     ensureOk(res);
@@ -104,19 +124,27 @@ export const fetchMultipartUploadURLsWithMetadata = async ({
     contentLength,
     partLength,
     partMd5s,
+    collectionID,
 }: {
     contentLength: number;
     partLength: number;
     partMd5s: string[];
+    collectionID?: number;
 }) => {
     const headers = new Headers(await authenticatedRequestHeaders());
     headers.set("Content-Type", "application/json");
+    const body: Record<string, unknown> = {
+        contentLength,
+        partLength,
+        partMd5s,
+    };
+    if (collectionID) body.collectionID = collectionID;
     const res = await fetch(
         await apiURL("/files/multipart-upload-url", { ts: Date.now() }),
         {
             method: "POST",
             headers,
-            body: JSON.stringify({ contentLength, partLength, partMd5s }),
+            body: JSON.stringify(body),
         },
     );
     ensureOk(res);
@@ -213,10 +241,18 @@ const MultipartUploadURLsResponse = z.object({ urls: MultipartUploadURLs });
  * @returns A structure ({@link MultipartUploadURLs}) containing pre-signed URLs
  * for uploading each part, a completion URL, and the final object key.
  */
-export const fetchMultipartUploadURLs = async (uploadPartCount: number) => {
+export const fetchMultipartUploadURLs = async (
+    uploadPartCount: number,
+    collectionID?: number,
+) => {
     const count = uploadPartCount;
+    const params: Record<string, string | number | boolean> = {
+        count,
+        ts: Date.now(),
+    };
+    if (collectionID) params.collectionID = collectionID;
     const res = await fetch(
-        await apiURL("/files/multipart-upload-urls", { count, ts: Date.now() }),
+        await apiURL("/files/multipart-upload-urls", params),
         { headers: await authenticatedRequestHeaders() },
     );
     ensureOk(res);

--- a/web/packages/gallery/services/upload/upload-service.ts
+++ b/web/packages/gallery/services/upload/upload-service.ts
@@ -161,10 +161,13 @@ class UploadService {
         this.pendingUploadCount--;
     }
 
-    async getUploadURL(metadata?: {
-        contentLength: number;
-        contentMd5: string;
-    }) {
+    async getUploadURL(
+        metadata?: {
+            contentLength: number;
+            contentMd5: string;
+        },
+        collectionID?: number,
+    ) {
         if (this.publicAlbumsCredentials) {
             if (
                 metadata &&
@@ -184,20 +187,20 @@ class UploadService {
             metadata.contentLength >= 0 &&
             metadata.contentMd5
         ) {
-            return fetchUploadURLWithMetadata(metadata);
+            return fetchUploadURLWithMetadata({ ...metadata, collectionID });
         }
         if (this.uploadURLs.length == 0 && this.pendingUploadCount) {
-            await this.refillUploadURLs();
+            await this.refillUploadURLs(collectionID);
         }
         const url = this.uploadURLs.pop();
         if (!url) throw new Error("Failed to obtain upload URL");
         return url;
     }
 
-    private async refillUploadURLs() {
+    private async refillUploadURLs(collectionID?: number) {
         try {
             if (!this.activeUploadURLRefill) {
-                this.activeUploadURLRefill = this._refillUploadURLs();
+                this.activeUploadURLRefill = this._refillUploadURLs(collectionID);
             }
             await this.activeUploadURLRefill;
         } finally {
@@ -216,7 +219,7 @@ class UploadService {
         }
     }
 
-    private async _refillUploadURLs() {
+    private async _refillUploadURLs(collectionID?: number) {
         if (this.publicAlbumsCredentials) {
             throw new Error(
                 "Public uploads should request metadata upload URLs",
@@ -224,7 +227,7 @@ class UploadService {
         }
         let urls: ObjectUploadURL[];
         try {
-            urls = await fetchUploadURLs(this.pendingUploadCount);
+            urls = await fetchUploadURLs(this.pendingUploadCount, collectionID);
         } catch (e) {
             throw translateURLFetchErrorIfNeeded(e);
         }
@@ -238,6 +241,7 @@ class UploadService {
             partLength: number;
             partMd5s: string[];
         },
+        collectionID?: number,
     ) {
         if (this.publicAlbumsCredentials) {
             if (
@@ -262,15 +266,18 @@ class UploadService {
             metadata.partLength > 0 &&
             metadata.partMd5s.length > 0
         ) {
-            return fetchMultipartUploadURLsWithMetadata(metadata).catch(
-                (e: unknown) => {
-                    throw translateURLFetchErrorIfNeeded(e);
-                },
-            );
+            return fetchMultipartUploadURLsWithMetadata({
+                ...metadata,
+                collectionID,
+            }).catch((e: unknown) => {
+                throw translateURLFetchErrorIfNeeded(e);
+            });
         }
-        return fetchMultipartUploadURLs(uploadPartCount).catch((e: unknown) => {
-            throw translateURLFetchErrorIfNeeded(e);
-        });
+        return fetchMultipartUploadURLs(uploadPartCount, collectionID).catch(
+            (e: unknown) => {
+                throw translateURLFetchErrorIfNeeded(e);
+            },
+        );
     }
 }
 
@@ -704,6 +711,13 @@ interface UploadContext {
      * 0 and 100 (inclusive).
      */
     updateUploadProgress: (fileLocalID: number, percentage: number) => void;
+    /**
+     * The destination collection's ID, when known. Forwarded to the upload-URL
+     * presign endpoints so the server scopes the quota check to the album
+     * owner instead of the actor (lets a collaborator at quota cap upload to
+     * a shared album whose owner has space).
+     */
+    collectionID?: number;
 }
 
 /**
@@ -724,6 +738,9 @@ export const upload = async (
     worker: CryptoWorker,
     uploadContext: UploadContext,
 ): Promise<UploadResult> => {
+    // Per-file context: the upload is scoped to this file's destination
+    // collection, so the presign quota check should target its owner.
+    uploadContext = { ...uploadContext, collectionID: collection.id };
     const { abortIfCancelled } = uploadContext;
 
     log.info(`Upload ${fileName} | start`);
@@ -1788,6 +1805,7 @@ const uploadToBucket = async (
             shouldSendContentChecksum
                 ? { contentLength: data.length, contentMd5: fileMd5! }
                 : undefined,
+            uploadContext.collectionID,
         );
         fileObjectKey = fileUploadURL.objectKey;
         const shouldUseWorker = !isCFUploadProxyDisabled;
@@ -1813,6 +1831,7 @@ const uploadToBucket = async (
                   contentMd5: thumbnailMd5!,
               }
             : undefined,
+        uploadContext.collectionID,
     );
     const shouldUseWorkerForThumbnail = !isCFUploadProxyDisabled;
     if (shouldUseWorkerForThumbnail) {
@@ -1927,11 +1946,15 @@ const uploadStreamUsingMultipart = async (
         const partLength = firstPartLength;
 
         const multipartUploadURLs =
-            await uploadService.fetchMultipartUploadURLs(uploadPartCount, {
-                contentLength: fileSize,
-                partLength,
-                partMd5s,
-            });
+            await uploadService.fetchMultipartUploadURLs(
+                uploadPartCount,
+                {
+                    contentLength: fileSize,
+                    partLength,
+                    partMd5s,
+                },
+                uploadContext.collectionID,
+            );
 
         const percentPerPart = maxPercent / uploadPartCount;
         const completedParts: MultipartCompletedPart[] = [];
@@ -1983,8 +2006,11 @@ const uploadStreamUsingMultipart = async (
         return { objectKey: multipartUploadURLs.objectKey, fileSize };
     }
 
-    const multipartUploadURLs =
-        await uploadService.fetchMultipartUploadURLs(uploadPartCount);
+    const multipartUploadURLs = await uploadService.fetchMultipartUploadURLs(
+        uploadPartCount,
+        undefined,
+        uploadContext.collectionID,
+    );
 
     const percentPerPart = maxPercent / uploadPartCount;
     let fileSize = 0;

--- a/web/packages/new/photos/components/CollectionSelector.tsx
+++ b/web/packages/new/photos/components/CollectionSelector.tsx
@@ -166,8 +166,13 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
                 } else if (attributes.action == "add") {
                     return canAddToCollection(cs) && cs.type != "userFavorites";
                 } else if (attributes.action == "upload") {
+                    // Use canAddToCollection (not canMoveToCollection) so that
+                    // collections shared with the user as a COLLABORATOR are
+                    // listed as upload destinations. canMoveToCollection
+                    // excludes all sharedIncoming, which hides collaborator
+                    // albums; canAddToCollection only excludes viewer shares.
                     return (
-                        (canMoveToCollection(cs) ||
+                        (canAddToCollection(cs) ||
                             cs.type == "uncategorized") &&
                         cs.type != "userFavorites"
                     );


### PR DESCRIPTION
Closes the gap behind #3008. Previously the museum POST /files endpoint hard-rejected any actor who was not the collection owner, so the mobile client worked around it by uploading to the collaborator's Uncategorized and then symlinking into the shared album. This produced duplicate rows, charged storage to the wrong user, and surprised collaborators when the "copy" persisted in their account after the share ended.

Server (museum):
- Migration 121 adds collection_files.added_by_user_id; legacy rows stay NULL and readers fall back to f_owner_id.
- POST /files now uses AccessCtrl.GetCollection + Role.CanAdd() instead of the owner-only check. file.OwnerID is pinned to the album owner (server-side, ignoring whatever the client sent), quota is charged to the album owner, and the actor is recorded on the collection_files row as added_by_user_id.
- POST /files/copy gets the same loosening so collaborators can copy existing files into a shared album without the Uncategorized detour.
- RemoveFilesV3 is repartitioned by added_by_user_id (with f_owner_id fallback for legacy rows). Collaborators can remove the files they themselves added even though those files are now owned by the album owner; the OWNER/ADMIN/suggest-action paths are preserved.

Web:
- CollectionSelector picker uses canAddToCollection for the upload destination list so collaborator-shared albums show up.

Mobile:
- collections_service.dart drops the shouldCopyViaUncategorized branch in addOrCopyToCollection; with the server changes the direct copy works.

Backwards compatibility: old clients still hitting the two-step add-files flow continue to work — those code paths are untouched. New clients get a single collection_files row per upload to a shared album.

