### PR TITLE
Fix Photos search filter localization race

### DIFF
--- a/mobile/apps/photos/lib/services/magic_cache_service.dart
+++ b/mobile/apps/photos/lib/services/magic_cache_service.dart
@@ -12,6 +12,7 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/offline_files_db.dart";
 import "package:photos/events/file_uploaded_event.dart";
 import "package:photos/events/magic_cache_updated_event.dart";
+import "package:photos/generated/l10n.dart";
 import "package:photos/l10n/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
@@ -77,39 +78,43 @@ class MagicCache {
 }
 
 String getLocalizedTitle(BuildContext context, String title) {
+  return getLocalizedTitleForL10n(context.l10n, title);
+}
+
+String getLocalizedTitleForL10n(AppLocalizations l10n, String title) {
   switch (title) {
     case 'Identity':
-      return context.l10n.discover_identity;
+      return l10n.discover_identity;
     case 'Screenshots':
-      return context.l10n.discover_screenshots;
+      return l10n.discover_screenshots;
     case 'QR Codes':
-      return context.l10n.discover_qr_codes;
+      return l10n.discover_qr_codes;
     case 'Receipts':
-      return context.l10n.discover_receipts;
+      return l10n.discover_receipts;
     case 'Notes':
-      return context.l10n.discover_notes;
+      return l10n.discover_notes;
     case 'Memes':
-      return context.l10n.discover_memes;
+      return l10n.discover_memes;
     case 'Visiting Cards':
-      return context.l10n.discover_visiting_cards;
+      return l10n.discover_visiting_cards;
     case 'Babies':
-      return context.l10n.discover_babies;
+      return l10n.discover_babies;
     case 'Pets':
-      return context.l10n.discover_pets;
+      return l10n.discover_pets;
     case 'Selfies':
-      return context.l10n.discover_selfies;
+      return l10n.discover_selfies;
     case 'Wallpapers':
-      return context.l10n.discover_wallpapers;
+      return l10n.discover_wallpapers;
     case 'Food':
-      return context.l10n.discover_food;
+      return l10n.discover_food;
     case 'Celebrations':
-      return context.l10n.discover_celebrations;
+      return l10n.discover_celebrations;
     case 'Sunset':
-      return context.l10n.discover_sunset;
+      return l10n.discover_sunset;
     case 'Hills':
-      return context.l10n.discover_hills;
+      return l10n.discover_hills;
     case 'Greenery':
-      return context.l10n.discover_greenery;
+      return l10n.discover_greenery;
     default:
       return title; // If no match, return the original string
   }

--- a/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
+++ b/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
@@ -183,8 +183,19 @@ Future<void> curateFilters(
   BuildContext context,
 ) async {
   try {
+    final l10n = Localizations.of<AppLocalizations>(
+      context,
+      AppLocalizations,
+    );
+    if (l10n == null) {
+      Logger("HierarchicalSearchUtil").warning(
+        "Skipping filter curation because localizations are unavailable",
+      );
+      return;
+    }
+
     final albumFilters = await _curateAlbumFilters(files);
-    final fileTypeFilters = _curateFileTypeFilters(files, context);
+    final fileTypeFilters = _curateFileTypeFilters(files, l10n);
     final locationFilters = await _curateLocationFilters(
       files,
     );
@@ -192,10 +203,10 @@ Future<void> curateFilters(
     final uploaderFilters = _curateUploaderFilter(files);
     final cameraFilters = _curateCameraFilters(files);
     final faceFilters = await curateFaceFilters(files);
-    final magicFilters = await curateMagicFilters(files, context);
+    final magicFilters = await curateMagicFilters(files, l10n);
     final onlyThemFilter = getOnlyThemFilter(
       searchFilterDataProvider,
-      context,
+      l10n,
     );
 
     searchFilterDataProvider.clearAndAddRecommendations(
@@ -218,7 +229,7 @@ Future<void> curateFilters(
 
 List<OnlyThemFilter> getOnlyThemFilter(
   SearchFilterDataProvider searchFilterDataProvider,
-  BuildContext context,
+  AppLocalizations l10n,
 ) {
   if (searchFilterDataProvider.initialGalleryFilter is FaceFilter &&
       searchFilterDataProvider.appliedFilters.isEmpty) {
@@ -227,7 +238,7 @@ List<OnlyThemFilter> getOnlyThemFilter(
         faceFilters: [
           searchFilterDataProvider.initialGalleryFilter as FaceFilter,
         ],
-        onlyThemString: AppLocalizations.of(context).onlyThem,
+        onlyThemString: l10n.onlyThem,
         occurrence: kMostRelevantFilter,
       ),
     ];
@@ -240,7 +251,7 @@ List<OnlyThemFilter> getOnlyThemFilter(
   } else {
     final onlyThemFilter = OnlyThemFilter(
       faceFilters: appliedFaceFilters,
-      onlyThemString: AppLocalizations.of(context).onlyThem,
+      onlyThemString: l10n.onlyThem,
       occurrence: kMostRelevantFilter,
     );
     return [onlyThemFilter];
@@ -284,7 +295,7 @@ Future<List<AlbumFilter>> _curateAlbumFilters(
 
 List<FileTypeFilter> _curateFileTypeFilters(
   List<EnteFile> files,
-  BuildContext context,
+  AppLocalizations l10n,
 ) {
   final fileTypeFilters = <FileTypeFilter>[];
   int photosCount = 0;
@@ -308,7 +319,7 @@ List<FileTypeFilter> _curateFileTypeFilters(
     fileTypeFilters.add(
       FileTypeFilter(
         fileType: FileType.image,
-        typeName: AppLocalizations.of(context).photos,
+        typeName: l10n.photos,
         occurrence: photosCount,
       ),
     );
@@ -317,7 +328,7 @@ List<FileTypeFilter> _curateFileTypeFilters(
     fileTypeFilters.add(
       FileTypeFilter(
         fileType: FileType.video,
-        typeName: AppLocalizations.of(context).videos,
+        typeName: l10n.videos,
         occurrence: videosCount,
       ),
     );
@@ -326,7 +337,7 @@ List<FileTypeFilter> _curateFileTypeFilters(
     fileTypeFilters.add(
       FileTypeFilter(
         fileType: FileType.livePhoto,
-        typeName: AppLocalizations.of(context).livePhotos,
+        typeName: l10n.livePhotos,
         occurrence: livePhotosCount,
       ),
     );
@@ -558,7 +569,7 @@ Future<List<FaceFilter>> curateFaceFilters(
 
 Future<List<MagicFilter>> curateMagicFilters(
   List<EnteFile> files,
-  BuildContext context,
+  AppLocalizations l10n,
 ) async {
   final magicFilters = <MagicFilter>[];
 
@@ -567,7 +578,7 @@ Future<List<MagicFilter>> curateMagicFilters(
   for (MagicCache magicCache in magicCaches) {
     final uploadedIDs = magicCache.fileUploadedIDs.toSet();
     final intersection = uploadedIDs.intersection(filesUploadedFileIDs);
-    final title = getLocalizedTitle(context, magicCache.title);
+    final title = getLocalizedTitleForL10n(l10n, magicCache.title);
 
     if (intersection.length > 3) {
       magicFilters.add(

--- a/mobile/apps/photos/test/utils/hierarchical_search_util_test.dart
+++ b/mobile/apps/photos/test/utils/hierarchical_search_util_test.dart
@@ -1,0 +1,54 @@
+import "package:flutter/widgets.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/models/search/hierarchical/hierarchical_search_filter.dart";
+import "package:photos/ui/viewer/gallery/state/search_filter_data_provider.dart";
+import "package:photos/utils/hierarchical_search_util.dart";
+
+void main() {
+  testWidgets("curateFilters skips when localizations are unavailable", (
+    tester,
+  ) async {
+    late final BuildContext context;
+    await tester.pumpWidget(
+      Builder(
+        builder: (builderContext) {
+          context = builderContext;
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    final searchFilterDataProvider = SearchFilterDataProvider(
+      initialGalleryFilter: _TestFilter(),
+    );
+
+    await curateFilters(searchFilterDataProvider, const [], context);
+
+    expect(searchFilterDataProvider.recommendations, isEmpty);
+    searchFilterDataProvider.dispose();
+  });
+}
+
+class _TestFilter extends HierarchicalSearchFilter {
+  _TestFilter()
+      : super(
+          filterTypeName: "topLevelGenericFilter",
+          matchedUploadedIDs: <int>{},
+        );
+
+  @override
+  IconData? icon() => null;
+
+  @override
+  bool isMatch(EnteFile file) => false;
+
+  @override
+  bool isSameFilter(HierarchicalSearchFilter other) => other.name() == name();
+
+  @override
+  String name() => "test";
+
+  @override
+  int relevance() => kLeastRelevantFilter;
+}


### PR DESCRIPTION
## Summary
- Capture Photos search filter localizations before async curation work and skip curation when localizations are unavailable.
- Pass AppLocalizations through file type, magic, and Only Them filter helpers so curation no longer reads from a stale BuildContext.
- Add coverage for the missing-localizations early return.

Fixes PHOTOS-MOBILE-63G.

## Validation
- `flutter analyze lib/services/magic_cache_service.dart lib/utils/hierarchical_search_util.dart test/utils/hierarchical_search_util_test.dart`
- `flutter test test/utils/date_query_parsing_test.dart`
- Full `flutter analyze` is blocked by existing generated-localization errors outside this PR.
