### PR TITLE
[mob][photos] Fix action sheet button dismissal

### DIFF
--- a/mobile/apps/photos/lib/ui/components/buttons/button_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/buttons/button_widget.dart
@@ -1,6 +1,7 @@
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import "package:modal_bottom_sheet/modal_bottom_sheet.dart";
 import "package:photos/models/button_result.dart";
 import 'package:photos/models/execution_states.dart';
 import 'package:photos/models/typedefs.dart';
@@ -515,7 +516,10 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
     if (mounted) {
       final route = ModalRoute.of(context);
       final navigator = Navigator.of(context);
-      if (route is PopupRoute && route.isCurrent && navigator.canPop()) {
+      if (route != null &&
+          route.isCurrent &&
+          (route is PopupRoute || route is ModalSheetRoute) &&
+          navigator.canPop()) {
         navigator.pop(ButtonResult(buttonAction, exception));
       } else if (exception != null) {
         //This is to show the execution was unsuccessful if the dialog is manually

--- a/mobile/apps/photos/test/ui/components/buttons/button_widget_test.dart
+++ b/mobile/apps/photos/test/ui/components/buttons/button_widget_test.dart
@@ -1,0 +1,107 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ente_theme_data.dart";
+import "package:photos/models/button_result.dart";
+import "package:photos/ui/components/buttons/button_widget.dart";
+import "package:photos/ui/components/models/button_type.dart";
+import "package:photos/utils/dialog_util.dart";
+
+void main() {
+  group("ButtonWidget", () {
+    testWidgets("alert button does not pop regular page routes", (
+      tester,
+    ) async {
+      ButtonResult? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: darkThemeData,
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () async {
+                    result = await Navigator.of(context).push<ButtonResult>(
+                      PageRouteBuilder(
+                        pageBuilder: (_, __, ___) => const _AlertRoutePage(),
+                      ),
+                    );
+                  },
+                  child: const Text("Open route"),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text("Open route"));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Cancel"));
+      await tester.pumpAndSettle();
+
+      expect(result, isNull);
+      expect(find.text("Cancel"), findsOneWidget);
+    });
+
+    testWidgets("action sheet buttons return their selected action", (
+      tester,
+    ) async {
+      ButtonResult? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: darkThemeData,
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: TextButton(
+                  onPressed: () async {
+                    result = await showChoiceActionSheet(
+                      context,
+                      title: "Clean Uncategorized",
+                      body: "Remove duplicate album entries",
+                      firstButtonLabel: "Confirm",
+                    );
+                  },
+                  child: const Text("Open sheet"),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text("Open sheet"));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Confirm"));
+      await tester.pumpAndSettle();
+
+      expect(result?.action, ButtonAction.first);
+      expect(find.text("Open sheet"), findsOneWidget);
+    });
+  });
+}
+
+class _AlertRoutePage extends StatelessWidget {
+  const _AlertRoutePage();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 240,
+          child: ButtonWidget(
+            buttonType: ButtonType.secondary,
+            labelText: "Cancel",
+            isInAlert: true,
+            buttonAction: ButtonAction.cancel,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Fix Photos alert buttons so modal action sheets created by `showChoiceActionSheet` can dismiss and return the selected `ButtonResult` again.

A recent Sentry hardening limited alert auto-pop to `PopupRoute`. That kept regular page routes from receiving a `ButtonResult`, but `modal_bottom_sheet` uses `ModalSheetRoute`, so action sheet buttons such as Clean Uncategorized Confirm/Cancel stopped closing or returning an action. The guard now allows current dialog popup routes and current modal sheet routes, while continuing to block regular page routes.

## Tests

- [x] `flutter test test/ui/components/buttons/button_widget_test.dart`
- [x] `flutter analyze lib/ui/components/buttons/button_widget.dart test/ui/components/buttons/button_widget_test.dart`
- [x] `git diff --check -- mobile/apps/photos/lib/ui/components/buttons/button_widget.dart mobile/apps/photos/test/ui/components/buttons/button_widget_test.dart`
- [ ] `flutter analyze .` (blocked by existing `plugins/ente_cast` `package:cast/cast.dart` resolution errors)