### PR TITLE
[mob][accounts] Require accountsUrl for passkey flows

### DIFF
--- a/mobile/apps/auth/lib/core/constants.dart
+++ b/mobile/apps/auth/lib/core/constants.dart
@@ -6,8 +6,6 @@ const int thumbnailDataLimit = 100 * 1024;
 const String sentryDSN =
     "https://ed4ddd6309b847ba8849935e26e9b648@sentry.ente.io/9";
 
-const String kAccountsUrl = "https://accounts.ente.com";
-
 final Uri githubFeatureRequestUri = Uri.https(
   "github.com",
   "/ente-io/ente/discussions/categories/enhancements",

--- a/mobile/apps/locker/lib/core/constants.dart
+++ b/mobile/apps/locker/lib/core/constants.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 
-const String kAccountsUrl = "https://accounts.ente.com";
 const int microSecondsInDay = 86400000000;
 const int android11SDKINT = 30;
 

--- a/mobile/apps/photos/lib/core/constants.dart
+++ b/mobile/apps/photos/lib/core/constants.dart
@@ -46,7 +46,6 @@ const kDefaultProductionEndpoint = 'https://api.ente.com';
 const kLegacyProductionEndpoint = 'https://api.ente.io';
 const kUploadProxyEndpoint = 'https://uploader.ente.com';
 const kPhotosWebDomain = 'photos.ente.com';
-const kAccountsUrl = 'https://accounts.ente.com';
 const kFamilyUrl = 'https://family.ente.io';
 
 const int intMaxValue = 9223372036854775807;

--- a/mobile/apps/photos/lib/services/account/passkey_service.dart
+++ b/mobile/apps/photos/lib/services/account/passkey_service.dart
@@ -1,6 +1,5 @@
 import "package:flutter/cupertino.dart";
 import "package:logging/logging.dart";
-import "package:photos/core/constants.dart";
 import "package:photos/gateways/users/passkey_gateway.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -14,7 +13,7 @@ class PasskeyService {
 
   Future<String> getAccountsUrl() async {
     final response = await _gateway.getAccountsToken();
-    final accountsUrl = response["accountsUrl"] ?? kAccountsUrl;
+    final accountsUrl = response["accountsUrl"] as String;
     final jwtToken = response["accountsToken"] as String;
     return "$accountsUrl/passkeys?token=$jwtToken";
   }

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -410,13 +410,13 @@ class UserService {
       await dialog.hide();
       Widget page;
       final String passkeySessionID = responseData["passkeySessionID"] ?? "";
-      final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
       String twoFASessionID = responseData["twoFactorSessionID"] ?? "";
       if (twoFASessionID.isEmpty &&
           responseData["twoFactorSessionIDV2"] != null) {
         twoFASessionID = responseData["twoFactorSessionIDV2"];
       }
       if (passkeySessionID.isNotEmpty) {
+        final accountsUrl = responseData["accountsUrl"] as String;
         page = PasskeyPage(
           passkeySessionID,
           totp2FASessionID: twoFASessionID,
@@ -686,10 +686,10 @@ class UserService {
       twoFASessionID = responseData["twoFactorSessionIDV2"];
     }
     final String passkeySessionID = responseData["passkeySessionID"] ?? "";
-    final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
 
     Configuration.instance.setVolatilePassword(userPassword);
     if (passkeySessionID.isNotEmpty) {
+      final accountsUrl = responseData["accountsUrl"] as String;
       page = PasskeyPage(
         passkeySessionID,
         totp2FASessionID: twoFASessionID,

--- a/mobile/packages/accounts/lib/services/passkey_service.dart
+++ b/mobile/packages/accounts/lib/services/passkey_service.dart
@@ -1,4 +1,3 @@
-import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_network/network.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import 'package:flutter/widgets.dart';
@@ -15,7 +14,7 @@ class PasskeyService {
     final response = await _enteDio.get(
       "/users/accounts-token",
     );
-    final accountsUrl = response.data!["accountsUrl"] ?? kAccountsUrl;
+    final accountsUrl = response.data!["accountsUrl"] as String;
     final jwtToken = response.data!["accountsToken"] as String;
     return "$accountsUrl/passkeys?token=$jwtToken";
   }

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -46,8 +46,6 @@ import "package:pointycastle/srp/srp6_verifier_generator.dart";
 import 'package:shared_preferences/shared_preferences.dart';
 import "package:uuid/uuid.dart";
 
-const String kAccountsUrl = "https://accounts.ente.com";
-
 class UserService {
   static const keyHasEnabledTwoFactor = "has_enabled_two_factor";
   static const keyUserDetails = "user_details";
@@ -471,13 +469,13 @@ class UserService {
         Widget page;
         final responseData = response.data;
         final String passkeySessionID = responseData["passkeySessionID"] ?? "";
-        final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
         String twoFASessionID = responseData["twoFactorSessionID"] ?? "";
         if (twoFASessionID.isEmpty &&
             responseData["twoFactorSessionIDV2"] != null) {
           twoFASessionID = responseData["twoFactorSessionIDV2"];
         }
         if (passkeySessionID.isNotEmpty) {
+          final accountsUrl = responseData["accountsUrl"] as String;
           page = PasskeyPage(
             _config,
             passkeySessionID,
@@ -801,7 +799,6 @@ class UserService {
       Widget? page;
       final responseData = response.data;
       final String passkeySessionID = responseData["passkeySessionID"] ?? "";
-      final String accountsUrl = responseData["accountsUrl"] ?? kAccountsUrl;
       String twoFASessionID = responseData["twoFactorSessionID"] ?? "";
       if (twoFASessionID.isEmpty &&
           responseData["twoFactorSessionIDV2"] != null) {
@@ -809,6 +806,7 @@ class UserService {
       }
       _config.setVolatilePassword(userPassword);
       if (passkeySessionID.isNotEmpty) {
+        final accountsUrl = responseData["accountsUrl"] as String;
         page = PasskeyPage(
           _config,
           passkeySessionID,


### PR DESCRIPTION
## Summary
- Remove hardcoded `accounts.ente.com` fallbacks from mobile passkey flows.
- Require Museum-provided `accountsUrl` when launching passkey verification and management.
- Drop now-unused mobile `kAccountsUrl` constants.

## Tests
- `dart format --output=none --set-exit-if-changed ...`
- `flutter analyze lib/services/account/user_service.dart lib/services/account/passkey_service.dart lib/core/constants.dart` in `mobile/apps/photos`
- `flutter analyze lib/services/user_service.dart lib/services/passkey_service.dart` in `mobile/packages/accounts`
- `flutter analyze lib/core/constants.dart` in `mobile/apps/auth` and `mobile/apps/locker`