### PR TITLE
[docs] Add mobile changelog sync

### DIFF
--- a/.github/scripts/sync_mobile_help_changelog.py
+++ b/.github/scripts/sync_mobile_help_changelog.py
@@ -4,14 +4,39 @@ import argparse
 import json
 import os
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
 
-TAG_PATTERN = re.compile(r"^photos-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
 BULLET_PATTERN = re.compile(r"^([-*+])\s+(?P<text>.+?)\s*$")
 ORDERED_PATTERN = re.compile(r"^\d+[.)]\s+(?P<text>.+?)\s*$")
+TAG_PATTERN = re.compile(
+    r"^(?P<product>photos|auth|locker)-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$"
+)
+
+
+@dataclass(frozen=True)
+class ProductConfig:
+    changelog_path: str
+    heading_has_mobile_label: bool
+
+
+PRODUCTS = {
+    "photos": ProductConfig(
+        changelog_path="docs/docs/photos/changelog.md",
+        heading_has_mobile_label=True,
+    ),
+    "auth": ProductConfig(
+        changelog_path="docs/docs/auth/changelog.md",
+        heading_has_mobile_label=False,
+    ),
+    "locker": ProductConfig(
+        changelog_path="docs/docs/locker/changelog.md",
+        heading_has_mobile_label=True,
+    ),
+}
 
 
 def set_output(name: str, value: str) -> None:
@@ -24,9 +49,8 @@ def set_output(name: str, value: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Sync docs/docs/photos/changelog.md with a photos release entry."
+        description="Sync mobile app help changelogs with release entries."
     )
-    parser.add_argument("--changelog-path", required=True)
     parser.add_argument("--event-path", default=os.getenv("GITHUB_EVENT_PATH", ""))
     parser.add_argument("--tag-name", default="")
     parser.add_argument("--published-at", default="")
@@ -72,11 +96,11 @@ def resolve_release_fields(args: argparse.Namespace) -> Tuple[str, str, str]:
     return tag_name, published_at, body
 
 
-def parse_tag(tag_name: str) -> Optional[str]:
+def parse_tag(tag_name: str) -> Tuple[Optional[str], Optional[str]]:
     match = TAG_PATTERN.match(tag_name)
     if not match:
-        return None
-    return match.group("version")
+        return None, None
+    return match.group("product"), match.group("version")
 
 
 def month_year_label(published_at: str) -> str:
@@ -135,15 +159,27 @@ def extract_bullets(body: str) -> List[str]:
     return dedupe_preserve_order(fallback)
 
 
-def build_section(version: str, date_label: str, bullets: List[str]) -> str:
-    section_lines = [f"## v{version} (mobile) - {date_label}", ""]
+def build_heading(version: str, date_label: str, config: ProductConfig) -> str:
+    if config.heading_has_mobile_label:
+        return f"## v{version} (mobile) - {date_label}"
+    return f"## v{version} - {date_label}"
+
+
+def build_section(
+    version: str,
+    date_label: str,
+    bullets: List[str],
+    config: ProductConfig,
+) -> str:
+    section_lines = [build_heading(version, date_label, config), ""]
     section_lines.extend(f"- {item}" for item in bullets)
     return "\n".join(section_lines).rstrip() + "\n"
 
 
 def replace_or_insert_section(content: str, version: str, section: str) -> str:
     heading_pattern = re.compile(
-        rf"^## v{re.escape(version)} \(mobile\) - .*$", re.MULTILINE
+        rf"^## v{re.escape(version)}(?: \(mobile\))? - .*$",
+        re.MULTILINE,
     )
     heading_match = heading_pattern.search(content)
 
@@ -171,16 +207,21 @@ def replace_or_insert_section(content: str, version: str, section: str) -> str:
 
 def main() -> int:
     args = parse_args()
-    changelog_path = Path(args.changelog_path)
 
     tag_name, published_at, body = resolve_release_fields(args)
-    version = parse_tag(tag_name)
+    product, version = parse_tag(tag_name)
 
-    if not version:
+    if not product or not version:
         print(f"Skipping: unsupported tag '{tag_name}'")
         set_output("changed", "false")
         set_output("reason", "unsupported_tag")
         return 0
+
+    config = PRODUCTS[product]
+    changelog_path = Path(config.changelog_path)
+
+    set_output("product", product)
+    set_output("changelog_path", config.changelog_path)
 
     bullets = extract_bullets(body)
     if not bullets:
@@ -192,7 +233,7 @@ def main() -> int:
         return 0
 
     date_label = month_year_label(published_at)
-    section = build_section(version, date_label, bullets)
+    section = build_section(version, date_label, bullets, config)
 
     original = changelog_path.read_text(encoding="utf-8")
     updated = replace_or_insert_section(original, version, section)

--- a/.github/workflows/docs-sync-mobile-changelogs.yml
+++ b/.github/workflows/docs-sync-mobile-changelogs.yml
@@ -1,4 +1,4 @@
-name: "Sync photos help changelog"
+name: "Sync mobile help changelogs"
 
 on:
     release:
@@ -6,11 +6,11 @@ on:
     workflow_dispatch:
         inputs:
             tag_name:
-                description: "Release tag, e.g. photos-v1.3.16"
+                description: "Release tag, e.g. photos-v1.3.40, auth-v4.4.22, locker-v1.0.3"
                 required: true
                 type: string
             published_at:
-                description: "Release publish date in ISO format, e.g. 2026-02-21T07:09:55Z"
+                description: "Release publish date in ISO format, e.g. 2026-05-08T08:49:36Z"
                 required: true
                 type: string
             body:
@@ -28,7 +28,7 @@ permissions:
     pull-requests: write
 
 concurrency:
-    group: docs-sync-photos-changelog-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.run_id }}
+    group: docs-sync-mobile-changelogs-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.run_id }}
     cancel-in-progress: true
 
 jobs:
@@ -37,7 +37,11 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             (
                 github.event_name == 'release' &&
-                startsWith(github.event.release.tag_name, 'photos-v') &&
+                (
+                    startsWith(github.event.release.tag_name, 'photos-v') ||
+                    startsWith(github.event.release.tag_name, 'auth-v') ||
+                    startsWith(github.event.release.tag_name, 'locker-v')
+                ) &&
                 github.event.release.draft == false &&
                 github.event.release.prerelease == false
             )
@@ -57,8 +61,7 @@ jobs:
                     DRY_RUN_FLAG="--dry-run"
                   fi
 
-                  python3 .github/scripts/sync_photos_help_changelog.py \
-                    --changelog-path docs/docs/photos/changelog.md \
+                  python3 .github/scripts/sync_mobile_help_changelog.py \
                     --event-path "$GITHUB_EVENT_PATH" \
                     --tag-name "$INPUT_TAG_NAME" \
                     --published-at "$INPUT_PUBLISHED_AT" \
@@ -74,17 +77,17 @@ jobs:
               if: steps.sync.outputs.changed == 'true' && github.event.inputs.dry_run != 'true'
               uses: peter-evans/create-pull-request@v7
               with:
-                  commit-message: "docs(photos): sync changelog for v${{ steps.sync.outputs.version }}"
-                  title: "docs(photos): sync changelog for v${{ steps.sync.outputs.version }}"
+                  commit-message: "docs(${{ steps.sync.outputs.product }}): sync changelog for v${{ steps.sync.outputs.version }}"
+                  title: "docs(${{ steps.sync.outputs.product }}): sync changelog for v${{ steps.sync.outputs.version }}"
                   body: |
-                      Sync [docs/docs/photos/changelog.md](docs/docs/photos/changelog.md) from the GitHub release `${{ steps.sync.outputs.tag_name }}`.
+                      Sync [${{ steps.sync.outputs.changelog_path }}](${{ steps.sync.outputs.changelog_path }}) from the GitHub release `${{ steps.sync.outputs.tag_name }}`.
 
                       Trigger: `${{ github.event_name }} / ${{ github.event.action || 'manual' }}`
-                  branch: automation/photos-changelog-v${{ steps.sync.outputs.version }}
+                  branch: automation/${{ steps.sync.outputs.product }}-changelog-v${{ steps.sync.outputs.version }}
                   base: main
                   delete-branch: true
                   add-paths: |
-                      docs/docs/photos/changelog.md
+                      ${{ steps.sync.outputs.changelog_path }}
 
             - name: No changes summary
               if: steps.sync.outputs.changed != 'true'

--- a/docs/docs/.vitepress/sidebar.ts
+++ b/docs/docs/.vitepress/sidebar.ts
@@ -377,6 +377,7 @@ export const sidebar = [
         text: "Locker",
         items: [
             { text: "Introduction", link: "/locker/" },
+            { text: "Changelog", link: "/locker/changelog" },
             {
                 text: "Getting Started",
                 collapsed: true,

--- a/docs/docs/locker/changelog.md
+++ b/docs/docs/locker/changelog.md
@@ -1,0 +1,14 @@
+---
+title: Ente Locker - Changelog
+description: Release notes of recent updates to Ente Locker
+---
+
+# Changelog - Ente Locker
+
+A short summary list of changes to Ente Locker.
+
+## v1.0.3 (mobile) - May 2026
+
+- Share collections as a link
+- Keep items locally for offline use
+- Bug fixes and improvements

--- a/docs/docs/locker/index.md
+++ b/docs/docs/locker/index.md
@@ -110,6 +110,10 @@ New to Locker? Start here:
 4. **[Family setup](/locker/getting-started/family-setup)**: Set up Locker for
    your family with shared collections and Legacy
 
+## Changelog
+
+For a list of recent changes, see the [Changelog](/locker/changelog).
+
 ## Getting Help
 
 If you need assistance with Ente Locker, multiple support channels are


### PR DESCRIPTION
## Summary
- replace the Photos-only changelog sync with a generic mobile changelog sync for Photos, Auth, and Locker release tags
- add a Locker help changelog page and sidebar/index links
- keep Auth changelog headings in the existing format while Photos and Locker use the mobile heading format

## Testing
- python3 -m py_compile .github/scripts/sync_mobile_help_changelog.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-sync-mobile-changelogs.yml"); puts "yaml_ok"'
- git diff --check --cached
- yarn --cwd docs build
- local script checks for photos-v1.3.40, auth-v4.4.22, locker-v1.0.4, and unsupported ensu-v0.1.15