### PR TITLE
Fix Photos mobile TypeError crash paths

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -474,6 +474,8 @@ class CollectionsService {
     }
     final int? userID = _config.getUserID();
     if (userID == null) {
+      _logger
+          .info("Skipping collections for UI because user ID is unavailable");
       return <Collection>[];
     }
     return _collectionIDToCollections.values

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -472,7 +472,10 @@ class CollectionsService {
       allowedRoles.add(CollectionParticipantRole.collaborator);
       allowedRoles.add(CollectionParticipantRole.admin);
     }
-    final int userID = _config.getUserID()!;
+    final int? userID = _config.getUserID();
+    if (userID == null) {
+      return <Collection>[];
+    }
     return _collectionIDToCollections.values
         .where(
           (c) =>
@@ -1535,7 +1538,8 @@ class CollectionsService {
     Map<String, dynamic> collectionData,
     Uint8List collectionKey,
   ) async {
-    collection.setName(_decryptCollectionNameWithKey(collection, collectionKey));
+    collection
+        .setName(_decryptCollectionNameWithKey(collection, collectionKey));
     if (collectionData['pubMagicMetadata'] != null) {
       final utfEncodedMmd = await CryptoUtil.decryptChaCha(
         CryptoUtil.base642bin(collectionData['pubMagicMetadata']['data']),
@@ -1546,8 +1550,7 @@ class CollectionsService {
       );
       collection.mMdPubEncodedJson = utf8.decode(utfEncodedMmd);
       collection.mMbPubVersion = collectionData['pubMagicMetadata']['version'];
-      collection.pubMagicMetadata =
-          CollectionPubMagicMetadata.fromEncodedJson(
+      collection.pubMagicMetadata = CollectionPubMagicMetadata.fromEncodedJson(
         collection.mMdPubEncodedJson ?? '{}',
       );
     }

--- a/mobile/apps/photos/lib/services/local_authentication_service.dart
+++ b/mobile/apps/photos/lib/services/local_authentication_service.dart
@@ -59,7 +59,7 @@ class LocalAuthenticationService {
           },
         ),
       );
-      if (result) {
+      if (result == true) {
         return true;
       }
     }
@@ -76,7 +76,7 @@ class LocalAuthenticationService {
           },
         ),
       );
-      if (result) {
+      if (result == true) {
         return true;
       }
     }

--- a/mobile/apps/photos/lib/services/smart_albums_service.dart
+++ b/mobile/apps/photos/lib/services/smart_albums_service.dart
@@ -89,7 +89,11 @@ class SmartAlbumsService {
 
     _logger.info("Syncing Smart Albums");
     final cachedConfigs = await getSmartConfigs();
-    final userId = Configuration.instance.getUserID()!;
+    final userId = Configuration.instance.getUserID();
+    if (userId == null) {
+      _logger.warning("No user ID, skipping smart album sync");
+      return;
+    }
 
     for (final entry in cachedConfigs.entries) {
       final collectionId = entry.key;

--- a/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
+++ b/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
@@ -43,6 +43,9 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
         isResettingPasswordScreen: widget.isResetPasswordScreen,
       );
     }
+    if (!mounted) {
+      return;
+    }
     FocusScope.of(context).unfocus();
   }
 

--- a/mobile/apps/photos/lib/ui/account/verify_recovery_page.dart
+++ b/mobile/apps/photos/lib/ui/account/verify_recovery_page.dart
@@ -89,7 +89,7 @@ class _VerifyRecoveryPageState extends State<VerifyRecoveryPage> {
         secondButtonLabel: AppLocalizations.of(context).viewRecoveryKey,
         secondButtonAction: ButtonAction.second,
       );
-      if (result!.action == ButtonAction.second) {
+      if (result?.action == ButtonAction.second) {
         await _onViewRecoveryKeyClick();
       }
     }

--- a/mobile/apps/photos/lib/ui/components/buttons/button_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/buttons/button_widget.dart
@@ -430,7 +430,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
         },
         onError: (error, stackTrace) {
           executionState = ExecutionState.error;
-          _exception = error as Exception;
+          _exception = error is Exception ? error : Exception(error.toString());
           _debouncer.cancelDebounceTimer();
         },
       );
@@ -462,6 +462,7 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
                       ? (widget.isInAlert ? 1 : 2)
                       : 0,
                 ), () {
+              if (!mounted) return;
               widget.isInAlert
                   ? _popWithButtonAction(
                       context,
@@ -497,8 +498,10 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       if (widget.isInAlert) {
         Future.delayed(
           Duration(seconds: widget.shouldShowSuccessConfirmation ? 1 : 0),
-          () =>
-              _popWithButtonAction(context, buttonAction: widget.buttonAction),
+          () {
+            if (!mounted) return;
+            _popWithButtonAction(context, buttonAction: widget.buttonAction);
+          },
         );
       }
     }
@@ -510,8 +513,10 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
     Exception? exception,
   }) {
     if (mounted) {
-      if (Navigator.of(context).canPop()) {
-        Navigator.of(context).pop(ButtonResult(buttonAction, exception));
+      final route = ModalRoute.of(context);
+      final navigator = Navigator.of(context);
+      if (route is PopupRoute && route.isCurrent && navigator.canPop()) {
+        navigator.pop(ButtonResult(buttonAction, exception));
       } else if (exception != null) {
         //This is to show the execution was unsuccessful if the dialog is manually
         //closed before the execution completes.

--- a/mobile/apps/photos/lib/ui/components/menu_item_widget/menu_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/menu_item_widget/menu_item_widget.dart
@@ -287,9 +287,14 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
     }
     Future.delayed(
       const Duration(milliseconds: 100),
-      () => setState(() {
-        menuItemColor = widget.menuItemColor;
-      }),
+      () {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          menuItemColor = widget.menuItemColor;
+        });
+      },
     );
   }
 

--- a/mobile/apps/photos/lib/ui/components/text_input_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/text_input_widget.dart
@@ -288,7 +288,7 @@ class _TextInputWidgetState extends State<TextInputWidget> {
     } catch (e) {
       executionState = ExecutionState.error;
       _debouncer.cancelDebounceTimer();
-      _exception = e as Exception;
+      _exception = e is Exception ? e : Exception(e.toString());
       if (e.toString().contains("Incorrect password")) {
         _logger.warning("Incorrect password");
         _surfaceWrongPasswordState();
@@ -329,6 +329,7 @@ class _TextInputWidgetState extends State<TextInputWidget> {
                         ? (widget.popNavAfterSubmission ? 1 : 2)
                         : 0,
                   ), () {
+                if (!mounted) return;
                 widget.popNavAfterSubmission
                     ? _popNavigatorStack(context)
                     : null;
@@ -357,7 +358,10 @@ class _TextInputWidgetState extends State<TextInputWidget> {
       if (widget.popNavAfterSubmission) {
         Future.delayed(
           Duration(seconds: widget.alwaysShowSuccessState ? 1 : 0),
-          () => _popNavigatorStack(context),
+          () {
+            if (!mounted) return;
+            _popNavigatorStack(context);
+          },
         );
       }
     }

--- a/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_cover_widget.dart
@@ -67,6 +67,7 @@ class _MemoryCoverWidgetState extends State<MemoryCoverWidget> {
               allTitles: widget.allTitle,
             ),
           );
+          if (!mounted) return;
           setState(() {});
         },
         child: Container(

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -617,7 +617,7 @@ class _HomeWidgetState extends State<HomeWidget> {
                   },
                 ),
               );
-            } else {
+            } else if (shouldOpenFile == false) {
               setState(() {
                 _shouldRenderCreateCollectionSheet = true;
                 _sharedFiles = value;

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -139,7 +139,7 @@ class _HomeWidgetState extends State<HomeWidget> {
   late StreamSubscription<BackupFoldersUpdatedEvent> _backupFoldersUpdatedEvent;
   late StreamSubscription<AccountConfiguredEvent> _accountConfiguredEvent;
   late StreamSubscription<CollectionUpdatedEvent> _collectionUpdatedEvent;
-  late StreamSubscription _publicAlbumLinkSubscription;
+  StreamSubscription? _publicAlbumLinkSubscription;
   StreamSubscription<Uri?>? _authDeepLinkSubscription;
   late StreamSubscription<HomepageSwipeToSelectInProgressEvent>
       _homepageSwipeToSelectInProgressEventSubscription;
@@ -552,7 +552,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     _collectionUpdatedEvent.cancel();
     isOnSearchTabNotifier.dispose();
     _pageController.dispose();
-    _publicAlbumLinkSubscription.cancel();
+    _publicAlbumLinkSubscription?.cancel();
     _authDeepLinkSubscription?.cancel();
     _homepageSwipeToSelectInProgressEventSubscription.cancel();
     _christmasBannerEventSubscription.cancel();
@@ -605,7 +605,10 @@ class _HomeWidgetState extends State<HomeWidget> {
               );
             },
           ).then((shouldOpenFile) {
-            if (shouldOpenFile) {
+            if (!mounted) {
+              return;
+            }
+            if (shouldOpenFile == true) {
               Navigator.pushReplacement(
                 context,
                 MaterialPageRoute(
@@ -615,12 +618,10 @@ class _HomeWidgetState extends State<HomeWidget> {
                 ),
               );
             } else {
-              if (mounted) {
-                setState(() {
-                  _shouldRenderCreateCollectionSheet = true;
-                  _sharedFiles = value;
-                });
-              }
+              setState(() {
+                _shouldRenderCreateCollectionSheet = true;
+                _sharedFiles = value;
+              });
             }
           });
         }
@@ -1078,12 +1079,15 @@ class _HomeWidgetState extends State<HomeWidget> {
     if (Configuration.instance.hasConfiguredAccount() || link == null) {
       return;
     }
-    final ott = link.queryParameters["ott"]!;
+    final ott = link.queryParameters["ott"];
+    if (ott == null || ott.isEmpty) {
+      return;
+    }
     UserService.instance.verifyEmail(context, ott);
   }
 
   showChangeLog(BuildContext context) async {
-    if (_isShowingChangeLog) {
+    if (_isShowingChangeLog || !mounted) {
       return;
     }
     _isShowingChangeLog = true;

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -1081,6 +1081,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     }
     final ott = link.queryParameters["ott"];
     if (ott == null || ott.isEmpty) {
+      _logger.info("Ignoring auth deep link without ott parameter");
       return;
     }
     UserService.instance.verifyEmail(context, ott);

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -696,7 +696,9 @@ class FileAppBarState extends State<FileAppBar> {
         );
       } catch (e) {
         _logger.warning("Failed to save file", e);
-        await showGenericErrorDialog(context: context, error: e);
+        if (mounted) {
+          await showGenericErrorDialog(context: context, error: e);
+        }
       }
       return;
     }
@@ -712,12 +714,18 @@ class FileAppBarState extends State<FileAppBar> {
         fileToDownload,
         persistToFilesDB: persistToFilesDB,
       );
+      if (!mounted) {
+        await dialog.hide();
+        return;
+      }
       showToast(context, AppLocalizations.of(context).fileSavedToGallery);
       await dialog.hide();
     } catch (e) {
       _logger.warning("Failed to save file", e);
       await dialog.hide();
-      await showGenericErrorDialog(context: context, error: e);
+      if (mounted) {
+        await showGenericErrorDialog(context: context, error: e);
+      }
     }
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/file_caption_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_caption_widget.dart
@@ -193,9 +193,15 @@ class _FileCaptionWidgetState extends State<FileCaptionWidget> {
   }
 
   bool _onEditFileFinish(bool isSuccess) {
+    if (!mounted) {
+      return isSuccess;
+    }
     if (isSuccess) {
       widget.file.pubMagicMetadata?.caption = editedCaption;
-      Bus.instance.fire(FileCaptionUpdatedEvent(widget.file.generatedID!));
+      final generatedID = widget.file.generatedID;
+      if (generatedID != null) {
+        Bus.instance.fire(FileCaptionUpdatedEvent(generatedID));
+      }
       return true;
     } else {
       showShortToast(context, AppLocalizations.of(context).somethingWentWrong);

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -173,6 +173,9 @@ class _SeekBarState extends State<SeekBar> with SingleTickerProviderStateMixin {
     if (target == 0) {
       await Future.delayed(const Duration(milliseconds: 450));
     }
+    if (!mounted) {
+      return;
+    }
 
     final duration = widget.controller.videoInfo?.durationInMilliseconds;
     final double fractionTarget =

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -426,15 +426,20 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   }
 
   Future<Uint8List?> _getLocalThumbnailUsingHeapPriorityQueue() async {
+    final localID = widget.file.localID;
+    if (localID == null) {
+      return null;
+    }
+
     final completer = Completer<Uint8List?>();
 
     late TaskQueue<String> relevantTaskQueue;
     if (widget.thumbnailSize == thumbnailLargeSize) {
       relevantTaskQueue = largeLocalThumbnailQueue;
-      _localThumbnailQueueTaskId = [widget.file.localID!, "-large"].join();
+      _localThumbnailQueueTaskId = [localID, "-large"].join();
     } else if (widget.thumbnailSize == thumbnailSmallSize) {
       relevantTaskQueue = smallLocalThumbnailQueue;
-      _localThumbnailQueueTaskId = [widget.file.localID!, "-small"].join();
+      _localThumbnailQueueTaskId = [localID, "-small"].join();
     } else {
       assert(false, "Invalid thumbnail size ${widget.thumbnailSize}");
       _logger.severe(
@@ -519,9 +524,8 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
         _imageProvider = imageProvider;
         _hasLoadedThumbnail = true;
       });
+      precacheImage(imageProvider, context);
     }
-
-    precacheImage(imageProvider, context);
   }
 
   void _reset() {

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -428,6 +428,9 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
   Future<Uint8List?> _getLocalThumbnailUsingHeapPriorityQueue() async {
     final localID = widget.file.localID;
     if (localID == null) {
+      _logger.info(
+        "Skipping local thumbnail load because localID is unavailable for ${widget.file.tag}",
+      );
       return null;
     }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -120,6 +120,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     });
     _guestViewEventSubscription =
         Bus.instance.on<GuestViewEvent>().listen((event) {
+      if (!mounted) return;
       setState(() {
         _isGuestView = event.isGuestView;
       });
@@ -174,7 +175,12 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   }
 
   void loadPreview({bool update = false}) async {
-    _setFilePathForNativePlayer(widget.playlistData!.preview.path, update);
+    final previewPath = widget.playlistData?.preview.path;
+    if (previewPath == null) {
+      loadOriginal(update: update);
+      return;
+    }
+    _setFilePathForNativePlayer(previewPath, update);
 
     await setVideoSource();
   }
@@ -199,7 +205,11 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
         } else {
           // ignore: unawaited_futures
           getFile(widget.file, isOrigin: true).then((file) {
-            _setFilePathForNativePlayer(file!.path, update);
+            if (file == null) {
+              _loadNetworkVideo(update);
+              return;
+            }
+            _setFilePathForNativePlayer(file.path, update);
             if (Platform.isIOS) {
               _shouldClearCache = true;
             }
@@ -732,6 +742,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
       _filePath = url;
     });
     _setAspectRatioFromVideoProps().then((_) {
+      if (!mounted) return;
       setState(() {});
     });
 

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -177,7 +177,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   void loadPreview({bool update = false}) async {
     final previewPath = widget.playlistData?.preview.path;
     if (previewPath == null) {
-      loadOriginal(update: update);
+      loadOriginal(update: true);
       return;
     }
     _setFilePathForNativePlayer(previewPath, update);

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -819,6 +819,10 @@ class _ZoomableImageState extends State<ZoomableImage> {
       );
     }
 
+    if (!mounted) {
+      return;
+    }
+
     if (compressedFile != null) {
       final imageProvider = MemoryImage(compressedFile);
 

--- a/mobile/apps/photos/lib/ui/viewer/file_details/favorite_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/favorite_widget.dart
@@ -149,6 +149,7 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
       }
     }
 
+    if (!mounted) return;
     setState(() {
       _isLoading = false;
       if (!hasError) {

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -99,10 +99,11 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
     Color selectionColor = Colors.white;
     if (_isFileSelected &&
         widget.file.isUploaded &&
+        widget.file.ownerID != null &&
         widget.file.ownerID != widget.currentUserID) {
       final avatarColors = getEnteColorScheme(context).avatarColors;
       selectionColor =
-          avatarColors[(widget.file.ownerID!).remainder(avatarColors.length)];
+          avatarColors[widget.file.ownerID!.remainder(avatarColors.length)];
     }
     final String heroTag = widget.tag + widget.file.tag;
     final Widget thumbnailWidget = ThumbnailWidget(
@@ -216,8 +217,11 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
   void _onTapNoSelectionLimit(BuildContext context, EnteFile file) async {
     final bool shouldToggleSelection =
         (widget.selectedFiles?.files.isNotEmpty ?? false) ||
-            GalleryContextState.of(context)!.inSelectionMode;
+            (GalleryContextState.of(context)?.inSelectionMode ?? false);
     if (shouldToggleSelection) {
+      if (widget.selectedFiles == null) {
+        return;
+      }
       _toggleFileSelection(file);
     } else {
       if (AppLifecycleService.instance.mediaExtensionAction.action ==
@@ -231,7 +235,8 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
   }
 
   void _onLongPressNoSelectionLimit(BuildContext context, EnteFile file) {
-    if (widget.selectedFiles!.files.isNotEmpty) {
+    final selectedFiles = widget.selectedFiles;
+    if (selectedFiles == null || selectedFiles.files.isNotEmpty) {
       _routeToDetailPage(file, context);
     } else {
       _toggleFileSelection(file);

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
@@ -158,7 +158,7 @@ class GalleryState extends State<Gallery> {
   final scrollBarInUseNotifier = ValueNotifier<bool>(false);
   late GroupType _groupType;
   final scrollbarBottomPaddingNotifier = ValueNotifier<double>(0);
-  late GalleryGroups galleryGroups;
+  GalleryGroups? galleryGroups;
   List<EnteFile> _allFilesWithDummies = [];
   SwipeToSelectHelper? _swipeHelper;
   final _swipeActiveNotifier = ValueNotifier<bool>(false);
@@ -283,6 +283,7 @@ class GalleryState extends State<Gallery> {
         ),
         context,
       ).then((size) {
+        if (!mounted) return;
         setState(() {
           groupHeaderExtent = size.height;
           _updateGalleryGroups(callSetState: false);
@@ -349,7 +350,7 @@ class GalleryState extends State<Gallery> {
 
   void _updateGalleryGroups({bool callSetState = true}) {
     if (groupHeaderExtent == null) return;
-    galleryGroups = GalleryGroups(
+    final groups = GalleryGroups(
       allFiles: _allGalleryFiles,
       groupType: _groupType,
       sortOrderAsc: _sortOrderAsc,
@@ -361,9 +362,10 @@ class GalleryState extends State<Gallery> {
       limitSelectionToOne: widget.limitSelectionToOne,
       showGallerySettingsCTA: widget.showGallerySettingsCTA,
     );
+    galleryGroups = groups;
 
     // Cache the list with dummies
-    _allFilesWithDummies = galleryGroups.allFilesWithDummies;
+    _allFilesWithDummies = groups.allFilesWithDummies;
 
     // Always update SwipeHelper when cache is updated
     _updateSwipeHelper();
@@ -610,7 +612,7 @@ class GalleryState extends State<Gallery> {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         if (mounted) {
           final offset = galleryGroups
-              .getOffsetOfGroupContainingFile(widget.fileToJumpTo!);
+              ?.getOffsetOfGroupContainingFile(widget.fileToJumpTo!);
           if (offset != null) {
             _logger.info("Jumping to date at offset: $offset");
             _scrollController.jumpTo(offset - 50);
@@ -675,8 +677,16 @@ class GalleryState extends State<Gallery> {
       return widget.loadingWidget;
     }
 
+    if (galleryGroups == null) {
+      _updateGalleryGroups(callSetState: false);
+    }
+    final groups = galleryGroups;
+    if (groups == null) {
+      return widget.loadingWidget;
+    }
+
     // Check if width changed due to orientation change and update gallery groups
-    if (galleryGroups.widthAvailable != widthAvailable) {
+    if (groups.widthAvailable != widthAvailable) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           _updateGalleryGroups();
@@ -708,7 +718,7 @@ class GalleryState extends State<Gallery> {
               )
             : CustomScrollBar(
                 scrollController: _scrollController,
-                galleryGroups: galleryGroups,
+                galleryGroups: groups,
                 inUseNotifier: scrollBarInUseNotifier,
                 heighOfViewport: MediaQuery.sizeOf(context).height,
                 topPadding: widget.disableVerticalPaddingForScrollbar
@@ -753,7 +763,7 @@ class GalleryState extends State<Gallery> {
                                 ),
                               ),
                               SectionedListSliver(
-                                sectionLayouts: galleryGroups.groupLayouts,
+                                sectionLayouts: groups.groupLayouts,
                               ),
                               SliverToBoxAdapter(
                                 child: widget.footer,
@@ -762,11 +772,11 @@ class GalleryState extends State<Gallery> {
                           );
                         },
                       ),
-                      galleryGroups.groupType.showGroupHeader() &&
+                      groups.groupType.showGroupHeader() &&
                               !widget.disablePinnedGroupHeader
                           ? PinnedGroupHeader(
                               scrollController: _scrollController,
-                              galleryGroups: galleryGroups,
+                              galleryGroups: groups,
                               headerHeightNotifier: _headerHeightNotifier,
                               selectedFiles: widget.selectedFiles,
                               showSelectAll: widget.showSelectAll &&

--- a/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/custom_scroll_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/scrollbar/custom_scroll_bar.dart
@@ -110,11 +110,23 @@ class _CustomScrollBarState extends State<CustomScrollBar> {
     _logger.info("Computing position to title map");
     final result = <({double position, String title})>[];
     heightOfScrollTrack = await _getHeightOfScrollTrack();
+    if (!mounted ||
+        heightOfScrollTrack == null ||
+        heightOfScrollTrack! <= 0 ||
+        heightOfScrollbarDivider == null) {
+      return;
+    }
     final maxScrollExtent = widget.scrollController.position.maxScrollExtent;
+    if (maxScrollExtent <= 0) {
+      return;
+    }
 
     for (final scrollbarDivision in widget.galleryGroups.scrollbarDivisions) {
       final scrollOffsetOfGroup = widget
-          .galleryGroups.groupIdToScrollOffsetMap[scrollbarDivision.groupID]!;
+          .galleryGroups.groupIdToScrollOffsetMap[scrollbarDivision.groupID];
+      if (scrollOffsetOfGroup == null) {
+        continue;
+      }
 
       final groupScrollOffsetToUse = scrollOffsetOfGroup - heightOfScrollTrack!;
       if (groupScrollOffsetToUse < 0) {
@@ -163,6 +175,10 @@ class _CustomScrollBarState extends State<CustomScrollBar> {
     }
     final filteredResult = <({double position, String title})>[];
 
+    if (result.isEmpty) {
+      return;
+    }
+
     // Remove first scrollbar division since it doesn't add value in terms of UX
     result.removeAt(0);
 
@@ -185,11 +201,13 @@ class _CustomScrollBarState extends State<CustomScrollBar> {
   Future<double> _getHeightOfScrollTrack() {
     final renderBox =
         _scrollbarKey.currentContext?.findRenderObject() as RenderBox?;
-    assert(renderBox != null, "RenderBox is null");
+    if (renderBox == null) {
+      return Future.value(0);
+    }
     // Retry for : https://github.com/flutter/flutter/issues/25827
     return MiscUtil()
         .getNonZeroDoubleWithRetry(
-          () => renderBox!.size.height,
+          () => renderBox.size.height,
           id: "getHeightOfScrollTrack",
         )
         .then(

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -107,7 +107,9 @@ Future<ParsedExifDateTime?> tryParseExifDateTime(
   Map<String, IfdTag>? exifData,
 ) async {
   try {
-    assert(file != null || exifData != null);
+    if (file == null && exifData == null) {
+      return null;
+    }
     final exif = exifData ?? await readExifAsync(file!);
     final exifTime = exif.containsKey(kDateTimeOriginal)
         ? exif[kDateTimeOriginal]!.printable

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -107,9 +107,7 @@ Future<ParsedExifDateTime?> tryParseExifDateTime(
   Map<String, IfdTag>? exifData,
 ) async {
   try {
-    if (file == null && exifData == null) {
-      return null;
-    }
+    assert(file != null || exifData != null);
     final exif = exifData ?? await readExifAsync(file!);
     final exifTime = exif.containsKey(kDateTimeOriginal)
         ? exif[kDateTimeOriginal]!.printable


### PR DESCRIPTION
## Summary
- Fix confirmed Photos mobile TypeError crash paths across alert controls, text input, home/share intents, galleries, thumbnails, native video, account/recovery flows, lock auth, EXIF parsing, smart albums, and collections.
- Add small diagnostics for skipped work when required IDs or deep-link params are unavailable.
- Include review fix so dismissing the shared media dialog does not start the backup flow.

SIssue: see commit bodies for per-root-cause references.

## Validation
- Full branch diff reviewed for release-blocking regressions; one dialog dismissal regression was found and fixed.
- Targeted `dart analyze` passed for each touched Dart file.
- `flutter analyze .` from `mobile/apps/photos` is still blocked by existing generated localization getter errors and missing `package:cast/cast.dart` resolution.
