### PR TITLE
[docs] Fix Photos changelog sync PR base

### DIFF
--- a/.github/workflows/docs-sync-photos-changelog.yml
+++ b/.github/workflows/docs-sync-photos-changelog.yml
@@ -46,6 +46,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v6
+              with:
+                  ref: main
 
             - name: Sync changelog entry
               id: sync
@@ -79,6 +81,7 @@ jobs:
 
                       Trigger: `${{ github.event_name }} / ${{ github.event.action || 'manual' }}`
                   branch: automation/photos-changelog-v${{ steps.sync.outputs.version }}
+                  base: main
                   delete-branch: true
                   add-paths: |
                       docs/docs/photos/changelog.md


### PR DESCRIPTION
## Summary
- check out main before generating the Photos help changelog update
- set the generated changelog PR base branch to main

## Context
The Photos help changelog sync workflow runs from release tag events. On tags, actions/checkout leaves the repo in detached HEAD, and peter-evans/create-pull-request fails with: "When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied."

The workflow still reads the release tag, publish date, and notes from the GitHub release event payload. The checkout only needs to be on main so the docs-only PR is generated against the branch that deploys ente.com/help.

## Test plan
- git diff --check
- Parsed .github/workflows/docs-sync-photos-changelog.yml as YAML
- Ran sync_photos_help_changelog.py in dry-run mode for photos-v1.3.40
- Ran sync_photos_help_changelog.py against a temp changelog file and verified it inserted v1.3.40