### PR TITLE
Fix mobile Sentry crashes in collections, search, and streaming

### DIFF
--- a/mobile/apps/photos/lib/gateways/collections/collections_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/collections/collections_gateway.dart
@@ -179,7 +179,7 @@ class CollectionsGateway {
   /// Returns the raw response data containing pending actions.
   Future<Map<String, dynamic>> fetchPendingRemovalActions() async {
     final response = await _enteDio.get(
-      "/collection-actions/pending-remove/",
+      "/collection-actions/pending-remove",
     );
     return response.data;
   }
@@ -189,7 +189,7 @@ class CollectionsGateway {
   /// Returns the raw response data containing delete suggestion actions.
   Future<Map<String, dynamic>> fetchDeleteSuggestions() async {
     final response = await _enteDio.get(
-      "/collection-actions/delete-suggestions/",
+      "/collection-actions/delete-suggestions",
     );
     return response.data;
   }

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -313,9 +313,17 @@ class VideoPreviewService {
     DateTime? beginDate,
     bool onlyFilesWithLocalId = true,
   }) async {
+    final userID = config.getUserID();
+    if (userID == null) {
+      _logger.warning(
+        "Skipping video preview queue because user ID is missing. "
+        "This can happen if queued preview work runs after logout or account mode changes.",
+      );
+      return [];
+    }
     return await filesDB.getStreamingEligibleVideoFiles(
       beginDate: beginDate,
-      userID: config.getUserID()!,
+      userID: userID,
       onlyFilesWithLocalId: onlyFilesWithLocalId,
     );
   }

--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -223,9 +223,10 @@ class SearchWidgetState extends State<SearchWidget> {
     final streamController = StreamController<List<SearchResult>>();
 
     if (query.isEmpty) {
-      streamController.sink.add([]);
-      streamController.close();
-      return streamController.stream.asBroadcastStream();
+      return Stream<List<SearchResult>>.multi((controller) {
+        controller.add([]);
+        controller.close();
+      });
     }
 
     void onResultsReceived(List<SearchResult> results) {

--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -225,7 +225,7 @@ class SearchWidgetState extends State<SearchWidget> {
     if (query.isEmpty) {
       streamController.sink.add([]);
       streamController.close();
-      return streamController.stream;
+      return streamController.stream.asBroadcastStream();
     }
 
     void onResultsReceived(List<SearchResult> results) {
@@ -325,7 +325,7 @@ class SearchWidgetState extends State<SearchWidget> {
       },
     );
 
-    return streamController.stream;
+    return streamController.stream.asBroadcastStream();
   }
 
   bool _isYearValid(String year) {


### PR DESCRIPTION
## Summary
- Match mobile collection-action endpoints to server paths to avoid redirect response type crashes.
- Allow overlapping search suggestion widgets to listen to generated search result streams while preserving the empty-query clear signal.
- Skip video preview queue processing when user ID is unavailable and log a warning for triage.

## Verification
- Reviewed full branch diff against main; no release-blocking findings found.
- flutter analyze lib/gateways/collections/collections_gateway.dart lib/ui/viewer/search/search_widget.dart lib/services/video_preview_service.dart
- git diff --check main...HEAD