### PR TITLE
Update Dockerfile to add dual stack capacity

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -49,39 +49,39 @@ COPY --from=builder /build/web/apps/memories/out /out/memories
 
 COPY <<EOF /etc/nginx/conf.d/default.conf
 server {
-    listen 3000; root /out/photos;
+    listen 3000; listen [::]:3000; root /out/photos;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3001; root /out/accounts;
+    listen 3001; listen [::]:3001; root /out/accounts;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3002; root /out/albums;
+    listen 3002; listen [::]:3002; root /out/albums;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3003; root /out/auth;
+    listen 3003; listen [::]:3003; root /out/auth;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3004; root /out/cast;
+    listen 3004; listen [::]:3004; root /out/cast;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3005; root /out/share;
+    listen 3005; listen [::]:3005; root /out/share;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3006; root /out/embed;
+    listen 3006; listen [::]:3006; root /out/embed;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3008; root /out/paste;
+    listen 3008; listen [::]:3008; root /out/paste;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 server {
-    listen 3010; root /out/memories;
+    listen 3010; listen [::]:3010; root /out/memories;
     location / { try_files \$uri \$uri.html /index.html; }
 }
 EOF


### PR DESCRIPTION
## Description

- Problem: The current Nginx configuration only listens on IPv4 sockets. In dual-stack environments (common in modern home labs and container orchestration), this can lead to connectivity issues when the host or network prefers IPv6.
- Solution: Added a companion listen [::]:PORT line for every active service port (3000 through 3010) within the Nginx Heredoc in the Dockerfile.
- Impact: Ensures broad network compatibility without changing the application logic or breaking existing IPv4 workflows.
- Verification: I audited the running container on my local system and confirmed that only IPv4 sockets were being opened by Nginx. Verified the syntax against standard Nginx dual-stack configuration practices. Confirmed that the Dockerfile correctly handles the $ escaping for the try_files directive within the edited blocks.

## Tests

- Manual Inspection: Audited the running container using podman exec and grep to confirm that the Nginx configuration only included IPv4 listen directives.
- Configuration Validation: Verified that adding listen [::]:PORT is the standard Nginx approach for enabling dual-stack support without breaking existing IPv4 connectivity.
- Syntax Check: Confirmed that the Dockerfile Heredoc correctly escapes the $ sign in the Nginx try_files directive to prevent issues during the image build process.