### PR TITLE
Handle CLIP text WiFi skip

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -15,9 +15,8 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photos/core/error-reporting/tunneled_transport.dart';
-import "package:photos/core/errors.dart";
+import "package:photos/core/exceptions.dart";
 import 'package:photos/models/typedefs.dart';
-import "package:photos/services/machine_learning/ml_exceptions.dart";
 import "package:photos/utils/device_info.dart";
 import "package:photos/utils/ram_check_util.dart";
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -323,14 +322,10 @@ class SuperLogging {
     if (error is DioException) {
       return true;
     }
-    final bool result = error is StorageLimitExceededError ||
-        error is WiFiUnavailableError ||
-        error is InvalidFileError ||
-        error is NoActiveSubscriptionError ||
+    final bool result = error is LocallyHandledError ||
         error is TaskQueueTimeoutException ||
         error is TaskQueueOverflowException ||
-        error is TaskQueueCancelledException ||
-        error is CouldNotRetrieveAnyFileData;
+        error is TaskQueueCancelledException;
     if (kDebugMode && result) {
       $.info('Not sending error to sentry: $error');
     }

--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -1,3 +1,5 @@
+import "package:photos/core/exceptions.dart";
+
 enum InvalidReason {
   assetDeleted,
   assetDeletedEvent,
@@ -17,7 +19,7 @@ extension InvalidReasonExn on InvalidReason {
       this == InvalidReason.livePhotoVideoMissing;
 }
 
-class InvalidFileError extends ArgumentError {
+class InvalidFileError extends ArgumentError implements LocallyHandledError {
   final InvalidReason reason;
 
   InvalidFileError(String super.message, this.reason);
@@ -30,13 +32,22 @@ class InvalidFileError extends ArgumentError {
 
 class SubscriptionAlreadyClaimedError extends Error {}
 
-class WiFiUnavailableError extends Error {}
+class WiFiUnavailableError extends Error implements LocallyHandledError {
+  final String? message;
+
+  WiFiUnavailableError([this.message]);
+
+  @override
+  String toString() => message == null
+      ? "WiFiUnavailableError"
+      : "WiFiUnavailableError: $message";
+}
 
 class SyncStopRequestedError extends Error {}
 
-class NoActiveSubscriptionError extends Error {}
+class NoActiveSubscriptionError extends Error implements LocallyHandledError {}
 
-class StorageLimitExceededError extends Error {}
+class StorageLimitExceededError extends Error implements LocallyHandledError {}
 
 // error when file size + current usage >= storage plan limit + buffer
 class FileTooLargeForPlanError extends Error {}

--- a/mobile/apps/photos/lib/core/exceptions.dart
+++ b/mobile/apps/photos/lib/core/exceptions.dart
@@ -1,6 +1,12 @@
 // Common runtime exceptions that can occur during normal app operation.
 // These are recoverable conditions that should be caught and handled.
 
+/// Marker for expected runtime conditions that are handled locally.
+///
+/// These may still be written to local logs, but should not be reported as app
+/// crashes.
+abstract interface class LocallyHandledError {}
+
 class WidgetUnmountedException implements Exception {
   final String? message;
 

--- a/mobile/apps/photos/lib/services/machine_learning/ml_computer.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_computer.dart
@@ -5,6 +5,7 @@ import "dart:typed_data" show Float32List;
 import "package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart"
     show Uint64List;
 import "package:logging/logging.dart";
+import "package:photos/core/errors.dart";
 import "package:photos/models/ml/vector.dart";
 import "package:photos/service_locator.dart"
     show flagService, isLocalGalleryMode;
@@ -105,6 +106,13 @@ class MLComputer extends SuperIsolate {
         },
       }) as List<double>;
       return textEmbedding;
+    } on WiFiUnavailableError catch (e, s) {
+      _logger.warning(
+        "Could not run clip text because model is unavailable",
+        e,
+        s,
+      );
+      rethrow;
     } catch (e, s) {
       _logger.severe("Could not run clip text in isolate", e, s);
       rethrow;
@@ -158,7 +166,10 @@ class MLComputer extends SuperIsolate {
         final String? downloadedModelPath =
             await ClipTextEncoder.instance.downloadModelSafe();
         if (downloadedModelPath == null) {
-          throw Exception("Could not download clip text model, no wifi");
+          throw WiFiUnavailableError(
+            "Could not download clip text model because high bandwidth "
+            "connectivity is unavailable",
+          );
         }
         _clipTextModelPath = downloadedModelPath;
 

--- a/mobile/apps/photos/lib/services/machine_learning/ml_exceptions.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_exceptions.dart
@@ -1,3 +1,5 @@
+import "package:photos/core/exceptions.dart";
+
 class GeneralFaceMlException implements Exception {
   final String message;
 
@@ -19,7 +21,7 @@ class ThumbnailRetrievalException implements Exception {
   }
 }
 
-class CouldNotRetrieveAnyFileData implements Exception {}
+class CouldNotRetrieveAnyFileData implements Exception, LocallyHandledError {}
 
 class CouldNotRunFaceDetector implements Exception {}
 

--- a/mobile/apps/photos/lib/services/machine_learning/ml_model_download_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_model_download_service.dart
@@ -33,6 +33,19 @@ class MLModelDownloadService {
         (onlyIndexingModels || _areNonIndexingModelsDownloaded);
   }
 
+  Future<bool> canLoadClipTextModel() async {
+    final hasModel = await RemoteAssetsService.instance.hasAsset(
+      ClipTextEncoder.instance.modelRemotePath,
+    );
+    final hasVocab = await RemoteAssetsService.instance.hasAsset(
+      ClipTextEncoder.instance.vocabRemotePath,
+    );
+    if (hasModel && hasVocab) {
+      return true;
+    }
+    return isLocalGalleryMode || await canUseHighBandwidth();
+  }
+
   /// Invalidate the download cache so the next ML run re-enters
   /// [ensureModelsDownloaded], which checks consent, local indexing, bandwidth,
   /// and downloads any newly required models.

--- a/mobile/apps/photos/lib/services/memories_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memories_cache_service.dart
@@ -29,6 +29,7 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/app_navigation_service.dart";
 import "package:photos/services/language_service.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
+import "package:photos/services/machine_learning/ml_model_download_service.dart";
 import "package:photos/services/memories/photo_selector.dart";
 import "package:photos/services/notification_service.dart";
 import "package:photos/services/search_service.dart";
@@ -168,9 +169,19 @@ class MemoriesCacheService {
           ? MLDataDB.localGalleryInstance
           : MLDataDB.instance;
       final clipIndexed = await mlDataDB.getClipIndexedFileCount();
-      return clipIndexed >= SmartMemoriesService.minimumMemoryLength;
+      if (clipIndexed < SmartMemoriesService.minimumMemoryLength) {
+        return false;
+      }
+      if (!await MLModelDownloadService.instance.canLoadClipTextModel()) {
+        _logger.info(
+          "ML not ready for smart memories because CLIP text model is not "
+          "cached and high bandwidth connectivity is unavailable",
+        );
+        return false;
+      }
+      return true;
     } catch (e, s) {
-      _logger.warning("Failed to read CLIP indexed count", e, s);
+      _logger.warning("Failed to determine ML readiness", e, s);
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Treat missing CLIP text model on unavailable high-bandwidth connectivity as a handled WiFi condition.
- Skip smart memories ML text embedding when the text model is not cached and cannot be downloaded.
- Use a handled-error marker for Sentry filtering.

## Validation
- dart format .
- flutter analyze lib/core/error-reporting/super_logging.dart lib/core/errors.dart lib/core/exceptions.dart lib/services/machine_learning/ml_exceptions.dart lib/services/machine_learning/ml_computer.dart lib/services/machine_learning/ml_model_download_service.dart lib/services/memories_cache_service.dart
- git diff --check HEAD

Full flutter analyze still reports existing unrelated UI/localization errors.