### PR TITLE
Add Gemma E2B mobile preset

### DIFF
--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/AppViewModel.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/AppViewModel.kt
@@ -181,6 +181,12 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 title = "Qwen 3.5 2B (Q8_0)",
                 url = "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf?download=true",
                 mmprojUrl = "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf"
+            ),
+            io.ente.ensu.domain.model.EnsuModelPreset(
+                id = "gemma-4-e2b-q4km",
+                title = "Gemma 4 E2B (Q4_K_M)",
+                url = "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true",
+                mmprojUrl = "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf"
             )
         ),
         desktopDefaultModel = io.ente.ensu.domain.model.EnsuModelPreset(

--- a/rust/ensu/inference/src/defaults.rs
+++ b/rust/ensu/inference/src/defaults.rs
@@ -94,6 +94,18 @@ fn gemma_4_e4b_q4km() -> EnsuModelPreset {
     }
 }
 
+fn gemma_4_e2b_q4km() -> EnsuModelPreset {
+    EnsuModelPreset {
+        id: "gemma-4-e2b-q4km".to_string(),
+        title: "Gemma 4 E2B (Q4_K_M)".to_string(),
+        url: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true".to_string(),
+        mmproj_url: Some(
+            "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf"
+                .to_string(),
+        ),
+    }
+}
+
 pub fn ensu_defaults() -> EnsuDefaults {
     let mobile_default_model = lfm_vl_1_6b();
     let desktop_default_model = gemma_4_e4b_q4km();
@@ -104,7 +116,7 @@ pub fn ensu_defaults() -> EnsuDefaults {
         system_prompt_date_placeholder: SYSTEM_PROMPT_DATE_PLACEHOLDER.to_string(),
         session_summary_system_prompt: SESSION_SUMMARY_SYSTEM_PROMPT.to_string(),
         mobile_default_model,
-        mobile_model_presets: vec![lfm_1_2b(), qwen_0_8b(), qwen_2b_q8()],
+        mobile_model_presets: vec![lfm_1_2b(), qwen_0_8b(), qwen_2b_q8(), gemma_4_e2b_q4km()],
         desktop_default_model,
         desktop_model_presets: vec![
             qwen_4b_q4km(),

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -65,7 +65,7 @@ export interface ResolvedModelPreset {
     mmproj?: string;
 }
 
-export const FALLBACK_MOBILE_MODEL_PRESETS: ResolvedModelPreset[] = [
+const FALLBACK_SHARED_MODEL_PRESETS: ResolvedModelPreset[] = [
     {
         name: "LFM 2.5 1.2B Instruct (Q4_0)",
         url: "https://huggingface.co/LiquidAI/LFM2.5-1.2B-GGUF/resolve/main/LFM2.5-1.2B-Q4_0.gguf?download=true",
@@ -80,6 +80,15 @@ export const FALLBACK_MOBILE_MODEL_PRESETS: ResolvedModelPreset[] = [
         url: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf?download=true",
         mmproj: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf",
     },
+    {
+        name: "Gemma 4 E2B (Q4_K_M)",
+        url: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true",
+        mmproj: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf",
+    },
+];
+
+export const FALLBACK_MOBILE_MODEL_PRESETS: ResolvedModelPreset[] = [
+    ...FALLBACK_SHARED_MODEL_PRESETS,
 ];
 
 export const FALLBACK_DESKTOP_MODEL_PRESETS: ResolvedModelPreset[] = [
@@ -93,7 +102,7 @@ export const FALLBACK_DESKTOP_MODEL_PRESETS: ResolvedModelPreset[] = [
         url: "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/LFM2.5-VL-1.6B-Q4_0.gguf?download=true",
         mmproj: "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf",
     },
-    ...FALLBACK_MOBILE_MODEL_PRESETS,
+    ...FALLBACK_SHARED_MODEL_PRESETS,
 ];
 
 export class LlmProvider {


### PR DESCRIPTION
## Summary
- Add Gemma 4 E2B (Q4_K_M) as an Ensu mobile model option.
- Keep existing default models unchanged.

## Tested
- cargo check --manifest-path rust/ensu/inference/Cargo.toml
- ./gradlew :app-ui:compileDebugKotlin
- git diff --check