### PR TITLE
[auth] Add is_maximized to preferences to preserve window state

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -183,6 +183,16 @@ class _AppState extends State<App>
   }
 
   @override
+  void onWindowMaximize() {
+    WindowListenerService.instance.onWindowMaximize().ignore();
+  }
+
+  @override
+  void onWindowUnmaximize() {
+    WindowListenerService.instance.onWindowUnmaximize().ignore();
+  }
+
+  @override
   void onTrayIconMouseDown() {
     if (Platform.isWindows) {
       windowManager.show();

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -83,9 +83,13 @@ void main() async {
       size: WindowListenerService.instance.getWindowSize(),
       maximumSize: const Size(8192, 8192),
     );
+    bool isMaximized = WindowListenerService.instance.getIsMaximized();
     await windowManager.waitUntilReadyToShow(windowOptions, () async {
       await auth_dir_utils.DirectoryUtils.migrateNamingChanges();
       await windowManager.show();
+      if (isMaximized) {
+        await windowManager.maximize();
+      }
       await windowManager.focus();
       initSystemTray().ignore();
     });

--- a/mobile/apps/auth/lib/services/window_listener_service.dart
+++ b/mobile/apps/auth/lib/services/window_listener_service.dart
@@ -8,6 +8,7 @@ import 'package:window_manager/window_manager.dart';
 class WindowListenerService {
   static const double initialWindowHeight = 1200.0;
   static const double initialWindowWidth = 800.0;
+  static const bool initialIsMaximized = false;
   static const double maxWindowHeight = 8192.0;
   static const double maxWindowWidth = 8192.0;
   late SharedPreferences _preferences;
@@ -31,11 +32,23 @@ class WindowListenerService {
     return Size(w, h);
   }
 
+  bool getIsMaximized() {
+    return _preferences.getBool('is_maximized') ?? initialIsMaximized;
+  }
+
   Future<void> onWindowResize() async {
     final width = (await windowManager.getSize()).width;
     final height = (await windowManager.getSize()).height;
     // Save the window size to shared preferences
     await _preferences.setDouble('windowWidth', width);
     await _preferences.setDouble('windowHeight', height);
+  }
+
+  Future<void> onWindowMaximize() async {
+    await _preferences.setBool('is_maximized', true);
+  }
+
+  Future<void> onWindowUnmaximize() async {
+    await _preferences.setBool('is_maximized', false);
   }
 }


### PR DESCRIPTION
## Description
The authenticator currently only saves windows size (width and height) for the next launch. It doesn't preserve if the window was maximized or not, thus always opening as a unmaximized window.

This PR adds the property `is_maximized` to the user preferences in the same way as the other 2. It adds the events `onWindowMaximize` and `onWindowUnmaximize` to set this value, in the same way `onWindowResize` is used for the others.

This mimicks the functionality of the Ente desktop app, where this is saved in a similar way: https://github.com/ente-io/ente/blob/de6f9fcc1618ee79c0bdcfd68074ef88acd936fa/desktop/src/main.ts#L453
This application uses `isMaximized` for the saved value. I chose `is_maximized` here to adhere to the naming scheme of the other existing preferences.

## Tests
This change only affects desktop.

OLD:
To reproduce, open Ente Auth, maximize it and close it.
Re-open Ente Auth, check if window is maximized.

NEW:
To reproduce, open Ente Auth, maximize it and close it.
Optional: Check `shared_preferenced.json` and look for the `flutter.is_maximized` key and value.
Re-open Ente Auth, check if window is maximized.
Repeat in inverse.

Tested only on Windows 11.