### PR TITLE
[mob][photos] Handle missing thumbnail cache files

### DIFF
--- a/mobile/apps/photos/lib/utils/thumbnail_util.dart
+++ b/mobile/apps/photos/lib/utils/thumbnail_util.dart
@@ -23,6 +23,7 @@ final _logger = Logger("ThumbnailUtil");
 final _uploadIDToDownloadItem = <int, FileDownloadItem>{};
 final _downloadQueue = Queue<int>();
 const int kMaximumConcurrentDownloads = 500;
+const int _noSuchFileOrDirectoryErrorCode = 2;
 
 class FileDownloadItem {
   final EnteFile file;
@@ -77,7 +78,17 @@ Future<File?> getThumbnailForUploadedFile(EnteFile file) async {
   if (thumbnail != null) {
     // it might be already written to this path during `getThumbnail(file)`
     if (!await cachedThumbnail.exists()) {
-      await cachedThumbnail.writeAsBytes(thumbnail, flush: true);
+      final didWrite = await _writeCachedThumbnail(
+        cachedThumbnail,
+        thumbnail,
+        flush: true,
+      );
+      if (!didWrite) {
+        _logger.info(
+          "Thumbnail obtained but not persisted for ${file.uploadedFileID}",
+        );
+        return null;
+      }
     }
     _logger.info("Thumbnail obtained for ${file.uploadedFileID}");
     return cachedThumbnail;
@@ -94,11 +105,10 @@ Future<Uint8List> getThumbnailFromServer(EnteFile file) async {
 Future<({Future<Uint8List> future, bool acquiredPendingRequestRef})>
     _getThumbnailFromServerRequest(EnteFile file) async {
   final cachedThumbnail = cachedThumbnailPath(file);
-  if (await cachedThumbnail.exists()) {
-    final data = await cachedThumbnail.readAsBytes();
-    ThumbnailInMemoryLruCache.put(file, data);
+  final cachedData = await _readCachedThumbnailIfPresent(cachedThumbnail, file);
+  if (cachedData != null) {
     return (
-      future: Future<Uint8List>.value(data),
+      future: Future<Uint8List>.value(cachedData),
       acquiredPendingRequestRef: false,
     );
   }
@@ -140,9 +150,12 @@ Future<Uint8List?> getThumbnailFromLocal(
   }
   if (file.isUploaded) {
     final cachedThumbnail = cachedThumbnailPath(file);
-    if ((await cachedThumbnail.exists())) {
-      final data = await cachedThumbnail.readAsBytes();
-      ThumbnailInMemoryLruCache.put(file, data);
+    final data = await _readCachedThumbnailIfPresent(
+      cachedThumbnail,
+      file,
+      size: size,
+    );
+    if (data != null) {
       return data;
     }
   }
@@ -259,11 +272,8 @@ Future<void> _downloadAndDecryptThumbnail(FileDownloadItem item) async {
   }
   ThumbnailInMemoryLruCache.put(item.file, data);
   final cachedThumbnail = cachedThumbnailPath(item.file);
-  if (await cachedThumbnail.exists()) {
-    await cachedThumbnail.delete();
-  }
-  // data is already cached in-memory, no need to await on dist write
-  unawaited(cachedThumbnail.writeAsBytes(data));
+  // data is already cached in-memory, no need to await on disk write
+  unawaited(_writeCachedThumbnail(cachedThumbnail, data));
   if (_uploadIDToDownloadItem.containsKey(file.uploadedFileID)) {
     try {
       item.completer.complete(data);
@@ -274,6 +284,67 @@ Future<void> _downloadAndDecryptThumbnail(FileDownloadItem item) async {
     }
   }
 }
+
+Future<Uint8List?> _readCachedThumbnailIfPresent(
+  File cachedThumbnail,
+  EnteFile file, {
+  int? size,
+}) async {
+  if (!await cachedThumbnail.exists()) {
+    return null;
+  }
+  try {
+    final data = await cachedThumbnail.readAsBytes();
+    ThumbnailInMemoryLruCache.put(file, data, size);
+    return data;
+  } on FileSystemException catch (e) {
+    if (_isPathMissing(e)) {
+      _logger.info(
+        "Thumbnail cache file missing during read; treating as cache miss: "
+        "${cachedThumbnail.path}",
+      );
+      return null;
+    }
+    rethrow;
+  }
+}
+
+Future<bool> _writeCachedThumbnail(
+  File cachedThumbnail,
+  Uint8List data, {
+  bool flush = false,
+}) async {
+  try {
+    await cachedThumbnail.writeAsBytes(data, flush: flush);
+    return true;
+  } on FileSystemException catch (e) {
+    if (!_isPathMissing(e)) {
+      rethrow;
+    }
+    _logger.info(
+      "Thumbnail cache directory missing during write; recreating: "
+      "${cachedThumbnail.parent.path}",
+    );
+    await cachedThumbnail.parent.create(recursive: true);
+    try {
+      await cachedThumbnail.writeAsBytes(data, flush: flush);
+      return true;
+    } on FileSystemException catch (retryError) {
+      if (_isPathMissing(retryError)) {
+        _logger.info(
+          "Thumbnail cache path still missing after recreate; skipping write: "
+          "${cachedThumbnail.path}",
+        );
+        return false;
+      }
+      rethrow;
+    }
+  }
+}
+
+bool _isPathMissing(FileSystemException e) =>
+    e is PathNotFoundException ||
+    e.osError?.errorCode == _noSuchFileOrDirectoryErrorCode;
 
 File cachedThumbnailPath(EnteFile file) {
   final thumbnailCacheDirectory =


### PR DESCRIPTION
## Summary
- Treat missing thumbnail cache files as cache misses when Android removes files from the app cache directory between `exists` and `readAsBytes`.
- Recreate the thumbnail cache directory on missing-path write failures, then retry the best-effort cache write.
- Keep this handling local to the thumbnail path instead of adding a Sentry filter.

Sentry: PHOTOS-MOBILE-9PQ

## Testing
- `dart format mobile/apps/photos/lib/utils/thumbnail_util.dart`
- `dart analyze lib/utils/thumbnail_util.dart`
- `flutter analyze` still fails on existing localization/generated-string errors outside this diff.