### PR TITLE
[auth]: remove hex color field from multi-hue icons that override/mask the actual SVG icons

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -2012,7 +2012,8 @@
       "altNames": [
         "Tally Forms",
         "Tally"
-      ]
+      ],
+      "hex": "000000"
     },
     {
       "title": "TCPShield"

--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -429,8 +429,7 @@
         "schwab",
         "charles-schwab",
         "charles schwab"
-      ],
-      "hex": "01A0E0"
+      ]
     },
     {
       "title": "Chaturbate",
@@ -605,8 +604,7 @@
     },
     {
       "title": "DeepSeek",
-      "slug": "deepseek",
-      "hex": "4D6BFE"
+      "slug": "deepseek"
     },
     {
       "title": "DEGIRO"
@@ -762,8 +760,7 @@
       "slug": "exaroton",
       "altNames": [
         "Exaroton"
-      ],
-      "hex": "17AB17"
+      ]
     },
     {
       "title": "ExoticaZ.to",
@@ -950,8 +947,7 @@
       "altNames": [
         "hsa bank",
         "hsabank"
-      ],
-      "hex": "00FF85"
+      ]
     },
     {
       "title": "HTX"
@@ -964,8 +960,7 @@
     },
     {
       "title": "Hulu",
-      "slug": "hulu",
-      "hex": "1CE783"
+      "slug": "hulu"
     },
     {
       "title": "Hytale",
@@ -1042,8 +1037,7 @@
       "altNames": [
         "Indian Railway Catering and Tourism Corporation",
         "Indian Railways"
-      ],
-      "hex": "000075"
+      ]
     },
     {
       "title": "ISC2",
@@ -1511,8 +1505,7 @@
     },
     {
       "title": "NumberBarn",
-      "slug": "numberbarn",
-      "hex": "1c5787"
+      "slug": "numberbarn"
     },
     {
       "title": "numerai"
@@ -1841,8 +1834,7 @@
         "Rose Hulman",
         "Rose Hulman Institute of Technology",
         "RHIT"
-      ],
-      "hex": "800000"
+      ]
     },
     {
       "title": "RuneMate"
@@ -2020,8 +2012,7 @@
       "altNames": [
         "Tally Forms",
         "Tally"
-      ],
-      "hex": "000000"
+      ]
     },
     {
       "title": "TCPShield"


### PR DESCRIPTION
This is an amendment fix of icons I added in prior PRs:
- #6682 exaroton icon
- #6683 Numberbarn icon
- #6685 Rose-Hulman Institute of Technology icon
- #6689 Tally.so icon
- #6690 Charles Schwab icon
- #6694 Misc. other icons I touched

This will fix the odd coloring issue for all the aforementioned icons. Same fix as precedent #6820

## Description

Previously added "hex" color field for multi-hue icons causes the SVG icon to be masked/overriden with the hex hue instead:
<img width="210" height="146" alt="SCR-20260507-oodf" src="https://github.com/user-attachments/assets/20b9254a-f470-4f57-a6db-e2a7d74504b1" />
<img width="184" height="151" alt="SCR-20260507-onzs" src="https://github.com/user-attachments/assets/b6561339-29ed-42c8-93c1-94ccf21aa3a8" />
<img width="206" height="143" alt="SCR-20260507-onxw" src="https://github.com/user-attachments/assets/e789b2ae-b680-4088-9169-5ad1c9f92b14" />
<img width="191" height="170" alt="SCR-20260507-onst" src="https://github.com/user-attachments/assets/1c6a9469-53b2-45ec-b5b7-7200bea86118" />


## Solution

Removing the hex field, resolves the issue and the icon SVGs render as expected, visually.
No SVG assets were modified.

