### PR TITLE
[mob][photos] Fix HEIC orientation flip on Android viewer

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -26,6 +26,7 @@ import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/actions/file/file_actions.dart";
 import 'package:photos/ui/common/loading_widget.dart';
 import 'package:photos/ui/viewer/file/thumbnail_widget.dart';
+import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
 import 'package:photos/utils/image_util.dart';
 import "package:photos/utils/ram_check_util.dart";
@@ -531,7 +532,34 @@ class _ZoomableImageState extends State<ZoomableImage> {
     if (!mounted) {
       return;
     }
+
+    // Image.file -> Android BitmapFactory does not apply EXIF orientation
+    // for HEIC. If the file declares a non-trivial orientation, route through
+    // _loadInSupportedFormat which uses FlutterImageCompress with
+    // autoCorrectionAngle=true (reads EXIF via ExifInterface and rotates the
+    // bitmap before returning bytes).
+    if (await _heicNeedsExifRotation(file)) {
+      await _loadInSupportedFormat(file, "HEIC requires EXIF rotation");
+      return;
+    }
+
     _loadWithPlatformDecoder(file);
+  }
+
+  Future<bool> _heicNeedsExifRotation(File file) async {
+    try {
+      final exif = await readExifAsync(file);
+      final orientation =
+          exif['Image Orientation']?.values.firstAsInt() ?? 1;
+      return orientation > 1;
+    } catch (e, s) {
+      _logger.warning(
+        "Failed to read EXIF orientation for ${_photo.displayName}",
+        e,
+        s,
+      );
+      return false;
+    }
   }
 
   void _loadWithPlatformDecoder(File file) {


### PR DESCRIPTION
## Issue

- iPhone HEIC photos rendered correctly as thumbnails but flipped onto their side once the full image loaded on Android.
- Reproduces with any iPhone HEIC having EXIF Orientation 3, 6, or 8 (any portrait shot).
- Same files render correctly in Google Photos and on iOS Ente, so the issue is Android-specific.

## Fix

- Before rendering a HEIC on Android, read its EXIF orientation. If it requires rotation, route the load through `_loadInSupportedFormat` instead of `Image.file`.
- `_loadInSupportedFormat` already calls `FlutterImageCompress.compressWithFile` with `autoCorrectionAngle: true`, which reads EXIF via `androidx.exifinterface.ExifInterface` and physically rotates the bitmap before returning bytes.
- Root cause: Flutter's `Image.file` on Android decodes HEIC via `BitmapFactory`/Skia, neither of which applies the EXIF orientation tag for HEIC. The Rust path that does apply it is still gated to internal users.



https://github.com/user-attachments/assets/354631ee-c8d5-415a-bd3a-3ebceb3921df


https://github.com/user-attachments/assets/4fdd8f0f-cc61-46ff-b38d-bfacf0e7507d

