### PR TITLE
Fix isolate Sentry bool errors

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/isolate_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/isolate_logging.dart
@@ -6,22 +6,51 @@ import "package:photos/core/error-reporting/super_logging.dart";
 
 class IsolateLogString {
   final String logString;
-  final Object? error;
+  final String? error;
+  final String? stackTrace;
+  final String loggerName;
+  final String levelName;
+  final String message;
 
-  IsolateLogString(this.logString, this.error);
+  IsolateLogString({
+    required this.logString,
+    required this.error,
+    required this.stackTrace,
+    required this.loggerName,
+    required this.levelName,
+    required this.message,
+  });
 
   String toJsonString() => jsonEncode({
         'logString': logString,
         'error': error,
+        'stackTrace': stackTrace,
+        'loggerName': loggerName,
+        'levelName': levelName,
+        'message': message,
       });
 
   static IsolateLogString fromJsonString(String jsonString) {
     final json = jsonDecode(jsonString);
+    final rawError = json['error'];
     return IsolateLogString(
-      json['logString'] as String,
-      json['error'],
+      logString: json['logString'] as String,
+      error: rawError is String ? rawError : null,
+      stackTrace: json['stackTrace'] as String?,
+      loggerName: json['loggerName'] as String? ?? 'isolate',
+      levelName: json['levelName'] as String? ?? Level.INFO.name,
+      message: json['message'] as String? ?? '',
     );
   }
+}
+
+class IsolateLogError implements Exception {
+  final String message;
+
+  const IsolateLogError(this.message);
+
+  @override
+  String toString() => message;
 }
 
 class IsolateLogger {
@@ -34,7 +63,16 @@ class IsolateLogger {
     SuperLogging.printLog(str);
 
     // push to log queue
-    fileQueueEntries.add(IsolateLogString(str, rec.error != null));
+    fileQueueEntries.add(
+      IsolateLogString(
+        logString: str,
+        error: rec.error?.toString(),
+        stackTrace: rec.stackTrace?.toString(),
+        loggerName: rec.loggerName,
+        levelName: rec.level.name,
+        message: rec.message,
+      ),
+    );
   }
 
   /// WARNING: only call this from the isolate
@@ -53,7 +91,42 @@ class IsolateLogger {
     while (logs.isNotEmpty) {
       final logString = logs.removeAt(0);
       final log = IsolateLogString.fromJsonString(logString);
-      SuperLogging.saveLogString(log.logString, log.error);
+      final error = log.error;
+      if (error == null) {
+        SuperLogging.saveLogString(log.logString, null);
+        continue;
+      }
+      final stackTraceString = log.stackTrace;
+      final stackTrace = stackTraceString == null || stackTraceString.isEmpty
+          ? null
+          : StackTrace.fromString(stackTraceString);
+      final isolateError = IsolateLogError(error);
+      SuperLogging.saveLogString(
+        log.logString,
+        isolateError,
+        stackTrace: stackTrace,
+        rec: LogRecord(
+          _levelFromName(log.levelName),
+          log.message,
+          log.loggerName,
+          isolateError,
+          stackTrace,
+        ),
+      );
     }
+  }
+
+  static Level _levelFromName(String levelName) {
+    return switch (levelName) {
+      'SHOUT' => Level.SHOUT,
+      'SEVERE' => Level.SEVERE,
+      'WARNING' => Level.WARNING,
+      'INFO' => Level.INFO,
+      'CONFIG' => Level.CONFIG,
+      'FINE' => Level.FINE,
+      'FINER' => Level.FINER,
+      'FINEST' => Level.FINEST,
+      _ => Level.INFO,
+    };
   }
 }

--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -408,7 +408,12 @@ class SuperLogging {
     saveLogString(str, rec.error, rec: rec);
   }
 
-  static void saveLogString(String str, Object? error, {LogRecord? rec}) {
+  static void saveLogString(
+    String str,
+    Object? error, {
+    LogRecord? rec,
+    StackTrace? stackTrace,
+  }) {
     // push to log queue
     if (fileIsEnabled) {
       fileQueueEntries.add(str + '\n');
@@ -419,7 +424,8 @@ class SuperLogging {
 
     // add error to sentry queue
     if (sentryIsEnabled && error != null) {
-      _sendErrorToSentry(error, rec?.stackTrace, rec: rec).ignore();
+      _sendErrorToSentry(error, rec?.stackTrace ?? stackTrace, rec: rec)
+          .ignore();
     }
   }
 


### PR DESCRIPTION
## Summary
- Stop forwarding isolate log presence as a boolean throwable.
- Preserve isolate error text, stack trace, logger, level, and message for real isolate errors.

## Validation
- dart format .
- flutter analyze lib/core/error-reporting/isolate_logging.dart lib/core/error-reporting/super_logging.dart
- git diff --check

Full flutter analyze still reports existing unrelated UI/localization errors.