### PR TITLE
[mobile][photos] Fix device folder hero collision

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -254,14 +254,11 @@ class _ZoomableImageState extends State<ZoomableImage> {
               child: SizedBox(
                 width: screenRelativeImageWidth,
                 height: screenRelativeImageHeight,
-                child: Hero(
-                  tag: widget.tagPrefix! + _photo.tag,
-                  child: widget.isFromMemories
-                      ? const _DelayedLoadingIndicator()
-                      : const EnteLoadingWidget(
-                          color: Colors.white,
-                        ),
-                ),
+                child: widget.isFromMemories
+                    ? const _DelayedLoadingIndicator()
+                    : const EnteLoadingWidget(
+                        color: Colors.white,
+                      ),
               ),
             );
           },


### PR DESCRIPTION
Removes the duplicate Hero wrapper used while loading local device-folder images, keeping PhotoView as the single Hero owner for the file tag.

Sentry issue id: 6802
