### PR TITLE
[rust] Add legacy kit client and e2e support

### DIFF
--- a/mobile/packages/rust/rust/src/api/contacts.rs
+++ b/mobile/packages/rust/rust/src/api/contacts.rs
@@ -286,7 +286,7 @@ pub struct LegacyKitRecoverySession {
     pub kit_id: String,
     /// Current recovery status.
     pub status: LegacyKitRecoveryStatus,
-    /// Timestamp when the recovery becomes usable.
+    /// Remaining microseconds until the recovery becomes usable.
     pub wait_till: i64,
     /// Session creation timestamp.
     pub created_at: i64,

--- a/mobile/packages/rust/rust/src/api/contacts.rs
+++ b/mobile/packages/rust/rust/src/api/contacts.rs
@@ -5,9 +5,15 @@ use std::sync::Arc;
 use ente_contacts::{
     AttachmentType as CoreAttachmentType, ContactData as CoreContactData,
     ContactRecord as CoreContactRecord, ContactsCtx as CoreContactsCtx,
-    ContactsError as CoreContactsError, OpenContactsCtxInput as CoreOpenContactsCtxInput,
+    ContactsError as CoreContactsError, LegacyKit as CoreLegacyKit,
+    LegacyKitCreateResult as CoreLegacyKitCreateResult, LegacyKitMetadata as CoreLegacyKitMetadata,
+    LegacyKitOwnerRecoverySession, LegacyKitPart as CoreLegacyKitPart, LegacyKitRecoveryInitiator,
+    LegacyKitRecoverySession as CoreLegacyKitRecoverySession,
+    LegacyKitRecoveryStatus as CoreLegacyKitRecoveryStatus, LegacyKitShare as CoreLegacyKitShare,
+    LegacyKitVariant as CoreLegacyKitVariant, OpenContactsCtxInput as CoreOpenContactsCtxInput,
     RootKeySource as CoreRootKeySource, WrappedRootContactKey as CoreWrappedRootContactKey,
 };
+use ente_core::auth::KeyAttributes as CoreKeyAttributes;
 use flutter_rust_bridge::frb;
 
 #[frb]
@@ -117,6 +123,55 @@ impl From<WrappedRootContactKey> for CoreWrappedRootContactKey {
 
 #[frb]
 #[derive(Clone)]
+/// Account key attributes required to decrypt the owner's recovery key.
+pub struct AccountKeyAttributes {
+    /// Salt for deriving key-encryption-key from password (base64).
+    pub kek_salt: String,
+    /// Master key encrypted with KEK (base64).
+    pub encrypted_key: String,
+    /// Nonce for master key decryption (base64).
+    pub key_decryption_nonce: String,
+    /// X25519 public key (base64).
+    pub public_key: String,
+    /// Secret key encrypted with master key (base64).
+    pub encrypted_secret_key: String,
+    /// Nonce for secret key decryption (base64).
+    pub secret_key_decryption_nonce: String,
+    /// Argon2 memory limit.
+    pub mem_limit: Option<u32>,
+    /// Argon2 ops limit.
+    pub ops_limit: Option<u32>,
+    /// Master key encrypted with recovery key (base64).
+    pub master_key_encrypted_with_recovery_key: Option<String>,
+    /// Nonce for master key decryption with recovery key (base64).
+    pub master_key_decryption_nonce: Option<String>,
+    /// Recovery key encrypted with master key (base64).
+    pub recovery_key_encrypted_with_master_key: Option<String>,
+    /// Nonce for recovery key decryption (base64).
+    pub recovery_key_decryption_nonce: Option<String>,
+}
+
+impl From<AccountKeyAttributes> for CoreKeyAttributes {
+    fn from(value: AccountKeyAttributes) -> Self {
+        Self {
+            kek_salt: value.kek_salt,
+            encrypted_key: value.encrypted_key,
+            key_decryption_nonce: value.key_decryption_nonce,
+            public_key: value.public_key,
+            encrypted_secret_key: value.encrypted_secret_key,
+            secret_key_decryption_nonce: value.secret_key_decryption_nonce,
+            mem_limit: value.mem_limit,
+            ops_limit: value.ops_limit,
+            master_key_encrypted_with_recovery_key: value.master_key_encrypted_with_recovery_key,
+            master_key_decryption_nonce: value.master_key_decryption_nonce,
+            recovery_key_encrypted_with_master_key: value.recovery_key_encrypted_with_master_key,
+            recovery_key_decryption_nonce: value.recovery_key_decryption_nonce,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
 /// Encrypted contact payload fields managed by the client.
 pub struct ContactData {
     /// User id of the contact being referenced.
@@ -173,6 +228,241 @@ impl From<CoreContactRecord> for ContactRecord {
             is_deleted: value.is_deleted,
             created_at: value.created_at,
             updated_at: value.updated_at,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone, Copy)]
+/// Offline legacy kit split variant.
+pub enum LegacyKitVariant {
+    /// Any two of three sheets can recover the account.
+    TwoOfThree,
+}
+
+impl From<CoreLegacyKitVariant> for LegacyKitVariant {
+    fn from(value: CoreLegacyKitVariant) -> Self {
+        match value {
+            CoreLegacyKitVariant::TwoOfThree => Self::TwoOfThree,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone, Copy)]
+/// Owner-visible recovery session status for an offline legacy kit.
+pub enum LegacyKitRecoveryStatus {
+    /// Waiting for the selected recovery time.
+    Waiting,
+    /// Recovery bundle is available.
+    Ready,
+    /// Owner blocked this recovery attempt.
+    Blocked,
+    /// Recovery was cancelled.
+    Cancelled,
+    /// Recovery completed.
+    Recovered,
+}
+
+impl From<CoreLegacyKitRecoveryStatus> for LegacyKitRecoveryStatus {
+    fn from(value: CoreLegacyKitRecoveryStatus) -> Self {
+        match value {
+            CoreLegacyKitRecoveryStatus::Waiting => Self::Waiting,
+            CoreLegacyKitRecoveryStatus::Ready => Self::Ready,
+            CoreLegacyKitRecoveryStatus::Blocked => Self::Blocked,
+            CoreLegacyKitRecoveryStatus::Cancelled => Self::Cancelled,
+            CoreLegacyKitRecoveryStatus::Recovered => Self::Recovered,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Owner-visible recovery session for an offline legacy kit.
+pub struct LegacyKitRecoverySession {
+    /// Recovery session id.
+    pub id: String,
+    /// Kit id being recovered.
+    pub kit_id: String,
+    /// Current recovery status.
+    pub status: LegacyKitRecoveryStatus,
+    /// Timestamp when the recovery becomes usable.
+    pub wait_till: i64,
+    /// Session creation timestamp.
+    pub created_at: i64,
+}
+
+impl From<CoreLegacyKitRecoverySession> for LegacyKitRecoverySession {
+    fn from(value: CoreLegacyKitRecoverySession) -> Self {
+        Self {
+            id: value.id,
+            kit_id: value.kit_id,
+            status: value.status.into(),
+            wait_till: value.wait_till,
+            created_at: value.created_at,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Owner-facing audit hint for a successful legacy kit recovery open.
+pub struct LegacyKitRecoveryInitiatorHint {
+    /// Client-reported sheet indexes used by the recovery flow.
+    pub used_part_indexes: Vec<u8>,
+    /// Server-observed IP address.
+    pub ip: String,
+    /// Server-observed user agent.
+    pub user_agent: String,
+}
+
+impl From<LegacyKitRecoveryInitiator> for LegacyKitRecoveryInitiatorHint {
+    fn from(value: LegacyKitRecoveryInitiator) -> Self {
+        Self {
+            used_part_indexes: value.used_part_indexes,
+            ip: value.ip,
+            user_agent: value.user_agent,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Owner-facing recovery session details for a legacy kit.
+pub struct LegacyKitOwnerRecoverySessionDetails {
+    /// Active session, if one exists.
+    pub session: Option<LegacyKitRecoverySession>,
+    /// Server-captured audit hints for successful recovery opens.
+    pub initiators: Vec<LegacyKitRecoveryInitiatorHint>,
+}
+
+impl From<LegacyKitOwnerRecoverySession> for LegacyKitOwnerRecoverySessionDetails {
+    fn from(value: LegacyKitOwnerRecoverySession) -> Self {
+        Self {
+            session: value.session.map(Into::into),
+            initiators: value.initiators.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// One named part of an offline legacy kit.
+pub struct LegacyKitPart {
+    /// One-based part index encoded in the recovery sheet.
+    pub index: u8,
+    /// Human-readable part holder/storage name.
+    pub name: String,
+}
+
+impl From<CoreLegacyKitPart> for LegacyKitPart {
+    fn from(value: CoreLegacyKitPart) -> Self {
+        Self {
+            index: value.index,
+            name: value.name,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Decrypted owner metadata for an offline legacy kit.
+pub struct LegacyKitMetadata {
+    /// Named recovery parts.
+    pub parts: Vec<LegacyKitPart>,
+}
+
+impl From<CoreLegacyKitMetadata> for LegacyKitMetadata {
+    fn from(value: CoreLegacyKitMetadata) -> Self {
+        Self {
+            parts: value.parts.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Offline legacy kit record visible to the owner.
+pub struct LegacyKit {
+    /// Stable kit id.
+    pub id: String,
+    /// Split variant.
+    pub variant: LegacyKitVariant,
+    /// Configured notice period in hours.
+    pub notice_period_in_hours: i32,
+    /// Decrypted owner metadata.
+    pub metadata: LegacyKitMetadata,
+    /// Kit creation timestamp.
+    pub created_at: i64,
+    /// Kit update timestamp.
+    pub updated_at: i64,
+    /// Active owner-visible recovery session, if any.
+    pub active_recovery_session: Option<LegacyKitRecoverySession>,
+}
+
+impl From<CoreLegacyKit> for LegacyKit {
+    fn from(value: CoreLegacyKit) -> Self {
+        Self {
+            id: value.id,
+            variant: value.variant.into(),
+            notice_period_in_hours: value.notice_period_in_hours,
+            metadata: value.metadata.into(),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            active_recovery_session: value.active_recovery_session.map(Into::into),
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// One offline legacy kit recovery share to encode into a recovery sheet.
+pub struct LegacyKitShare {
+    /// Payload version.
+    pub payload_version: u8,
+    /// Split variant.
+    pub variant: LegacyKitVariant,
+    /// Kit id.
+    pub kit_id: String,
+    /// One-based share index.
+    pub share_index: u8,
+    /// Encoded share bytes.
+    pub share: String,
+    /// Share checksum.
+    pub checksum: String,
+    /// Human-readable part name.
+    pub part_name: String,
+}
+
+impl From<CoreLegacyKitShare> for LegacyKitShare {
+    fn from(value: CoreLegacyKitShare) -> Self {
+        Self {
+            payload_version: value.payload_version,
+            variant: value.variant.into(),
+            kit_id: value.kit_id,
+            share_index: value.share_index,
+            share: value.share,
+            checksum: value.checksum,
+            part_name: value.part_name,
+        }
+    }
+}
+
+#[frb]
+#[derive(Clone)]
+/// Result of creating an offline legacy kit.
+pub struct LegacyKitCreateResult {
+    /// Created kit record.
+    pub kit: LegacyKit,
+    /// Recovery shares that must be exported immediately.
+    pub shares: Vec<LegacyKitShare>,
+}
+
+impl From<CoreLegacyKitCreateResult> for LegacyKitCreateResult {
+    fn from(value: CoreLegacyKitCreateResult) -> Self {
+        Self {
+            kit: value.kit.into(),
+            shares: value.shares.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -414,5 +704,90 @@ impl ContactsCtx {
     ) -> Result<ContactRecord, ContactsError> {
         self.delete_attachment(contact_id, AttachmentType::ProfilePicture)
             .await
+    }
+
+    /// List owner-created offline legacy kits.
+    pub async fn legacy_kits(&self) -> Result<Vec<LegacyKit>, ContactsError> {
+        self.inner
+            .legacy_kits()
+            .await
+            .map(|kits| kits.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Create an offline legacy kit and return the printable recovery shares.
+    pub async fn legacy_kit_create(
+        &self,
+        current_user_key_attrs: AccountKeyAttributes,
+        part_names: Vec<String>,
+        notice_period_in_hours: i32,
+    ) -> Result<LegacyKitCreateResult, ContactsError> {
+        let part_names: [String; 3] =
+            part_names
+                .try_into()
+                .map_err(|_| ContactsError::InvalidInput {
+                    message: "legacy kit requires exactly three part names".into(),
+                })?;
+        self.inner
+            .legacy_kit_create(
+                &current_user_key_attrs.into(),
+                part_names,
+                notice_period_in_hours,
+            )
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Download the printable recovery shares for an existing offline legacy kit.
+    pub async fn legacy_kit_download_shares(
+        &self,
+        kit_id: String,
+    ) -> Result<Vec<LegacyKitShare>, ContactsError> {
+        self.inner
+            .legacy_kit_download_shares(&kit_id)
+            .await
+            .map(|shares| shares.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
+    }
+
+    /// Fetch owner-visible active recovery session details for a legacy kit.
+    pub async fn legacy_kit_recovery_session(
+        &self,
+        kit_id: String,
+    ) -> Result<LegacyKitOwnerRecoverySessionDetails, ContactsError> {
+        self.inner
+            .legacy_kit_recovery_session(&kit_id)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    /// Update the recovery wait time for a legacy kit.
+    pub async fn legacy_kit_update_recovery_notice(
+        &self,
+        kit_id: String,
+        notice_period_in_hours: i32,
+    ) -> Result<(), ContactsError> {
+        self.inner
+            .legacy_kit_update_recovery_notice(&kit_id, notice_period_in_hours)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Block the active recovery session for a legacy kit.
+    pub async fn legacy_kit_block_recovery(&self, kit_id: String) -> Result<(), ContactsError> {
+        self.inner
+            .legacy_kit_block_recovery(&kit_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Delete an offline legacy kit.
+    pub async fn legacy_kit_delete(&self, kit_id: String) -> Result<(), ContactsError> {
+        self.inner
+            .legacy_kit_delete(&kit_id)
+            .await
+            .map_err(Into::into)
     }
 }

--- a/rust/contacts/src/client.rs
+++ b/rust/contacts/src/client.rs
@@ -10,13 +10,15 @@ use crate::crypto as contacts_crypto;
 use crate::error::{ContactsError, Result};
 use crate::legacy_kit::{
     create_legacy_kit_request, decode_download_content, decode_legacy_kit_record,
+    validate_notice_period,
 };
 use crate::legacy_kit_models::{
     LegacyKit, LegacyKitCreateResult, LegacyKitOwnerRecoverySession, LegacyKitShare,
 };
 use crate::legacy_kit_transport::{
     LegacyKitDownloadContentResponse, LegacyKitOwnerActionRequest,
-    LegacyKitOwnerRecoverySessionResponse, LegacyKitRecordResponse, ListLegacyKitsResponse,
+    LegacyKitOwnerRecoverySessionResponse, LegacyKitRecordResponse,
+    LegacyKitUpdateRecoveryNoticeRequest, ListLegacyKitsResponse,
 };
 use crate::legacy_models::{LegacyContactState, LegacyInfo, LegacyRecoveryBundle};
 use crate::legacy_transport::{
@@ -598,14 +600,14 @@ impl ContactsCtx {
             &bundle.user_key_attributes,
             &bundle.recovery_key,
         )?;
-        let (updated_key_attrs, _) = auth::generate_key_attributes_for_new_password(
+        let (updated_key_attrs, login_key) = auth::generate_key_attributes_for_new_password(
             &target_master_key,
             &bundle.user_key_attributes,
             new_password,
         )?;
         let srp_user_id = Uuid::new_v4().to_string();
         let (mut srp_session, setup_request) =
-            password_reset_setup_request(&srp_user_id, new_password, &updated_key_attrs)?;
+            password_reset_setup_request(&srp_user_id, &login_key)?;
         let init_response = self
             .http
             .post_json::<LegacySetupSrpResponse, _>(
@@ -674,15 +676,16 @@ impl ContactsCtx {
         part_names: [String; 3],
         notice_period_in_hours: i32,
     ) -> Result<LegacyKitCreateResult> {
-        let recovery_key = self.current_recovery_key(current_user_key_attrs)?;
-        let master_key = self.master_key.read().expect("master key lock poisoned");
-        let (request, shares) = create_legacy_kit_request(
-            &recovery_key,
-            &master_key,
-            part_names,
-            notice_period_in_hours,
-        )?;
-        drop(master_key);
+        let (request, shares) = {
+            let recovery_key = self.current_recovery_key(current_user_key_attrs)?;
+            let master_key = self.master_key.read().expect("master key lock poisoned");
+            create_legacy_kit_request(
+                &recovery_key,
+                &master_key,
+                part_names,
+                notice_period_in_hours,
+            )?
+        };
 
         let response = self
             .http
@@ -725,6 +728,25 @@ impl ContactsCtx {
                 with_http_context("legacy kit recovery session fetch failed", error)
             })?;
         Ok(response.into())
+    }
+
+    pub async fn legacy_kit_update_recovery_notice(
+        &self,
+        kit_id: &str,
+        notice_period_in_hours: i32,
+    ) -> Result<()> {
+        validate_notice_period(notice_period_in_hours)?;
+        self.http
+            .post_empty(
+                "/legacy-kits/update-recovery-notice",
+                &LegacyKitUpdateRecoveryNoticeRequest {
+                    kit_id: kit_id.to_string(),
+                    notice_period_in_hours,
+                },
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit recovery notice update failed", error))
     }
 
     pub async fn legacy_kit_block_recovery(&self, kit_id: &str) -> Result<()> {
@@ -1020,22 +1042,9 @@ fn decrypt_master_key_with_recovery_key(
 
 fn password_reset_setup_request(
     srp_user_id: &str,
-    new_password: &str,
-    updated_key_attrs: &KeyAttributes,
+    login_key: &[u8],
 ) -> Result<(SrpSession, LegacySetupSrpRequest)> {
-    let mem_limit = updated_key_attrs.mem_limit.ok_or_else(|| {
-        ContactsError::InvalidInput("updated key attributes missing memLimit".into())
-    })?;
-    let ops_limit = updated_key_attrs.ops_limit.ok_or_else(|| {
-        ContactsError::InvalidInput("updated key attributes missing opsLimit".into())
-    })?;
-    let kek = auth::derive_kek(
-        new_password,
-        &updated_key_attrs.kek_salt,
-        mem_limit,
-        ops_limit,
-    )?;
-    let generated_srp = auth::generate_srp_setup(&kek, srp_user_id)?;
+    let generated_srp = auth::generate_srp_setup_with_login_key(login_key, srp_user_id)?;
     let srp_session = SrpSession::new(
         srp_user_id,
         &generated_srp.srp_salt,

--- a/rust/contacts/src/client.rs
+++ b/rust/contacts/src/client.rs
@@ -8,6 +8,16 @@ use uuid::Uuid;
 
 use crate::crypto as contacts_crypto;
 use crate::error::{ContactsError, Result};
+use crate::legacy_kit::{
+    create_legacy_kit_request, decode_download_content, decode_legacy_kit_record,
+};
+use crate::legacy_kit_models::{
+    LegacyKit, LegacyKitCreateResult, LegacyKitOwnerRecoverySession, LegacyKitShare,
+};
+use crate::legacy_kit_transport::{
+    LegacyKitDownloadContentResponse, LegacyKitOwnerActionRequest,
+    LegacyKitOwnerRecoverySessionResponse, LegacyKitRecordResponse, ListLegacyKitsResponse,
+};
 use crate::legacy_models::{LegacyContactState, LegacyInfo, LegacyRecoveryBundle};
 use crate::legacy_transport::{
     LegacyAddContactRequest, LegacyChangePasswordRequest, LegacyChangePasswordResponse,
@@ -570,7 +580,7 @@ impl ContactsCtx {
             self.decrypt_legacy_recovery_key(&response.encrypted_key, current_user_key_attrs)?;
 
         Ok(LegacyRecoveryBundle {
-            recovery_key: crypto::encode_hex(&recovery_key),
+            recovery_key,
             user_key_attributes: response.user_key_attr,
         })
     }
@@ -584,9 +594,10 @@ impl ContactsCtx {
         let bundle = self
             .legacy_recovery_bundle(recovery_id, current_user_key_attrs)
             .await?;
-        let recovery_key = auth::recovery_key_from_mnemonic_or_hex(&bundle.recovery_key)?;
-        let target_master_key =
-            decrypt_master_key_with_recovery_key(&bundle.user_key_attributes, &recovery_key)?;
+        let target_master_key = decrypt_master_key_with_recovery_key(
+            &bundle.user_key_attributes,
+            &bundle.recovery_key,
+        )?;
         let (updated_key_attrs, _) = auth::generate_key_attributes_for_new_password(
             &target_master_key,
             &bundle.user_key_attributes,
@@ -640,6 +651,101 @@ impl ContactsCtx {
         let server_m2 = crypto::decode_b64(&change_response.srp_m2)?;
         srp_session.verify_m2(&server_m2)?;
         Ok(())
+    }
+
+    pub async fn legacy_kits(&self) -> Result<Vec<LegacyKit>> {
+        let response = self
+            .http
+            .get_json::<ListLegacyKitsResponse>("/legacy-kits", &[])
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit list failed", error))?;
+        let master_key = self.master_key.read().expect("master key lock poisoned");
+        response
+            .kits
+            .into_iter()
+            .map(|kit| decode_legacy_kit_record(kit, &master_key))
+            .collect()
+    }
+
+    pub async fn legacy_kit_create(
+        &self,
+        current_user_key_attrs: &KeyAttributes,
+        part_names: [String; 3],
+        notice_period_in_hours: i32,
+    ) -> Result<LegacyKitCreateResult> {
+        let recovery_key = self.current_recovery_key(current_user_key_attrs)?;
+        let master_key = self.master_key.read().expect("master key lock poisoned");
+        let (request, shares) = create_legacy_kit_request(
+            &recovery_key,
+            &master_key,
+            part_names,
+            notice_period_in_hours,
+        )?;
+        drop(master_key);
+
+        let response = self
+            .http
+            .post_json::<LegacyKitRecordResponse, _>("/legacy-kits", &request)
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit create failed", error))?;
+        let master_key = self.master_key.read().expect("master key lock poisoned");
+        let kit = decode_legacy_kit_record(response, &master_key)?;
+        Ok(LegacyKitCreateResult { kit, shares })
+    }
+
+    pub async fn legacy_kit_download_shares(&self, kit_id: &str) -> Result<Vec<LegacyKitShare>> {
+        let response = self
+            .http
+            .get_json::<LegacyKitDownloadContentResponse>(
+                &format!("/legacy-kits/{kit_id}/download-content"),
+                &[],
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit download failed", error))?;
+        let master_key = self.master_key.read().expect("master key lock poisoned");
+        decode_download_content(response, &master_key)
+    }
+
+    pub async fn legacy_kit_recovery_session(
+        &self,
+        kit_id: &str,
+    ) -> Result<LegacyKitOwnerRecoverySession> {
+        let response = self
+            .http
+            .get_json::<LegacyKitOwnerRecoverySessionResponse>(
+                &format!("/legacy-kits/{kit_id}/recovery-session"),
+                &[],
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(|error| {
+                with_http_context("legacy kit recovery session fetch failed", error)
+            })?;
+        Ok(response.into())
+    }
+
+    pub async fn legacy_kit_block_recovery(&self, kit_id: &str) -> Result<()> {
+        self.http
+            .post_empty(
+                "/legacy-kits/block-recovery",
+                &LegacyKitOwnerActionRequest {
+                    kit_id: kit_id.to_string(),
+                },
+            )
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit block failed", error))
+    }
+
+    pub async fn legacy_kit_delete(&self, kit_id: &str) -> Result<()> {
+        self.http
+            .delete_empty(&format!("/legacy-kits/{kit_id}"), &[])
+            .await
+            .map_err(Into::into)
+            .map_err(|error| with_http_context("legacy kit delete failed", error))
     }
 
     fn decode_contact(&self, entity: ContactEntityResponse) -> Result<ContactRecord> {

--- a/rust/contacts/src/legacy_kit/mod.rs
+++ b/rust/contacts/src/legacy_kit/mod.rs
@@ -135,12 +135,26 @@ pub struct LegacyKitRecoveryHandle {
 
 impl LegacyKitRecoveryClient {
     pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        Self::new_with_headers(
+            base_url,
+            None,
+            None,
+            Some("ente-rust-legacy-kit".to_string()),
+        )
+    }
+
+    pub fn new_with_headers(
+        base_url: impl Into<String>,
+        client_package: Option<String>,
+        client_version: Option<String>,
+        user_agent: Option<String>,
+    ) -> Result<Self> {
         let http = HttpClient::new_with_config(HttpConfig {
             base_url: base_url.into(),
             auth_token: None,
-            user_agent: Some("ente-rust-legacy-kit".to_string()),
-            client_package: None,
-            client_version: None,
+            user_agent,
+            client_package,
+            client_version,
             timeout_secs: Some(30),
         })?;
         Ok(Self {
@@ -241,14 +255,14 @@ impl LegacyKitRecoveryHandle {
             &bundle.user_key_attributes,
             &bundle.recovery_key,
         )?;
-        let (updated_key_attrs, _) = auth::generate_key_attributes_for_new_password(
+        let (updated_key_attrs, login_key) = auth::generate_key_attributes_for_new_password(
             &target_master_key,
             &bundle.user_key_attributes,
             new_password,
         )?;
         let srp_user_id = Uuid::new_v4().to_string();
         let (mut srp_session, setup_request) =
-            password_reset_setup_request(&srp_user_id, new_password, &updated_key_attrs)?;
+            password_reset_setup_request(&srp_user_id, &login_key)?;
         let init_response = self
             .http
             .post_json::<LegacyKitSetupSrpResponse, _>(
@@ -328,7 +342,7 @@ impl LegacyKitRecoveryClient {
     }
 }
 
-fn validate_notice_period(hours: i32) -> Result<()> {
+pub(crate) fn validate_notice_period(hours: i32) -> Result<()> {
     if LEGACY_KIT_NOTICE_OPTIONS.contains(&hours) {
         Ok(())
     } else {
@@ -391,22 +405,9 @@ fn decrypt_master_key_with_recovery_key(
 
 fn password_reset_setup_request(
     srp_user_id: &str,
-    new_password: &str,
-    updated_key_attrs: &KeyAttributes,
+    login_key: &[u8],
 ) -> Result<(SrpSession, LegacyKitSetupSrpRequest)> {
-    let mem_limit = updated_key_attrs.mem_limit.ok_or_else(|| {
-        ContactsError::InvalidInput("updated key attributes missing memLimit".into())
-    })?;
-    let ops_limit = updated_key_attrs.ops_limit.ok_or_else(|| {
-        ContactsError::InvalidInput("updated key attributes missing opsLimit".into())
-    })?;
-    let kek = auth::derive_kek(
-        new_password,
-        &updated_key_attrs.kek_salt,
-        mem_limit,
-        ops_limit,
-    )?;
-    let generated_srp = auth::generate_srp_setup(&kek, srp_user_id)?;
+    let generated_srp = auth::generate_srp_setup_with_login_key(login_key, srp_user_id)?;
     let srp_session = SrpSession::new(
         srp_user_id,
         &generated_srp.srp_salt,

--- a/rust/contacts/src/legacy_kit/mod.rs
+++ b/rust/contacts/src/legacy_kit/mod.rs
@@ -1,0 +1,434 @@
+mod owner_blob;
+mod shares;
+
+use std::sync::Arc;
+
+use ente_core::{
+    auth::{self, KeyAttributes, SrpSession},
+    crypto::{self, SecretString, SecretVec, kdf, sealed, secretbox},
+    http::{HttpClient, HttpConfig},
+};
+use uuid::Uuid;
+
+use crate::{
+    ContactsError, Result,
+    legacy_kit_models::{
+        LEGACY_KIT_PAYLOAD_VERSION, LegacyKit, LegacyKitRecoveryBundle, LegacyKitRecoverySession,
+        LegacyKitShare, LegacyKitVariant,
+    },
+    legacy_kit_transport::{
+        CreateLegacyKitRequest, LegacyKitChallengeRequest, LegacyKitChallengeResponse,
+        LegacyKitChangePasswordRequest, LegacyKitChangePasswordResponse,
+        LegacyKitDownloadContentResponse, LegacyKitInitChangePasswordRequest,
+        LegacyKitOpenRecoveryRequest, LegacyKitOpenRecoveryResponse, LegacyKitRecordResponse,
+        LegacyKitRecoveryInfoResponse, LegacyKitSessionRequest, LegacyKitSetupSrpRequest,
+        LegacyKitSetupSrpResponse, LegacyKitUpdateSrpAndKeysRequest, LegacyKitUpdatedKeyAttr,
+    },
+};
+use owner_blob::{
+    create_owner_blob, decrypt_owner_blob, encrypt_owner_blob, metadata_from_owner_blob,
+};
+use shares::{checksum, reconstruct_secret_2_of_3, split_secret_2_of_3, used_part_indexes};
+
+const LEGACY_KIT_NOTICE_OPTIONS: [i32; 5] = [0, 24, 168, 360, 720];
+
+pub(crate) fn create_legacy_kit_request(
+    recovery_key: &[u8],
+    master_key: &[u8],
+    part_names: [String; 3],
+    notice_period_in_hours: i32,
+) -> Result<(CreateLegacyKitRequest, Vec<LegacyKitShare>)> {
+    validate_notice_period(notice_period_in_hours)?;
+    if part_names.iter().any(|name| name.trim().is_empty()) {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit part names must be non-empty".into(),
+        ));
+    }
+
+    let kit_id = Uuid::new_v4().to_string();
+    let variant = LegacyKitVariant::TwoOfThree;
+    let kit_secret = crypto::keys::generate_key_secure();
+    let checksum = checksum(LEGACY_KIT_PAYLOAD_VERSION, variant, &kit_id, &kit_secret);
+    let shares = split_secret_2_of_3(&kit_secret)?;
+    let result_shares = shares
+        .into_iter()
+        .zip(part_names.iter())
+        .enumerate()
+        .map(|(index, (share_bytes, part_name))| LegacyKitShare {
+            payload_version: LEGACY_KIT_PAYLOAD_VERSION,
+            variant,
+            kit_id: kit_id.clone(),
+            share_index: (index + 1) as u8,
+            share: crypto::encode_b64(&share_bytes),
+            checksum: checksum.clone(),
+            part_name: part_name.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let enc_key = derive_kit_enc_key(&kit_secret)?;
+    let (auth_public_key, _auth_secret_key) = derive_kit_auth_keypair(&kit_secret)?;
+
+    let encrypted_recovery_blob = secretbox::encrypt(recovery_key, enc_key.as_ref())?;
+    let owner_blob = create_owner_blob(&result_shares);
+    let encrypted_owner_blob = encrypt_owner_blob(&owner_blob, master_key)?;
+
+    Ok((
+        CreateLegacyKitRequest {
+            id: kit_id,
+            variant,
+            notice_period_in_hours,
+            encrypted_recovery_blob: crypto::encode_b64(&encrypted_recovery_blob.encrypted_data),
+            auth_public_key: crypto::encode_b64(&auth_public_key),
+            encrypted_owner_blob,
+        },
+        result_shares,
+    ))
+}
+
+pub(crate) fn decode_legacy_kit_record(
+    response: LegacyKitRecordResponse,
+    master_key: &[u8],
+) -> Result<LegacyKit> {
+    let owner_blob = decrypt_owner_blob(&response.encrypted_owner_blob, master_key)?;
+    let metadata = metadata_from_owner_blob(&owner_blob);
+    Ok(LegacyKit {
+        id: response.id,
+        variant: response.variant,
+        notice_period_in_hours: response.notice_period_in_hours,
+        metadata,
+        created_at: response.created_at,
+        updated_at: response.updated_at,
+        active_recovery_session: response.active_recovery_session,
+    })
+}
+
+pub(crate) fn decode_download_content(
+    response: LegacyKitDownloadContentResponse,
+    master_key: &[u8],
+) -> Result<Vec<LegacyKitShare>> {
+    let owner_blob = decrypt_owner_blob(&response.encrypted_owner_blob, master_key)?;
+    Ok(owner_blob
+        .parts
+        .into_iter()
+        .map(|part| LegacyKitShare {
+            payload_version: LEGACY_KIT_PAYLOAD_VERSION,
+            variant: response.variant,
+            kit_id: response.id.clone(),
+            share_index: part.index,
+            share: part.share,
+            checksum: part.checksum,
+            part_name: part.name,
+        })
+        .collect::<Vec<_>>())
+}
+
+pub struct LegacyKitRecoveryClient {
+    http: Arc<HttpClient>,
+}
+
+pub struct LegacyKitRecoveryHandle {
+    http: Arc<HttpClient>,
+    session: LegacyKitRecoverySession,
+    session_token: SecretString,
+    kit_secret: SecretVec,
+}
+
+impl LegacyKitRecoveryClient {
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        let http = HttpClient::new_with_config(HttpConfig {
+            base_url: base_url.into(),
+            auth_token: None,
+            user_agent: Some("ente-rust-legacy-kit".to_string()),
+            client_package: None,
+            client_version: None,
+            timeout_secs: Some(30),
+        })?;
+        Ok(Self {
+            http: Arc::new(http),
+        })
+    }
+
+    pub fn reconstruct_secret(shares: &[LegacyKitShare]) -> Result<SecretVec> {
+        reconstruct_secret_2_of_3(shares)
+    }
+
+    pub async fn open_from_shares(
+        &self,
+        shares: &[LegacyKitShare],
+        email: Option<&str>,
+    ) -> Result<LegacyKitRecoveryHandle> {
+        let first_share = shares.first().ok_or_else(|| {
+            ContactsError::InvalidInput("at least two legacy kit shares are required".into())
+        })?;
+        let challenge = self
+            .http
+            .post_json::<LegacyKitChallengeResponse, _>(
+                "/legacy-kits/recovery/challenge",
+                &LegacyKitChallengeRequest {
+                    kit_id: first_share.kit_id.clone(),
+                },
+            )
+            .await
+            .map_err(ContactsError::from)?;
+        self.open_from_encrypted_challenge(shares, &challenge.encrypted_challenge, email)
+            .await
+    }
+
+    pub async fn open_from_encrypted_challenge(
+        &self,
+        shares: &[LegacyKitShare],
+        encrypted_challenge: &str,
+        email: Option<&str>,
+    ) -> Result<LegacyKitRecoveryHandle> {
+        let kit_secret = reconstruct_secret_2_of_3(shares)?;
+        let first_share = shares.first().ok_or_else(|| {
+            ContactsError::InvalidInput("at least two legacy kit shares are required".into())
+        })?;
+        let used_part_indexes = used_part_indexes(shares)?;
+        self.open_with_kit_secret(
+            first_share,
+            kit_secret,
+            encrypted_challenge,
+            Some(used_part_indexes),
+            email.map(ToOwned::to_owned),
+        )
+        .await
+    }
+}
+
+impl LegacyKitRecoveryHandle {
+    pub fn session(&self) -> &LegacyKitRecoverySession {
+        &self.session
+    }
+
+    pub async fn refresh_session(&self) -> Result<LegacyKitRecoverySession> {
+        self.http
+            .post_json(
+                "/legacy-kits/recovery/session",
+                &LegacyKitSessionRequest {
+                    session_id: self.session.id.clone(),
+                    session_token: self.session_token.as_ref().to_owned(),
+                },
+            )
+            .await
+            .map_err(ContactsError::from)
+    }
+
+    pub async fn recovery_bundle(&self) -> Result<LegacyKitRecoveryBundle> {
+        let response = self
+            .http
+            .post_json::<LegacyKitRecoveryInfoResponse, _>(
+                "/legacy-kits/recovery/info",
+                &LegacyKitSessionRequest {
+                    session_id: self.session.id.clone(),
+                    session_token: self.session_token.as_ref().to_owned(),
+                },
+            )
+            .await
+            .map_err(ContactsError::from)?;
+        let enc_key = derive_kit_enc_key(&self.kit_secret)?;
+        let encrypted_recovery_blob = crypto::decode_b64(&response.encrypted_recovery_blob)?;
+        let recovery_key = secretbox::decrypt_box(&encrypted_recovery_blob, enc_key.as_ref())?;
+        Ok(LegacyKitRecoveryBundle {
+            recovery_key: SecretVec::new(recovery_key),
+            user_key_attributes: response.user_key_attr,
+        })
+    }
+
+    pub async fn change_password(&self, new_password: &str) -> Result<()> {
+        let bundle = self.recovery_bundle().await?;
+        let target_master_key = decrypt_master_key_with_recovery_key(
+            &bundle.user_key_attributes,
+            &bundle.recovery_key,
+        )?;
+        let (updated_key_attrs, _) = auth::generate_key_attributes_for_new_password(
+            &target_master_key,
+            &bundle.user_key_attributes,
+            new_password,
+        )?;
+        let srp_user_id = Uuid::new_v4().to_string();
+        let (mut srp_session, setup_request) =
+            password_reset_setup_request(&srp_user_id, new_password, &updated_key_attrs)?;
+        let init_response = self
+            .http
+            .post_json::<LegacyKitSetupSrpResponse, _>(
+                "/legacy-kits/recovery/init-change-password",
+                &LegacyKitInitChangePasswordRequest {
+                    session_id: self.session.id.clone(),
+                    session_token: self.session_token.as_ref().to_owned(),
+                    setup_srp_request: setup_request,
+                },
+            )
+            .await
+            .map_err(ContactsError::from)?;
+        let srp_m1 = srp_session_m1(&mut srp_session, &init_response)?;
+        let updated_key_attr = LegacyKitUpdatedKeyAttr {
+            kek_salt: updated_key_attrs.kek_salt.clone(),
+            encrypted_key: updated_key_attrs.encrypted_key.clone(),
+            key_decryption_nonce: updated_key_attrs.key_decryption_nonce.clone(),
+            mem_limit: updated_key_attrs.mem_limit.ok_or_else(|| {
+                ContactsError::InvalidInput("updated key attributes missing memLimit".into())
+            })?,
+            ops_limit: updated_key_attrs.ops_limit.ok_or_else(|| {
+                ContactsError::InvalidInput("updated key attributes missing opsLimit".into())
+            })?,
+        };
+        let change_response = self
+            .http
+            .post_json::<LegacyKitChangePasswordResponse, _>(
+                "/legacy-kits/recovery/change-password",
+                &LegacyKitChangePasswordRequest {
+                    session_id: self.session.id.clone(),
+                    session_token: self.session_token.as_ref().to_owned(),
+                    update_srp_and_keys_request: LegacyKitUpdateSrpAndKeysRequest {
+                        setup_id: init_response.setup_id,
+                        srp_m1,
+                        updated_key_attr,
+                    },
+                },
+            )
+            .await
+            .map_err(ContactsError::from)?;
+        let server_m2 = crypto::decode_b64(&change_response.srp_m2)?;
+        srp_session.verify_m2(&server_m2)?;
+        Ok(())
+    }
+}
+
+impl LegacyKitRecoveryClient {
+    async fn open_with_kit_secret(
+        &self,
+        first_share: &LegacyKitShare,
+        kit_secret: SecretVec,
+        encrypted_challenge: &str,
+        used_part_indexes: Option<Vec<u8>>,
+        email: Option<String>,
+    ) -> Result<LegacyKitRecoveryHandle> {
+        let (auth_public_key, auth_secret_key) = derive_kit_auth_keypair(&kit_secret)?;
+        let challenge = decrypt_challenge(&auth_public_key, &auth_secret_key, encrypted_challenge)?;
+        let response = self
+            .http
+            .post_json::<LegacyKitOpenRecoveryResponse, _>(
+                "/legacy-kits/recovery/open",
+                &LegacyKitOpenRecoveryRequest {
+                    kit_id: first_share.kit_id.clone(),
+                    challenge,
+                    used_part_indexes,
+                    email,
+                },
+            )
+            .await
+            .map_err(ContactsError::from)?;
+        Ok(LegacyKitRecoveryHandle {
+            http: Arc::clone(&self.http),
+            session: response.session,
+            session_token: SecretString::new(response.session_token),
+            kit_secret,
+        })
+    }
+}
+
+fn validate_notice_period(hours: i32) -> Result<()> {
+    if LEGACY_KIT_NOTICE_OPTIONS.contains(&hours) {
+        Ok(())
+    } else {
+        Err(ContactsError::InvalidInput(
+            "legacy kit notice period must be one of 0, 24, 168, 360, 720 hours".into(),
+        ))
+    }
+}
+
+fn derive_kit_enc_key(kit_secret: &[u8]) -> Result<SecretVec> {
+    let key = kdf::derive_subkey(kit_secret, 32, 1, b"lgkenc01").map_err(ContactsError::from)?;
+    Ok(SecretVec::new(key))
+}
+
+fn derive_kit_auth_keypair(kit_secret: &[u8]) -> Result<(Vec<u8>, SecretVec)> {
+    let seed = SecretVec::new(
+        kdf::derive_subkey(kit_secret, 32, 2, b"lgkauth1").map_err(ContactsError::from)?,
+    );
+    crypto::keys::derive_keypair_from_seed_secure(seed.as_ref()).map_err(Into::into)
+}
+
+fn decrypt_challenge(
+    auth_public_key: &[u8],
+    auth_secret_key: &[u8],
+    encrypted_challenge_b64: &str,
+) -> Result<String> {
+    let encrypted_challenge = crypto::decode_b64(encrypted_challenge_b64)?;
+    let plaintext = sealed::open(&encrypted_challenge, auth_public_key, auth_secret_key)?;
+    String::from_utf8(plaintext).map_err(|error| {
+        ContactsError::InvalidInput(format!("legacy kit challenge was not valid UTF-8: {error}"))
+    })
+}
+
+fn decrypt_master_key_with_recovery_key(
+    key_attributes: &KeyAttributes,
+    recovery_key: &[u8],
+) -> Result<SecretVec> {
+    let encrypted_master_key = key_attributes
+        .master_key_encrypted_with_recovery_key
+        .as_ref()
+        .ok_or_else(|| {
+            ContactsError::InvalidInput(
+                "target key attributes missing masterKeyEncryptedWithRecoveryKey".into(),
+            )
+        })?;
+    let master_key_nonce = key_attributes
+        .master_key_decryption_nonce
+        .as_ref()
+        .ok_or_else(|| {
+            ContactsError::InvalidInput(
+                "target key attributes missing masterKeyDecryptionNonce".into(),
+            )
+        })?;
+    let encrypted_master_key = crypto::decode_b64(encrypted_master_key)?;
+    let master_key_nonce = crypto::decode_b64(master_key_nonce)?;
+    secretbox::decrypt(&encrypted_master_key, &master_key_nonce, recovery_key)
+        .map(SecretVec::new)
+        .map_err(Into::into)
+}
+
+fn password_reset_setup_request(
+    srp_user_id: &str,
+    new_password: &str,
+    updated_key_attrs: &KeyAttributes,
+) -> Result<(SrpSession, LegacyKitSetupSrpRequest)> {
+    let mem_limit = updated_key_attrs.mem_limit.ok_or_else(|| {
+        ContactsError::InvalidInput("updated key attributes missing memLimit".into())
+    })?;
+    let ops_limit = updated_key_attrs.ops_limit.ok_or_else(|| {
+        ContactsError::InvalidInput("updated key attributes missing opsLimit".into())
+    })?;
+    let kek = auth::derive_kek(
+        new_password,
+        &updated_key_attrs.kek_salt,
+        mem_limit,
+        ops_limit,
+    )?;
+    let generated_srp = auth::generate_srp_setup(&kek, srp_user_id)?;
+    let srp_session = SrpSession::new(
+        srp_user_id,
+        &generated_srp.srp_salt,
+        &generated_srp.login_sub_key,
+    )?;
+    let srp_a = crypto::encode_b64(&srp_session.public_a());
+    Ok((
+        srp_session,
+        LegacyKitSetupSrpRequest {
+            srp_user_id: srp_user_id.to_string(),
+            srp_salt: crypto::encode_b64(&generated_srp.srp_salt),
+            srp_verifier: crypto::encode_b64(&generated_srp.srp_verifier),
+            srp_a,
+        },
+    ))
+}
+
+fn srp_session_m1(
+    srp_session: &mut SrpSession,
+    init_response: &LegacyKitSetupSrpResponse,
+) -> Result<String> {
+    let server_b = crypto::decode_b64(&init_response.srp_b)?;
+    let client_m1 = srp_session.compute_m1(&server_b)?;
+    Ok(crypto::encode_b64(&client_m1))
+}

--- a/rust/contacts/src/legacy_kit/owner_blob.rs
+++ b/rust/contacts/src/legacy_kit/owner_blob.rs
@@ -1,0 +1,81 @@
+use ente_core::crypto::{self, secretbox};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::{
+    ContactsError, Result,
+    legacy_kit_models::{LegacyKitMetadata, LegacyKitPart, LegacyKitShare},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct StoredOwnerPart {
+    pub(super) index: u8,
+    pub(super) name: String,
+    pub(super) share: String,
+    pub(super) checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct StoredOwnerBlob {
+    pub(super) parts: Vec<StoredOwnerPart>,
+}
+
+pub(super) fn create_owner_blob(shares: &[LegacyKitShare]) -> StoredOwnerBlob {
+    StoredOwnerBlob {
+        parts: shares
+            .iter()
+            .map(|share| StoredOwnerPart {
+                index: share.share_index,
+                name: share.part_name.clone(),
+                share: share.share.clone(),
+                checksum: share.checksum.clone(),
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn encrypt_owner_blob(
+    owner_blob: &StoredOwnerBlob,
+    master_key: &[u8],
+) -> Result<String> {
+    encrypt_blob(owner_blob, master_key, "legacy kit owner")
+}
+
+pub(super) fn decrypt_owner_blob(
+    encrypted_blob_b64: &str,
+    master_key: &[u8],
+) -> Result<StoredOwnerBlob> {
+    decrypt_blob(encrypted_blob_b64, master_key, "legacy kit owner")
+}
+
+fn encrypt_blob<T: Serialize>(payload: &T, master_key: &[u8], label: &str) -> Result<String> {
+    let payload = serde_json::to_vec(payload).map_err(|error| {
+        ContactsError::InvalidInput(format!("failed to encode {label} payload: {error}"))
+    })?;
+    let encrypted = secretbox::encrypt(&payload, master_key)?;
+    Ok(crypto::encode_b64(&encrypted.encrypted_data))
+}
+
+fn decrypt_blob<T: DeserializeOwned>(
+    encrypted_blob_b64: &str,
+    master_key: &[u8],
+    label: &str,
+) -> Result<T> {
+    let encrypted_blob = crypto::decode_b64(encrypted_blob_b64)?;
+    let plaintext = secretbox::decrypt_box(&encrypted_blob, master_key)?;
+    serde_json::from_slice(&plaintext).map_err(|error| {
+        ContactsError::InvalidInput(format!("failed to decode {label} payload: {error}"))
+    })
+}
+
+pub(super) fn metadata_from_owner_blob(owner_blob: &StoredOwnerBlob) -> LegacyKitMetadata {
+    LegacyKitMetadata {
+        parts: owner_blob
+            .parts
+            .iter()
+            .map(|part| LegacyKitPart {
+                index: part.index,
+                name: part.name.clone(),
+            })
+            .collect(),
+    }
+}

--- a/rust/contacts/src/legacy_kit/shares.rs
+++ b/rust/contacts/src/legacy_kit/shares.rs
@@ -1,0 +1,180 @@
+use ente_core::crypto::{self, SecretVec};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    ContactsError, Result,
+    legacy_kit_models::{LEGACY_KIT_PAYLOAD_VERSION, LegacyKitShare, LegacyKitVariant},
+};
+
+pub(super) fn checksum(
+    payload_version: u8,
+    variant: LegacyKitVariant,
+    kit_id: &str,
+    kit_secret: &[u8],
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update([payload_version, variant.code()]);
+    digest.update(kit_id.as_bytes());
+    digest.update(kit_secret);
+    let hash = digest.finalize();
+    crypto::encode_b64(&hash[..8])
+}
+
+pub(super) fn split_secret_2_of_3(secret: &[u8]) -> Result<Vec<Vec<u8>>> {
+    if secret.len() != 32 {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit secret must be 32 bytes".into(),
+        ));
+    }
+    let slope = crypto::keys::generate_key_secure();
+    let xs = [1u8, 2u8, 3u8];
+    let mut shares = Vec::with_capacity(3);
+    for x in xs {
+        let share = secret
+            .iter()
+            .zip(slope.iter())
+            .map(|(s, a)| *s ^ gf_mul(*a, x))
+            .collect::<Vec<_>>();
+        shares.push(share);
+    }
+    Ok(shares)
+}
+
+pub(super) fn reconstruct_secret_2_of_3(shares: &[LegacyKitShare]) -> Result<SecretVec> {
+    if shares.len() < 2 {
+        return Err(ContactsError::InvalidInput(
+            "at least two legacy kit shares are required".into(),
+        ));
+    }
+    let first = &shares[0];
+    let second = &shares[1];
+    validate_share_header(first)?;
+    validate_share_header(second)?;
+    if first.payload_version != second.payload_version {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit share payload version mismatch".into(),
+        ));
+    }
+    if first.variant != second.variant {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit share variant mismatch".into(),
+        ));
+    }
+    if first.kit_id != second.kit_id {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit shares must belong to the same kit".into(),
+        ));
+    }
+    if first.checksum != second.checksum {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit share checksum mismatch".into(),
+        ));
+    }
+    if first.share_index == second.share_index {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit shares must use different indices".into(),
+        ));
+    }
+
+    let y1 = crypto::decode_b64(&first.share)?;
+    let y2 = crypto::decode_b64(&second.share)?;
+    if y1.len() != 32 || y2.len() != 32 {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit shares must be 32 bytes".into(),
+        ));
+    }
+
+    let x1 = first.share_index;
+    let x2 = second.share_index;
+    let denom = x1 ^ x2;
+    if denom == 0 {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit shares must use different x coordinates".into(),
+        ));
+    }
+    let mut secret = vec![0u8; 32];
+    for i in 0..32 {
+        let slope = gf_div(y1[i] ^ y2[i], denom)?;
+        secret[i] = y1[i] ^ gf_mul(slope, x1);
+    }
+    let expected = checksum(first.payload_version, first.variant, &first.kit_id, &secret);
+    if expected != first.checksum {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit shares failed checksum verification".into(),
+        ));
+    }
+    Ok(SecretVec::new(secret))
+}
+
+pub(super) fn used_part_indexes(shares: &[LegacyKitShare]) -> Result<Vec<u8>> {
+    let first = shares.first().ok_or_else(|| {
+        ContactsError::InvalidInput("at least two legacy kit shares are required".into())
+    })?;
+    validate_share_header(first)?;
+    if shares.len() < first.variant.threshold() {
+        return Err(ContactsError::InvalidInput(
+            "at least two legacy kit shares are required".into(),
+        ));
+    }
+    Ok(vec![shares[0].share_index, shares[1].share_index])
+}
+
+fn validate_share_header(share: &LegacyKitShare) -> Result<()> {
+    if share.payload_version != LEGACY_KIT_PAYLOAD_VERSION {
+        return Err(ContactsError::InvalidInput(
+            "unsupported legacy kit share payload version".into(),
+        ));
+    }
+    if share.variant != LegacyKitVariant::TwoOfThree {
+        return Err(ContactsError::InvalidInput(
+            "unsupported legacy kit share variant".into(),
+        ));
+    }
+    if share.share_index == 0 || share.share_index as usize > share.variant.part_count() {
+        return Err(ContactsError::InvalidInput(
+            "legacy kit share index is out of range".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn gf_mul(mut a: u8, mut b: u8) -> u8 {
+    let mut product = 0u8;
+    while b != 0 {
+        if b & 1 != 0 {
+            product ^= a;
+        }
+        let high = a & 0x80;
+        a <<= 1;
+        if high != 0 {
+            a ^= 0x1b;
+        }
+        b >>= 1;
+    }
+    product
+}
+
+fn gf_pow(mut base: u8, mut exp: u8) -> u8 {
+    let mut acc = 1u8;
+    while exp != 0 {
+        if exp & 1 != 0 {
+            acc = gf_mul(acc, base);
+        }
+        base = gf_mul(base, base);
+        exp >>= 1;
+    }
+    acc
+}
+
+fn gf_inv(value: u8) -> Result<u8> {
+    if value == 0 {
+        return Err(ContactsError::InvalidInput(
+            "cannot invert zero in GF(256)".into(),
+        ));
+    }
+    Ok(gf_pow(value, 254))
+}
+
+fn gf_div(value: u8, divisor: u8) -> Result<u8> {
+    Ok(gf_mul(value, gf_inv(divisor)?))
+}

--- a/rust/contacts/src/legacy_kit_models.rs
+++ b/rust/contacts/src/legacy_kit_models.rs
@@ -73,6 +73,8 @@ pub struct LegacyKitRecoverySession {
     #[serde(rename = "kitID")]
     pub kit_id: String,
     pub status: LegacyKitRecoveryStatus,
+    /// Remaining microseconds until recovery is ready, matching the existing
+    /// emergency legacy recovery API response contract.
     pub wait_till: i64,
     pub created_at: i64,
 }

--- a/rust/contacts/src/legacy_kit_models.rs
+++ b/rust/contacts/src/legacy_kit_models.rs
@@ -1,0 +1,184 @@
+use ente_core::{auth::KeyAttributes, crypto::SecretVec};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+pub const LEGACY_KIT_PAYLOAD_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyKitVariant {
+    TwoOfThree,
+}
+
+impl LegacyKitVariant {
+    pub const TWO_OF_THREE_CODE: u8 = 1;
+
+    pub fn code(self) -> u8 {
+        match self {
+            Self::TwoOfThree => Self::TWO_OF_THREE_CODE,
+        }
+    }
+
+    pub fn threshold(self) -> usize {
+        match self {
+            Self::TwoOfThree => 2,
+        }
+    }
+
+    pub fn part_count(self) -> usize {
+        match self {
+            Self::TwoOfThree => 3,
+        }
+    }
+
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            Self::TWO_OF_THREE_CODE => Some(Self::TwoOfThree),
+            _ => None,
+        }
+    }
+}
+
+impl Serialize for LegacyKitVariant {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(self.code())
+    }
+}
+
+impl<'de> Deserialize<'de> for LegacyKitVariant {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let code = u8::deserialize(deserializer)?;
+        Self::from_code(code).ok_or_else(|| de::Error::custom("invalid legacy kit variant"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LegacyKitRecoveryStatus {
+    Waiting,
+    Ready,
+    Blocked,
+    Cancelled,
+    Recovered,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitRecoverySession {
+    pub id: String,
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+    pub status: LegacyKitRecoveryStatus,
+    pub wait_till: i64,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitRecoveryInitiator {
+    #[serde(default)]
+    pub used_part_indexes: Vec<u8>,
+    pub ip: String,
+    pub user_agent: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitOwnerRecoverySession {
+    pub session: Option<LegacyKitRecoverySession>,
+    pub initiators: Vec<LegacyKitRecoveryInitiator>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitPart {
+    pub index: u8,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitMetadata {
+    pub parts: Vec<LegacyKitPart>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKit {
+    pub id: String,
+    pub variant: LegacyKitVariant,
+    pub notice_period_in_hours: i32,
+    pub metadata: LegacyKitMetadata,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub active_recovery_session: Option<LegacyKitRecoverySession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LegacyKitShare {
+    #[serde(rename = "pv")]
+    pub payload_version: u8,
+    #[serde(rename = "kv")]
+    pub variant: LegacyKitVariant,
+    #[serde(rename = "k")]
+    pub kit_id: String,
+    #[serde(rename = "i")]
+    pub share_index: u8,
+    #[serde(rename = "s")]
+    pub share: String,
+    #[serde(rename = "c")]
+    pub checksum: String,
+    #[serde(rename = "n")]
+    pub part_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitCreateResult {
+    pub kit: LegacyKit,
+    pub shares: Vec<LegacyKitShare>,
+}
+
+#[derive(Debug)]
+pub struct LegacyKitRecoveryBundle {
+    pub recovery_key: SecretVec,
+    pub user_key_attributes: KeyAttributes,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_kit_share_serializes_with_compact_qr_keys() {
+        let share = LegacyKitShare {
+            payload_version: LEGACY_KIT_PAYLOAD_VERSION,
+            variant: LegacyKitVariant::TwoOfThree,
+            kit_id: "kit-id".into(),
+            share_index: 1,
+            share: "share".into(),
+            checksum: "checksum".into(),
+            part_name: "North".into(),
+        };
+
+        let json = serde_json::to_string(&share).unwrap();
+        assert_eq!(
+            json,
+            r#"{"pv":1,"kv":1,"k":"kit-id","i":1,"s":"share","c":"checksum","n":"North"}"#
+        );
+        let decoded: LegacyKitShare = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, share);
+    }
+
+    #[test]
+    fn legacy_kit_share_rejects_unknown_variant() {
+        let result = serde_json::from_str::<LegacyKitShare>(
+            r#"{"pv":1,"kv":9,"k":"kit-id","i":1,"s":"share","c":"checksum","n":"North"}"#,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/rust/contacts/src/legacy_kit_transport.rs
+++ b/rust/contacts/src/legacy_kit_transport.rs
@@ -1,0 +1,185 @@
+use ente_core::auth::KeyAttributes;
+use serde::{Deserialize, Serialize};
+
+use crate::legacy_kit_models::{
+    LegacyKitOwnerRecoverySession, LegacyKitRecoverySession, LegacyKitVariant,
+};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateLegacyKitRequest {
+    pub id: String,
+    pub variant: LegacyKitVariant,
+    pub notice_period_in_hours: i32,
+    pub encrypted_recovery_blob: String,
+    pub auth_public_key: String,
+    pub encrypted_owner_blob: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitRecordResponse {
+    pub id: String,
+    pub variant: LegacyKitVariant,
+    pub notice_period_in_hours: i32,
+    pub encrypted_owner_blob: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub active_recovery_session: Option<LegacyKitRecoverySession>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListLegacyKitsResponse {
+    pub kits: Vec<LegacyKitRecordResponse>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitDownloadContentResponse {
+    pub id: String,
+    pub variant: LegacyKitVariant,
+    pub encrypted_owner_blob: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitOwnerActionRequest {
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitChallengeRequest {
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitChallengeResponse {
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+    pub encrypted_challenge: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitOpenRecoveryRequest {
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+    pub challenge: String,
+    pub used_part_indexes: Option<Vec<u8>>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitOpenRecoveryResponse {
+    pub session: LegacyKitRecoverySession,
+    pub session_token: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitOwnerRecoverySessionResponse {
+    pub session: Option<LegacyKitRecoverySession>,
+    pub initiators: Vec<crate::legacy_kit_models::LegacyKitRecoveryInitiator>,
+}
+
+impl From<LegacyKitOwnerRecoverySessionResponse> for LegacyKitOwnerRecoverySession {
+    fn from(value: LegacyKitOwnerRecoverySessionResponse) -> Self {
+        Self {
+            session: value.session,
+            initiators: value.initiators,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitSessionRequest {
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub session_token: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitRecoveryInfoResponse {
+    pub encrypted_recovery_blob: String,
+    #[serde(rename = "userKeyAttr")]
+    pub user_key_attr: KeyAttributes,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitSetupSrpRequest {
+    #[serde(rename = "srpUserID")]
+    pub srp_user_id: String,
+    pub srp_salt: String,
+    pub srp_verifier: String,
+    #[serde(rename = "srpA")]
+    pub srp_a: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitInitChangePasswordRequest {
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub session_token: String,
+    #[serde(rename = "setupSRPRequest")]
+    pub setup_srp_request: LegacyKitSetupSrpRequest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitSetupSrpResponse {
+    #[serde(rename = "setupID")]
+    pub setup_id: String,
+    #[serde(rename = "srpB")]
+    pub srp_b: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitUpdatedKeyAttr {
+    pub kek_salt: String,
+    pub encrypted_key: String,
+    pub key_decryption_nonce: String,
+    pub mem_limit: u32,
+    pub ops_limit: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitUpdateSrpAndKeysRequest {
+    #[serde(rename = "setupID")]
+    pub setup_id: String,
+    #[serde(rename = "srpM1")]
+    pub srp_m1: String,
+    #[serde(rename = "updatedKeyAttr")]
+    pub updated_key_attr: LegacyKitUpdatedKeyAttr,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitChangePasswordRequest {
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    pub session_token: String,
+    #[serde(rename = "updateSrpAndKeysRequest")]
+    pub update_srp_and_keys_request: LegacyKitUpdateSrpAndKeysRequest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyKitChangePasswordResponse {
+    #[serde(rename = "setupID")]
+    pub setup_id: String,
+    #[serde(rename = "srpM2")]
+    pub srp_m2: String,
+}

--- a/rust/contacts/src/legacy_kit_transport.rs
+++ b/rust/contacts/src/legacy_kit_transport.rs
@@ -51,6 +51,14 @@ pub struct LegacyKitOwnerActionRequest {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct LegacyKitUpdateRecoveryNoticeRequest {
+    #[serde(rename = "kitID")]
+    pub kit_id: String,
+    pub notice_period_in_hours: i32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LegacyKitChallengeRequest {
     #[serde(rename = "kitID")]
     pub kit_id: String,

--- a/rust/contacts/src/legacy_models.rs
+++ b/rust/contacts/src/legacy_models.rs
@@ -1,4 +1,4 @@
-use ente_core::auth::KeyAttributes;
+use ente_core::{auth::KeyAttributes, crypto::SecretVec};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -60,9 +60,8 @@ pub struct LegacyInfo {
     pub others_recovery_session: Vec<LegacyRecoverySession>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct LegacyRecoveryBundle {
-    pub recovery_key: String,
+    pub recovery_key: SecretVec,
     pub user_key_attributes: KeyAttributes,
 }

--- a/rust/contacts/src/lib.rs
+++ b/rust/contacts/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod client;
 pub mod crypto;
 pub mod error;
+pub mod legacy_kit;
+pub mod legacy_kit_models;
+pub mod legacy_kit_transport;
 pub mod legacy_models;
 pub mod legacy_transport;
 pub mod models;
@@ -8,6 +11,13 @@ pub mod transport;
 
 pub use client::{ContactsCtx, OpenContactsCtxInput, OpenContactsCtxResult, RootKeySource};
 pub use error::{ContactsError, Result};
+pub use legacy_kit::{LegacyKitRecoveryClient, LegacyKitRecoveryHandle};
+pub use legacy_kit_models::{
+    LEGACY_KIT_PAYLOAD_VERSION, LegacyKit, LegacyKitCreateResult, LegacyKitMetadata,
+    LegacyKitOwnerRecoverySession, LegacyKitPart, LegacyKitRecoveryBundle,
+    LegacyKitRecoveryInitiator, LegacyKitRecoverySession, LegacyKitRecoveryStatus, LegacyKitShare,
+    LegacyKitVariant,
+};
 pub use legacy_models::{
     LegacyContactRecord, LegacyContactState, LegacyInfo, LegacyRecoveryBundle,
     LegacyRecoverySession, LegacyRecoveryStatus, LegacyUser,

--- a/rust/core/src/auth/api.rs
+++ b/rust/core/src/auth/api.rs
@@ -207,14 +207,30 @@ pub fn generate_interactive_kek(password: &str) -> Result<GeneratedKek> {
 #[cfg(feature = "srp")]
 pub fn generate_srp_setup(kek: &[u8], srp_user_id: &str) -> Result<GeneratedSrpSetup> {
     let login_sub_key = kdf::derive_login_key_secure(kek)?;
+    generate_srp_setup_with_login_key(&login_sub_key, srp_user_id)
+}
+
+/// Generate the SRP setup payload from an already-derived login key.
+#[cfg(feature = "srp")]
+pub fn generate_srp_setup_with_login_key(
+    login_key: &[u8],
+    srp_user_id: &str,
+) -> Result<GeneratedSrpSetup> {
+    if login_key.len() != 16 {
+        return Err(AuthError::InvalidKey(format!(
+            "Login key must be 16 bytes, got {}",
+            login_key.len()
+        )));
+    }
+
     let srp_salt = keys::generate_salt();
     let client = ClientG4096::<Sha256>::new();
-    let srp_verifier = client.compute_verifier(srp_user_id.as_bytes(), &login_sub_key, &srp_salt);
+    let srp_verifier = client.compute_verifier(srp_user_id.as_bytes(), login_key, &srp_salt);
 
     Ok(GeneratedSrpSetup {
         srp_salt,
         srp_verifier,
-        login_sub_key,
+        login_sub_key: SecretVec::new(login_key.to_vec()),
     })
 }
 
@@ -437,6 +453,19 @@ mod tests {
 
         assert_eq!(srp_setup.srp_salt.len(), 16);
         assert_eq!(srp_setup.login_sub_key.len(), 16);
+        assert!(!srp_setup.srp_verifier.is_empty());
+    }
+
+    #[cfg(feature = "srp")]
+    #[test]
+    fn test_generate_srp_setup_with_login_key() {
+        crate::crypto::init().unwrap();
+
+        let login_key = [1u8; 16];
+        let srp_setup = generate_srp_setup_with_login_key(&login_key, "test-user-id").unwrap();
+
+        assert_eq!(srp_setup.srp_salt.len(), 16);
+        assert_eq!(srp_setup.login_sub_key.as_ref(), login_key);
         assert!(!srp_setup.srp_verifier.is_empty());
     }
 

--- a/rust/core/src/auth/mod.rs
+++ b/rust/core/src/auth/mod.rs
@@ -64,13 +64,13 @@ impl SrpSession {
 // High-level API (recommended for applications)
 #[cfg(feature = "srp")]
 pub use api::GeneratedSrpSetup;
-#[cfg(feature = "srp")]
-pub use api::generate_srp_setup;
 pub use api::{DecryptedSecrets, GeneratedKek, SrpCredentials};
 pub use api::{
     decrypt_keys_only, decrypt_secrets, derive_kek, derive_srp_credentials,
     generate_interactive_kek, generate_sensitive_kek,
 };
+#[cfg(feature = "srp")]
+pub use api::{generate_srp_setup, generate_srp_setup_with_login_key};
 
 // Key generation (for signup)
 pub use key_gen::{

--- a/rust/core/src/crypto/impl_pure/keys.rs
+++ b/rust/core/src/crypto/impl_pure/keys.rs
@@ -4,7 +4,7 @@ use rand_core::{OsRng, RngCore};
 use x25519_dalek::{PublicKey, StaticSecret};
 use zeroize::Zeroize;
 
-use crate::crypto::{Result, SecretVec};
+use crate::crypto::{CryptoError, Result, SecretVec};
 
 /// Size of a SecretBox key in bytes.
 pub const SECRETBOX_KEY_BYTES: usize = 32;
@@ -132,6 +132,33 @@ pub fn generate_keypair_secure() -> Result<(Vec<u8>, SecretVec)> {
     ))
 }
 
+/// Deterministically derive an X25519 key pair from a 32-byte seed.
+///
+/// The seed is clamped by `StaticSecret::from` per the X25519 construction,
+/// making this suitable for deriving stable box keys from a higher-entropy
+/// master secret.
+pub fn derive_keypair_from_seed_secure(seed: &[u8]) -> Result<(Vec<u8>, SecretVec)> {
+    if seed.len() != BOX_SECRET_KEY_BYTES {
+        return Err(CryptoError::InvalidKeyLength {
+            expected: BOX_SECRET_KEY_BYTES,
+            actual: seed.len(),
+        });
+    }
+
+    let mut secret_bytes = [0u8; BOX_SECRET_KEY_BYTES];
+    secret_bytes.copy_from_slice(seed);
+
+    let secret = StaticSecret::from(secret_bytes);
+    let public = PublicKey::from(&secret);
+
+    secret_bytes.zeroize();
+
+    Ok((
+        public.as_bytes().to_vec(),
+        SecretVec::new(secret.to_bytes().to_vec()),
+    ))
+}
+
 /// Generate random bytes of specified length.
 ///
 /// # Arguments
@@ -203,6 +230,22 @@ mod tests {
         let (pk2, sk2) = generate_keypair().unwrap();
         assert_ne!(pk, pk2);
         assert_ne!(sk, sk2);
+    }
+
+    #[test]
+    fn test_derive_keypair_from_seed_secure() {
+        let seed = [7u8; BOX_SECRET_KEY_BYTES];
+        let (pk1, sk1) = derive_keypair_from_seed_secure(&seed).unwrap();
+        let (pk2, sk2) = derive_keypair_from_seed_secure(&seed).unwrap();
+
+        assert_eq!(pk1, pk2);
+        assert_eq!(sk1.as_ref(), sk2.as_ref());
+    }
+
+    #[test]
+    fn test_derive_keypair_from_seed_secure_rejects_wrong_length() {
+        let err = derive_keypair_from_seed_secure(&[1u8; 16]).unwrap_err();
+        assert!(matches!(err, CryptoError::InvalidKeyLength { .. }));
     }
 
     #[test]

--- a/rust/e2e/COVERAGE.md
+++ b/rust/e2e/COVERAGE.md
@@ -2,7 +2,9 @@
 
 Current suite entrypoint:
 
-- [`auth_contacts_and_legacy_recovery_suite`](tests/full_e2e.rs)
+- [`auth_contacts_e2e`](tests/full_e2e.rs)
+- [`legacy_contact_recovery_e2e`](tests/full_e2e.rs)
+- [`legacy_kit_recovery_e2e`](tests/full_e2e.rs)
 
 Shared setup and helpers:
 
@@ -44,4 +46,4 @@ Shared setup and helpers:
 - object-store-backed scenarios
 - passkey flows
 - recovery via elapsed notice period without explicit owner approval
-- multiple independent tests with failure isolation; current default is one ordered suite on a shared owner/trusted pair
+- multi-process shared fixtures; current reuse is scoped to one test binary

--- a/rust/e2e/Cargo.lock
+++ b/rust/e2e/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "hmac 0.13.0",
  "reqwest",
  "serde",
+ "serde_json",
  "sha1 0.11.0",
  "tokio",
  "uuid",

--- a/rust/e2e/Cargo.toml
+++ b/rust/e2e/Cargo.toml
@@ -16,4 +16,5 @@ uuid = { version = "1.11", features = ["v4"] }
 base64 = "0.22"
 hmac = "0.13"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sha1 = "0.11"

--- a/rust/e2e/README.md
+++ b/rust/e2e/README.md
@@ -4,8 +4,9 @@ Rust end-to-end tests that require a live Museum instance belong here.
 
 Current server-backed coverage in this crate:
 
-- a single ignored full e2e suite that reuses one owner/trusted pair and covers
-  auth, contacts CRUD, and the legacy recovery lifecycle
+- ignored stage tests that reuse shared fixtures inside one test binary:
+  `auth_contacts_e2e`, `legacy_contact_recovery_e2e`, and
+  `legacy_kit_recovery_e2e`
 
 Detailed scenario coverage lives in [`COVERAGE.md`](COVERAGE.md).
 
@@ -37,6 +38,19 @@ For ad hoc runs against an already-running server:
 
 ```sh
 ENTE_E2E_ENDPOINT=http://localhost:8080 cargo test --manifest-path rust/e2e/Cargo.toml -- --ignored --nocapture
+```
+
+To run only one ignored stage:
+
+```sh
+ENTE_E2E_ENDPOINT=http://localhost:8080 cargo test --manifest-path rust/e2e/Cargo.toml legacy_kit_recovery_e2e -- --ignored --nocapture
+```
+
+To skip or select stages during a full ignored run:
+
+```sh
+ENTE_E2E_SKIP=legacy_kit_recovery_e2e rust/e2e/scripts/run.sh
+ENTE_E2E_ONLY=legacy_contact_recovery_e2e rust/e2e/scripts/run.sh
 ```
 
 Attachment/object-store coverage can be added as a separate fixture later, but

--- a/rust/e2e/tests/full_e2e.rs
+++ b/rust/e2e/tests/full_e2e.rs
@@ -556,6 +556,14 @@ async fn run_legacy_kit_stage(endpoint: &str, owner: &mut legacy_kit::LegacyKitO
         waiting_handle.session().status,
         LegacyKitRecoveryStatus::Waiting
     );
+    assert!(
+        waiting_handle.session().wait_till > 0,
+        "legacy kit waitTill should be remaining wait duration"
+    );
+    assert!(
+        waiting_handle.session().wait_till <= 24 * 60 * 60 * 1_000_000,
+        "legacy kit waitTill should not be an epoch timestamp"
+    );
 
     let resumed_waiting_handle = recovery_client
         .open_from_encrypted_challenge(

--- a/rust/e2e/tests/full_e2e.rs
+++ b/rust/e2e/tests/full_e2e.rs
@@ -1,28 +1,114 @@
 mod support;
 
 use ente_accounts::Error as CliError;
-use ente_contacts::legacy_models::{LegacyContactState, LegacyRecoveryStatus};
 use ente_contacts::models::ContactData;
+use ente_contacts::{
+    LegacyKitRecoveryClient, LegacyKitRecoveryStatus,
+    legacy_models::{LegacyContactState, LegacyRecoveryStatus},
+};
 use ente_core::http::Error as CoreHttpError;
+use ente_rs::models::account::App;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
 
-use support::{auth, contacts, legacy};
+use support::{auth, contacts, legacy, legacy_kit};
+
+const STAGE_AUTH_CONTACTS: &str = "auth_contacts_e2e";
+const STAGE_LEGACY_CONTACT_RECOVERY: &str = "legacy_contact_recovery_e2e";
+const STAGE_LEGACY_KIT_RECOVERY: &str = "legacy_kit_recovery_e2e";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyKitChallengeRequest {
+    #[serde(rename = "kitID")]
+    kit_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyKitChallengeResponse {
+    #[serde(rename = "encryptedChallenge")]
+    encrypted_challenge: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyKitOpenRecoveryRequest {
+    #[serde(rename = "kitID")]
+    kit_id: String,
+    challenge: String,
+    used_part_indexes: Option<Vec<u8>>,
+    email: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateLegacyKitRequest {
+    id: String,
+    variant: i32,
+    notice_period_in_hours: i32,
+    encrypted_recovery_blob: String,
+    auth_public_key: String,
+    encrypted_owner_blob: String,
+}
 
 #[tokio::test]
 #[ignore = "requires local Museum at ENTE_E2E_ENDPOINT or http://localhost:8080"]
-async fn auth_contacts_and_legacy_recovery_suite() {
+async fn auth_contacts_e2e() {
     let endpoint = support::endpoint();
-    if !support::assert_server_or_skip(&endpoint, "full rust e2e suite").await {
+    if !support::assert_stage_enabled_or_skip(STAGE_AUTH_CONTACTS) {
+        return;
+    }
+    if !support::assert_server_or_skip(&endpoint, STAGE_AUTH_CONTACTS).await {
         return;
     }
 
-    let pair = legacy::accepted_pair(&endpoint, 14).await;
+    let suite = support::suite::lock_suite(&endpoint).await;
+    let pair = legacy::open_pair(&endpoint, &suite.legacy_pair).await;
 
     run_auth_stage(&endpoint, &pair.owner).await;
     run_contacts_stage(&pair).await;
+}
+
+#[tokio::test]
+#[ignore = "requires local Museum at ENTE_E2E_ENDPOINT or http://localhost:8080"]
+async fn legacy_contact_recovery_e2e() {
+    let endpoint = support::endpoint();
+    if !support::assert_stage_enabled_or_skip(STAGE_LEGACY_CONTACT_RECOVERY) {
+        return;
+    }
+    if !support::assert_server_or_skip(&endpoint, STAGE_LEGACY_CONTACT_RECOVERY).await {
+        return;
+    }
+
+    let mut suite = support::suite::lock_suite(&endpoint).await;
+    let mut pair = legacy::open_pair(&endpoint, &suite.legacy_pair).await;
+
+    ensure_totp_enabled(&endpoint, &pair.owner).await;
     run_legacy_reject_stage(&pair).await;
     run_legacy_stop_stage(&pair).await;
     run_legacy_reinvite_stage(&pair).await;
-    run_legacy_reset_stage(&endpoint, &pair).await;
+    run_legacy_reset_stage(&endpoint, &mut pair).await;
+    legacy::persist_pair_state(&mut suite.legacy_pair, &pair);
+}
+
+#[tokio::test]
+#[ignore = "requires local Museum at ENTE_E2E_ENDPOINT or http://localhost:8080"]
+async fn legacy_kit_recovery_e2e() {
+    let endpoint = support::endpoint();
+    if !support::assert_stage_enabled_or_skip(STAGE_LEGACY_KIT_RECOVERY) {
+        return;
+    }
+    if !support::assert_server_or_skip(&endpoint, STAGE_LEGACY_KIT_RECOVERY).await {
+        return;
+    }
+
+    let mut suite = support::suite::lock_suite(&endpoint).await;
+    let mut owner = legacy_kit::open_owner(&endpoint, &suite.legacy_kit_owner).await;
+    ensure_totp_enabled(&endpoint, &owner.owner).await;
+    run_legacy_kit_stage(&endpoint, &mut owner).await;
+    legacy_kit::persist_owner_state(&mut suite.legacy_kit_owner, &owner);
 }
 
 async fn run_auth_stage(endpoint: &str, owner: &auth::TestAccount) {
@@ -43,6 +129,21 @@ async fn run_auth_stage(endpoint: &str, owner: &auth::TestAccount) {
         auth::fetch_two_factor_status(endpoint, owner)
             .await
             .expect("two-factor status fetch failed")
+    );
+}
+
+async fn ensure_totp_enabled(endpoint: &str, owner: &auth::TestAccount) {
+    if auth::fetch_two_factor_status(endpoint, owner)
+        .await
+        .expect("two-factor status fetch before recovery failed")
+    {
+        return;
+    }
+    let _secret = auth::enable_totp(endpoint, owner).await;
+    assert!(
+        auth::fetch_two_factor_status(endpoint, owner)
+            .await
+            .expect("two-factor status fetch after enable failed")
     );
 }
 
@@ -199,7 +300,7 @@ async fn run_legacy_reinvite_stage(pair: &legacy::LegacyPair) {
     assert_eq!(trusted_contact.state, LegacyContactState::Accepted);
 }
 
-async fn run_legacy_reset_stage(endpoint: &str, pair: &legacy::LegacyPair) {
+async fn run_legacy_reset_stage(endpoint: &str, pair: &mut legacy::LegacyPair) {
     assert!(
         auth::fetch_two_factor_status(endpoint, &pair.owner)
             .await
@@ -228,6 +329,7 @@ async fn run_legacy_reset_stage(endpoint: &str, pair: &legacy::LegacyPair) {
             .expect("approved recovery session missing");
     assert_eq!(recovery.status, LegacyRecoveryStatus::Ready);
 
+    let previous_password = pair.owner.password.clone();
     let new_password = support::unique_password("LegacyRecovered");
     pair.trusted_ctx
         .legacy_change_password(
@@ -238,7 +340,7 @@ async fn run_legacy_reset_stage(endpoint: &str, pair: &legacy::LegacyPair) {
         .await
         .unwrap();
 
-    match auth::login_without_totp(endpoint, &pair.owner.email, &pair.owner.password).await {
+    match auth::login_without_totp(endpoint, &pair.owner.email, &previous_password).await {
         Err(CliError::AuthenticationFailed(message)) => {
             assert_eq!(message, "Incorrect password");
         }
@@ -279,4 +381,347 @@ async fn run_legacy_reset_stage(endpoint: &str, pair: &legacy::LegacyPair) {
         contacts::owner_contact(&owner_info, pair.owner.user_id, pair.trusted.user_id)
             .expect("legacy contact should remain configured after recovery");
     assert_eq!(owner_contact.state, LegacyContactState::Accepted);
+
+    pair.owner = recovered_owner;
+    pair.owner_ctx = recovered_owner_ctx;
+}
+
+async fn run_legacy_kit_stage(endpoint: &str, owner: &mut legacy_kit::LegacyKitOwner) {
+    let recovery_client = LegacyKitRecoveryClient::new(endpoint).expect("legacy kit client");
+    let public_client = reqwest::Client::new();
+    let missing_notice_period = public_client
+        .post(format!("{endpoint}/legacy-kits"))
+        .header("X-Auth-Token", owner.owner.auth_token.clone())
+        .header("X-Client-Package", App::Photos.client_package())
+        .json(&json!({
+            "id": Uuid::new_v4().to_string(),
+            "variant": 1,
+            "encryptedRecoveryBlob": "AA==",
+            "authPublicKey": "not-a-valid-public-key",
+            "encryptedOwnerBlob": "AA=="
+        }))
+        .send()
+        .await
+        .expect("legacy kit missing notice period request failed");
+    assert_eq!(
+        missing_notice_period.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+
+    let invalid_create = public_client
+        .post(format!("{endpoint}/legacy-kits"))
+        .header("X-Auth-Token", owner.owner.auth_token.clone())
+        .header("X-Client-Package", App::Photos.client_package())
+        .json(&CreateLegacyKitRequest {
+            id: Uuid::new_v4().to_string(),
+            variant: 1,
+            notice_period_in_hours: 24,
+            encrypted_recovery_blob: "AA==".into(),
+            auth_public_key: "not-a-valid-public-key".into(),
+            encrypted_owner_blob: "AA==".into(),
+        })
+        .send()
+        .await
+        .expect("legacy kit invalid create request failed");
+    assert_eq!(invalid_create.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let waiting_kit = owner
+        .owner_ctx
+        .legacy_kit_create(
+            &contacts::to_core_key_attributes(&owner.owner.key_attributes),
+            ["North".into(), "East".into(), "West".into()],
+            24,
+        )
+        .await
+        .expect("waiting legacy kit create failed");
+    assert_eq!(waiting_kit.kit.notice_period_in_hours, 24);
+    assert_eq!(waiting_kit.kit.metadata.parts.len(), 3);
+    assert_eq!(waiting_kit.shares.len(), 3);
+
+    let listed = owner
+        .owner_ctx
+        .legacy_kits()
+        .await
+        .expect("legacy kit list failed");
+    let listed_waiting_kit = listed
+        .iter()
+        .find(|kit| kit.id == waiting_kit.kit.id)
+        .expect("created waiting legacy kit missing from list");
+    assert_eq!(listed_waiting_kit.metadata.parts.len(), 3);
+    assert_eq!(listed_waiting_kit.metadata.parts[0].name, "North");
+
+    let downloaded_shares = owner
+        .owner_ctx
+        .legacy_kit_download_shares(&waiting_kit.kit.id)
+        .await
+        .expect("legacy kit share download failed");
+    assert_eq!(downloaded_shares.len(), 3);
+    assert_eq!(downloaded_shares[0].kit_id, waiting_kit.kit.id);
+    assert_eq!(
+        downloaded_shares[1].checksum,
+        waiting_kit.shares[1].checksum
+    );
+
+    let invalid_challenge = public_client
+        .post(format!("{endpoint}/legacy-kits/recovery/challenge"))
+        .json(&LegacyKitChallengeRequest {
+            kit_id: waiting_kit.kit.id.clone(),
+        })
+        .send()
+        .await
+        .expect("legacy kit challenge request failed");
+    assert!(
+        invalid_challenge.status().is_success(),
+        "challenge request should succeed, got {}",
+        invalid_challenge.status()
+    );
+    let invalid_challenge: LegacyKitChallengeResponse = invalid_challenge
+        .json()
+        .await
+        .expect("legacy kit challenge response decode failed");
+    let invalid_open = public_client
+        .post(format!("{endpoint}/legacy-kits/recovery/open"))
+        .json(&LegacyKitOpenRecoveryRequest {
+            kit_id: waiting_kit.kit.id.clone(),
+            challenge: invalid_challenge.encrypted_challenge,
+            used_part_indexes: None,
+            email: Some("bad-beneficiary@ente-rust-test.org".into()),
+        })
+        .send()
+        .await
+        .expect("legacy kit invalid recovery open request failed");
+    assert_eq!(invalid_open.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let listed_after_invalid_open = owner
+        .owner_ctx
+        .legacy_kits()
+        .await
+        .expect("legacy kit list after invalid challenge failed");
+    let listed_waiting_after_invalid_open = listed_after_invalid_open
+        .iter()
+        .find(|kit| kit.id == waiting_kit.kit.id)
+        .expect("waiting legacy kit missing after invalid challenge");
+    assert!(
+        listed_waiting_after_invalid_open
+            .active_recovery_session
+            .is_none(),
+        "invalid challenge must not create a recovery session"
+    );
+
+    let first_waiting_challenge = public_client
+        .post(format!("{endpoint}/legacy-kits/recovery/challenge"))
+        .json(&LegacyKitChallengeRequest {
+            kit_id: waiting_kit.kit.id.clone(),
+        })
+        .send()
+        .await
+        .expect("first waiting legacy kit challenge request failed");
+    assert!(
+        first_waiting_challenge.status().is_success(),
+        "first waiting challenge request should succeed, got {}",
+        first_waiting_challenge.status()
+    );
+    let first_waiting_challenge: LegacyKitChallengeResponse = first_waiting_challenge
+        .json()
+        .await
+        .expect("first waiting challenge response decode failed");
+
+    let second_waiting_challenge = public_client
+        .post(format!("{endpoint}/legacy-kits/recovery/challenge"))
+        .json(&LegacyKitChallengeRequest {
+            kit_id: waiting_kit.kit.id.clone(),
+        })
+        .send()
+        .await
+        .expect("second waiting legacy kit challenge request failed");
+    assert!(
+        second_waiting_challenge.status().is_success(),
+        "second waiting challenge request should succeed, got {}",
+        second_waiting_challenge.status()
+    );
+    let second_waiting_challenge: LegacyKitChallengeResponse = second_waiting_challenge
+        .json()
+        .await
+        .expect("second waiting challenge response decode failed");
+
+    let waiting_handle = recovery_client
+        .open_from_encrypted_challenge(
+            &downloaded_shares[0..2],
+            &first_waiting_challenge.encrypted_challenge,
+            Some("beneficiary@ente-rust-test.org"),
+        )
+        .await
+        .expect("legacy kit waiting recovery open failed");
+    assert_eq!(
+        waiting_handle.session().status,
+        LegacyKitRecoveryStatus::Waiting
+    );
+
+    let resumed_waiting_handle = recovery_client
+        .open_from_encrypted_challenge(
+            &downloaded_shares[1..3],
+            &second_waiting_challenge.encrypted_challenge,
+            None,
+        )
+        .await
+        .expect("legacy kit resumed recovery open failed");
+    assert_eq!(
+        resumed_waiting_handle.session().id,
+        waiting_handle.session().id
+    );
+    assert_eq!(
+        resumed_waiting_handle.session().status,
+        LegacyKitRecoveryStatus::Waiting
+    );
+    let original_waiting_session = waiting_handle
+        .refresh_session()
+        .await
+        .expect("original legacy kit session fetch after resume failed");
+    assert_eq!(
+        original_waiting_session.status,
+        LegacyKitRecoveryStatus::Waiting
+    );
+    let resumed_session = resumed_waiting_handle
+        .refresh_session()
+        .await
+        .expect("resumed legacy kit session fetch failed");
+    assert_eq!(resumed_session.status, LegacyKitRecoveryStatus::Waiting);
+    let owner_recovery_session = owner
+        .owner_ctx
+        .legacy_kit_recovery_session(&waiting_kit.kit.id)
+        .await
+        .expect("owner legacy kit recovery session fetch failed");
+    let owner_active_session = owner_recovery_session
+        .session
+        .as_ref()
+        .expect("owner recovery session should be present while waiting");
+    assert_eq!(owner_active_session.id, waiting_handle.session().id);
+    assert_eq!(owner_recovery_session.initiators.len(), 2);
+    assert_eq!(
+        owner_recovery_session.initiators[0].used_part_indexes,
+        vec![1, 2]
+    );
+    assert_eq!(
+        owner_recovery_session.initiators[1].used_part_indexes,
+        vec![2, 3]
+    );
+    assert!(
+        owner_recovery_session
+            .initiators
+            .iter()
+            .all(|initiator| !initiator.ip.is_empty())
+    );
+    assert!(
+        owner_recovery_session
+            .initiators
+            .iter()
+            .all(|initiator| !initiator.user_agent.is_empty())
+    );
+
+    owner
+        .owner_ctx
+        .legacy_kit_block_recovery(&waiting_kit.kit.id)
+        .await
+        .expect("legacy kit block failed");
+    let blocked_session = resumed_waiting_handle
+        .refresh_session()
+        .await
+        .expect("legacy kit blocked session fetch failed");
+    assert_eq!(blocked_session.status, LegacyKitRecoveryStatus::Blocked);
+    let blocked_original_session = waiting_handle
+        .refresh_session()
+        .await
+        .expect("legacy kit blocked session fetch for original browser failed");
+    assert_eq!(
+        blocked_original_session.status,
+        LegacyKitRecoveryStatus::Blocked
+    );
+    let blocked_owner_recovery_session = owner
+        .owner_ctx
+        .legacy_kit_recovery_session(&waiting_kit.kit.id)
+        .await
+        .expect("owner legacy kit recovery session fetch after block failed");
+    assert!(blocked_owner_recovery_session.session.is_none());
+    assert!(blocked_owner_recovery_session.initiators.is_empty());
+
+    owner
+        .owner_ctx
+        .legacy_kit_delete(&waiting_kit.kit.id)
+        .await
+        .expect("legacy kit delete failed");
+    let listed_after_delete = owner
+        .owner_ctx
+        .legacy_kits()
+        .await
+        .expect("legacy kit list after delete failed");
+    assert!(
+        listed_after_delete
+            .iter()
+            .all(|kit| kit.id != waiting_kit.kit.id)
+    );
+
+    let immediate_kit = owner
+        .owner_ctx
+        .legacy_kit_create(
+            &contacts::to_core_key_attributes(&owner.owner.key_attributes),
+            ["Alpha".into(), "Bravo".into(), "Charlie".into()],
+            0,
+        )
+        .await
+        .expect("immediate legacy kit create failed");
+    let ready_handle = recovery_client
+        .open_from_shares(
+            &immediate_kit.shares[0..2],
+            Some("beneficiary@ente-rust-test.org"),
+        )
+        .await
+        .expect("immediate legacy kit recovery open failed");
+    assert_eq!(
+        ready_handle.session().status,
+        LegacyKitRecoveryStatus::Ready
+    );
+
+    let bundle = ready_handle
+        .recovery_bundle()
+        .await
+        .expect("legacy kit recovery bundle fetch failed");
+    assert!(
+        !bundle.recovery_key.is_empty(),
+        "legacy kit recovery key should be returned once ready"
+    );
+
+    let previous_password = owner.owner.password.clone();
+    let recovery_password = support::unique_password("LegacyKitRecovered");
+    ready_handle
+        .change_password(&recovery_password)
+        .await
+        .expect("legacy kit password reset failed");
+
+    match auth::login_without_totp(endpoint, &owner.owner.email, &previous_password).await {
+        Err(CliError::AuthenticationFailed(message)) => {
+            assert_eq!(message, "Incorrect password");
+        }
+        Err(error) if error.is_http_status(&[401]) => {}
+        other => panic!("expected old legacy kit password login to fail, got {other:?}"),
+    }
+
+    let recovered_login =
+        auth::login_without_totp(endpoint, &owner.owner.email, &recovery_password)
+            .await
+            .expect("new password login should succeed after legacy kit recovery");
+    assert_eq!(recovered_login.user_id, owner.owner.user_id);
+    assert_eq!(recovered_login.secrets.master_key, owner.owner.master_key);
+
+    let recovered_owner = auth::test_account_from_authenticated(
+        owner.owner.email.clone(),
+        recovery_password,
+        recovered_login,
+    );
+    assert!(
+        !auth::fetch_two_factor_status(endpoint, &recovered_owner)
+            .await
+            .expect("two-factor status after legacy kit recovery fetch failed")
+    );
+
+    owner.owner = recovered_owner;
 }

--- a/rust/e2e/tests/support/auth.rs
+++ b/rust/e2e/tests/support/auth.rs
@@ -120,6 +120,19 @@ pub async fn create_account(endpoint: &str, email: String, password: String) -> 
     test_account_from_authenticated(email, password, authenticated)
 }
 
+pub async fn create_account_strict(
+    endpoint: &str,
+    email_prefix: &str,
+    password_prefix: &str,
+) -> TestAccount {
+    create_account(
+        endpoint,
+        crate::support::unique_test_email(email_prefix),
+        crate::support::unique_password(password_prefix),
+    )
+    .await
+}
+
 pub async fn login_without_totp(
     endpoint: &str,
     email: &str,

--- a/rust/e2e/tests/support/legacy.rs
+++ b/rust/e2e/tests/support/legacy.rs
@@ -1,9 +1,14 @@
-use ente_contacts::client::ContactsCtx;
-
 use crate::support::{
     auth::{self, TestAccount},
-    contacts, unique_password, unique_test_email,
+    contacts,
 };
+use ente_contacts::client::ContactsCtx;
+
+#[derive(Clone)]
+pub struct LegacyPairState {
+    pub owner: TestAccount,
+    pub trusted: TestAccount,
+}
 
 pub struct LegacyPair {
     pub owner: TestAccount,
@@ -12,19 +17,12 @@ pub struct LegacyPair {
     pub trusted_ctx: ContactsCtx,
 }
 
-pub async fn accepted_pair(endpoint: &str, recovery_notice_in_days: i32) -> LegacyPair {
-    let (owner, trusted) = tokio::join!(
-        auth::create_account(
-            endpoint,
-            unique_test_email("legacy-owner"),
-            unique_password("LegacyOwner"),
-        ),
-        auth::create_account(
-            endpoint,
-            unique_test_email("legacy-trusted"),
-            unique_password("LegacyTrusted"),
-        )
-    );
+pub async fn create_accepted_pair_state(
+    endpoint: &str,
+    recovery_notice_in_days: i32,
+) -> LegacyPairState {
+    let owner = auth::create_account_strict(endpoint, "legacy-owner", "LegacyOwner").await;
+    let trusted = auth::create_account_strict(endpoint, "legacy-trusted", "LegacyTrusted").await;
 
     let (owner_ctx, trusted_ctx) = tokio::join!(
         contacts::open_ctx(endpoint, &owner),
@@ -40,10 +38,26 @@ pub async fn accepted_pair(endpoint: &str, recovery_notice_in_days: i32) -> Lega
     )
     .await;
 
+    LegacyPairState { owner, trusted }
+}
+
+pub async fn open_pair(endpoint: &str, state: &LegacyPairState) -> LegacyPair {
+    let owner = state.owner.clone();
+    let trusted = state.trusted.clone();
+    let (owner_ctx, trusted_ctx) = tokio::join!(
+        contacts::open_ctx(endpoint, &owner),
+        contacts::open_ctx(endpoint, &trusted)
+    );
+
     LegacyPair {
         owner,
         trusted,
         owner_ctx,
         trusted_ctx,
     }
+}
+
+pub fn persist_pair_state(state: &mut LegacyPairState, runtime: &LegacyPair) {
+    state.owner = runtime.owner.clone();
+    state.trusted = runtime.trusted.clone();
 }

--- a/rust/e2e/tests/support/legacy_kit.rs
+++ b/rust/e2e/tests/support/legacy_kit.rs
@@ -1,0 +1,33 @@
+use ente_contacts::client::ContactsCtx;
+
+use crate::support::{
+    auth::{self, TestAccount},
+    contacts,
+};
+
+#[derive(Clone)]
+pub struct LegacyKitOwnerState {
+    pub owner: TestAccount,
+}
+
+pub struct LegacyKitOwner {
+    pub owner: TestAccount,
+    pub owner_ctx: ContactsCtx,
+}
+
+pub async fn create_owner_state(endpoint: &str) -> LegacyKitOwnerState {
+    let owner = auth::create_account_strict(endpoint, "legacy-kit-owner", "LegacyKitOwner").await;
+    let owner_ctx = contacts::open_ctx(endpoint, &owner).await;
+    drop(owner_ctx);
+    LegacyKitOwnerState { owner }
+}
+
+pub async fn open_owner(endpoint: &str, state: &LegacyKitOwnerState) -> LegacyKitOwner {
+    let owner = state.owner.clone();
+    let owner_ctx = contacts::open_ctx(endpoint, &owner).await;
+    LegacyKitOwner { owner, owner_ctx }
+}
+
+pub fn persist_owner_state(state: &mut LegacyKitOwnerState, runtime: &LegacyKitOwner) {
+    state.owner = runtime.owner.clone();
+}

--- a/rust/e2e/tests/support/mod.rs
+++ b/rust/e2e/tests/support/mod.rs
@@ -1,7 +1,10 @@
 pub mod auth;
 pub mod contacts;
 pub mod legacy;
+pub mod legacy_kit;
+pub mod suite;
 
+use std::collections::HashSet;
 use uuid::Uuid;
 
 pub fn endpoint() -> String {
@@ -23,6 +26,43 @@ pub async fn assert_server_or_skip(endpoint: &str, test_name: &str) -> bool {
             eprintln!("skipping {test_name}: could not reach {ping_url}: {error}");
             false
         }
+    }
+}
+
+pub fn assert_stage_enabled_or_skip(stage_name: &str) -> bool {
+    let normalized_stage = stage_name.trim().to_ascii_lowercase();
+    if let Some(only) = env_list("ENTE_E2E_ONLY") {
+        if !only.contains(&normalized_stage) {
+            eprintln!(
+                "skipping {stage_name}: not selected by ENTE_E2E_ONLY={}",
+                std::env::var("ENTE_E2E_ONLY").unwrap_or_default()
+            );
+            return false;
+        }
+    }
+    if let Some(skip) = env_list("ENTE_E2E_SKIP") {
+        if skip.contains(&normalized_stage) {
+            eprintln!(
+                "skipping {stage_name}: selected by ENTE_E2E_SKIP={}",
+                std::env::var("ENTE_E2E_SKIP").unwrap_or_default()
+            );
+            return false;
+        }
+    }
+    true
+}
+
+fn env_list(name: &str) -> Option<HashSet<String>> {
+    let raw = std::env::var(name).ok()?;
+    let values = raw
+        .split(',')
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect::<HashSet<_>>();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
     }
 }
 

--- a/rust/e2e/tests/support/suite.rs
+++ b/rust/e2e/tests/support/suite.rs
@@ -1,0 +1,23 @@
+use tokio::sync::{Mutex, MutexGuard, OnceCell};
+
+use crate::support::{legacy, legacy_kit};
+
+pub struct SuiteState {
+    pub legacy_pair: legacy::LegacyPairState,
+    pub legacy_kit_owner: legacy_kit::LegacyKitOwnerState,
+}
+
+static SUITE: OnceCell<Mutex<SuiteState>> = OnceCell::const_new();
+
+pub async fn lock_suite(endpoint: &str) -> MutexGuard<'static, SuiteState> {
+    let endpoint = endpoint.to_string();
+    let suite = SUITE
+        .get_or_init(|| async move {
+            Mutex::new(SuiteState {
+                legacy_pair: legacy::create_accepted_pair_state(&endpoint, 14).await,
+                legacy_kit_owner: legacy_kit::create_owner_state(&endpoint).await,
+            })
+        })
+        .await;
+    suite.lock().await
+}

--- a/web/packages/wasm/src/contacts.rs
+++ b/web/packages/wasm/src/contacts.rs
@@ -89,6 +89,13 @@ struct ContactRecordJs {
     updated_at: i64,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyRecoveryBundleJs {
+    recovery_key: String,
+    user_key_attributes: KeyAttributes,
+}
+
 impl From<ente_contacts::ContactRecord> for ContactRecordJs {
     fn from(value: ente_contacts::ContactRecord) -> Self {
         Self {
@@ -311,7 +318,11 @@ impl ContactsCtxHandle {
             .inner
             .legacy_recovery_bundle(&recovery_id, &current_user_key_attrs)
             .await?;
-        swb::to_value(&bundle).map_err(Into::into)
+        swb::to_value(&LegacyRecoveryBundleJs {
+            recovery_key: crypto::encode_b64(bundle.recovery_key.as_ref()),
+            user_key_attributes: bundle.user_key_attributes,
+        })
+        .map_err(Into::into)
     }
 
     /// Complete the legacy password reset flow fully in Rust.

--- a/web/packages/wasm/src/legacy_kit.rs
+++ b/web/packages/wasm/src/legacy_kit.rs
@@ -1,0 +1,67 @@
+//! WASM bindings for offline legacy-kit recovery.
+
+use ente_contacts::{
+    LegacyKitRecoveryClient, LegacyKitRecoveryHandle as CoreLegacyKitRecoveryHandle, LegacyKitShare,
+};
+use serde::Deserialize;
+use serde_wasm_bindgen as swb;
+use wasm_bindgen::prelude::*;
+
+use crate::contacts::ContactsError;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenLegacyKitRecoveryInput {
+    base_url: String,
+    shares: Vec<LegacyKitShare>,
+    email: Option<String>,
+    client_package: Option<String>,
+    client_version: Option<String>,
+    user_agent: Option<String>,
+}
+
+/// Open a legacy-kit recovery session from two matching kit shares.
+#[wasm_bindgen]
+pub async fn legacy_kit_open_recovery(
+    input: JsValue,
+) -> Result<LegacyKitRecoveryHandle, ContactsError> {
+    let input: OpenLegacyKitRecoveryInput = swb::from_value(input)?;
+    let client = LegacyKitRecoveryClient::new_with_headers(
+        input.base_url,
+        input.client_package,
+        input.client_version,
+        input.user_agent,
+    )?;
+    let handle = client
+        .open_from_shares(&input.shares, input.email.as_deref())
+        .await?;
+    Ok(LegacyKitRecoveryHandle { inner: handle })
+}
+
+/// Handle to an opened legacy-kit recovery session.
+#[wasm_bindgen]
+pub struct LegacyKitRecoveryHandle {
+    inner: CoreLegacyKitRecoveryHandle,
+}
+
+#[wasm_bindgen]
+impl LegacyKitRecoveryHandle {
+    /// Return the currently opened session.
+    pub fn session(&self) -> Result<JsValue, ContactsError> {
+        swb::to_value(self.inner.session()).map_err(Into::into)
+    }
+
+    /// Refresh the recovery session status.
+    pub async fn refresh_session(&self) -> Result<JsValue, ContactsError> {
+        let session = self.inner.refresh_session().await?;
+        swb::to_value(&session).map_err(Into::into)
+    }
+
+    /// Complete password reset using this recovery session.
+    pub async fn change_password(&self, new_password: String) -> Result<(), ContactsError> {
+        self.inner
+            .change_password(&new_password)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/web/packages/wasm/src/lib.rs
+++ b/web/packages/wasm/src/lib.rs
@@ -4,4 +4,5 @@ mod auth;
 mod contacts;
 mod crypto;
 mod http;
+mod legacy_kit;
 mod urls;


### PR DESCRIPTION
## Summary

- add Rust contacts Legacy Kit models, crypto/share helpers, and transport/client support
- expose Legacy Kit support through the mobile Rust wrapper and WASM package
- add Docker-backed Rust E2E coverage for Legacy Kit recovery
- document the `waitTill` response contract as remaining microseconds to match the existing legacy recovery API pattern

## Context

The server-side Legacy Kit support has already landed in upstream `main` via #10285. This PR builds on that server API from the Rust, WASM, mobile wrapper, and E2E surfaces.

## Validation

- `git diff --check upstream/main...legacy_rust_e2ee`

Full Rust/E2E test commands were not rerun in this publish-only step.
