### PR TITLE
[locker][web] Fix Locker two-factor status settings

### DIFF
--- a/web/apps/locker/src/components/LockerAccountDrawer.tsx
+++ b/web/apps/locker/src/components/LockerAccountDrawer.tsx
@@ -21,6 +21,7 @@ import {
     LockerTitledNestedSidebarDrawer,
     type LockerNestedSidebarDrawerVisibilityProps,
 } from "./LockerSidebarShell";
+import { LockerTwoFactorDrawer } from "./LockerTwoFactorDrawer";
 
 export const LockerAccountDrawer: React.FC<
     LockerNestedSidebarDrawerVisibilityProps
@@ -31,17 +32,20 @@ export const LockerAccountDrawer: React.FC<
 
     const [isRecoveryKeyOpen, setIsRecoveryKeyOpen] = useState(false);
     const [isSessionsOpen, setIsSessionsOpen] = useState(false);
+    const [isTwoFactorOpen, setIsTwoFactorOpen] = useState(false);
 
     useEffect(() => {
         if (!open) {
             setIsRecoveryKeyOpen(false);
             setIsSessionsOpen(false);
+            setIsTwoFactorOpen(false);
         }
     }, [open]);
 
     const handleRootClose = () => {
         setIsRecoveryKeyOpen(false);
         setIsSessionsOpen(false);
+        setIsTwoFactorOpen(false);
         onClose();
         onRootClose();
     };
@@ -101,7 +105,7 @@ export const LockerAccountDrawer: React.FC<
                         <LockerSidebarCardButton
                             icon={SecurityCheckIcon}
                             label={t("two_factor")}
-                            onClick={() => handleNavigate("/two-factor/setup")}
+                            onClick={() => setIsTwoFactorOpen(true)}
                         />
                         <LockerSidebarCardButton
                             icon={Key01Icon}
@@ -137,6 +141,12 @@ export const LockerAccountDrawer: React.FC<
             <LockerSessionsDrawer
                 open={isSessionsOpen}
                 onClose={() => setIsSessionsOpen(false)}
+                onRootClose={handleRootClose}
+            />
+
+            <LockerTwoFactorDrawer
+                open={isTwoFactorOpen}
+                onClose={() => setIsTwoFactorOpen(false)}
                 onRootClose={handleRootClose}
             />
 

--- a/web/apps/locker/src/components/LockerTwoFactorDrawer.tsx
+++ b/web/apps/locker/src/components/LockerTwoFactorDrawer.tsx
@@ -1,0 +1,241 @@
+import LockIcon from "@mui/icons-material/Lock";
+import { CircularProgress, Stack, Typography } from "@mui/material";
+import { sessionExpiredDialogAttributes } from "ente-accounts-rs/components/utils/dialog";
+import { updateSavedLocalUser } from "ente-accounts-rs/services/accounts-db";
+import {
+    disableTwoFactor,
+    getTwoFactorStatus,
+} from "ente-accounts-rs/services/user";
+import {
+    RowButton,
+    RowButtonGroup,
+    RowButtonGroupHint,
+    RowSwitch,
+} from "ente-base/components/RowButton";
+import { FocusVisibleButton } from "ente-base/components/mui/FocusVisibleButton";
+import { useBaseContext } from "ente-base/context";
+import { isHTTP401Error } from "ente-base/http";
+import log from "ente-base/log";
+import { t } from "i18next";
+import { useRouter } from "next/router";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+    LockerTitledNestedSidebarDrawer,
+    type LockerNestedSidebarDrawerVisibilityProps,
+} from "./LockerSidebarShell";
+
+export const LockerTwoFactorDrawer: React.FC<
+    LockerNestedSidebarDrawerVisibilityProps
+> = ({ open, onClose, onRootClose }) => {
+    const router = useRouter();
+
+    const handleRootClose = () => {
+        onClose();
+        onRootClose();
+    };
+
+    const handleConfigure = () => {
+        handleRootClose();
+        void router.push("/two-factor/setup");
+    };
+
+    return (
+        <LockerTitledNestedSidebarDrawer
+            {...{ open, onClose }}
+            onRootClose={handleRootClose}
+            title={t("two_factor_authentication")}
+            hideRootCloseButton
+        >
+            <TwoFactorContents
+                open={open}
+                onRootClose={handleRootClose}
+                onConfigure={handleConfigure}
+            />
+        </LockerTitledNestedSidebarDrawer>
+    );
+};
+
+interface TwoFactorContentsProps {
+    open: boolean;
+    onRootClose: () => void;
+    onConfigure: () => void;
+}
+
+const TwoFactorContents: React.FC<TwoFactorContentsProps> = ({
+    open,
+    onRootClose,
+    onConfigure,
+}) => {
+    const { logout, showMiniDialog } = useBaseContext();
+
+    const [isTwoFactorEnabled, setIsTwoFactorEnabled] = useState<
+        boolean | undefined
+    >();
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | undefined>();
+
+    const handleError = useCallback(
+        (e: unknown, message: string) => {
+            log.error(message, e);
+            if (isHTTP401Error(e)) {
+                setTimeout(() => {
+                    showMiniDialog(sessionExpiredDialogAttributes(logout));
+                }, 0);
+            } else {
+                const isNetworkError =
+                    e instanceof TypeError && e.message === "Failed to fetch";
+                setError(
+                    isNetworkError ? t("network_error") : t("generic_error"),
+                );
+            }
+        },
+        [logout, showMiniDialog],
+    );
+
+    const refreshStatus = useCallback(async () => {
+        setIsLoading(true);
+        setError(undefined);
+        try {
+            const isEnabled = await getTwoFactorStatus();
+            setIsTwoFactorEnabled(isEnabled);
+            updateSavedLocalUser({ isTwoFactorEnabled: isEnabled });
+        } catch (e) {
+            handleError(e, "Failed to fetch two-factor status");
+        } finally {
+            setIsLoading(false);
+        }
+    }, [handleError]);
+
+    useEffect(() => {
+        if (!open) return;
+        setIsTwoFactorEnabled(undefined);
+        void refreshStatus();
+    }, [open, refreshStatus]);
+
+    const confirmDisable = () =>
+        showMiniDialog({
+            title: t("disable_two_factor"),
+            message: t("disable_two_factor_message"),
+            continue: {
+                text: t("disable"),
+                color: "critical",
+                action: async () => {
+                    setError(undefined);
+                    try {
+                        await disableTwoFactor();
+                        onRootClose();
+                    } catch (e) {
+                        log.error("Failed to disable two-factor", e);
+                        if (isHTTP401Error(e)) {
+                            setTimeout(() => {
+                                showMiniDialog(
+                                    sessionExpiredDialogAttributes(logout),
+                                );
+                            }, 0);
+                            return;
+                        }
+                        throw e;
+                    }
+                },
+            },
+        });
+
+    const confirmReconfigure = () =>
+        showMiniDialog({
+            title: t("update_two_factor"),
+            message: t("update_two_factor_message"),
+            continue: {
+                text: t("update"),
+                color: "primary",
+                action: onConfigure,
+            },
+        });
+
+    if (isLoading && isTwoFactorEnabled === undefined) {
+        return (
+            <Stack
+                sx={{
+                    flex: 1,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    py: 4,
+                }}
+            >
+                <CircularProgress color="accent" />
+            </Stack>
+        );
+    }
+
+    if (error && isTwoFactorEnabled === undefined) {
+        return (
+            <Stack sx={{ px: 2, py: 2 }}>
+                <Typography
+                    variant="small"
+                    sx={{ color: "critical.main", textAlign: "center" }}
+                >
+                    {error}
+                </Typography>
+            </Stack>
+        );
+    }
+
+    return isTwoFactorEnabled ? (
+        <ManageTwoFactor
+            onDisable={confirmDisable}
+            onReconfigure={confirmReconfigure}
+        />
+    ) : (
+        <SetupTwoFactor onConfigure={onConfigure} />
+    );
+};
+
+interface SetupTwoFactorProps {
+    onConfigure: () => void;
+}
+
+const SetupTwoFactor: React.FC<SetupTwoFactorProps> = ({ onConfigure }) => (
+    <Stack sx={{ px: "16px", py: "20px", alignItems: "center" }}>
+        <LockIcon sx={{ fontSize: "40px", color: "text.muted" }} />
+        <Typography
+            sx={{
+                color: "text.muted",
+                textAlign: "center",
+                marginBlock: "32px 36px",
+            }}
+        >
+            {t("two_factor_info")}
+        </Typography>
+        <FocusVisibleButton color="accent" fullWidth onClick={onConfigure}>
+            {t("enable_two_factor")}
+        </FocusVisibleButton>
+    </Stack>
+);
+
+interface ManageTwoFactorProps {
+    onDisable: () => void;
+    onReconfigure: () => void;
+}
+
+const ManageTwoFactor: React.FC<ManageTwoFactorProps> = ({
+    onDisable,
+    onReconfigure,
+}) => (
+    <Stack sx={{ px: "16px", py: "20px", gap: "24px" }}>
+        <RowButtonGroup>
+            <RowSwitch
+                label={t("enabled")}
+                checked={true}
+                onClick={onDisable}
+            />
+        </RowButtonGroup>
+
+        <Stack>
+            <RowButtonGroup>
+                <RowButton label={t("reconfigure")} onClick={onReconfigure} />
+            </RowButtonGroup>
+            <RowButtonGroupHint>
+                {t("reconfigure_two_factor_hint")}
+            </RowButtonGroupHint>
+        </Stack>
+    </Stack>
+);

--- a/web/packages/accounts-rs/services/user.ts
+++ b/web/packages/accounts-rs/services/user.ts
@@ -323,6 +323,17 @@ export const getPublicKey = async (email: string) => {
         .publicKey;
 };
 
+/**
+ * Fetch the TOTP based two-factor status for the logged in user from remote.
+ */
+export const getTwoFactorStatus = async () => {
+    const res = await fetch(await apiURL("/users/two-factor/status"), {
+        headers: await authenticatedRequestHeaders(),
+    });
+    ensureOk(res);
+    return z.object({ status: z.boolean() }).parse(await res.json()).status;
+};
+
 export interface GenerateKeysAndAttributesResult {
     masterKey: string;
     kek: string;
@@ -876,6 +887,19 @@ export const setupTwoFactorFinish = async (
         twoFactorSecretDecryptionNonce: box.nonce,
     });
     updateSavedLocalUser({ isTwoFactorEnabled: true });
+};
+
+/**
+ * Disable TOTP based two-factor authentication for the logged in user.
+ */
+export const disableTwoFactor = async () => {
+    ensureOk(
+        await fetch(await apiURL("/users/two-factor/disable"), {
+            method: "POST",
+            headers: await authenticatedRequestHeaders(),
+        }),
+    );
+    updateSavedLocalUser({ isTwoFactorEnabled: false });
 };
 
 interface EnableTwoFactorRequest {


### PR DESCRIPTION
## Summary
- add a Locker 2FA account drawer that fetches remote TOTP status before showing enable or manage state
- support disable and reconfigure actions from Locker while keeping local account state in sync
- share accounts-rs helpers for TOTP status and disable endpoints

## Validation
- yarn build:wasm
- yarn lint
- yarn test
- yarn audit --level critical (no critical vulnerabilities reported)
- yarn build:locker
