### PR TITLE
Enable Safari OTP AutoFill for Locker 2FA

### DIFF
--- a/web/packages/accounts-rs/components/Verify2FACodeForm.tsx
+++ b/web/packages/accounts-rs/components/Verify2FACodeForm.tsx
@@ -85,8 +85,16 @@ export const Verify2FACodeForm: React.FC<Verify2FACodeFormProps> = ({
                     value={values.otp}
                     onChange={handleChange("otp")}
                     numInputs={6}
+                    inputType="tel"
                     renderSeparator={<span>-</span>}
-                    renderInput={(props) => <IndividualInput {...props} />}
+                    renderInput={(props, index) => (
+                        <IndividualInput
+                            {...props}
+                            autoComplete={index === 0 ? "one-time-code" : "off"}
+                            name={index === 0 ? "otp" : undefined}
+                            pattern="[0-9]*"
+                        />
+                    )}
                 />
                 {errors.otp && (
                     <Typography variant="mini" sx={{ color: "critical.main" }}>


### PR DESCRIPTION
## Summary
- Mark the shared 2FA OTP input used by Locker as a browser one-time-code target.
- Use a telephone input type for the OTP boxes so Safari/iOS gets numeric-friendly behavior.
- Keep the existing six-box UI and submit flow unchanged.

## Review
- Reviewed the full branch diff against `main`; no release-blocking findings found.

## Testing
- `yarn build:wasm`
- `yarn lint`
- `yarn test`
- `yarn build:locker`
- `yarn audit --level critical` reported no critical advisories; Yarn exited 14 due to existing low/moderate/high advisories.

Note: `yarn test:run` is not defined in `web/package.json`, so `yarn test` was run instead.