### PR TITLE
[mobile][infra] Scope mobile Crowdin untranslated-string skipping

### DIFF
--- a/.github/workflows/mobile-crowdin-sync.yml
+++ b/.github/workflows/mobile-crowdin-sync.yml
@@ -68,7 +68,6 @@ jobs:
                   download_translations: true
                   localization_branch_name: ${{ matrix.localization_branch_name }}
                   create_pull_request: true
-                  skip_untranslated_strings: true
                   pull_request_title: ${{ matrix.pull_request_title }}
                   pull_request_body: ${{ matrix.pull_request_body }}
                   pull_request_base_branch_name: "main"

--- a/mobile/apps/auth/crowdin.yml
+++ b/mobile/apps/auth/crowdin.yml
@@ -3,3 +3,4 @@ api_token_env: CROWDIN_PERSONAL_TOKEN
 files:
   - source: /lib/l10n/arb/app_en.arb
     translation: /lib/l10n/arb/app_%two_letters_code%.arb
+    skip_untranslated_strings: true

--- a/mobile/apps/locker/crowdin.yml
+++ b/mobile/apps/locker/crowdin.yml
@@ -6,4 +6,5 @@ files:
     translation: /lib/l10n/app_%two_letters_code%.arb
     dest: /%original_file_name%
     type: arb
+    skip_untranslated_strings: true
     skip_untranslated_files: false

--- a/mobile/apps/photos/crowdin.yml
+++ b/mobile/apps/photos/crowdin.yml
@@ -6,6 +6,7 @@ files:
     translation: /lib/l10n/intl_%two_letters_code%.arb
     dest: /%original_file_name%
     type: arb
+    skip_untranslated_strings: true
     skip_untranslated_files: false
   - source: /fastlane/metadata/playstore/en-US/*.txt
     translation: /fastlane/metadata/playstore/%two_letters_code%/%original_file_name%


### PR DESCRIPTION
Behavior matrix after this change:

- photos: skip untranslated ARB strings; skip untranslated metadata files.

- auth: skip untranslated ARB strings; no metadata files.

- locker: skip untranslated ARB strings; no metadata file entries.

This removes the workflow-level skip_untranslated_strings input so Photos does not combine global string skipping with per-file metadata skipping in the same Crowdin download.

