### PR TITLE
[Ensu] Improve Ensu model downloads

### DIFF
--- a/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
+++ b/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
@@ -16,6 +16,9 @@ import io.ente.labs.inference_rs.GenerateChatRequest
 import io.ente.labs.inference_rs.GenerateEvent
 import io.ente.labs.inference_rs.GenerateEventCallback
 import io.ente.labs.inference_rs.GenerateSummary as NativeSummary
+import io.ente.labs.inference_rs.LlmModelDownloadCallback
+import io.ente.labs.inference_rs.LlmModelDownloadProgress
+import io.ente.labs.inference_rs.LlmModelDownloadTarget
 import io.ente.labs.inference_rs.ModelHandle
 import io.ente.labs.inference_rs.ModelLoadParams
 import io.ente.labs.inference_rs.initBackend
@@ -24,6 +27,7 @@ import io.ente.labs.inference_rs.createContext
 import io.ente.labs.inference_rs.generateChatStream
 import io.ente.labs.inference_rs.prewarmMultimodalContext
 import io.ente.labs.inference_rs.cancel
+import io.ente.labs.inference_rs.downloadLlmModelFiles
 import io.ente.labs.inference_rs.uniffiEnsureInitialized
 import io.ente.labs.inference_rs.InferenceException
 import kotlinx.coroutines.Dispatchers
@@ -449,15 +453,44 @@ class InferenceRsProvider(
         manualDownloadActive = true
         try {
             val targets = ModelDownloadSupport.expectedTargets(modelDir, target)
-            ModelDownloadSupport.downloadTargets(
-                httpClient,
+                .map {
+                    LlmModelDownloadTarget(
+                        label = it.label,
+                        url = it.url,
+                        destinationPath = it.destination.absolutePath
+                    )
+                }
+            downloadLlmModelFiles(
                 targets,
-                onProgress,
-                isCancelled = { manualDownloadCancelled }
+                object : LlmModelDownloadCallback {
+                    override fun onProgress(progress: LlmModelDownloadProgress) {
+                        onProgress(progress.toDomainProgress())
+                    }
+
+                    override fun isCancelled(): Boolean = manualDownloadCancelled
+                }
             )
         } finally {
             manualDownloadActive = false
         }
+    }
+
+    private fun LlmModelDownloadProgress.toDomainProgress(): DownloadProgress {
+        val downloaded = downloadedBytes.coerceAtLeast(0L)
+        val total = totalBytes?.takeIf { it > 0 }
+        val percent = if (total != null) {
+            ((downloaded * 100) / total).toInt().coerceIn(0, 99)
+        } else {
+            0
+        }
+        val status = if (total != null) {
+            "Downloading... ${io.ente.ensu.domain.util.formatBytes(downloaded)} / ${io.ente.ensu.domain.util.formatBytes(total)}"
+        } else if (fileDownloadedBytes > 0) {
+            "Downloading ${label.lowercase()}... ${io.ente.ensu.domain.util.formatBytes(fileDownloadedBytes)}"
+        } else {
+            "Downloading ${label.lowercase()}..."
+        }
+        return DownloadProgress(percent, status)
     }
 
     private fun ensureDownloadsEnqueued(target: LlmModelTarget) {

--- a/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
+++ b/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
@@ -10,6 +10,7 @@ import io.ente.ensu.domain.llm.GenerationSummary
 import io.ente.ensu.domain.llm.LlmMessage
 import io.ente.ensu.domain.llm.LlmModelTarget
 import io.ente.ensu.domain.llm.LlmProvider
+import io.ente.ensu.domain.util.formatBytes
 import io.ente.labs.inference_rs.ContextHandle
 import io.ente.labs.inference_rs.ContextParams
 import io.ente.labs.inference_rs.GenerateChatRequest
@@ -464,6 +465,7 @@ class InferenceRsProvider(
                 targets,
                 object : LlmModelDownloadCallback {
                     override fun onProgress(progress: LlmModelDownloadProgress) {
+                        logDownloadMetrics(progress)
                         onProgress(progress.toDomainProgress())
                     }
 
@@ -473,6 +475,37 @@ class InferenceRsProvider(
         } finally {
             manualDownloadActive = false
         }
+    }
+
+    private fun logDownloadMetrics(progress: LlmModelDownloadProgress) {
+        if (progress.fileComplete) {
+            Log.i(
+                "InferenceRsProvider",
+                "Model download file complete label=${progress.label} " +
+                    "bytes=${progress.fileDownloadedBytes} " +
+                    "elapsedMs=${progress.fileElapsedMs} " +
+                    "rate=${formatRate(progress.fileBytesPerSecond)} " +
+                    "retries=${progress.fileRetryCount}"
+            )
+        }
+        if (progress.complete) {
+            Log.i(
+                "InferenceRsProvider",
+                "Model download complete bytes=${progress.downloadedBytes} " +
+                    "elapsedMs=${progress.elapsedMs} " +
+                    "rate=${formatRate(progress.bytesPerSecond)} " +
+                    "retries=${progress.retryCount}"
+            )
+        }
+    }
+
+    private fun formatRate(bytesPerSecond: Double): String {
+        val bytes = if (java.lang.Double.isFinite(bytesPerSecond) && bytesPerSecond > 0.0) {
+            bytesPerSecond.toLong()
+        } else {
+            0L
+        }
+        return "${formatBytes(bytes)}/s"
     }
 
     private fun LlmModelDownloadProgress.toDomainProgress(): DownloadProgress {

--- a/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
+++ b/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
@@ -32,6 +32,7 @@ import io.ente.labs.inference_rs.downloadLlmModelFiles
 import io.ente.labs.inference_rs.uniffiEnsureInitialized
 import io.ente.labs.inference_rs.InferenceException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -44,6 +45,7 @@ import java.io.File
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.coroutines.coroutineContext
 import kotlin.math.max
 
 class InferenceRsProvider(
@@ -364,7 +366,7 @@ class InferenceRsProvider(
         migrateLegacyDownloads(target)
         val modelFile = ModelDownloadSupport.modelPathFor(modelDir, target)
         if (!ModelDownloadSupport.isTargetDownloaded(modelDir, target)) {
-            awaitBackgroundDownload(target, onProgress)
+            awaitForegroundDownload(target, onProgress)
         }
 
         onProgress(DownloadProgress(100, "Loading model..."))
@@ -408,12 +410,31 @@ class InferenceRsProvider(
         throw lastError ?: IllegalStateException("Failed to load model")
     }
 
+    private suspend fun awaitForegroundDownload(
+        target: LlmModelTarget,
+        onProgress: (DownloadProgress) -> Unit
+    ) {
+        cancelNativeDownloads(target)
+        try {
+            awaitRustForegroundDownload(target, onProgress)
+        } catch (error: Throwable) {
+            if (manualDownloadCancelled || error.isDownloadCancellation()) {
+                throw error
+            }
+            if (externalDownloadsRoot == null || downloadManager == null) {
+                throw error
+            }
+            Log.w("InferenceRsProvider", "Rust model download failed; falling back to DownloadManager", error)
+            awaitBackgroundDownload(target, onProgress)
+        }
+    }
+
     private suspend fun awaitBackgroundDownload(
         target: LlmModelTarget,
         onProgress: (DownloadProgress) -> Unit
     ) {
         if (externalDownloadsRoot == null || downloadManager == null) {
-            awaitManualDownload(target, onProgress)
+            awaitRustForegroundDownload(target, onProgress)
             return
         }
         ensureDownloadsEnqueued(target)
@@ -446,10 +467,11 @@ class InferenceRsProvider(
         }
     }
 
-    private fun awaitManualDownload(
+    private suspend fun awaitRustForegroundDownload(
         target: LlmModelTarget,
         onProgress: (DownloadProgress) -> Unit
     ) {
+        val downloadJob = coroutineContext[Job]
         manualDownloadCancelled = false
         manualDownloadActive = true
         try {
@@ -469,12 +491,25 @@ class InferenceRsProvider(
                         onProgress(progress.toDomainProgress())
                     }
 
-                    override fun isCancelled(): Boolean = manualDownloadCancelled
+                    override fun isCancelled(): Boolean =
+                        manualDownloadCancelled || downloadJob?.isCancelled == true
                 }
             )
         } finally {
             manualDownloadActive = false
         }
+    }
+
+    private fun Throwable.isDownloadCancellation(): Boolean {
+        return message?.contains("cancelled", ignoreCase = true) == true
+    }
+
+    private fun cancelNativeDownloads(target: LlmModelTarget) {
+        val ids = loadDownloadRecords(target).map { it.downloadId }.distinct()
+        if (ids.isNotEmpty() && downloadManager != null) {
+            downloadManager.remove(*ids.toLongArray())
+        }
+        clearDownloadRecords(target)
     }
 
     private fun logDownloadMetrics(progress: LlmModelDownloadProgress) {

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
@@ -97,6 +97,8 @@ final class InferenceRsProvider {
     private var backendInitialized = false
     private var currentJobId: Int64?
     private let modelLoadGate = AsyncSerialGate()
+    private let rustDownloadCancelLock = NSLock()
+    private var rustDownloadCancelled = false
 
     init(modelDir: URL) {
         self.modelDir = modelDir
@@ -155,8 +157,17 @@ final class InferenceRsProvider {
 
         if !downloads.isEmpty {
             onProgress(InferenceDownloadProgress(percent: 0, status: "Starting download..."))
-            await downloadManager.enqueueDownloads(downloads.map(downloadTarget(for:)))
-            try await waitForDownloads(expectedTargets, onProgress: onProgress)
+            do {
+                await downloadManager.enqueueDownloads(downloads.map(downloadTarget(for:)))
+                try await waitForDownloads(expectedTargets, onProgress: onProgress)
+            } catch {
+                if error is CancellationError {
+                    await downloadManager.cancelAllDownloads()
+                    throw error
+                }
+                await downloadManager.cancelAllDownloads()
+                try await downloadWithRust(expectedTargets, onProgress: onProgress)
+            }
         }
 
         onProgress(InferenceDownloadProgress(percent: 100, status: "Loading model..."))
@@ -302,6 +313,7 @@ final class InferenceRsProvider {
     }
 
     func cancelDownload() {
+        setRustDownloadCancelled(true)
         Task {
             await downloadManager.cancelAllDownloads()
         }
@@ -530,6 +542,42 @@ final class InferenceRsProvider {
             try await Task.sleep(nanoseconds: 500_000_000)
         }
     }
+
+    private func downloadWithRust(
+        _ expectedTargets: [DownloadTarget],
+        onProgress: @escaping (InferenceDownloadProgress) -> Void
+    ) async throws {
+        setRustDownloadCancelled(false)
+        let targets = expectedTargets.map {
+            LlmModelDownloadTarget(label: $0.label, url: $0.url, destinationPath: $0.destination.path)
+        }
+
+        try await Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            let callback = ModelDownloadCallbackSink(
+                onProgress: { progress in
+                    onProgress(progress.toInferenceProgress())
+                },
+                isCancelled: { [weak self] in
+                    self?.isRustDownloadCancelled() ?? true
+                }
+            )
+            try downloadLlmModelFiles(targets: targets, callback: callback)
+        }.value
+    }
+
+    private func setRustDownloadCancelled(_ cancelled: Bool) {
+        rustDownloadCancelLock.lock()
+        rustDownloadCancelled = cancelled
+        rustDownloadCancelLock.unlock()
+    }
+
+    private func isRustDownloadCancelled() -> Bool {
+        rustDownloadCancelLock.lock()
+        let cancelled = rustDownloadCancelled
+        rustDownloadCancelLock.unlock()
+        return cancelled
+    }
 }
 
 private final class CallbackSink: GenerateEventCallback, @unchecked Sendable {
@@ -541,5 +589,45 @@ private final class CallbackSink: GenerateEventCallback, @unchecked Sendable {
 
     func onEvent(event: GenerateEvent) {
         handler(event)
+    }
+}
+
+private final class ModelDownloadCallbackSink: LlmModelDownloadCallback, @unchecked Sendable {
+    private let onProgressHandler: (LlmModelDownloadProgress) -> Void
+    private let isCancelledHandler: () -> Bool
+
+    init(
+        onProgress: @escaping (LlmModelDownloadProgress) -> Void,
+        isCancelled: @escaping () -> Bool
+    ) {
+        self.onProgressHandler = onProgress
+        self.isCancelledHandler = isCancelled
+    }
+
+    func onProgress(progress: LlmModelDownloadProgress) {
+        onProgressHandler(progress)
+    }
+
+    func isCancelled() -> Bool {
+        isCancelledHandler()
+    }
+}
+
+private extension LlmModelDownloadProgress {
+    func toInferenceProgress() -> InferenceDownloadProgress {
+        let total = totalBytes.flatMap { $0 > 0 ? $0 : nil }
+        let percent: Int
+        let status: String
+        if let total {
+            percent = min(99, max(0, Int((Double(downloadedBytes) / Double(total)) * 100.0)))
+            status = "Downloading... \(downloadedBytes.formattedFileSize) / \(total.formattedFileSize)"
+        } else if fileDownloadedBytes > 0 {
+            percent = 0
+            status = "Downloading \(label.lowercased())... \(fileDownloadedBytes.formattedFileSize)"
+        } else {
+            percent = 0
+            status = "Downloading \(label.lowercased())..."
+        }
+        return InferenceDownloadProgress(percent: percent, status: status)
     }
 }

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
@@ -158,16 +158,19 @@ final class InferenceRsProvider {
 
         if !downloads.isEmpty {
             onProgress(InferenceDownloadProgress(percent: 0, status: "Starting download..."))
+            await downloadManager.cancelDownloads(for: downloads.map(downloadTarget(for:)))
             do {
-                await downloadManager.enqueueDownloads(downloads.map(downloadTarget(for:)))
-                try await waitForDownloads(expectedTargets, onProgress: onProgress)
+                try await downloadWithRust(expectedTargets, onProgress: onProgress)
             } catch {
-                if error is CancellationError {
-                    await downloadManager.cancelAllDownloads()
+                if isDownloadCancellation(error) {
                     throw error
                 }
-                await downloadManager.cancelAllDownloads()
-                try await downloadWithRust(expectedTargets, onProgress: onProgress)
+                logger.warning(
+                    "Rust model download failed; falling back to URLSession",
+                    details: "\(error.localizedDescription)"
+                )
+                await downloadManager.enqueueDownloads(downloads.map(downloadTarget(for:)))
+                try await waitForDownloads(expectedTargets, onProgress: onProgress)
             }
         }
 
@@ -553,7 +556,7 @@ final class InferenceRsProvider {
             LlmModelDownloadTarget(label: $0.label, url: $0.url, destinationPath: $0.destination.path)
         }
 
-        try await Task.detached(priority: .utility) { [weak self] in
+        let downloadTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
             let callback = ModelDownloadCallbackSink(
                 onProgress: { progress in
@@ -561,11 +564,18 @@ final class InferenceRsProvider {
                     onProgress(progress.toInferenceProgress())
                 },
                 isCancelled: { [weak self] in
-                    self?.isRustDownloadCancelled() ?? true
+                    (self?.isRustDownloadCancelled() ?? true) || Task.isCancelled
                 }
             )
             try downloadLlmModelFiles(targets: targets, callback: callback)
-        }.value
+        }
+
+        try await withTaskCancellationHandler {
+            try await downloadTask.value
+        } onCancel: {
+            self.setRustDownloadCancelled(true)
+            downloadTask.cancel()
+        }
     }
 
     private func setRustDownloadCancelled(_ cancelled: Bool) {
@@ -579,6 +589,12 @@ final class InferenceRsProvider {
         let cancelled = rustDownloadCancelled
         rustDownloadCancelLock.unlock()
         return cancelled
+    }
+
+    private func isDownloadCancellation(_ error: Error) -> Bool {
+        error is CancellationError ||
+            isRustDownloadCancelled() ||
+            error.localizedDescription.range(of: "cancelled", options: .caseInsensitive) != nil
     }
 
     private func logDownloadMetrics(_ progress: LlmModelDownloadProgress) {

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
@@ -99,6 +99,7 @@ final class InferenceRsProvider {
     private let modelLoadGate = AsyncSerialGate()
     private let rustDownloadCancelLock = NSLock()
     private var rustDownloadCancelled = false
+    private let logger = EnsuLogging.shared.logger("InferenceRsProvider")
 
     init(modelDir: URL) {
         self.modelDir = modelDir
@@ -556,6 +557,7 @@ final class InferenceRsProvider {
             guard let self else { return }
             let callback = ModelDownloadCallbackSink(
                 onProgress: { progress in
+                    self.logDownloadMetrics(progress)
                     onProgress(progress.toInferenceProgress())
                 },
                 isCancelled: { [weak self] in
@@ -577,6 +579,28 @@ final class InferenceRsProvider {
         let cancelled = rustDownloadCancelled
         rustDownloadCancelLock.unlock()
         return cancelled
+    }
+
+    private func logDownloadMetrics(_ progress: LlmModelDownloadProgress) {
+        if progress.fileComplete {
+            logger.info(
+                "Model download file complete",
+                details: "label=\(progress.label) bytes=\(progress.fileDownloadedBytes) elapsedMs=\(progress.fileElapsedMs) rate=\(formatRate(progress.fileBytesPerSecond)) retries=\(progress.fileRetryCount)"
+            )
+        }
+        if progress.complete {
+            logger.info(
+                "Model download complete",
+                details: "bytes=\(progress.downloadedBytes) elapsedMs=\(progress.elapsedMs) rate=\(formatRate(progress.bytesPerSecond)) retries=\(progress.retryCount)"
+            )
+        }
+    }
+
+    private func formatRate(_ bytesPerSecond: Double) -> String {
+        guard bytesPerSecond.isFinite, bytesPerSecond > 0 else {
+            return "0 B/s"
+        }
+        return "\(Int64(bytesPerSecond).formattedFileSize)/s"
     }
 }
 

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelDownloadManager.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelDownloadManager.swift
@@ -157,6 +157,21 @@ final class ModelDownloadManager: NSObject {
         clearAllRecords()
     }
 
+    func cancelDownloads(for targets: [ModelDownloadTarget]) async {
+        let cancelledIds = Set(targets.map { recordId(for: $0.destination) })
+        let tasks = await allTasks()
+        tasks.forEach { task in
+            guard let taskId = task.taskDescription, cancelledIds.contains(taskId) else { return }
+            task.cancel()
+        }
+        mutateRecords { records in
+            cancelledIds.forEach { id in
+                guard let record = records.removeValue(forKey: id) else { return }
+                removeResumeData(for: record)
+            }
+        }
+    }
+
     func cancelDownloads(except targets: [ModelDownloadTarget]) async {
         let allowedIds = Set(targets.map { recordId(for: $0.destination) })
         let tasks = await allTasks()

--- a/rust/apps/ensu/src-tauri/Cargo.lock
+++ b/rust/apps/ensu/src-tauri/Cargo.lock
@@ -2761,6 +2761,7 @@ dependencies = [
 name = "inference_rs"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "llama-cpp-2",
  "parking_lot",
  "reqwest 0.12.28",

--- a/rust/apps/ensu/src-tauri/Cargo.lock
+++ b/rust/apps/ensu/src-tauri/Cargo.lock
@@ -2763,10 +2763,12 @@ version = "0.1.0"
 dependencies = [
  "llama-cpp-2",
  "parking_lot",
+ "reqwest 0.12.28",
  "self_cell",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/apps/ensu/src-tauri/src/commands.rs
+++ b/rust/apps/ensu/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -27,6 +28,18 @@ pub struct SrpState {
 pub struct LlmState {
     model: Mutex<Option<llm::ModelHandleRef>>,
     context: Mutex<Option<llm::ContextHandleRef>>,
+}
+
+pub struct LlmModelDownloadState {
+    cancel_requested: Arc<AtomicBool>,
+}
+
+impl Default for LlmModelDownloadState {
+    fn default() -> Self {
+        Self {
+            cancel_requested: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -93,6 +106,26 @@ pub struct TauriEnsuDefaults {
     mobile_model_presets: Vec<TauriEnsuModelPreset>,
     desktop_default_model: TauriEnsuModelPreset,
     desktop_model_presets: Vec<TauriEnsuModelPreset>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TauriLlmModelDownloadTarget {
+    label: String,
+    url: String,
+    path: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TauriLlmModelDownloadProgress {
+    label: String,
+    percent: i32,
+    status: String,
+    bytes_downloaded: u64,
+    total_bytes: Option<u64>,
+    file_bytes_downloaded: u64,
+    file_total_bytes: Option<u64>,
 }
 
 impl From<llm::EnsuModelPreset> for TauriEnsuModelPreset {
@@ -1578,6 +1611,105 @@ pub fn system_info() -> SystemInfo {
 #[tauri::command]
 pub fn get_ensu_defaults() -> TauriEnsuDefaults {
     llm::ensu_defaults().into()
+}
+
+#[tauri::command]
+pub async fn llm_download_model_files(
+    window: Window,
+    state: State<'_, LlmModelDownloadState>,
+    downloads: Vec<TauriLlmModelDownloadTarget>,
+) -> Result<(), ApiError> {
+    let cancel_requested = Arc::clone(&state.cancel_requested);
+    cancel_requested.store(false, Ordering::SeqCst);
+    let targets = downloads
+        .into_iter()
+        .map(|download| llm::LlmModelDownloadTarget {
+            label: download.label,
+            url: download.url,
+            destination_path: download.path,
+        })
+        .collect::<Vec<_>>();
+
+    async_runtime::spawn_blocking(move || {
+        let progress_window = window.clone();
+        llm::download_llm_model_files(
+            targets,
+            move |progress| {
+                let payload = tauri_download_progress(progress);
+                let _ = progress_window.emit("llm-download-progress", payload);
+            },
+            move || cancel_requested.load(Ordering::SeqCst),
+        )
+        .map_err(llm_error)
+    })
+    .await
+    .map_err(|_| fs_thread_error())?
+}
+
+#[tauri::command]
+pub fn llm_cancel_model_download(state: State<'_, LlmModelDownloadState>) {
+    state.cancel_requested.store(true, Ordering::SeqCst);
+}
+
+fn tauri_download_progress(
+    progress: llm::LlmModelDownloadProgress,
+) -> TauriLlmModelDownloadProgress {
+    let percent = if progress.total_bytes.is_some() {
+        progress.percentage.round().clamp(0.0, 100.0) as i32
+    } else {
+        0
+    };
+    let status = download_progress_status(&progress);
+
+    TauriLlmModelDownloadProgress {
+        label: progress.label,
+        percent,
+        status,
+        bytes_downloaded: progress.downloaded_bytes,
+        total_bytes: progress.total_bytes,
+        file_bytes_downloaded: progress.file_downloaded_bytes,
+        file_total_bytes: progress.file_total_bytes,
+    }
+}
+
+fn download_progress_status(progress: &llm::LlmModelDownloadProgress) -> String {
+    if progress.label == "Complete" {
+        return "Download complete".to_string();
+    }
+    if progress.label == "Preparing downloads" {
+        return "Preparing downloads...".to_string();
+    }
+
+    if let Some(total) = progress.total_bytes {
+        format!(
+            "Downloading... {} / {}",
+            format_bytes(progress.downloaded_bytes),
+            format_bytes(total)
+        )
+    } else if progress.file_downloaded_bytes > 0 {
+        format!(
+            "Downloading {}... {}",
+            progress.label.to_lowercase(),
+            format_bytes(progress.file_downloaded_bytes)
+        )
+    } else {
+        format!("Downloading {}...", progress.label.to_lowercase())
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit = 0usize;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
 }
 
 #[tauri::command]

--- a/rust/apps/ensu/src-tauri/src/commands.rs
+++ b/rust/apps/ensu/src-tauri/src/commands.rs
@@ -1635,6 +1635,7 @@ pub async fn llm_download_model_files(
         llm::download_llm_model_files(
             targets,
             move |progress| {
+                log_download_metrics(&progress);
                 let payload = tauri_download_progress(progress);
                 let _ = progress_window.emit("llm-download-progress", payload);
             },
@@ -1697,6 +1698,35 @@ fn download_progress_status(progress: &llm::LlmModelDownloadProgress) -> String 
     }
 }
 
+fn log_download_metrics(progress: &llm::LlmModelDownloadProgress) {
+    if progress.file_complete {
+        logging::log(
+            "LLMDownload",
+            format!(
+                "file_complete label={} bytes={} elapsed_ms={} rate={} retries={}",
+                progress.label,
+                progress.file_downloaded_bytes,
+                progress.file_elapsed_ms,
+                format_rate(progress.file_bytes_per_second),
+                progress.file_retry_count
+            ),
+        );
+    }
+
+    if progress.complete {
+        logging::log(
+            "LLMDownload",
+            format!(
+                "complete bytes={} elapsed_ms={} rate={} retries={}",
+                progress.downloaded_bytes,
+                progress.elapsed_ms,
+                format_rate(progress.bytes_per_second),
+                progress.retry_count
+            ),
+        );
+    }
+}
+
 fn format_bytes(bytes: u64) -> String {
     const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
     let mut value = bytes as f64;
@@ -1710,6 +1740,13 @@ fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{value:.1} {}", UNITS[unit])
     }
+}
+
+fn format_rate(bytes_per_second: f64) -> String {
+    if !bytes_per_second.is_finite() || bytes_per_second <= 0.0 {
+        return "0 B/s".to_string();
+    }
+    format!("{}/s", format_bytes(bytes_per_second.round() as u64))
 }
 
 #[tauri::command]

--- a/rust/apps/ensu/src-tauri/src/main.rs
+++ b/rust/apps/ensu/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
     let app = tauri::Builder::default()
         .manage(commands::SrpState::default())
         .manage(commands::LlmState::default())
+        .manage(commands::LlmModelDownloadState::default())
         .manage(commands::ChatDbState::default())
         .setup(|app| {
             logging::init_logging(&app.handle());
@@ -80,6 +81,8 @@ fn main() {
             commands::llm_cancel,
             commands::system_info,
             commands::get_ensu_defaults,
+            commands::llm_download_model_files,
+            commands::llm_cancel_model_download,
             commands::fs_file_size,
             commands::fs_read_head,
             commands::fs_append_bytes,

--- a/rust/ensu/inference/Cargo.lock
+++ b/rust/ensu/inference/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +48,18 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -65,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +112,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -120,6 +177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,15 +198,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -153,16 +285,263 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "inference_rs"
 version = "0.1.0"
 dependencies = [
  "llama-cpp-2",
  "parking_lot",
+ "reqwest",
  "self_cell",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -185,8 +564,20 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -204,6 +595,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
@@ -249,16 +646,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nom"
@@ -300,10 +720,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -325,6 +769,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +837,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -378,10 +906,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -448,16 +1078,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -468,6 +1138,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -511,6 +1222,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,10 +1361,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -565,6 +1413,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +1437,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -587,6 +1534,53 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -598,10 +1592,248 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/ensu/inference/Cargo.lock
+++ b/rust/ensu/inference/Cargo.lock
@@ -228,6 +228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -527,6 +539,7 @@ dependencies = [
 name = "inference_rs"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "llama-cpp-2",
  "parking_lot",
  "reqwest",

--- a/rust/ensu/inference/Cargo.toml
+++ b/rust/ensu/inference/Cargo.toml
@@ -9,9 +9,11 @@ crate-type = ["rlib"]
 
 [dependencies]
 parking_lot = "0.12"
+reqwest = { version = "0.12", default-features = false, features = ["http2", "charset", "system-proxy", "rustls-tls-webpki-roots"] }
 self_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt", "time"] }
 thiserror = "1"
 
 # llama-cpp-2's default features are "openmp" and "android-shared-stdcxx".

--- a/rust/ensu/inference/Cargo.toml
+++ b/rust/ensu/inference/Cargo.toml
@@ -8,6 +8,7 @@ name = "inference_rs"
 crate-type = ["rlib"]
 
 [dependencies]
+futures-util = "0.3"
 parking_lot = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["http2", "charset", "system-proxy", "rustls-tls-webpki-roots"] }
 self_cell = "1"

--- a/rust/ensu/inference/src/lib.rs
+++ b/rust/ensu/inference/src/lib.rs
@@ -1,6 +1,8 @@
 mod api;
 mod capi;
 mod defaults;
+mod model_download;
 
 pub use api::*;
 pub use defaults::*;
+pub use model_download::*;

--- a/rust/ensu/inference/src/model_download.rs
+++ b/rust/ensu/inference/src/model_download.rs
@@ -1,0 +1,488 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use reqwest::header::RANGE;
+use reqwest::{Client, Response};
+use serde::{Deserialize, Serialize};
+use tokio::runtime::Builder;
+use tokio::time::timeout;
+
+const MIN_GGUF_BYTES: u64 = 1024 * 1024;
+const MAX_ATTEMPTS: usize = 3;
+const PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const RESPONSE_START_TIMEOUT: Duration = Duration::from_secs(30);
+const READ_STALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmModelDownloadTarget {
+    pub label: String,
+    pub url: String,
+    pub destination_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmModelDownloadProgress {
+    pub label: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub file_downloaded_bytes: u64,
+    pub file_total_bytes: Option<u64>,
+    pub percentage: f64,
+}
+
+pub fn download_llm_model_files(
+    targets: Vec<LlmModelDownloadTarget>,
+    on_progress: impl FnMut(LlmModelDownloadProgress),
+    is_cancelled: impl Fn() -> bool,
+) -> Result<(), String> {
+    let runtime = Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .map_err(|err| err.to_string())?;
+    runtime.block_on(download_llm_model_files_async(
+        targets,
+        on_progress,
+        is_cancelled,
+    ))
+}
+
+async fn download_llm_model_files_async(
+    targets: Vec<LlmModelDownloadTarget>,
+    mut on_progress: impl FnMut(LlmModelDownloadProgress),
+    is_cancelled: impl Fn() -> bool,
+) -> Result<(), String> {
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let client = Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+        .map_err(|err| err.to_string())?;
+    let mut file_totals = Vec::with_capacity(targets.len());
+
+    for target in &targets {
+        let destination = Path::new(&target.destination_path);
+        if destination.exists() && is_valid_gguf_download(destination) {
+            file_totals.push(file_size(destination));
+        } else {
+            file_totals.push(fetch_content_length(&client, &target.url).await);
+        }
+    }
+
+    let total_bytes = if file_totals.iter().all(Option::is_some) {
+        let total = file_totals.iter().flatten().copied().sum::<u64>();
+        (total > 0).then_some(total)
+    } else {
+        None
+    };
+
+    let mut downloaded_so_far = targets
+        .iter()
+        .zip(&file_totals)
+        .map(|(target, total)| {
+            let existing = existing_download_bytes(Path::new(&target.destination_path));
+            total.map_or(existing, |value| existing.min(value))
+        })
+        .sum::<u64>();
+
+    emit_combined_progress(
+        "Preparing downloads",
+        downloaded_so_far,
+        total_bytes,
+        0,
+        None,
+        &mut on_progress,
+    );
+
+    for (index, target) in targets.iter().enumerate() {
+        if is_cancelled() {
+            return Err("Download cancelled".to_string());
+        }
+
+        let destination = PathBuf::from(&target.destination_path);
+        if destination.exists() && is_valid_gguf_download(&destination) {
+            continue;
+        }
+
+        let existing_for_file = existing_download_bytes(&destination);
+        let bytes_before_file = downloaded_so_far.saturating_sub(existing_for_file);
+        let expected_file_total = file_totals.get(index).copied().flatten();
+
+        let final_file_size = download_llm_model_file(
+            &client,
+            target,
+            &destination,
+            expected_file_total,
+            |file_downloaded, file_total| {
+                let overall_downloaded = bytes_before_file.saturating_add(file_downloaded);
+                let overall_total = total_bytes.or_else(|| {
+                    let mut known_total = 0u64;
+                    for (known_index, total) in file_totals.iter().enumerate() {
+                        known_total += if known_index == index {
+                            file_total.unwrap_or(0)
+                        } else {
+                            total.unwrap_or(0)
+                        };
+                    }
+                    (known_total > 0).then_some(known_total)
+                });
+                emit_combined_progress(
+                    &target.label,
+                    overall_downloaded,
+                    overall_total,
+                    file_downloaded,
+                    file_total,
+                    &mut on_progress,
+                );
+            },
+            &is_cancelled,
+        )
+        .await?;
+
+        downloaded_so_far = bytes_before_file.saturating_add(final_file_size);
+    }
+
+    emit_combined_progress(
+        "Complete",
+        total_bytes.unwrap_or(downloaded_so_far),
+        total_bytes.or(Some(downloaded_so_far)),
+        0,
+        None,
+        &mut on_progress,
+    );
+
+    Ok(())
+}
+
+async fn download_llm_model_file(
+    client: &Client,
+    target: &LlmModelDownloadTarget,
+    destination: &Path,
+    expected_file_total: Option<u64>,
+    mut on_progress: impl FnMut(u64, Option<u64>),
+    is_cancelled: &impl Fn() -> bool,
+) -> Result<u64, String> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| format!("Invalid destination path: {}", destination.display()))?;
+    fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+
+    let tmp_path = tmp_path_for(destination);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        if is_cancelled() {
+            return Err("Download cancelled".to_string());
+        }
+
+        let mut resume_from = valid_resume_bytes(&tmp_path)?;
+        let mut response = match request_model(client, &target.url, resume_from).await {
+            Ok(response) => response,
+            Err(err) => {
+                if attempt == MAX_ATTEMPTS {
+                    return Err(format!("Failed to download {}: {}", target.label, err));
+                }
+                continue;
+            }
+        };
+
+        if resume_from > 0 && response.status() == reqwest::StatusCode::OK {
+            let _ = fs::remove_file(&tmp_path);
+            resume_from = 0;
+            response = match request_model(client, &target.url, 0).await {
+                Ok(response) => response,
+                Err(err) => {
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!("Failed to download {}: {}", target.label, err));
+                    }
+                    continue;
+                }
+            };
+        }
+
+        if !response.status().is_success() {
+            if attempt == MAX_ATTEMPTS {
+                return Err(format!(
+                    "Failed to download {}: HTTP {}",
+                    target.label,
+                    response.status()
+                ));
+            }
+            continue;
+        }
+
+        let file_total = content_total(&response, resume_from).or(expected_file_total);
+        if let Some(total) = file_total {
+            if total <= resume_from {
+                let _ = fs::remove_file(&tmp_path);
+                continue;
+            }
+        }
+
+        let append = resume_from > 0 && response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .append(append)
+            .truncate(!append)
+            .open(&tmp_path)
+            .map_err(|err| err.to_string())?;
+
+        let mut downloaded = resume_from;
+        let mut first_bytes = if resume_from == 0 {
+            Vec::with_capacity(4)
+        } else {
+            Vec::new()
+        };
+        let mut last_progress = Instant::now();
+        let mut retry_attempt = false;
+
+        on_progress(downloaded, file_total);
+
+        loop {
+            if is_cancelled() {
+                file.flush().ok();
+                return Err("Download cancelled".to_string());
+            }
+
+            let chunk = match timeout(READ_STALL_TIMEOUT, response.chunk()).await {
+                Ok(Ok(chunk)) => chunk,
+                Ok(Err(err)) => {
+                    file.flush().ok();
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!("Failed to download {}: {}", target.label, err));
+                    }
+                    retry_attempt = true;
+                    break;
+                }
+                Err(_) => {
+                    file.flush().ok();
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!(
+                            "Failed to download {}: stalled for {} seconds",
+                            target.label,
+                            READ_STALL_TIMEOUT.as_secs()
+                        ));
+                    }
+                    retry_attempt = true;
+                    break;
+                }
+            };
+            let Some(chunk) = chunk else {
+                break;
+            };
+
+            if downloaded < 4 {
+                let needed = 4usize.saturating_sub(first_bytes.len());
+                first_bytes.extend_from_slice(&chunk[..chunk.len().min(needed)]);
+                if first_bytes.len() == 4 && !is_gguf_header(&first_bytes) {
+                    let _ = fs::remove_file(&tmp_path);
+                    return Err("Downloaded file is not GGUF".to_string());
+                }
+            }
+
+            file.write_all(&chunk).map_err(|err| err.to_string())?;
+            downloaded = downloaded.saturating_add(chunk.len() as u64);
+
+            if last_progress.elapsed() >= PROGRESS_INTERVAL {
+                on_progress(downloaded, file_total);
+                last_progress = Instant::now();
+            }
+        }
+
+        if retry_attempt {
+            drop(file);
+            continue;
+        }
+
+        file.flush().map_err(|err| err.to_string())?;
+        drop(file);
+
+        on_progress(downloaded, file_total);
+
+        if let Some(total) = file_total {
+            if downloaded < total {
+                if attempt == MAX_ATTEMPTS {
+                    return Err(format!(
+                        "Download incomplete: expected {total} bytes, got {downloaded}"
+                    ));
+                }
+                continue;
+            }
+        }
+
+        if downloaded < MIN_GGUF_BYTES {
+            let _ = fs::remove_file(&tmp_path);
+            return Err("Downloaded file too small".to_string());
+        }
+
+        if !looks_like_gguf(&tmp_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err("Downloaded file is not GGUF".to_string());
+        }
+
+        if destination.exists() {
+            fs::remove_file(destination).map_err(|err| err.to_string())?;
+        }
+        fs::rename(&tmp_path, destination).map_err(|err| err.to_string())?;
+
+        let final_size = file_size(destination).unwrap_or(downloaded);
+        if final_size != downloaded {
+            let _ = fs::remove_file(destination);
+            return Err(format!(
+                "Downloaded file size mismatch ({final_size} != {downloaded})"
+            ));
+        }
+
+        return Ok(final_size);
+    }
+
+    Err("Failed to download model".to_string())
+}
+
+async fn request_model(client: &Client, url: &str, resume_from: u64) -> Result<Response, String> {
+    let mut request = client.get(url);
+    if resume_from > 0 {
+        request = request.header(RANGE, format!("bytes={resume_from}-"));
+    }
+    timeout(RESPONSE_START_TIMEOUT, request.send())
+        .await
+        .map_err(|_| {
+            format!(
+                "request did not receive a response within {} seconds",
+                RESPONSE_START_TIMEOUT.as_secs()
+            )
+        })?
+        .map_err(|err| err.to_string())
+}
+
+async fn fetch_content_length(client: &Client, url: &str) -> Option<u64> {
+    let response = timeout(RESPONSE_START_TIMEOUT, client.head(url).send())
+        .await
+        .ok()?
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response
+        .content_length()
+        .or_else(|| {
+            response
+                .headers()
+                .get("Content-Length")?
+                .to_str()
+                .ok()?
+                .parse()
+                .ok()
+        })
+        .filter(|value| *value > 0)
+}
+
+fn content_total(response: &Response, resume_from: u64) -> Option<u64> {
+    let content_range_total = response
+        .headers()
+        .get("Content-Range")
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_content_range_total);
+    let content_length = response.content_length().filter(|value| *value > 0);
+
+    content_range_total.or_else(|| {
+        if resume_from > 0 && response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+            content_length.map(|value| value.saturating_add(resume_from))
+        } else {
+            content_length
+        }
+    })
+}
+
+fn parse_content_range_total(value: &str) -> Option<u64> {
+    let (_, total) = value.rsplit_once('/')?;
+    if total == "*" {
+        None
+    } else {
+        total.parse().ok()
+    }
+}
+
+fn emit_combined_progress(
+    label: &str,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    file_downloaded_bytes: u64,
+    file_total_bytes: Option<u64>,
+    on_progress: &mut impl FnMut(LlmModelDownloadProgress),
+) {
+    let percentage = total_bytes
+        .filter(|value| *value > 0)
+        .map(|total| ((downloaded_bytes as f64 / total as f64) * 100.0).clamp(0.0, 100.0))
+        .unwrap_or(0.0);
+
+    on_progress(LlmModelDownloadProgress {
+        label: label.to_string(),
+        downloaded_bytes,
+        total_bytes,
+        file_downloaded_bytes,
+        file_total_bytes,
+        percentage,
+    });
+}
+
+fn existing_download_bytes(destination: &Path) -> u64 {
+    if destination.exists() {
+        return if is_valid_gguf_download(destination) {
+            file_size(destination).unwrap_or(0)
+        } else {
+            0
+        };
+    }
+    let tmp_path = tmp_path_for(destination);
+    valid_resume_bytes(&tmp_path).unwrap_or(0)
+}
+
+fn valid_resume_bytes(tmp_path: &Path) -> Result<u64, String> {
+    if !tmp_path.exists() {
+        return Ok(0);
+    }
+
+    let size = file_size(tmp_path).unwrap_or(0);
+    if size == 0 {
+        let _ = fs::remove_file(tmp_path);
+        return Ok(0);
+    }
+
+    if size < 4 || !looks_like_gguf(tmp_path) {
+        let _ = fs::remove_file(tmp_path);
+        return Ok(0);
+    }
+
+    Ok(size)
+}
+
+fn file_size(path: &Path) -> Option<u64> {
+    fs::metadata(path).ok().map(|metadata| metadata.len())
+}
+
+fn tmp_path_for(destination: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.tmp", destination.display()))
+}
+
+fn looks_like_gguf(path: &Path) -> bool {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(_) => return false,
+    };
+    let mut header = [0u8; 4];
+    file.read_exact(&mut header).is_ok() && is_gguf_header(&header)
+}
+
+fn is_gguf_header(bytes: &[u8]) -> bool {
+    bytes == b"GGUF"
+}
+
+fn is_valid_gguf_download(path: &Path) -> bool {
+    file_size(path).is_some_and(|size| size >= MIN_GGUF_BYTES) && looks_like_gguf(path)
+}

--- a/rust/ensu/inference/src/model_download.rs
+++ b/rust/ensu/inference/src/model_download.rs
@@ -31,6 +31,43 @@ pub struct LlmModelDownloadProgress {
     pub file_downloaded_bytes: u64,
     pub file_total_bytes: Option<u64>,
     pub percentage: f64,
+    pub elapsed_ms: u64,
+    pub bytes_per_second: f64,
+    pub file_elapsed_ms: u64,
+    pub file_bytes_per_second: f64,
+    pub retry_count: u32,
+    pub file_retry_count: u32,
+    pub file_complete: bool,
+    pub complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct DownloadProgressMetrics {
+    elapsed_ms: u64,
+    bytes_per_second: f64,
+    file_elapsed_ms: u64,
+    file_bytes_per_second: f64,
+    retry_count: u32,
+    file_retry_count: u32,
+    file_complete: bool,
+    complete: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileDownloadProgress {
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    network_downloaded_bytes: u64,
+    elapsed: Duration,
+    retry_count: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileDownloadReport {
+    final_size: u64,
+    network_downloaded_bytes: u64,
+    elapsed: Duration,
+    retry_count: u32,
 }
 
 pub fn download_llm_model_files(
@@ -63,6 +100,7 @@ async fn download_llm_model_files_async(
         .connect_timeout(CONNECT_TIMEOUT)
         .build()
         .map_err(|err| err.to_string())?;
+    let download_started_at = Instant::now();
     let mut file_totals = Vec::with_capacity(targets.len());
 
     for target in &targets {
@@ -89,6 +127,8 @@ async fn download_llm_model_files_async(
             total.map_or(existing, |value| existing.min(value))
         })
         .sum::<u64>();
+    let mut network_downloaded_so_far = 0u64;
+    let mut completed_retry_count = 0u32;
 
     emit_combined_progress(
         "Preparing downloads",
@@ -96,6 +136,7 @@ async fn download_llm_model_files_async(
         total_bytes,
         0,
         None,
+        DownloadProgressMetrics::default(),
         &mut on_progress,
     );
 
@@ -113,18 +154,19 @@ async fn download_llm_model_files_async(
         let bytes_before_file = downloaded_so_far.saturating_sub(existing_for_file);
         let expected_file_total = file_totals.get(index).copied().flatten();
 
-        let final_file_size = download_llm_model_file(
+        let file_report = download_llm_model_file(
             &client,
             target,
             &destination,
             expected_file_total,
-            |file_downloaded, file_total| {
-                let overall_downloaded = bytes_before_file.saturating_add(file_downloaded);
+            |file_progress| {
+                let overall_downloaded =
+                    bytes_before_file.saturating_add(file_progress.downloaded_bytes);
                 let overall_total = total_bytes.or_else(|| {
                     let mut known_total = 0u64;
                     for (known_index, total) in file_totals.iter().enumerate() {
                         known_total += if known_index == index {
-                            file_total.unwrap_or(0)
+                            file_progress.total_bytes.unwrap_or(0)
                         } else {
                             total.unwrap_or(0)
                         };
@@ -135,8 +177,19 @@ async fn download_llm_model_files_async(
                     &target.label,
                     overall_downloaded,
                     overall_total,
-                    file_downloaded,
-                    file_total,
+                    file_progress.downloaded_bytes,
+                    file_progress.total_bytes,
+                    progress_metrics(
+                        download_started_at.elapsed(),
+                        network_downloaded_so_far
+                            .saturating_add(file_progress.network_downloaded_bytes),
+                        file_progress.elapsed,
+                        file_progress.network_downloaded_bytes,
+                        completed_retry_count.saturating_add(file_progress.retry_count),
+                        file_progress.retry_count,
+                        false,
+                        false,
+                    ),
                     &mut on_progress,
                 );
             },
@@ -144,7 +197,29 @@ async fn download_llm_model_files_async(
         )
         .await?;
 
-        downloaded_so_far = bytes_before_file.saturating_add(final_file_size);
+        downloaded_so_far = bytes_before_file.saturating_add(file_report.final_size);
+        network_downloaded_so_far =
+            network_downloaded_so_far.saturating_add(file_report.network_downloaded_bytes);
+        completed_retry_count = completed_retry_count.saturating_add(file_report.retry_count);
+
+        emit_combined_progress(
+            &target.label,
+            downloaded_so_far,
+            total_bytes.or(Some(downloaded_so_far)),
+            file_report.final_size,
+            expected_file_total.or(Some(file_report.final_size)),
+            progress_metrics(
+                download_started_at.elapsed(),
+                network_downloaded_so_far,
+                file_report.elapsed,
+                file_report.network_downloaded_bytes,
+                completed_retry_count,
+                file_report.retry_count,
+                true,
+                false,
+            ),
+            &mut on_progress,
+        );
     }
 
     emit_combined_progress(
@@ -153,6 +228,16 @@ async fn download_llm_model_files_async(
         total_bytes.or(Some(downloaded_so_far)),
         0,
         None,
+        progress_metrics(
+            download_started_at.elapsed(),
+            network_downloaded_so_far,
+            Duration::ZERO,
+            0,
+            completed_retry_count,
+            0,
+            false,
+            true,
+        ),
         &mut on_progress,
     );
 
@@ -164,15 +249,18 @@ async fn download_llm_model_file(
     target: &LlmModelDownloadTarget,
     destination: &Path,
     expected_file_total: Option<u64>,
-    mut on_progress: impl FnMut(u64, Option<u64>),
+    mut on_progress: impl FnMut(FileDownloadProgress),
     is_cancelled: &impl Fn() -> bool,
-) -> Result<u64, String> {
+) -> Result<FileDownloadReport, String> {
     let parent = destination
         .parent()
         .ok_or_else(|| format!("Invalid destination path: {}", destination.display()))?;
     fs::create_dir_all(parent).map_err(|err| err.to_string())?;
 
     let tmp_path = tmp_path_for(destination);
+    let file_started_at = Instant::now();
+    let mut network_downloaded_bytes = 0u64;
+    let mut retry_count = 0u32;
 
     for attempt in 1..=MAX_ATTEMPTS {
         if is_cancelled() {
@@ -186,6 +274,7 @@ async fn download_llm_model_file(
                 if attempt == MAX_ATTEMPTS {
                     return Err(format!("Failed to download {}: {}", target.label, err));
                 }
+                retry_count = retry_count.saturating_add(1);
                 continue;
             }
         };
@@ -199,6 +288,7 @@ async fn download_llm_model_file(
                     if attempt == MAX_ATTEMPTS {
                         return Err(format!("Failed to download {}: {}", target.label, err));
                     }
+                    retry_count = retry_count.saturating_add(1);
                     continue;
                 }
             };
@@ -212,6 +302,7 @@ async fn download_llm_model_file(
                     response.status()
                 ));
             }
+            retry_count = retry_count.saturating_add(1);
             continue;
         }
 
@@ -219,6 +310,7 @@ async fn download_llm_model_file(
         if let Some(total) = file_total {
             if total <= resume_from {
                 let _ = fs::remove_file(&tmp_path);
+                retry_count = retry_count.saturating_add(1);
                 continue;
             }
         }
@@ -241,7 +333,13 @@ async fn download_llm_model_file(
         let mut last_progress = Instant::now();
         let mut retry_attempt = false;
 
-        on_progress(downloaded, file_total);
+        on_progress(FileDownloadProgress {
+            downloaded_bytes: downloaded,
+            total_bytes: file_total,
+            network_downloaded_bytes,
+            elapsed: file_started_at.elapsed(),
+            retry_count,
+        });
 
         loop {
             if is_cancelled() {
@@ -256,6 +354,7 @@ async fn download_llm_model_file(
                     if attempt == MAX_ATTEMPTS {
                         return Err(format!("Failed to download {}: {}", target.label, err));
                     }
+                    retry_count = retry_count.saturating_add(1);
                     retry_attempt = true;
                     break;
                 }
@@ -268,6 +367,7 @@ async fn download_llm_model_file(
                             READ_STALL_TIMEOUT.as_secs()
                         ));
                     }
+                    retry_count = retry_count.saturating_add(1);
                     retry_attempt = true;
                     break;
                 }
@@ -287,9 +387,16 @@ async fn download_llm_model_file(
 
             file.write_all(&chunk).map_err(|err| err.to_string())?;
             downloaded = downloaded.saturating_add(chunk.len() as u64);
+            network_downloaded_bytes = network_downloaded_bytes.saturating_add(chunk.len() as u64);
 
             if last_progress.elapsed() >= PROGRESS_INTERVAL {
-                on_progress(downloaded, file_total);
+                on_progress(FileDownloadProgress {
+                    downloaded_bytes: downloaded,
+                    total_bytes: file_total,
+                    network_downloaded_bytes,
+                    elapsed: file_started_at.elapsed(),
+                    retry_count,
+                });
                 last_progress = Instant::now();
             }
         }
@@ -302,7 +409,13 @@ async fn download_llm_model_file(
         file.flush().map_err(|err| err.to_string())?;
         drop(file);
 
-        on_progress(downloaded, file_total);
+        on_progress(FileDownloadProgress {
+            downloaded_bytes: downloaded,
+            total_bytes: file_total,
+            network_downloaded_bytes,
+            elapsed: file_started_at.elapsed(),
+            retry_count,
+        });
 
         if let Some(total) = file_total {
             if downloaded < total {
@@ -311,6 +424,7 @@ async fn download_llm_model_file(
                         "Download incomplete: expected {total} bytes, got {downloaded}"
                     ));
                 }
+                retry_count = retry_count.saturating_add(1);
                 continue;
             }
         }
@@ -338,7 +452,12 @@ async fn download_llm_model_file(
             ));
         }
 
-        return Ok(final_size);
+        return Ok(FileDownloadReport {
+            final_size,
+            network_downloaded_bytes,
+            elapsed: file_started_at.elapsed(),
+            retry_count,
+        });
     }
 
     Err("Failed to download model".to_string())
@@ -414,6 +533,7 @@ fn emit_combined_progress(
     total_bytes: Option<u64>,
     file_downloaded_bytes: u64,
     file_total_bytes: Option<u64>,
+    metrics: DownloadProgressMetrics,
     on_progress: &mut impl FnMut(LlmModelDownloadProgress),
 ) {
     let percentage = total_bytes
@@ -428,7 +548,50 @@ fn emit_combined_progress(
         file_downloaded_bytes,
         file_total_bytes,
         percentage,
+        elapsed_ms: metrics.elapsed_ms,
+        bytes_per_second: metrics.bytes_per_second,
+        file_elapsed_ms: metrics.file_elapsed_ms,
+        file_bytes_per_second: metrics.file_bytes_per_second,
+        retry_count: metrics.retry_count,
+        file_retry_count: metrics.file_retry_count,
+        file_complete: metrics.file_complete,
+        complete: metrics.complete,
     });
+}
+
+fn progress_metrics(
+    elapsed: Duration,
+    downloaded_bytes: u64,
+    file_elapsed: Duration,
+    file_downloaded_bytes: u64,
+    retry_count: u32,
+    file_retry_count: u32,
+    file_complete: bool,
+    complete: bool,
+) -> DownloadProgressMetrics {
+    DownloadProgressMetrics {
+        elapsed_ms: duration_ms(elapsed),
+        bytes_per_second: bytes_per_second(downloaded_bytes, elapsed),
+        file_elapsed_ms: duration_ms(file_elapsed),
+        file_bytes_per_second: bytes_per_second(file_downloaded_bytes, file_elapsed),
+        retry_count,
+        file_retry_count,
+        file_complete,
+        complete,
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn bytes_per_second(bytes: u64, elapsed: Duration) -> f64 {
+    let seconds = elapsed.as_secs_f64();
+    if seconds > 0.0 {
+        bytes as f64 / seconds
+    } else {
+        0.0
+    }
 }
 
 fn existing_download_bytes(destination: &Path) -> u64 {

--- a/rust/ensu/inference/src/model_download.rs
+++ b/rust/ensu/inference/src/model_download.rs
@@ -1,19 +1,20 @@
 use std::cell::RefCell;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Error, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use futures_util::future::try_join_all;
-use reqwest::header::RANGE;
-use reqwest::{Client, Response};
+use reqwest::header::{ACCEPT_RANGES, CONTENT_RANGE, ETAG, IF_RANGE, LAST_MODIFIED, RANGE};
+use reqwest::{Client, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Builder;
 use tokio::time::timeout;
 
 const MIN_GGUF_BYTES: u64 = 1024 * 1024;
 const MAX_ATTEMPTS: usize = 3;
+const RANGE_DOWNLOAD_CONCURRENCY: usize = 4;
 const PROGRESS_INTERVAL: Duration = Duration::from_millis(250);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const RESPONSE_START_TIMEOUT: Duration = Duration::from_secs(30);
@@ -89,6 +90,13 @@ struct ResponseMetadata {
     last_modified: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct DownloadProbe {
+    content_length: Option<u64>,
+    supports_ranges: bool,
+    response_metadata: Option<ResponseMetadata>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct FileDownloadState {
     downloaded_bytes: u64,
@@ -96,6 +104,36 @@ struct FileDownloadState {
     network_downloaded_bytes: u64,
     elapsed: Duration,
     retry_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RangeDownloadMetadata {
+    url: String,
+    size_bytes: u64,
+    etag: Option<String>,
+    last_modified: Option<String>,
+    ranges: Vec<RangeDownloadPartMetadata>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+struct RangeDownloadPartMetadata {
+    start: u64,
+    end: u64,
+    complete: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RangePartState {
+    downloaded_bytes: u64,
+    network_downloaded_bytes: u64,
+    retry_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ContentRange {
+    start: u64,
+    end: u64,
+    total: Option<u64>,
 }
 
 pub fn download_llm_model_files(
@@ -129,19 +167,34 @@ async fn download_llm_model_files_async(
         .build()
         .map_err(|err| err.to_string())?;
     let download_started_at = Instant::now();
-    let mut file_totals = Vec::with_capacity(targets.len());
+    let mut download_probes = Vec::with_capacity(targets.len());
 
     for target in &targets {
         let destination = Path::new(&target.destination_path);
         if prepare_cached_download(target, destination) {
-            file_totals.push(file_size(destination));
+            download_probes.push(DownloadProbe {
+                content_length: file_size(destination),
+                supports_ranges: false,
+                response_metadata: read_download_metadata(destination).map(|metadata| {
+                    ResponseMetadata {
+                        etag: metadata.etag,
+                        last_modified: metadata.last_modified,
+                    }
+                }),
+            });
         } else {
-            file_totals.push(fetch_content_length(&client, &target.url).await);
+            download_probes.push(fetch_download_probe(&client, &target.url).await);
         }
     }
 
-    let total_bytes = if file_totals.iter().all(Option::is_some) {
-        let total = file_totals.iter().flatten().copied().sum::<u64>();
+    let total_bytes = if download_probes
+        .iter()
+        .all(|probe| probe.content_length.is_some())
+    {
+        let total = download_probes
+            .iter()
+            .filter_map(|probe| probe.content_length)
+            .sum::<u64>();
         (total > 0).then_some(total)
     } else {
         None
@@ -149,12 +202,15 @@ async fn download_llm_model_files_async(
 
     let file_states = targets
         .iter()
-        .zip(&file_totals)
-        .map(|(target, total)| {
-            let existing = existing_download_bytes(Path::new(&target.destination_path));
+        .zip(&download_probes)
+        .map(|(target, probe)| {
+            let existing =
+                existing_download_bytes(target, Path::new(&target.destination_path), probe);
             FileDownloadState {
-                downloaded_bytes: total.map_or(existing, |value| existing.min(value)),
-                total_bytes: *total,
+                downloaded_bytes: probe
+                    .content_length
+                    .map_or(existing, |value| existing.min(value)),
+                total_bytes: probe.content_length,
                 network_downloaded_bytes: 0,
                 elapsed: Duration::ZERO,
                 retry_count: 0,
@@ -181,7 +237,11 @@ async fn download_llm_model_files_async(
             continue;
         }
 
-        let expected_file_total = file_totals.get(index).copied().flatten();
+        let download_probe = download_probes
+            .get(index)
+            .cloned()
+            .unwrap_or_else(DownloadProbe::default);
+        let expected_file_total = download_probe.content_length;
         let progress_states = Rc::clone(&file_states);
         let progress_callback = Rc::clone(&on_progress);
         let target_label = target.label.clone();
@@ -198,7 +258,7 @@ async fn download_llm_model_files_async(
                 client,
                 target,
                 &destination,
-                expected_file_total,
+                &download_probe,
                 |file_progress| {
                     {
                         let mut states = progress_states.borrow_mut();
@@ -281,7 +341,7 @@ async fn download_llm_model_file(
     client: &Client,
     target: &LlmModelDownloadTarget,
     destination: &Path,
-    expected_file_total: Option<u64>,
+    download_probe: &DownloadProbe,
     mut on_progress: impl FnMut(FileDownloadProgress),
     is_cancelled: &impl Fn() -> bool,
 ) -> Result<FileDownloadReport, String> {
@@ -290,6 +350,61 @@ async fn download_llm_model_file(
         .ok_or_else(|| format!("Invalid destination path: {}", destination.display()))?;
     fs::create_dir_all(parent).map_err(|err| err.to_string())?;
 
+    let mut range_error = None;
+    if let Some(total) = download_probe.content_length {
+        if should_use_range_download(destination, total, download_probe) {
+            match download_llm_model_file_ranged(
+                client,
+                target,
+                destination,
+                total,
+                download_probe.response_metadata.clone(),
+                &mut on_progress,
+                is_cancelled,
+            )
+            .await
+            {
+                Ok(report) => return Ok(report),
+                Err(err) if is_download_cancelled_error(&err) => return Err(err),
+                Err(err) => {
+                    range_error = Some(err);
+                    cleanup_range_download(destination);
+                }
+            }
+        } else if range_metadata_path_for(destination).exists() {
+            cleanup_range_download(destination);
+        }
+    } else if range_metadata_path_for(destination).exists() {
+        cleanup_range_download(destination);
+    }
+
+    let single_result = download_llm_model_file_single(
+        client,
+        target,
+        destination,
+        download_probe.content_length,
+        &mut on_progress,
+        is_cancelled,
+    )
+    .await;
+
+    match (single_result, range_error) {
+        (Ok(report), _) => Ok(report),
+        (Err(single_error), Some(range_error)) => Err(format!(
+            "{single_error}; range download fallback was used after: {range_error}"
+        )),
+        (Err(single_error), None) => Err(single_error),
+    }
+}
+
+async fn download_llm_model_file_single(
+    client: &Client,
+    target: &LlmModelDownloadTarget,
+    destination: &Path,
+    expected_file_total: Option<u64>,
+    on_progress: &mut dyn FnMut(FileDownloadProgress),
+    is_cancelled: &impl Fn() -> bool,
+) -> Result<FileDownloadReport, String> {
     let tmp_path = tmp_path_for(destination);
     let file_started_at = Instant::now();
     let mut network_downloaded_bytes = 0u64;
@@ -477,6 +592,7 @@ async fn download_llm_model_file(
             fs::remove_file(destination).map_err(|err| err.to_string())?;
         }
         fs::rename(&tmp_path, destination).map_err(|err| err.to_string())?;
+        let _ = fs::remove_file(range_metadata_path_for(destination));
 
         let final_size = file_size(destination).unwrap_or(downloaded);
         if final_size != downloaded {
@@ -499,6 +615,322 @@ async fn download_llm_model_file(
     Err("Failed to download model".to_string())
 }
 
+async fn download_llm_model_file_ranged(
+    client: &Client,
+    target: &LlmModelDownloadTarget,
+    destination: &Path,
+    total: u64,
+    response_metadata: Option<ResponseMetadata>,
+    on_progress: &mut dyn FnMut(FileDownloadProgress),
+    is_cancelled: &impl Fn() -> bool,
+) -> Result<FileDownloadReport, String> {
+    let tmp_path = tmp_path_for(destination);
+    let range_metadata_path = range_metadata_path_for(destination);
+    let file_started_at = Instant::now();
+    let range_metadata =
+        prepare_range_download_metadata(target, destination, total, response_metadata.clone())?;
+
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&tmp_path)
+        .map_err(|err| err.to_string())?;
+    file.set_len(total).map_err(|err| err.to_string())?;
+    let file = Rc::new(file);
+
+    let range_states = range_metadata
+        .ranges
+        .iter()
+        .map(|range| RangePartState {
+            downloaded_bytes: if range.complete {
+                range_download_len(*range)
+            } else {
+                0
+            },
+            network_downloaded_bytes: 0,
+            retry_count: 0,
+        })
+        .collect::<Vec<_>>();
+    let range_states = Rc::new(RefCell::new(range_states));
+    let range_metadata = Rc::new(RefCell::new(range_metadata));
+    let on_progress = Rc::new(RefCell::new(on_progress));
+
+    emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+
+    let mut downloads = Vec::new();
+    {
+        let metadata = range_metadata.borrow();
+        for (part_index, range) in metadata.ranges.iter().copied().enumerate() {
+            if range.complete {
+                continue;
+            }
+
+            let file = Rc::clone(&file);
+            let range_states = Rc::clone(&range_states);
+            let range_metadata = Rc::clone(&range_metadata);
+            let range_metadata_path = range_metadata_path.clone();
+            let response_metadata = response_metadata.clone();
+            let on_progress = Rc::clone(&on_progress);
+
+            downloads.push(async move {
+                download_range_part(
+                    client,
+                    target,
+                    file,
+                    part_index,
+                    range,
+                    total,
+                    response_metadata,
+                    range_states,
+                    range_metadata,
+                    range_metadata_path,
+                    file_started_at,
+                    on_progress,
+                    is_cancelled,
+                )
+                .await
+            });
+        }
+    }
+
+    try_join_all(downloads).await?;
+    drop(file);
+
+    emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+
+    if total < MIN_GGUF_BYTES {
+        let _ = fs::remove_file(&tmp_path);
+        let _ = fs::remove_file(&range_metadata_path);
+        return Err("Downloaded file too small".to_string());
+    }
+
+    if !looks_like_gguf(&tmp_path) {
+        let _ = fs::remove_file(&tmp_path);
+        let _ = fs::remove_file(&range_metadata_path);
+        return Err("Downloaded file is not GGUF".to_string());
+    }
+
+    if destination.exists() {
+        fs::remove_file(destination).map_err(|err| err.to_string())?;
+    }
+    fs::rename(&tmp_path, destination).map_err(|err| err.to_string())?;
+    let _ = fs::remove_file(&range_metadata_path);
+
+    let final_size = file_size(destination).unwrap_or(total);
+    if final_size != total {
+        let _ = fs::remove_file(destination);
+        return Err(format!(
+            "Downloaded file size mismatch ({final_size} != {total})"
+        ));
+    }
+
+    let network_downloaded_bytes = range_states
+        .borrow()
+        .iter()
+        .map(|state| state.network_downloaded_bytes)
+        .sum::<u64>();
+    let retry_count = range_states
+        .borrow()
+        .iter()
+        .map(|state| state.retry_count)
+        .fold(0u32, u32::saturating_add);
+    let elapsed = file_started_at.elapsed();
+    let _ = write_download_metadata(destination, target, final_size, response_metadata);
+
+    Ok(FileDownloadReport {
+        final_size,
+        network_downloaded_bytes,
+        elapsed,
+        retry_count,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn download_range_part(
+    client: &Client,
+    target: &LlmModelDownloadTarget,
+    file: Rc<File>,
+    part_index: usize,
+    range: RangeDownloadPartMetadata,
+    total: u64,
+    response_metadata: Option<ResponseMetadata>,
+    range_states: Rc<RefCell<Vec<RangePartState>>>,
+    range_metadata: Rc<RefCell<RangeDownloadMetadata>>,
+    range_metadata_path: PathBuf,
+    file_started_at: Instant,
+    on_progress: Rc<RefCell<&mut dyn FnMut(FileDownloadProgress)>>,
+    is_cancelled: &impl Fn() -> bool,
+) -> Result<(), String> {
+    let range_len = range_download_len(range);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        if is_cancelled() {
+            return Err("Download cancelled".to_string());
+        }
+
+        {
+            let mut states = range_states.borrow_mut();
+            if let Some(state) = states.get_mut(part_index) {
+                state.downloaded_bytes = 0;
+            }
+        }
+        emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+
+        let mut response =
+            match request_model_range(client, &target.url, range, response_metadata.as_ref()).await
+            {
+                Ok(response) => response,
+                Err(err) => {
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!(
+                            "Failed to download {} range: {}",
+                            target.label, err
+                        ));
+                    }
+                    increment_range_retry(&range_states, part_index);
+                    emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+                    continue;
+                }
+            };
+
+        if response.status() != StatusCode::PARTIAL_CONTENT {
+            if response.status() == StatusCode::OK
+                || response.status() == StatusCode::RANGE_NOT_SATISFIABLE
+            {
+                return Err(format!(
+                    "Failed to download {} range: HTTP {}",
+                    target.label,
+                    response.status()
+                ));
+            }
+            if attempt == MAX_ATTEMPTS {
+                return Err(format!(
+                    "Failed to download {} range: HTTP {}",
+                    target.label,
+                    response.status()
+                ));
+            }
+            increment_range_retry(&range_states, part_index);
+            emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+            continue;
+        }
+
+        validate_range_response(&response, range, total)?;
+
+        let mut downloaded_in_range = 0u64;
+        let mut first_bytes = if range.start == 0 {
+            Vec::with_capacity(4)
+        } else {
+            Vec::new()
+        };
+        let mut last_progress = Instant::now();
+        let mut retry_attempt = false;
+
+        loop {
+            if is_cancelled() {
+                return Err("Download cancelled".to_string());
+            }
+
+            let chunk = match timeout(READ_STALL_TIMEOUT, response.chunk()).await {
+                Ok(Ok(chunk)) => chunk,
+                Ok(Err(err)) => {
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!(
+                            "Failed to download {} range: {}",
+                            target.label, err
+                        ));
+                    }
+                    increment_range_retry(&range_states, part_index);
+                    retry_attempt = true;
+                    break;
+                }
+                Err(_) => {
+                    if attempt == MAX_ATTEMPTS {
+                        return Err(format!(
+                            "Failed to download {} range: stalled for {} seconds",
+                            target.label,
+                            READ_STALL_TIMEOUT.as_secs()
+                        ));
+                    }
+                    increment_range_retry(&range_states, part_index);
+                    retry_attempt = true;
+                    break;
+                }
+            };
+            let Some(chunk) = chunk else {
+                break;
+            };
+
+            let chunk_len = chunk.len() as u64;
+            if downloaded_in_range.saturating_add(chunk_len) > range_len {
+                return Err(format!(
+                    "Failed to download {} range: received more bytes than requested",
+                    target.label
+                ));
+            }
+
+            if range.start == 0 && downloaded_in_range < 4 {
+                let needed = 4usize.saturating_sub(first_bytes.len());
+                first_bytes.extend_from_slice(&chunk[..chunk.len().min(needed)]);
+                if first_bytes.len() == 4 && !is_gguf_header(&first_bytes) {
+                    return Err("Downloaded file is not GGUF".to_string());
+                }
+            }
+
+            write_all_at(
+                file.as_ref(),
+                chunk.as_ref(),
+                range.start + downloaded_in_range,
+            )
+            .map_err(|err| err.to_string())?;
+            downloaded_in_range = downloaded_in_range.saturating_add(chunk_len);
+
+            {
+                let mut states = range_states.borrow_mut();
+                if let Some(state) = states.get_mut(part_index) {
+                    state.downloaded_bytes = downloaded_in_range;
+                    state.network_downloaded_bytes =
+                        state.network_downloaded_bytes.saturating_add(chunk_len);
+                }
+            }
+
+            if last_progress.elapsed() >= PROGRESS_INTERVAL {
+                emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+                last_progress = Instant::now();
+            }
+        }
+
+        if retry_attempt {
+            emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+            continue;
+        }
+
+        if downloaded_in_range != range_len {
+            if attempt == MAX_ATTEMPTS {
+                return Err(format!(
+                    "Download incomplete: expected {range_len} bytes, got {downloaded_in_range}"
+                ));
+            }
+            increment_range_retry(&range_states, part_index);
+            emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+            continue;
+        }
+
+        {
+            let mut states = range_states.borrow_mut();
+            if let Some(state) = states.get_mut(part_index) {
+                state.downloaded_bytes = range_len;
+            }
+        }
+        mark_range_complete(&range_metadata, &range_metadata_path, part_index)?;
+        emit_range_file_progress(total, file_started_at, &range_states, &on_progress);
+        return Ok(());
+    }
+
+    Err("Failed to download model range".to_string())
+}
+
 async fn request_model(client: &Client, url: &str, resume_from: u64) -> Result<Response, String> {
     let mut request = client.get(url);
     if resume_from > 0 {
@@ -515,32 +947,296 @@ async fn request_model(client: &Client, url: &str, resume_from: u64) -> Result<R
         .map_err(|err| err.to_string())
 }
 
-async fn fetch_content_length(client: &Client, url: &str) -> Option<u64> {
+async fn request_model_range(
+    client: &Client,
+    url: &str,
+    range: RangeDownloadPartMetadata,
+    response_metadata: Option<&ResponseMetadata>,
+) -> Result<Response, String> {
+    let mut request = client
+        .get(url)
+        .header(RANGE, format!("bytes={}-{}", range.start, range.end));
+    if let Some(if_range) = if_range_header_value(response_metadata) {
+        request = request.header(IF_RANGE, if_range);
+    }
+    timeout(RESPONSE_START_TIMEOUT, request.send())
+        .await
+        .map_err(|_| {
+            format!(
+                "request did not receive a response within {} seconds",
+                RESPONSE_START_TIMEOUT.as_secs()
+            )
+        })?
+        .map_err(|err| err.to_string())
+}
+
+async fn fetch_download_probe(client: &Client, url: &str) -> DownloadProbe {
     let response = timeout(RESPONSE_START_TIMEOUT, client.head(url).send())
         .await
-        .ok()?
-        .ok()?;
+        .ok()
+        .and_then(Result::ok);
+    let Some(response) = response else {
+        return DownloadProbe::default();
+    };
     if !response.status().is_success() {
-        return None;
+        return DownloadProbe::default();
     }
-    response
+    let content_length = response
         .content_length()
+        .filter(|value| *value > 0)
         .or_else(|| {
+            // HEAD responses have no body, so reqwest can report a semantic length of 0.
             response
                 .headers()
-                .get("Content-Length")?
-                .to_str()
-                .ok()?
-                .parse()
-                .ok()
-        })
-        .filter(|value| *value > 0)
+                .get("Content-Length")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse().ok())
+                .filter(|value| *value > 0)
+        });
+    let supports_ranges = response
+        .headers()
+        .get(ACCEPT_RANGES)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("bytes"));
+
+    DownloadProbe {
+        content_length,
+        supports_ranges,
+        response_metadata: Some(response_metadata(&response)),
+    }
+}
+
+fn should_use_range_download(destination: &Path, total: u64, probe: &DownloadProbe) -> bool {
+    if total < MIN_GGUF_BYTES || !probe.supports_ranges {
+        return false;
+    }
+    if range_metadata_path_for(destination).exists() {
+        return true;
+    }
+
+    let tmp_path = tmp_path_for(destination);
+    if tmp_path.exists() && valid_resume_bytes(&tmp_path).unwrap_or(0) > 0 {
+        return false;
+    }
+
+    true
+}
+
+fn is_download_cancelled_error(err: &str) -> bool {
+    err == "Download cancelled"
+}
+
+fn prepare_range_download_metadata(
+    target: &LlmModelDownloadTarget,
+    destination: &Path,
+    total: u64,
+    response_metadata: Option<ResponseMetadata>,
+) -> Result<RangeDownloadMetadata, String> {
+    let tmp_path = tmp_path_for(destination);
+    let ranges = range_download_parts(total, RANGE_DOWNLOAD_CONCURRENCY);
+
+    if tmp_path.exists() {
+        if let Some(metadata) = read_range_download_metadata(destination) {
+            if file_size(&tmp_path) == Some(total)
+                && range_download_metadata_matches(
+                    &metadata,
+                    target,
+                    total,
+                    response_metadata.as_ref(),
+                    &ranges,
+                )
+            {
+                return Ok(metadata);
+            }
+        }
+    }
+
+    cleanup_range_download(destination);
+    let metadata = RangeDownloadMetadata {
+        url: target.url.clone(),
+        size_bytes: total,
+        etag: response_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.etag.clone()),
+        last_modified: response_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.last_modified.clone()),
+        ranges,
+    };
+    write_range_download_metadata(&range_metadata_path_for(destination), &metadata)?;
+    Ok(metadata)
+}
+
+fn range_download_parts(total: u64, concurrency: usize) -> Vec<RangeDownloadPartMetadata> {
+    if total == 0 || concurrency == 0 {
+        return Vec::new();
+    }
+
+    let max_parts = usize::try_from(total).unwrap_or(concurrency);
+    let part_count = concurrency.min(max_parts).max(1);
+    let part_count_u64 = part_count as u64;
+    let base_len = total / part_count_u64;
+    let remainder = total % part_count_u64;
+    let mut start = 0u64;
+    let mut ranges = Vec::with_capacity(part_count);
+
+    for index in 0..part_count {
+        let len = base_len + if (index as u64) < remainder { 1 } else { 0 };
+        let end = start + len - 1;
+        ranges.push(RangeDownloadPartMetadata {
+            start,
+            end,
+            complete: false,
+        });
+        start = end + 1;
+    }
+
+    ranges
+}
+
+fn range_download_metadata_matches(
+    metadata: &RangeDownloadMetadata,
+    target: &LlmModelDownloadTarget,
+    total: u64,
+    response_metadata: Option<&ResponseMetadata>,
+    ranges: &[RangeDownloadPartMetadata],
+) -> bool {
+    metadata.url == target.url
+        && metadata.size_bytes == total
+        && range_download_validators_match(metadata, response_metadata)
+        && metadata.ranges.len() == ranges.len()
+        && metadata
+            .ranges
+            .iter()
+            .zip(ranges)
+            .all(|(left, right)| left.start == right.start && left.end == right.end)
+}
+
+fn range_download_validators_match(
+    metadata: &RangeDownloadMetadata,
+    response_metadata: Option<&ResponseMetadata>,
+) -> bool {
+    let Some(response_metadata) = response_metadata else {
+        return metadata.etag.is_none() && metadata.last_modified.is_none();
+    };
+
+    if let Some(expected_etag) = response_metadata.etag.as_deref() {
+        return metadata.etag.as_deref() == Some(expected_etag);
+    }
+    if let Some(expected_last_modified) = response_metadata.last_modified.as_deref() {
+        return metadata.last_modified.as_deref() == Some(expected_last_modified);
+    }
+
+    metadata.etag.is_none() && metadata.last_modified.is_none()
+}
+
+fn range_download_len(range: RangeDownloadPartMetadata) -> u64 {
+    range.end.saturating_sub(range.start).saturating_add(1)
+}
+
+fn emit_range_file_progress(
+    total_bytes: u64,
+    file_started_at: Instant,
+    range_states: &Rc<RefCell<Vec<RangePartState>>>,
+    on_progress: &Rc<RefCell<&mut dyn FnMut(FileDownloadProgress)>>,
+) {
+    let states = range_states.borrow();
+    let downloaded_bytes = states
+        .iter()
+        .map(|state| state.downloaded_bytes)
+        .sum::<u64>()
+        .min(total_bytes);
+    let network_downloaded_bytes = states
+        .iter()
+        .map(|state| state.network_downloaded_bytes)
+        .sum::<u64>();
+    let retry_count = states
+        .iter()
+        .map(|state| state.retry_count)
+        .fold(0u32, u32::saturating_add);
+    drop(states);
+
+    let mut callback = on_progress.borrow_mut();
+    (&mut **callback)(FileDownloadProgress {
+        downloaded_bytes,
+        total_bytes: Some(total_bytes),
+        network_downloaded_bytes,
+        elapsed: file_started_at.elapsed(),
+        retry_count,
+    });
+}
+
+fn increment_range_retry(range_states: &Rc<RefCell<Vec<RangePartState>>>, part_index: usize) {
+    let mut states = range_states.borrow_mut();
+    if let Some(state) = states.get_mut(part_index) {
+        state.retry_count = state.retry_count.saturating_add(1);
+    }
+}
+
+fn mark_range_complete(
+    range_metadata: &Rc<RefCell<RangeDownloadMetadata>>,
+    range_metadata_path: &Path,
+    part_index: usize,
+) -> Result<(), String> {
+    let mut metadata = range_metadata.borrow_mut();
+    if let Some(range) = metadata.ranges.get_mut(part_index) {
+        range.complete = true;
+    }
+    write_range_download_metadata(range_metadata_path, &metadata)
+}
+
+fn validate_range_response(
+    response: &Response,
+    range: RangeDownloadPartMetadata,
+    total: u64,
+) -> Result<(), String> {
+    let content_range = response
+        .headers()
+        .get(CONTENT_RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_content_range)
+        .ok_or_else(|| "Range response did not include a valid Content-Range".to_string())?;
+
+    if content_range.start != range.start || content_range.end != range.end {
+        return Err(format!(
+            "Range response mismatch: expected {}-{}, got {}-{}",
+            range.start, range.end, content_range.start, content_range.end
+        ));
+    }
+
+    if let Some(content_total) = content_range.total {
+        if content_total != total {
+            return Err(format!(
+                "Range response total mismatch: expected {total}, got {content_total}"
+            ));
+        }
+    }
+
+    if let Some(content_length) = response.content_length() {
+        let expected_length = range_download_len(range);
+        if content_length != expected_length {
+            return Err(format!(
+                "Range response length mismatch: expected {expected_length}, got {content_length}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn if_range_header_value(response_metadata: Option<&ResponseMetadata>) -> Option<String> {
+    response_metadata.and_then(|metadata| {
+        metadata
+            .etag
+            .clone()
+            .or_else(|| metadata.last_modified.clone())
+    })
 }
 
 fn content_total(response: &Response, resume_from: u64) -> Option<u64> {
     let content_range_total = response
         .headers()
-        .get("Content-Range")
+        .get(CONTENT_RANGE)
         .and_then(|value| value.to_str().ok())
         .and_then(parse_content_range_total);
     let content_length = response.content_length().filter(|value| *value > 0);
@@ -555,12 +1251,26 @@ fn content_total(response: &Response, resume_from: u64) -> Option<u64> {
 }
 
 fn parse_content_range_total(value: &str) -> Option<u64> {
-    let (_, total) = value.rsplit_once('/')?;
-    if total == "*" {
+    parse_content_range(value)?.total
+}
+
+fn parse_content_range(value: &str) -> Option<ContentRange> {
+    let value = value.trim();
+    let value = value.strip_prefix("bytes ")?;
+    let (range, total) = value.split_once('/')?;
+    let (start, end) = range.split_once('-')?;
+    let start = start.parse().ok()?;
+    let end = end.parse().ok()?;
+    if end < start {
+        return None;
+    }
+    let total = if total == "*" {
         None
     } else {
-        total.parse().ok()
-    }
+        Some(total.parse().ok()?)
+    };
+
+    Some(ContentRange { start, end, total })
 }
 
 fn emit_progress_from_states<F: FnMut(LlmModelDownloadProgress)>(
@@ -767,6 +1477,7 @@ fn prepare_cached_download(target: &LlmModelDownloadTarget, destination: &Path) 
         }
         let _ = fs::remove_file(destination);
         let _ = fs::remove_file(metadata_path_for(destination));
+        let _ = fs::remove_file(range_metadata_path_for(destination));
     }
 
     false
@@ -820,6 +1531,7 @@ fn copy_cached_download(source: &Path, destination: &Path) -> Result<(), String>
 
     let tmp_path = tmp_path_for(destination);
     let _ = fs::remove_file(&tmp_path);
+    let _ = fs::remove_file(range_metadata_path_for(destination));
     fs::copy(source, &tmp_path).map_err(|err| err.to_string())?;
     if !is_valid_gguf_download(&tmp_path) {
         let _ = fs::remove_file(&tmp_path);
@@ -871,26 +1583,48 @@ fn response_metadata(response: &Response) -> ResponseMetadata {
     ResponseMetadata {
         etag: response
             .headers()
-            .get("ETag")
+            .get(ETAG)
             .and_then(|value| value.to_str().ok())
             .map(ToString::to_string),
         last_modified: response
             .headers()
-            .get("Last-Modified")
+            .get(LAST_MODIFIED)
             .and_then(|value| value.to_str().ok())
             .map(ToString::to_string),
     }
+}
+
+fn read_range_download_metadata(path: &Path) -> Option<RangeDownloadMetadata> {
+    let text = fs::read_to_string(range_metadata_path_for(path)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_range_download_metadata(
+    path: &Path,
+    metadata: &RangeDownloadMetadata,
+) -> Result<(), String> {
+    let text = serde_json::to_string_pretty(metadata).map_err(|err| err.to_string())?;
+    fs::write(path, text).map_err(|err| err.to_string())
 }
 
 fn metadata_path_for(path: &Path) -> PathBuf {
     PathBuf::from(format!("{}.metadata.json", path.display()))
 }
 
+fn range_metadata_path_for(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.tmp.ranges.json", path.display()))
+}
+
+fn cleanup_range_download(destination: &Path) {
+    let _ = fs::remove_file(tmp_path_for(destination));
+    let _ = fs::remove_file(range_metadata_path_for(destination));
+}
+
 fn is_sidecar_download_file(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
-    name.ends_with(".tmp") || name.ends_with(".metadata.json")
+    name.ends_with(".tmp") || name.ends_with(".metadata.json") || name.ends_with(".tmp.ranges.json")
 }
 
 fn now_ms() -> u64 {
@@ -900,7 +1634,11 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
-fn existing_download_bytes(destination: &Path) -> u64 {
+fn existing_download_bytes(
+    target: &LlmModelDownloadTarget,
+    destination: &Path,
+    probe: &DownloadProbe,
+) -> u64 {
     if destination.exists() {
         return if is_valid_gguf_download(destination) {
             file_size(destination).unwrap_or(0)
@@ -908,6 +1646,32 @@ fn existing_download_bytes(destination: &Path) -> u64 {
             0
         };
     }
+
+    if range_metadata_path_for(destination).exists() {
+        if let Some(total) = probe.content_length {
+            let ranges = range_download_parts(total, RANGE_DOWNLOAD_CONCURRENCY);
+            if let Some(metadata) = read_range_download_metadata(destination) {
+                if file_size(&tmp_path_for(destination)) == Some(total)
+                    && range_download_metadata_matches(
+                        &metadata,
+                        target,
+                        total,
+                        probe.response_metadata.as_ref(),
+                        &ranges,
+                    )
+                {
+                    return metadata
+                        .ranges
+                        .iter()
+                        .filter(|range| range.complete)
+                        .map(|range| range_download_len(*range))
+                        .sum();
+                }
+            }
+        }
+        return 0;
+    }
+
     let tmp_path = tmp_path_for(destination);
     valid_resume_bytes(&tmp_path).unwrap_or(0)
 }
@@ -954,4 +1718,313 @@ fn is_gguf_header(bytes: &[u8]) -> bool {
 
 fn is_valid_gguf_download(path: &Path) -> bool {
     file_size(path).is_some_and(|size| size >= MIN_GGUF_BYTES) && looks_like_gguf(path)
+}
+
+#[cfg(unix)]
+fn write_all_at(file: &File, mut bytes: &[u8], mut offset: u64) -> std::io::Result<()> {
+    use std::os::unix::fs::FileExt;
+
+    while !bytes.is_empty() {
+        let written = file.write_at(bytes, offset)?;
+        if written == 0 {
+            return Err(Error::new(
+                ErrorKind::WriteZero,
+                "failed to write range bytes",
+            ));
+        }
+        offset = offset.saturating_add(written as u64);
+        bytes = &bytes[written..];
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_all_at(file: &File, mut bytes: &[u8], mut offset: u64) -> std::io::Result<()> {
+    use std::os::windows::fs::FileExt;
+
+    while !bytes.is_empty() {
+        let written = file.seek_write(bytes, offset)?;
+        if written == 0 {
+            return Err(Error::new(
+                ErrorKind::WriteZero,
+                "failed to write range bytes",
+            ));
+        }
+        offset = offset.saturating_add(written as u64);
+        bytes = &bytes[written..];
+    }
+
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn write_all_at(file: &File, bytes: &[u8], offset: u64) -> std::io::Result<()> {
+    use std::io::{Seek, SeekFrom};
+
+    let mut file = file.try_clone()?;
+    file.seek(SeekFrom::Start(offset))?;
+    file.write_all(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::thread;
+
+    #[test]
+    fn range_download_parts_split_file_into_four_ranges() {
+        let ranges = range_download_parts(10, 4);
+
+        assert_eq!(
+            ranges,
+            vec![
+                RangeDownloadPartMetadata {
+                    start: 0,
+                    end: 2,
+                    complete: false,
+                },
+                RangeDownloadPartMetadata {
+                    start: 3,
+                    end: 5,
+                    complete: false,
+                },
+                RangeDownloadPartMetadata {
+                    start: 6,
+                    end: 7,
+                    complete: false,
+                },
+                RangeDownloadPartMetadata {
+                    start: 8,
+                    end: 9,
+                    complete: false,
+                },
+            ]
+        );
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| range_download_len(*range))
+                .sum::<u64>(),
+            10
+        );
+    }
+
+    #[test]
+    fn range_download_parts_do_not_create_empty_ranges() {
+        let ranges = range_download_parts(3, 4);
+
+        assert_eq!(ranges.len(), 3);
+        assert!(ranges.iter().all(|range| range_download_len(*range) == 1));
+    }
+
+    #[test]
+    fn parse_content_range_accepts_known_and_unknown_totals() {
+        assert_eq!(
+            parse_content_range("bytes 10-19/100"),
+            Some(ContentRange {
+                start: 10,
+                end: 19,
+                total: Some(100),
+            })
+        );
+        assert_eq!(
+            parse_content_range("bytes 10-19/*"),
+            Some(ContentRange {
+                start: 10,
+                end: 19,
+                total: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_content_range_rejects_invalid_ranges() {
+        assert_eq!(parse_content_range("bytes 20-10/100"), None);
+        assert_eq!(parse_content_range("items 10-19/100"), None);
+        assert_eq!(parse_content_range("bytes 10-19/not-a-number"), None);
+    }
+
+    #[test]
+    fn download_uses_four_ranges_when_server_supports_ranges() {
+        let mut bytes = vec![0u8; MIN_GGUF_BYTES as usize + 123];
+        bytes[..4].copy_from_slice(b"GGUF");
+        for (index, byte) in bytes.iter_mut().enumerate().skip(4) {
+            *byte = (index % 251) as u8;
+        }
+        let bytes = Arc::new(bytes);
+        let head_count = Arc::new(AtomicUsize::new(0));
+        let range_get_count = Arc::new(AtomicUsize::new(0));
+        let full_get_count = Arc::new(AtomicUsize::new(0));
+        let running = Arc::new(AtomicBool::new(true));
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        listener
+            .set_nonblocking(true)
+            .expect("configure test server");
+        let address = listener.local_addr().expect("test server address");
+        let server = {
+            let bytes = Arc::clone(&bytes);
+            let head_count = Arc::clone(&head_count);
+            let range_get_count = Arc::clone(&range_get_count);
+            let full_get_count = Arc::clone(&full_get_count);
+            let running = Arc::clone(&running);
+            thread::spawn(move || {
+                while running.load(Ordering::SeqCst) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            stream.set_nonblocking(false).ok();
+                            let bytes = Arc::clone(&bytes);
+                            let head_count = Arc::clone(&head_count);
+                            let range_get_count = Arc::clone(&range_get_count);
+                            let full_get_count = Arc::clone(&full_get_count);
+                            thread::spawn(move || {
+                                handle_range_test_request(
+                                    stream,
+                                    bytes,
+                                    head_count,
+                                    range_get_count,
+                                    full_get_count,
+                                );
+                            });
+                        }
+                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })
+        };
+
+        let test_dir = std::env::temp_dir().join(format!("ensu-range-download-test-{}", now_ms()));
+        fs::create_dir_all(&test_dir).expect("create test dir");
+        let destination = test_dir.join("model.gguf");
+        let url = format!("http://{address}/model.gguf");
+
+        let probe_client = Client::builder().build().expect("build probe client");
+        let probe_runtime = Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .expect("build probe runtime");
+        let probe = probe_runtime.block_on(fetch_download_probe(&probe_client, &url));
+        assert_eq!(probe.content_length, Some(bytes.len() as u64));
+        assert!(probe.supports_ranges);
+
+        let result = download_llm_model_files(
+            vec![LlmModelDownloadTarget {
+                label: "Model".to_string(),
+                url,
+                destination_path: destination.display().to_string(),
+            }],
+            |_| {},
+            || false,
+        );
+
+        running.store(false, Ordering::SeqCst);
+        let _ = TcpStream::connect(address);
+        server.join().expect("join test server");
+
+        result.expect("range download succeeds");
+        assert_eq!(
+            fs::read(&destination).expect("read downloaded file"),
+            *bytes
+        );
+        assert_eq!(head_count.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            range_get_count.load(Ordering::SeqCst),
+            RANGE_DOWNLOAD_CONCURRENCY,
+            "full GET count: {}",
+            full_get_count.load(Ordering::SeqCst)
+        );
+        assert_eq!(full_get_count.load(Ordering::SeqCst), 0);
+        assert!(!range_metadata_path_for(&destination).exists());
+
+        let _ = fs::remove_dir_all(test_dir);
+    }
+
+    fn handle_range_test_request(
+        mut stream: TcpStream,
+        bytes: Arc<Vec<u8>>,
+        head_count: Arc<AtomicUsize>,
+        range_get_count: Arc<AtomicUsize>,
+        full_get_count: Arc<AtomicUsize>,
+    ) {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone test stream"));
+        let mut request_line = String::new();
+        if reader.read_line(&mut request_line).is_err() {
+            return;
+        }
+
+        let mut range_header = None;
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = line.split_once(':') {
+                if name.eq_ignore_ascii_case("range") {
+                    range_header = Some(value.trim().to_string());
+                }
+            }
+        }
+
+        if request_line.starts_with("HEAD ") {
+            head_count.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nETag: \"test-etag\"\r\nConnection: close\r\n\r\n",
+                bytes.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            return;
+        }
+
+        if let Some(range_header) = range_header {
+            let Some((start, end)) = parse_test_range_header(&range_header, bytes.len() as u64)
+            else {
+                let _ = stream
+                    .write_all(b"HTTP/1.1 416 Range Not Satisfiable\r\nConnection: close\r\n\r\n");
+                return;
+            };
+            range_get_count.fetch_add(1, Ordering::SeqCst);
+            let body = &bytes[start as usize..=end as usize];
+            let response = format!(
+                "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\nAccept-Ranges: bytes\r\nETag: \"test-etag\"\r\nConnection: close\r\n\r\n",
+                body.len(),
+                start,
+                end,
+                bytes.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(body);
+        } else {
+            full_get_count.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nETag: \"test-etag\"\r\nConnection: close\r\n\r\n",
+                bytes.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(bytes.as_slice());
+        }
+    }
+
+    fn parse_test_range_header(value: &str, total: u64) -> Option<(u64, u64)> {
+        let value = value.strip_prefix("bytes=")?;
+        let (start, end) = value.split_once('-')?;
+        let start = start.parse().ok()?;
+        let end = if end.is_empty() {
+            total.checked_sub(1)?
+        } else {
+            end.parse().ok()?
+        };
+        if start > end || end >= total {
+            return None;
+        }
+        Some((start, end))
+    }
 }

--- a/rust/ensu/inference/src/model_download.rs
+++ b/rust/ensu/inference/src/model_download.rs
@@ -1,8 +1,11 @@
+use std::cell::RefCell;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+use futures_util::future::try_join_all;
 use reqwest::header::RANGE;
 use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
@@ -70,6 +73,15 @@ struct FileDownloadReport {
     retry_count: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FileDownloadState {
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    network_downloaded_bytes: u64,
+    elapsed: Duration,
+    retry_count: u32,
+}
+
 pub fn download_llm_model_files(
     targets: Vec<LlmModelDownloadTarget>,
     on_progress: impl FnMut(LlmModelDownloadProgress),
@@ -89,7 +101,7 @@ pub fn download_llm_model_files(
 
 async fn download_llm_model_files_async(
     targets: Vec<LlmModelDownloadTarget>,
-    mut on_progress: impl FnMut(LlmModelDownloadProgress),
+    on_progress: impl FnMut(LlmModelDownloadProgress),
     is_cancelled: impl Fn() -> bool,
 ) -> Result<(), String> {
     if targets.is_empty() {
@@ -119,126 +131,131 @@ async fn download_llm_model_files_async(
         None
     };
 
-    let mut downloaded_so_far = targets
+    let file_states = targets
         .iter()
         .zip(&file_totals)
         .map(|(target, total)| {
             let existing = existing_download_bytes(Path::new(&target.destination_path));
-            total.map_or(existing, |value| existing.min(value))
+            FileDownloadState {
+                downloaded_bytes: total.map_or(existing, |value| existing.min(value)),
+                total_bytes: *total,
+                network_downloaded_bytes: 0,
+                elapsed: Duration::ZERO,
+                retry_count: 0,
+            }
         })
-        .sum::<u64>();
-    let mut network_downloaded_so_far = 0u64;
-    let mut completed_retry_count = 0u32;
+        .collect::<Vec<_>>();
+    let file_states = Rc::new(RefCell::new(file_states));
+    let on_progress = Rc::new(RefCell::new(on_progress));
 
-    emit_combined_progress(
+    emit_progress_from_states(
         "Preparing downloads",
-        downloaded_so_far,
         total_bytes,
-        0,
-        None,
         DownloadProgressMetrics::default(),
-        &mut on_progress,
+        None,
+        &file_states,
+        &on_progress,
     );
 
-    for (index, target) in targets.iter().enumerate() {
-        if is_cancelled() {
-            return Err("Download cancelled".to_string());
-        }
+    let mut downloads = Vec::new();
 
+    for (index, target) in targets.iter().enumerate() {
         let destination = PathBuf::from(&target.destination_path);
         if destination.exists() && is_valid_gguf_download(&destination) {
             continue;
         }
 
-        let existing_for_file = existing_download_bytes(&destination);
-        let bytes_before_file = downloaded_so_far.saturating_sub(existing_for_file);
         let expected_file_total = file_totals.get(index).copied().flatten();
+        let progress_states = Rc::clone(&file_states);
+        let progress_callback = Rc::clone(&on_progress);
+        let target_label = target.label.clone();
+        let download_started_at = download_started_at;
+        let client = &client;
+        let is_cancelled = &is_cancelled;
 
-        let file_report = download_llm_model_file(
-            &client,
-            target,
-            &destination,
-            expected_file_total,
-            |file_progress| {
-                let overall_downloaded =
-                    bytes_before_file.saturating_add(file_progress.downloaded_bytes);
-                let overall_total = total_bytes.or_else(|| {
-                    let mut known_total = 0u64;
-                    for (known_index, total) in file_totals.iter().enumerate() {
-                        known_total += if known_index == index {
-                            file_progress.total_bytes.unwrap_or(0)
-                        } else {
-                            total.unwrap_or(0)
-                        };
+        downloads.push(async move {
+            if is_cancelled() {
+                return Err("Download cancelled".to_string());
+            }
+
+            let file_report = download_llm_model_file(
+                client,
+                target,
+                &destination,
+                expected_file_total,
+                |file_progress| {
+                    {
+                        let mut states = progress_states.borrow_mut();
+                        if let Some(state) = states.get_mut(index) {
+                            state.downloaded_bytes = file_progress.downloaded_bytes;
+                            state.total_bytes = file_progress.total_bytes;
+                            state.network_downloaded_bytes = file_progress.network_downloaded_bytes;
+                            state.elapsed = file_progress.elapsed;
+                            state.retry_count = file_progress.retry_count;
+                        }
                     }
-                    (known_total > 0).then_some(known_total)
-                });
-                emit_combined_progress(
-                    &target.label,
-                    overall_downloaded,
-                    overall_total,
-                    file_progress.downloaded_bytes,
-                    file_progress.total_bytes,
-                    progress_metrics(
+
+                    let metrics = aggregate_progress_metrics(
                         download_started_at.elapsed(),
-                        network_downloaded_so_far
-                            .saturating_add(file_progress.network_downloaded_bytes),
-                        file_progress.elapsed,
-                        file_progress.network_downloaded_bytes,
-                        completed_retry_count.saturating_add(file_progress.retry_count),
-                        file_progress.retry_count,
+                        &progress_states,
+                        index,
                         false,
                         false,
-                    ),
-                    &mut on_progress,
-                );
-            },
-            &is_cancelled,
-        )
-        .await?;
+                    );
+                    emit_progress_from_states(
+                        &target_label,
+                        total_bytes,
+                        metrics,
+                        Some(index),
+                        &progress_states,
+                        &progress_callback,
+                    );
+                },
+                is_cancelled,
+            )
+            .await?;
 
-        downloaded_so_far = bytes_before_file.saturating_add(file_report.final_size);
-        network_downloaded_so_far =
-            network_downloaded_so_far.saturating_add(file_report.network_downloaded_bytes);
-        completed_retry_count = completed_retry_count.saturating_add(file_report.retry_count);
+            {
+                let mut states = progress_states.borrow_mut();
+                if let Some(state) = states.get_mut(index) {
+                    state.downloaded_bytes = file_report.final_size;
+                    state.total_bytes = expected_file_total.or(Some(file_report.final_size));
+                    state.network_downloaded_bytes = file_report.network_downloaded_bytes;
+                    state.elapsed = file_report.elapsed;
+                    state.retry_count = file_report.retry_count;
+                }
+            }
 
-        emit_combined_progress(
-            &target.label,
-            downloaded_so_far,
-            total_bytes.or(Some(downloaded_so_far)),
-            file_report.final_size,
-            expected_file_total.or(Some(file_report.final_size)),
-            progress_metrics(
+            let metrics = aggregate_progress_metrics(
                 download_started_at.elapsed(),
-                network_downloaded_so_far,
-                file_report.elapsed,
-                file_report.network_downloaded_bytes,
-                completed_retry_count,
-                file_report.retry_count,
+                &progress_states,
+                index,
                 true,
                 false,
-            ),
-            &mut on_progress,
-        );
+            );
+            emit_progress_from_states(
+                &target_label,
+                total_bytes,
+                metrics,
+                Some(index),
+                &progress_states,
+                &progress_callback,
+            );
+
+            Ok(file_report)
+        });
     }
 
-    emit_combined_progress(
+    let _reports = try_join_all(downloads).await?;
+    let complete_metrics = aggregate_complete_metrics(download_started_at.elapsed(), &file_states);
+
+    emit_progress_from_states(
         "Complete",
-        total_bytes.unwrap_or(downloaded_so_far),
-        total_bytes.or(Some(downloaded_so_far)),
-        0,
+        total_bytes.or_else(|| Some(downloaded_bytes_from_states(&file_states))),
+        complete_metrics,
         None,
-        progress_metrics(
-            download_started_at.elapsed(),
-            network_downloaded_so_far,
-            Duration::ZERO,
-            0,
-            completed_retry_count,
-            0,
-            false,
-            true,
-        ),
-        &mut on_progress,
+        &file_states,
+        &on_progress,
     );
 
     Ok(())
@@ -525,6 +542,120 @@ fn parse_content_range_total(value: &str) -> Option<u64> {
     } else {
         total.parse().ok()
     }
+}
+
+fn emit_progress_from_states<F: FnMut(LlmModelDownloadProgress)>(
+    label: &str,
+    total_bytes: Option<u64>,
+    metrics: DownloadProgressMetrics,
+    file_index: Option<usize>,
+    file_states: &Rc<RefCell<Vec<FileDownloadState>>>,
+    on_progress: &Rc<RefCell<F>>,
+) {
+    let states = file_states.borrow();
+    let downloaded_bytes = states
+        .iter()
+        .map(|state| state.downloaded_bytes)
+        .sum::<u64>();
+    let resolved_total_bytes = total_bytes.or_else(|| partial_total_from_states(&states));
+    let (file_downloaded_bytes, file_total_bytes) = file_index
+        .and_then(|index| states.get(index))
+        .map(|state| (state.downloaded_bytes, state.total_bytes))
+        .unwrap_or((0, None));
+    drop(states);
+
+    emit_combined_progress(
+        label,
+        downloaded_bytes,
+        resolved_total_bytes,
+        file_downloaded_bytes,
+        file_total_bytes,
+        metrics,
+        &mut *on_progress.borrow_mut(),
+    );
+}
+
+fn aggregate_progress_metrics(
+    elapsed: Duration,
+    file_states: &Rc<RefCell<Vec<FileDownloadState>>>,
+    file_index: usize,
+    file_complete: bool,
+    complete: bool,
+) -> DownloadProgressMetrics {
+    let states = file_states.borrow();
+    let network_downloaded_bytes = states
+        .iter()
+        .map(|state| state.network_downloaded_bytes)
+        .sum::<u64>();
+    let retry_count = states
+        .iter()
+        .map(|state| state.retry_count)
+        .fold(0u32, u32::saturating_add);
+    let file_state = states
+        .get(file_index)
+        .copied()
+        .unwrap_or(FileDownloadState {
+            downloaded_bytes: 0,
+            total_bytes: None,
+            network_downloaded_bytes: 0,
+            elapsed: Duration::ZERO,
+            retry_count: 0,
+        });
+    drop(states);
+
+    progress_metrics(
+        elapsed,
+        network_downloaded_bytes,
+        file_state.elapsed,
+        file_state.network_downloaded_bytes,
+        retry_count,
+        file_state.retry_count,
+        file_complete,
+        complete,
+    )
+}
+
+fn aggregate_complete_metrics(
+    elapsed: Duration,
+    file_states: &Rc<RefCell<Vec<FileDownloadState>>>,
+) -> DownloadProgressMetrics {
+    let states = file_states.borrow();
+    let network_downloaded_bytes = states
+        .iter()
+        .map(|state| state.network_downloaded_bytes)
+        .sum::<u64>();
+    let retry_count = states
+        .iter()
+        .map(|state| state.retry_count)
+        .fold(0u32, u32::saturating_add);
+    drop(states);
+
+    progress_metrics(
+        elapsed,
+        network_downloaded_bytes,
+        Duration::ZERO,
+        0,
+        retry_count,
+        0,
+        false,
+        true,
+    )
+}
+
+fn downloaded_bytes_from_states(file_states: &Rc<RefCell<Vec<FileDownloadState>>>) -> u64 {
+    file_states
+        .borrow()
+        .iter()
+        .map(|state| state.downloaded_bytes)
+        .sum()
+}
+
+fn partial_total_from_states(states: &[FileDownloadState]) -> Option<u64> {
+    let total = states
+        .iter()
+        .filter_map(|state| state.total_bytes)
+        .sum::<u64>();
+    (total > 0).then_some(total)
 }
 
 fn emit_combined_progress(

--- a/rust/ensu/inference/src/model_download.rs
+++ b/rust/ensu/inference/src/model_download.rs
@@ -3,7 +3,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use futures_util::future::try_join_all;
 use reqwest::header::RANGE;
@@ -73,6 +73,22 @@ struct FileDownloadReport {
     retry_count: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DownloadMetadata {
+    url: String,
+    label: String,
+    size_bytes: u64,
+    etag: Option<String>,
+    last_modified: Option<String>,
+    downloaded_at_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ResponseMetadata {
+    etag: Option<String>,
+    last_modified: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct FileDownloadState {
     downloaded_bytes: u64,
@@ -117,7 +133,7 @@ async fn download_llm_model_files_async(
 
     for target in &targets {
         let destination = Path::new(&target.destination_path);
-        if destination.exists() && is_valid_gguf_download(destination) {
+        if prepare_cached_download(target, destination) {
             file_totals.push(file_size(destination));
         } else {
             file_totals.push(fetch_content_length(&client, &target.url).await);
@@ -323,6 +339,7 @@ async fn download_llm_model_file(
             continue;
         }
 
+        let response_metadata = response_metadata(&response);
         let file_total = content_total(&response, resume_from).or(expected_file_total);
         if let Some(total) = file_total {
             if total <= resume_from {
@@ -468,6 +485,8 @@ async fn download_llm_model_file(
                 "Downloaded file size mismatch ({final_size} != {downloaded})"
             ));
         }
+
+        let _ = write_download_metadata(destination, target, final_size, Some(response_metadata));
 
         return Ok(FileDownloadReport {
             final_size,
@@ -723,6 +742,162 @@ fn bytes_per_second(bytes: u64, elapsed: Duration) -> f64 {
     } else {
         0.0
     }
+}
+
+fn prepare_cached_download(target: &LlmModelDownloadTarget, destination: &Path) -> bool {
+    if is_valid_gguf_download(destination) {
+        if !download_metadata_matches(destination, &target.url) {
+            let size = file_size(destination).unwrap_or(0);
+            let _ = write_download_metadata(destination, target, size, None);
+        }
+        return true;
+    }
+
+    if let Some(source) = find_reusable_cached_download(destination, &target.url) {
+        if copy_cached_download(&source, destination).is_ok() && is_valid_gguf_download(destination)
+        {
+            let size = file_size(destination).unwrap_or(0);
+            let source_metadata =
+                read_download_metadata(&source).map(|metadata| ResponseMetadata {
+                    etag: metadata.etag,
+                    last_modified: metadata.last_modified,
+                });
+            let _ = write_download_metadata(destination, target, size, source_metadata);
+            return true;
+        }
+        let _ = fs::remove_file(destination);
+        let _ = fs::remove_file(metadata_path_for(destination));
+    }
+
+    false
+}
+
+fn find_reusable_cached_download(destination: &Path, url: &str) -> Option<PathBuf> {
+    for root in cache_search_roots(destination) {
+        let entries = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path == destination || !path.is_file() || is_sidecar_download_file(&path) {
+                continue;
+            }
+            if !is_valid_gguf_download(&path) {
+                continue;
+            }
+            if download_metadata_matches(&path, url) {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+fn cache_search_roots(destination: &Path) -> Vec<PathBuf> {
+    let Some(parent) = destination.parent() else {
+        return Vec::new();
+    };
+
+    let mut roots = vec![parent.to_path_buf()];
+    if parent.file_name().and_then(|name| name.to_str()) == Some("custom") {
+        if let Some(models_dir) = parent.parent() {
+            roots.push(models_dir.to_path_buf());
+        }
+    } else {
+        roots.push(parent.join("custom"));
+    }
+    roots
+}
+
+fn copy_cached_download(source: &Path, destination: &Path) -> Result<(), String> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| format!("Invalid destination path: {}", destination.display()))?;
+    fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+
+    let tmp_path = tmp_path_for(destination);
+    let _ = fs::remove_file(&tmp_path);
+    fs::copy(source, &tmp_path).map_err(|err| err.to_string())?;
+    if !is_valid_gguf_download(&tmp_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err("Cached model copy is invalid".to_string());
+    }
+    if destination.exists() {
+        fs::remove_file(destination).map_err(|err| err.to_string())?;
+    }
+    fs::rename(&tmp_path, destination).map_err(|err| err.to_string())
+}
+
+fn read_download_metadata(path: &Path) -> Option<DownloadMetadata> {
+    let text = fs::read_to_string(metadata_path_for(path)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn download_metadata_matches(path: &Path, url: &str) -> bool {
+    let Some(metadata) = read_download_metadata(path) else {
+        return false;
+    };
+    let Some(size) = file_size(path) else {
+        return false;
+    };
+    metadata.url == url && metadata.size_bytes == size && size >= MIN_GGUF_BYTES
+}
+
+fn write_download_metadata(
+    path: &Path,
+    target: &LlmModelDownloadTarget,
+    size_bytes: u64,
+    response_metadata: Option<ResponseMetadata>,
+) -> Result<(), String> {
+    let (etag, last_modified) = response_metadata
+        .map(|metadata| (metadata.etag, metadata.last_modified))
+        .unwrap_or((None, None));
+    let metadata = DownloadMetadata {
+        url: target.url.clone(),
+        label: target.label.clone(),
+        size_bytes,
+        etag,
+        last_modified,
+        downloaded_at_ms: now_ms(),
+    };
+    let text = serde_json::to_string_pretty(&metadata).map_err(|err| err.to_string())?;
+    fs::write(metadata_path_for(path), text).map_err(|err| err.to_string())
+}
+
+fn response_metadata(response: &Response) -> ResponseMetadata {
+    ResponseMetadata {
+        etag: response
+            .headers()
+            .get("ETag")
+            .and_then(|value| value.to_str().ok())
+            .map(ToString::to_string),
+        last_modified: response
+            .headers()
+            .get("Last-Modified")
+            .and_then(|value| value.to_str().ok())
+            .map(ToString::to_string),
+    }
+}
+
+fn metadata_path_for(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.metadata.json", path.display()))
+}
+
+fn is_sidecar_download_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    name.ends_with(".tmp") || name.ends_with(".metadata.json")
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 fn existing_download_bytes(destination: &Path) -> u64 {

--- a/rust/uniffi/ensu/inference/Cargo.lock
+++ b/rust/uniffi/ensu/inference/Cargo.lock
@@ -348,6 +348,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -675,6 +687,7 @@ dependencies = [
 name = "inference_rs"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "llama-cpp-2",
  "parking_lot",
  "reqwest",

--- a/rust/uniffi/ensu/inference/Cargo.lock
+++ b/rust/uniffi/ensu/inference/Cargo.lock
@@ -60,10 +60,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "basic-toml"
@@ -99,6 +111,12 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -166,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +207,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -233,7 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -258,6 +309,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,15 +333,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -296,6 +416,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +445,209 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -335,11 +677,19 @@ version = "0.1.0"
 dependencies = [
  "llama-cpp-2",
  "parking_lot",
+ "reqwest",
  "self_cell",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -362,8 +712,20 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -387,6 +749,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
@@ -432,16 +800,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nom"
@@ -501,6 +892,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +929,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +997,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -573,6 +1066,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,8 +1136,55 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -695,6 +1290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +1312,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -719,10 +1332,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -736,16 +1371,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -798,6 +1474,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1575,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1650,12 @@ dependencies = [
  "once_cell",
  "valuable",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -994,6 +1783,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,12 +1823,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1033,7 +1945,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1043,6 +1955,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +2009,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1065,6 +2153,115 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/uniffi/ensu/inference/src/api.rs
+++ b/rust/uniffi/ensu/inference/src/api.rs
@@ -124,6 +124,14 @@ pub struct LlmModelDownloadProgress {
     pub file_downloaded_bytes: i64,
     pub file_total_bytes: Option<i64>,
     pub percentage: f64,
+    pub elapsed_ms: i64,
+    pub bytes_per_second: f64,
+    pub file_elapsed_ms: i64,
+    pub file_bytes_per_second: f64,
+    pub retry_count: i32,
+    pub file_retry_count: i32,
+    pub file_complete: bool,
+    pub complete: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Enum)]
@@ -311,6 +319,14 @@ impl From<core::LlmModelDownloadProgress> for LlmModelDownloadProgress {
             file_downloaded_bytes: u64_to_i64(value.file_downloaded_bytes),
             file_total_bytes: value.file_total_bytes.map(u64_to_i64),
             percentage: value.percentage,
+            elapsed_ms: u64_to_i64(value.elapsed_ms),
+            bytes_per_second: value.bytes_per_second,
+            file_elapsed_ms: u64_to_i64(value.file_elapsed_ms),
+            file_bytes_per_second: value.file_bytes_per_second,
+            retry_count: u32_to_i32(value.retry_count),
+            file_retry_count: u32_to_i32(value.file_retry_count),
+            file_complete: value.file_complete,
+            complete: value.complete,
         }
     }
 }
@@ -337,6 +353,10 @@ impl From<core::GenerateEvent> for GenerateEvent {
 
 fn u64_to_i64(value: u64) -> i64 {
     i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn u32_to_i32(value: u32) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 struct CallbackSink {

--- a/rust/uniffi/ensu/inference/src/api.rs
+++ b/rust/uniffi/ensu/inference/src/api.rs
@@ -109,6 +109,23 @@ pub struct GenerateSummary {
     pub total_time_ms: Option<i64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct LlmModelDownloadTarget {
+    pub label: String,
+    pub url: String,
+    pub destination_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct LlmModelDownloadProgress {
+    pub label: String,
+    pub downloaded_bytes: i64,
+    pub total_bytes: Option<i64>,
+    pub file_downloaded_bytes: i64,
+    pub file_total_bytes: Option<i64>,
+    pub percentage: f64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Enum)]
 pub enum GenerateEvent {
     Text {
@@ -138,6 +155,12 @@ pub struct ContextHandle {
 #[uniffi::export(callback_interface)]
 pub trait GenerateEventCallback: Send + Sync {
     fn on_event(&self, event: GenerateEvent);
+}
+
+#[uniffi::export(callback_interface)]
+pub trait LlmModelDownloadCallback: Send + Sync {
+    fn on_progress(&self, progress: LlmModelDownloadProgress);
+    fn is_cancelled(&self) -> bool;
 }
 
 impl From<ModelLoadParams> for core::ModelLoadParams {
@@ -258,6 +281,16 @@ impl From<GenerateChatRequest> for core::GenerateChatRequest {
     }
 }
 
+impl From<LlmModelDownloadTarget> for core::LlmModelDownloadTarget {
+    fn from(value: LlmModelDownloadTarget) -> Self {
+        Self {
+            label: value.label,
+            url: value.url,
+            destination_path: value.destination_path,
+        }
+    }
+}
+
 impl From<core::GenerateSummary> for GenerateSummary {
     fn from(value: core::GenerateSummary) -> Self {
         Self {
@@ -265,6 +298,19 @@ impl From<core::GenerateSummary> for GenerateSummary {
             prompt_tokens: value.prompt_tokens,
             generated_tokens: value.generated_tokens,
             total_time_ms: value.total_time_ms,
+        }
+    }
+}
+
+impl From<core::LlmModelDownloadProgress> for LlmModelDownloadProgress {
+    fn from(value: core::LlmModelDownloadProgress) -> Self {
+        Self {
+            label: value.label,
+            downloaded_bytes: u64_to_i64(value.downloaded_bytes),
+            total_bytes: value.total_bytes.map(u64_to_i64),
+            file_downloaded_bytes: u64_to_i64(value.file_downloaded_bytes),
+            file_total_bytes: value.file_total_bytes.map(u64_to_i64),
+            percentage: value.percentage,
         }
     }
 }
@@ -287,6 +333,10 @@ impl From<core::GenerateEvent> for GenerateEvent {
             core::GenerateEvent::Error { job_id, message } => Self::Error { job_id, message },
         }
     }
+}
+
+fn u64_to_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
 }
 
 struct CallbackSink {
@@ -345,6 +395,23 @@ pub fn get_model_info(model: Arc<ModelHandle>) -> Result<ModelInfo, InferenceErr
 #[uniffi::export]
 pub fn get_ensu_defaults() -> EnsuDefaults {
     core::ensu_defaults().into()
+}
+
+#[uniffi::export]
+pub fn download_llm_model_files(
+    targets: Vec<LlmModelDownloadTarget>,
+    callback: Box<dyn LlmModelDownloadCallback>,
+) -> Result<(), InferenceError> {
+    let callback: Arc<dyn LlmModelDownloadCallback> = Arc::from(callback);
+    let progress_callback = Arc::clone(&callback);
+    let cancel_callback = Arc::clone(&callback);
+    let targets = targets.into_iter().map(Into::into).collect();
+    core::download_llm_model_files(
+        targets,
+        move |progress| progress_callback.on_progress(progress.into()),
+        move || cancel_callback.is_cancelled(),
+    )
+    .map_err(InferenceError::from)
 }
 
 #[uniffi::export]

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -13,7 +13,6 @@ const DEFAULT_WEB_CONTEXT_SIZE = 4096;
 const DEFAULT_TAURI_CONTEXT_SIZE = 12000;
 const DEFAULT_GENERATION_MAX_TOKENS = 8_192;
 const OVERFLOW_SAFETY_TOKENS = 256;
-const MIN_GGUF_BYTES = 1024 * 1024; // 1MB
 const MIN_DESKTOP_DEFAULT_MEMORY_BYTES = 16 * 1024 * 1024 * 1024;
 
 // These fallback values must stay in sync with rust/ensu/inference/src/defaults.rs.
@@ -57,6 +56,16 @@ interface TauriEnsuDefaults {
     mobileModelPresets: TauriEnsuModelPreset[];
     desktopDefaultModel: TauriEnsuModelPreset;
     desktopModelPresets: TauriEnsuModelPreset[];
+}
+
+interface TauriLlmModelDownloadProgress {
+    label: string;
+    percent: number;
+    status: string;
+    bytesDownloaded: number;
+    totalBytes?: number;
+    fileBytesDownloaded: number;
+    fileTotalBytes?: number;
 }
 
 export interface ResolvedModelPreset {
@@ -111,7 +120,7 @@ export class LlmProvider {
     private ensuDefaults?: TauriEnsuDefaults;
     private useDesktopRustDefaults = false;
 
-    private downloadAbort?: AbortController;
+    private downloadActive = false;
     private progressListeners = new Set<(progress: DownloadProgress) => void>();
     private modelReady = false;
     private ensureInFlight?: {
@@ -444,9 +453,12 @@ export class LlmProvider {
     }
 
     public cancelDownload() {
-        if (this.downloadAbort) {
-            this.downloadAbort.abort("cancelled");
-            this.downloadAbort = undefined;
+        if (this.downloadActive && this.backend.kind === "tauri") {
+            void import("@tauri-apps/api/tauri").then(({ invoke }) =>
+                invoke("llm_cancel_model_download").catch((error) => {
+                    log.warn("LLM cancel model download failed", { error });
+                }),
+            );
         }
         this.emitProgress({ percent: -1, status: "Cancelled" });
     }
@@ -605,62 +617,7 @@ export class LlmProvider {
     private async downloadModelsCombined(
         downloads: Array<{ url: string; path: string; label: string }>,
     ) {
-        const totals = new Map<string, number>();
-        const loaded = new Map<string, number>();
-
-        const emitCombined = () => {
-            const totalBytes = Array.from(totals.values()).reduce(
-                (sum, value) => sum + value,
-                0,
-            );
-            const bytesDownloaded = Array.from(loaded.values()).reduce(
-                (sum, value) => sum + value,
-                0,
-            );
-            const percent = totalBytes
-                ? Math.min(99, Math.round((bytesDownloaded / totalBytes) * 100))
-                : 0;
-            this.emitProgress({
-                percent,
-                status: `Downloading models... ${formatBytes(
-                    bytesDownloaded,
-                )} / ${totalBytes ? formatBytes(totalBytes) : "?"}`,
-                bytesDownloaded,
-                totalBytes: totalBytes || undefined,
-            });
-        };
-
-        this.emitProgress({ percent: 0, status: "Preparing downloads..." });
-
-        for (const download of downloads) {
-            const size = await fetchRemoteSize(download.url);
-            if (size !== undefined) {
-                totals.set(download.label, size);
-            }
-            if (!loaded.has(download.label)) {
-                loaded.set(download.label, 0);
-            }
-        }
-
-        emitCombined();
-
-        for (const download of downloads) {
-            const progressHandler = (progress: DownloadProgress) => {
-                if (progress.totalBytes !== undefined) {
-                    totals.set(download.label, progress.totalBytes);
-                }
-                if (progress.bytesDownloaded !== undefined) {
-                    loaded.set(download.label, progress.bytesDownloaded);
-                }
-                emitCombined();
-            };
-
-            await this.downloadModel(
-                download.url,
-                download.path,
-                progressHandler,
-            );
-        }
+        await this.downloadModelsNative(downloads);
     }
 
     private async downloadModel(
@@ -676,321 +633,43 @@ export class LlmProvider {
             totalBytes: 0,
         });
 
-        const { createDir, exists, removeFile, renameFile } = await import(
-            "@tauri-apps/api/fs"
-        );
-        const { invoke } = await import("@tauri-apps/api/tauri");
-        const { dirname } = await import("@tauri-apps/api/path");
+        await this.downloadModelsNative([{ url, path: destPath, label: "Model" }], emit);
+    }
 
-        log.info("LLM download start", { url, destPath });
+    private async downloadModelsNative(
+        downloads: Array<{ url: string; path: string; label: string }>,
+        onProgress?: (progress: DownloadProgress) => void,
+    ) {
+        const emit = onProgress ?? ((progress) => this.emitProgress(progress));
+        const [{ invoke }, { listen }] = await Promise.all([
+            import("@tauri-apps/api/tauri"),
+            import("@tauri-apps/api/event"),
+        ]);
 
-        const dir = await dirname(destPath);
-        await createDir(dir, { recursive: true });
-
-        const tmpPath = `${destPath}.tmp`;
-        const maxAttempts = 3;
-        const stallTimeoutMs = 30_000;
-
-        const delay = (ms: number) =>
-            new Promise<void>((resolve) => {
-                window.setTimeout(resolve, ms);
-            });
-
-        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-            let downloaded = 0;
-            let totalBytes = 0;
-            const controller = new AbortController();
-            this.downloadAbort = controller;
-
-            let stallTimer: number | null = null;
-            const resetStallTimer = () => {
-                if (stallTimer) {
-                    window.clearTimeout(stallTimer);
-                }
-                stallTimer = window.setTimeout(() => {
-                    if (!controller.signal.aborted) {
-                        controller.abort("stall");
-                    }
-                }, stallTimeoutMs);
-            };
-
-            try {
-                if (await exists(tmpPath)) {
-                    try {
-                        const size = await invoke<number | null>(
-                            "fs_file_size",
-                            { path: tmpPath },
-                        );
-                        downloaded = size ?? 0;
-                        if (downloaded > 0) {
-                            const head = await invoke<number[]>(
-                                "fs_read_head",
-                                { path: tmpPath, length: 4 },
-                            );
-                            if (!isGgufHeader(new Uint8Array(head))) {
-                                log.warn(
-                                    "LLM resume header invalid, restarting",
-                                    { tmpPath },
-                                );
-                                await removeFile(tmpPath);
-                                downloaded = 0;
-                            }
-                        }
-                    } catch {
-                        downloaded = 0;
-                    }
-                }
-
+        log.info("LLM native download start", { downloads });
+        this.downloadActive = true;
+        const unlisten = await listen<TauriLlmModelDownloadProgress>(
+            "llm-download-progress",
+            (event) => {
+                const progress = event.payload;
                 emit({
-                    percent: 0,
-                    status:
-                        downloaded > 0
-                            ? "Resuming download..."
-                            : "Starting download...",
-                    bytesDownloaded: downloaded,
-                    totalBytes: 0,
+                    percent: Math.min(99, progress.percent),
+                    status: progress.status,
+                    bytesDownloaded: progress.bytesDownloaded,
+                    totalBytes: progress.totalBytes,
                 });
+            },
+        );
 
-                if (downloaded > 0) {
-                    log.info("LLM download resume", { destPath, downloaded });
-                }
-
-                resetStallTimer();
-
-                const headers: HeadersInit | undefined = downloaded
-                    ? { Range: `bytes=${downloaded}-` }
-                    : undefined;
-                let res = await fetch(url, {
-                    signal: controller.signal,
-                    headers,
-                });
-                log.info("LLM download response", {
-                    url,
-                    status: res.status,
-                    contentLength: res.headers.get("Content-Length"),
-                    contentRange: res.headers.get("Content-Range"),
-                });
-                if (!res.ok || !res.body) {
-                    throw new Error(`Failed to download model (${res.status})`);
-                }
-
-                if (downloaded > 0 && res.status === 200) {
-                    downloaded = 0;
-                    try {
-                        await removeFile(tmpPath);
-                    } catch {
-                        // ignore missing tmp
-                    }
-                    res = await fetch(url, { signal: controller.signal });
-                    log.info("LLM download restart", {
-                        url,
-                        status: res.status,
-                        contentLength: res.headers.get("Content-Length"),
-                        contentRange: res.headers.get("Content-Range"),
-                    });
-                    if (!res.ok || !res.body) {
-                        throw new Error(
-                            `Failed to download model (${res.status})`,
-                        );
-                    }
-                }
-
-                const contentRangeTotal = parseContentRangeTotal(
-                    res.headers.get("Content-Range"),
-                );
-                const contentLength = Number(
-                    res.headers.get("Content-Length") ?? 0,
-                );
-                totalBytes =
-                    contentRangeTotal ??
-                    (contentLength ? contentLength + downloaded : 0);
-
-                const reader = res.body.getReader();
-                let headerBytes: Uint8Array | null = null;
-                const maxChunkSize = 1024 * 1024;
-                const yieldAfterBytes = 4 * 1024 * 1024;
-                let bytesSinceYield = 0;
-
-                while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) break;
-                    if (!value) continue;
-
-                    resetStallTimer();
-
-                    for (
-                        let offset = 0;
-                        offset < value.length;
-                        offset += maxChunkSize
-                    ) {
-                        const chunk = value.subarray(
-                            offset,
-                            Math.min(offset + maxChunkSize, value.length),
-                        );
-
-                        if (!headerBytes && downloaded === 0) {
-                            headerBytes = chunk.slice(0, 4);
-                        }
-
-                        await invoke("fs_append_bytes", {
-                            path: tmpPath,
-                            bytes: Array.from(chunk),
-                        });
-
-                        downloaded += chunk.length;
-                        bytesSinceYield += chunk.length;
-
-                        const percent = totalBytes
-                            ? Math.min(
-                                  99,
-                                  Math.round((downloaded / totalBytes) * 100),
-                              )
-                            : 0;
-                        emit({
-                            percent,
-                            status: `Downloading... ${formatBytes(downloaded)} / ${
-                                totalBytes ? formatBytes(totalBytes) : "?"
-                            }`,
-                            bytesDownloaded: downloaded,
-                            totalBytes,
-                        });
-
-                        if (bytesSinceYield >= yieldAfterBytes) {
-                            bytesSinceYield = 0;
-                            await delay(0);
-                            resetStallTimer();
-                        }
-                    }
-                }
-
-                if (stallTimer) {
-                    window.clearTimeout(stallTimer);
-                    stallTimer = null;
-                }
-
-                if (headerBytes && !isGgufHeader(headerBytes)) {
-                    await removeFile(tmpPath);
-                    emit({
-                        percent: -1,
-                        status: "Downloaded file is not GGUF",
-                        bytesDownloaded: downloaded,
-                        totalBytes,
-                    });
-                    throw new Error("Downloaded file is not GGUF");
-                }
-
-                if (downloaded < MIN_GGUF_BYTES) {
-                    await removeFile(tmpPath);
-                    emit({
-                        percent: -1,
-                        status: "Downloaded file too small",
-                        bytesDownloaded: downloaded,
-                        totalBytes,
-                    });
-                    throw new Error("Downloaded file too small");
-                }
-
-                try {
-                    await removeFile(destPath);
-                } catch {
-                    // ignore missing dest
-                }
-
-                await renameFile(tmpPath, destPath);
-
-                const finalSize = await invoke<number | null>("fs_file_size", {
-                    path: destPath,
-                });
-                if (finalSize !== null && finalSize !== downloaded) {
-                    await removeFile(destPath);
-                    throw new Error(
-                        `Downloaded file size mismatch (${finalSize} != ${downloaded})`,
-                    );
-                }
-
-                const head = await invoke<number[]>("fs_read_head", {
-                    path: destPath,
-                    length: 4,
-                });
-                if (!isGgufHeader(new Uint8Array(head))) {
-                    await removeFile(destPath);
-                    throw new Error("Downloaded file header is not GGUF");
-                }
-
-                log.info("LLM download complete", {
-                    destPath,
-                    bytesDownloaded: downloaded,
-                    totalBytes,
-                });
-
-                return;
-            } catch (error) {
-                if (stallTimer) {
-                    window.clearTimeout(stallTimer);
-                    stallTimer = null;
-                }
-
-                const aborted = controller.signal.aborted;
-                const reason = controller.signal.reason;
-                if (aborted && reason === "cancelled") {
-                    throw new Error("Download cancelled");
-                }
-
-                if (attempt >= maxAttempts) {
-                    log.error("LLM download failed", { url, destPath, error });
-                    throw error;
-                }
-
-                log.warn("LLM download retry", {
-                    url,
-                    destPath,
-                    attempt,
-                    error,
-                });
-                await delay(1500 * attempt);
-            } finally {
-                if (this.downloadAbort === controller) {
-                    this.downloadAbort = undefined;
-                }
-            }
+        try {
+            await invoke("llm_download_model_files", { downloads });
+            log.info("LLM native download complete", { downloads });
+        } finally {
+            this.downloadActive = false;
+            unlisten();
         }
     }
 }
-
-const parseContentRangeTotal = (header: string | null) => {
-    if (!header) return undefined;
-    const match = header.match(/\/(\d+)/);
-    if (!match) return undefined;
-    const total = Number(match[1]);
-    return Number.isFinite(total) ? total : undefined;
-};
-
-const fetchRemoteSize = async (url: string): Promise<number | undefined> => {
-    try {
-        const head = await fetch(url, { method: "HEAD" });
-        if (head.ok) {
-            const length = Number(head.headers.get("Content-Length") ?? 0);
-            if (length > 0) return length;
-            const range = parseContentRangeTotal(
-                head.headers.get("Content-Range"),
-            );
-            if (range) return range;
-        }
-    } catch {
-        // ignore head failures
-    }
-
-    try {
-        const res = await fetch(url, { headers: { Range: "bytes=0-0" } });
-        if (!res.ok) return undefined;
-        const range = parseContentRangeTotal(res.headers.get("Content-Range"));
-        if (range) return range;
-        const length = Number(res.headers.get("Content-Length") ?? 0);
-        return length > 0 ? length : undefined;
-    } catch {
-        return undefined;
-    }
-};
 
 const filenameFromUrl = (url: string) => {
     try {
@@ -1008,22 +687,4 @@ const hashUrl = async (url: string) => {
     return Array.from(new Uint8Array(digest))
         .map((byte) => byte.toString(16).padStart(2, "0"))
         .join("");
-};
-
-const isGgufHeader = (bytes: Uint8Array) =>
-    bytes.length >= 4 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x47 &&
-    bytes[2] === 0x55 &&
-    bytes[3] === 0x46;
-
-const formatBytes = (bytes: number) => {
-    if (!bytes || bytes <= 0) return "0 B";
-    const units = ["B", "KB", "MB", "GB", "TB"];
-    const idx = Math.min(
-        units.length - 1,
-        Math.floor(Math.log(bytes) / Math.log(1024)),
-    );
-    const value = bytes / Math.pow(1024, idx);
-    return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[idx]}`;
 };

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -455,7 +455,7 @@ export class LlmProvider {
     public cancelDownload() {
         if (this.downloadActive && this.backend.kind === "tauri") {
             void import("@tauri-apps/api/tauri").then(({ invoke }) =>
-                invoke("llm_cancel_model_download").catch((error) => {
+                invoke("llm_cancel_model_download").catch((error: unknown) => {
                     log.warn("LLM cancel model download failed", { error });
                 }),
             );
@@ -633,7 +633,10 @@ export class LlmProvider {
             totalBytes: 0,
         });
 
-        await this.downloadModelsNative([{ url, path: destPath, label: "Model" }], emit);
+        await this.downloadModelsNative(
+            [{ url, path: destPath, label: "Model" }],
+            emit,
+        );
     }
 
     private async downloadModelsNative(


### PR DESCRIPTION
- Add a shared Rust model downloader for Ensu across platforms.
- Use Rust as the mobile foreground downloader with native background fallbacks.
- Add download metrics, parallel model/mmproj downloads, and stronger cache reuse.
- Add default 4-way range downloads with single-stream fallback.