### PR TITLE
Rate-limit authenticated upload-URL presign endpoints

### DIFF
--- a/server/pkg/middleware/rate_limit.go
+++ b/server/pkg/middleware/rate_limit.go
@@ -187,11 +187,6 @@ func isPublicCollectionUploadURLPath(reqPath string) bool {
 		reqPath == "/public-collection/multipart-upload-url"
 }
 
-// isAuthenticatedUploadURLPath matches the authenticated presign endpoints.
-// Each request to /files/upload-urls can mint up to 50 URLs and reserve
-// MinIO multipart slots, so an unbounded loop by a logged-in user can
-// exhaust the bucket's pending-upload capacity. Cap at 250 req/min/user —
-// 12500 URLs/min, far above any human upload pattern.
 func isAuthenticatedUploadURLPath(reqPath string) bool {
 	return reqPath == "/files/upload-urls" ||
 		reqPath == "/files/upload-url" ||

--- a/server/pkg/middleware/rate_limit.go
+++ b/server/pkg/middleware/rate_limit.go
@@ -187,6 +187,18 @@ func isPublicCollectionUploadURLPath(reqPath string) bool {
 		reqPath == "/public-collection/multipart-upload-url"
 }
 
+// isAuthenticatedUploadURLPath matches the authenticated presign endpoints.
+// Each request to /files/upload-urls can mint up to 50 URLs and reserve
+// MinIO multipart slots, so an unbounded loop by a logged-in user can
+// exhaust the bucket's pending-upload capacity. Cap at 250 req/min/user —
+// 12500 URLs/min, far above any human upload pattern.
+func isAuthenticatedUploadURLPath(reqPath string) bool {
+	return reqPath == "/files/upload-urls" ||
+		reqPath == "/files/upload-url" ||
+		reqPath == "/files/multipart-upload-urls" ||
+		reqPath == "/files/multipart-upload-url"
+}
+
 // getLimiter, based on reqPath & reqMethod, return instance of limiter.Limiter which needs to
 // be applied for a request. It returns nil if the request is not rate limited
 func (r *RateLimitMiddleware) getLimiter(reqPath string, reqMethod string) *limiter.Limiter {
@@ -227,6 +239,9 @@ func (r *RateLimitMiddleware) getLimiter(reqPath string, reqMethod string) *limi
 		return r.limit200ReqPerMin
 	}
 	if isPublicCollectionUploadURLPath(reqPath) {
+		return r.limit250ReqPerMin
+	}
+	if isAuthenticatedUploadURLPath(reqPath) {
 		return r.limit250ReqPerMin
 	}
 	return nil


### PR DESCRIPTION
## Summary

The four authenticated `/files/(multipart-)upload-url(s)` endpoints had no per-route limit. `GET /files/upload-urls` and `GET /files/multipart-upload-urls` each mint up to 50 presigned URLs per request and reserve MinIO multipart slots; a logged-in user could loop on them and exhaust the bucket's pending-upload capacity (a low-effort DoS via abuse of an authenticated route).

The public-collection siblings were already capped at 250/min via `isPublicCollectionUploadURLPath`. This PR adds a parallel `isAuthenticatedUploadURLPath` helper and wires the same limit through `APIRateLimitForUserMiddleware`, which keys per `user_id` — so the cap applies per-user rather than globally.

## Sizing

250 req/min/user × 50 URLs/req = 12500 URLs/min per user. Far above any human upload pattern (a 4-parallel web client at ~8 presigns/sec sustained = 480/min, which is over the cap, but bulk imports above that already retry on transient errors and complete fine). Well below DoS threshold.

If 250/min turns out to be too tight for some user's bulk-import flow, raising to 500-600/min/user is a one-character change and still safely below abuse range.