### PR TITLE
Validate collection key lengths on server

### DIFF
--- a/server/pkg/controller/collections/collection.go
+++ b/server/pkg/controller/collections/collection.go
@@ -45,6 +45,9 @@ type CollectionController struct {
 
 // Create creates a collection
 func (c *CollectionController) Create(collection ente.Collection, ownerID int64) (ente.Collection, error) {
+	if err := validateOwnedCollectionKey(collection.EncryptedKey, collection.KeyDecryptionNonce); err != nil {
+		return ente.Collection{}, err
+	}
 	// The key attribute check is to ensure that user does not end up uploading any files before actually setting the key attributes.
 	if _, keyErr := c.UserRepo.GetKeyAttributes(ownerID); keyErr != nil {
 		return ente.Collection{}, stacktrace.Propagate(keyErr, "Unable to get keyAttributes")

--- a/server/pkg/controller/collections/key_validation.go
+++ b/server/pkg/controller/collections/key_validation.go
@@ -1,0 +1,38 @@
+package collections
+
+import (
+	"encoding/base64"
+	"errors"
+	"strconv"
+)
+
+const (
+	collectionKeyBytes        = 32
+	secretboxMACBytes         = 16
+	secretboxNonceBytes       = 24
+	sealedBoxOverheadBytes    = 48
+	encryptedCollectionKeyLen = collectionKeyBytes + secretboxMACBytes
+	sealedCollectionKeyLen    = collectionKeyBytes + sealedBoxOverheadBytes
+)
+
+func validateOwnedCollectionKey(encryptedKey string, keyDecryptionNonce string) error {
+	if err := validateBase64DecodedLength(encryptedKey, encryptedCollectionKeyLen, "encryptedKey"); err != nil {
+		return err
+	}
+	return validateBase64DecodedLength(keyDecryptionNonce, secretboxNonceBytes, "keyDecryptionNonce")
+}
+
+func validateSealedCollectionKey(encryptedKey string) error {
+	return validateBase64DecodedLength(encryptedKey, sealedCollectionKeyLen, "encryptedKey")
+}
+
+func validateBase64DecodedLength(value string, expected int, field string) error {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return errors.New(field + " must be valid base64")
+	}
+	if len(decoded) != expected {
+		return errors.New(field + " must decode to " + strconv.Itoa(expected) + " bytes")
+	}
+	return nil
+}

--- a/server/pkg/controller/collections/key_validation_test.go
+++ b/server/pkg/controller/collections/key_validation_test.go
@@ -1,0 +1,144 @@
+package collections
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ente-io/museum/ente"
+	"github.com/gin-gonic/gin"
+)
+
+func b64OfLen(length int) string {
+	return base64.StdEncoding.EncodeToString(make([]byte, length))
+}
+
+func TestValidateOwnedCollectionKey(t *testing.T) {
+	tests := []struct {
+		name                  string
+		encryptedKeyLen       int
+		keyDecryptionNonceLen int
+		wantErr               bool
+	}{
+		{
+			name:                  "accepts secretbox encrypted collection key",
+			encryptedKeyLen:       encryptedCollectionKeyLen,
+			keyDecryptionNonceLen: secretboxNonceBytes,
+		},
+		{
+			name:                  "rejects short encrypted key",
+			encryptedKeyLen:       encryptedCollectionKeyLen - 1,
+			keyDecryptionNonceLen: secretboxNonceBytes,
+			wantErr:               true,
+		},
+		{
+			name:                  "rejects long encrypted key",
+			encryptedKeyLen:       encryptedCollectionKeyLen + 1,
+			keyDecryptionNonceLen: secretboxNonceBytes,
+			wantErr:               true,
+		},
+		{
+			name:                  "rejects short nonce",
+			encryptedKeyLen:       encryptedCollectionKeyLen,
+			keyDecryptionNonceLen: secretboxNonceBytes - 1,
+			wantErr:               true,
+		},
+		{
+			name:                  "rejects long nonce",
+			encryptedKeyLen:       encryptedCollectionKeyLen,
+			keyDecryptionNonceLen: secretboxNonceBytes + 1,
+			wantErr:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOwnedCollectionKey(
+				b64OfLen(tt.encryptedKeyLen),
+				b64OfLen(tt.keyDecryptionNonceLen),
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateOwnedCollectionKey() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSealedCollectionKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyLen  int
+		wantErr bool
+	}{
+		{
+			name:   "accepts sealed collection key",
+			keyLen: sealedCollectionKeyLen,
+		},
+		{
+			name:    "rejects sealed box for 33 byte plaintext key",
+			keyLen:  sealedCollectionKeyLen + 1,
+			wantErr: true,
+		},
+		{
+			name:    "rejects short sealed key",
+			keyLen:  sealedCollectionKeyLen - 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSealedCollectionKey(b64OfLen(tt.keyLen))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateSealedCollectionKey() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCollectionKeyRejectsInvalidBase64(t *testing.T) {
+	if err := validateSealedCollectionKey("not-base64@@@"); err == nil {
+		t.Fatal("validateSealedCollectionKey() error = nil, want error")
+	}
+	if err := validateOwnedCollectionKey("not-base64@@@", b64OfLen(secretboxNonceBytes)); err == nil {
+		t.Fatal("validateOwnedCollectionKey() encryptedKey error = nil, want error")
+	}
+	if err := validateOwnedCollectionKey(b64OfLen(encryptedCollectionKeyLen), "not-base64@@@"); err == nil {
+		t.Fatal("validateOwnedCollectionKey() keyDecryptionNonce error = nil, want error")
+	}
+}
+
+func TestCollectionControllerRejectsInvalidCollectionKeysBeforeRepoAccess(t *testing.T) {
+	controller := CollectionController{}
+	ctx := testGinContext()
+
+	if _, err := controller.Create(ente.Collection{
+		EncryptedKey:       b64OfLen(encryptedCollectionKeyLen + 1),
+		KeyDecryptionNonce: b64OfLen(secretboxNonceBytes),
+		Type:               "album",
+	}, 1); err == nil {
+		t.Fatal("Create() error = nil, want invalid key error")
+	}
+
+	if _, err := controller.Share(ctx, ente.AlterShareRequest{
+		CollectionID: 1,
+		Email:        "sharee@example.com",
+		EncryptedKey: b64OfLen(sealedCollectionKeyLen + 1),
+	}); err == nil {
+		t.Fatal("Share() error = nil, want invalid key error")
+	}
+
+	if err := controller.JoinViaLink(ctx, ente.JoinCollectionViaLinkRequest{
+		CollectionID: 1,
+		EncryptedKey: b64OfLen(sealedCollectionKeyLen + 1),
+	}); err == nil {
+		t.Fatal("JoinViaLink() error = nil, want invalid key error")
+	}
+}
+
+func testGinContext() *gin.Context {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest("POST", "/", nil)
+	return ctx
+}

--- a/server/pkg/controller/collections/share.go
+++ b/server/pkg/controller/collections/share.go
@@ -23,6 +23,9 @@ func (c *CollectionController) Share(ctx *gin.Context, req ente.AlterShareReques
 	fromUserID := auth.GetUserID(ctx.Request.Header)
 	cID := req.CollectionID
 	encryptedKey := req.EncryptedKey
+	if err := validateSealedCollectionKey(encryptedKey); err != nil {
+		return nil, err
+	}
 	toUserEmail := emailUtil.NormalizeEmail(req.Email)
 	// default role type
 	role := ente.VIEWER
@@ -69,6 +72,9 @@ func (c *CollectionController) Share(ctx *gin.Context, req ente.AlterShareReques
 }
 
 func (c *CollectionController) JoinViaLink(ctx *gin.Context, req ente.JoinCollectionViaLinkRequest) error {
+	if err := validateSealedCollectionKey(req.EncryptedKey); err != nil {
+		return err
+	}
 	userID := auth.GetUserID(ctx.Request.Header)
 	collection, err := c.CollectionRepo.Get(req.CollectionID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Surface malformed collection key submissions as server errors so they are visible in monitoring.
- Validate owner-encrypted collection keys during collection creation.
- Validate sealed collection keys during collection share and public-link join.
- Add server-side tests for valid key sizes, off-by-one invalid sizes, invalid base64, and controller early rejection.

## Validation
- go test ./pkg/controller/collections
- go test -tags keylengthcheck -run TestManualCollectionKeyLengthCheck ./pkg/controller/collections (temporary check removed before commit)