### PR TITLE
[mob][photos] Run ML in continuous mode on local gallery

### DIFF
--- a/mobile/apps/photos/lib/service_locator.dart
+++ b/mobile/apps/photos/lib/service_locator.dart
@@ -2,7 +2,6 @@ import "package:dio/dio.dart";
 import "package:ente_cast/ente_cast.dart";
 import "package:ente_feature_flag/ente_feature_flag.dart";
 import "package:package_info_plus/package_info_plus.dart";
-import "package:photos/app_mode.dart";
 import "package:photos/core/configuration.dart";
 import "package:photos/gateways/billing/billing_gateway.dart";
 import "package:photos/gateways/collections/collection_files_gateway.dart";
@@ -95,7 +94,7 @@ LocalSettings get localSettings {
 ///
 /// This does not mean the device is offline. It means the active gallery mode is
 /// local-device focused rather than Ente-account focused.
-bool get isLocalGalleryMode => localSettings.appMode == AppMode.localGallery;
+bool get isLocalGalleryMode => localSettings.isLocalGalleryMode;
 
 bool get hasGrantedMLConsent {
   if (isLocalGalleryMode) {

--- a/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
@@ -84,7 +84,7 @@ class ComputeController {
       // Initialize interaction tracking before any await to avoid first-tap races.
       _startInteractionTimer(kDefaultInteractionTimeout);
 
-      await setMLDebugInteractionOverride(
+      await setMLInteractionOverride(
         turnOn: _localSettings.runMLDuringInteractionOverride,
         persist: false,
       );
@@ -245,7 +245,7 @@ class ComputeController {
     _fireControlEvent();
   }
 
-  Future<void> setMLDebugInteractionOverride({
+  Future<void> setMLInteractionOverride({
     required bool turnOn,
     bool persist = true,
   }) async {

--- a/mobile/apps/photos/lib/ui/settings/debug/ml_debug_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/debug/ml_debug_settings_page.dart
@@ -712,7 +712,7 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
   Future<void> _onRunMLDuringInteractionChanged() async {
     try {
       final enabled = !localSettings.runMLDuringInteractionOverride;
-      await computeController.setMLDebugInteractionOverride(turnOn: enabled);
+      await computeController.setMLInteractionOverride(turnOn: enabled);
       logger.info(
         'run ML during interaction is turned ${enabled ? 'on' : 'off'}',
       );

--- a/mobile/apps/photos/lib/ui/settings/ml/ml_user_dev_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/ml_user_dev_screen.dart
@@ -183,7 +183,7 @@ class _MLUserDeveloperOptionsState extends State<MLUserDeveloperOptions> {
                                   final enabled = !localSettings
                                       .runMLDuringInteractionOverride;
                                   await computeController
-                                      .setMLDebugInteractionOverride(
+                                      .setMLInteractionOverride(
                                     turnOn: enabled,
                                   );
                                   _logger.info(

--- a/mobile/apps/photos/lib/utils/local_settings.dart
+++ b/mobile/apps/photos/lib/utils/local_settings.dart
@@ -289,11 +289,13 @@ class LocalSettings {
     await _setFlag(LocalGalleryFlag.mapEnabled, value);
   }
 
-  String get _mlLocalIndexingKey => appMode == AppMode.localGallery
+  bool get isLocalGalleryMode => appMode == AppMode.localGallery;
+
+  String get _mlLocalIndexingKey => isLocalGalleryMode
       ? _kLocalGalleryMLLocalIndexingEnabled
       : _kisMLLocalIndexingEnabled;
 
-  bool get _defaultMLLocalIndexingEnabled => appMode == AppMode.localGallery
+  bool get _defaultMLLocalIndexingEnabled => isLocalGalleryMode
       ? enoughRamForLocalGalleryLocalIndexing
       : enoughRamForLocalIndexing;
 
@@ -335,7 +337,7 @@ class LocalSettings {
   }
 
   bool get runMLDuringInteractionOverride =>
-      _prefs.getBool(_kRunMLDuringInteractionOverride) ?? false;
+      _prefs.getBool(_kRunMLDuringInteractionOverride) ?? isLocalGalleryMode;
 
   Future<void> setRunMLDuringInteractionOverride(bool value) async {
     await _prefs.setBool(_kRunMLDuringInteractionOverride, value);


### PR DESCRIPTION
## Description

Run ML in continuous mode on local gallery. This means user taps don't pause ML if the app is in local gallery mode. Other safeguards and consent checks are still in place. 
