### PR TITLE
[cli] Write per-file metadata sidecars to metadata/ directory on export

### DIFF
--- a/cli/pkg/disk.go
+++ b/cli/pkg/disk.go
@@ -14,6 +14,7 @@ import (
 const (
 	albumMetaFile   = "album_meta.json"
 	albumMetaFolder = ".meta"
+	metadataFolder  = "metadata"
 )
 
 type albumDiskInfo struct {

--- a/cli/pkg/disk_test.go
+++ b/cli/pkg/disk_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func TestFolderConstants(t *testing.T) {
+	if albumMetaFolder != ".meta" {
+		t.Errorf("albumMetaFolder = %q, want %q", albumMetaFolder, ".meta")
+	}
+	if metadataFolder != "metadata" {
+		t.Errorf("metadataFolder = %q, want %q", metadataFolder, "metadata")
+	}
+}
+
 func TestGenerateUniqueFileName(t *testing.T) {
 	existingFilenames := make(map[string]bool)
 	testFilename := "FullSizeRender.jpg" // what Apple calls shared files

--- a/cli/pkg/remote_to_disk_album.go
+++ b/cli/pkg/remote_to_disk_album.go
@@ -44,7 +44,10 @@ func (c *ClICtrl) createLocalFolderForRemoteAlbums(ctx context.Context, account 
 
 		if metaByID != nil {
 			if strings.EqualFold(metaByID.AlbumName, album.AlbumName) {
-				//log.Printf("Skipping album %s as it already exists", album.AlbumName)
+				existingAlbumPath := filepath.Join(path, metaByID.FolderName)
+				if err = migrateMetaToMetadataDir(existingAlbumPath); err != nil {
+					return err
+				}
 				continue
 			}
 		}
@@ -68,10 +71,11 @@ func (c *ClICtrl) createLocalFolderForRemoteAlbums(ctx context.Context, account 
 		}
 		// Create album and meta folders if they don't exist
 		albumPath := filepath.Clean(filepath.Join(path, albumFolderName))
-		metaPath := filepath.Join(albumPath, ".meta")
+		metaPath := filepath.Join(albumPath, albumMetaFolder)
+		metadataPath := filepath.Join(albumPath, metadataFolder)
 		if metaByID == nil {
 			log.Printf("Adding folder %s for album %s", albumFolderName, album.AlbumName)
-			for _, p := range []string{albumPath, metaPath} {
+			for _, p := range []string{albumPath, metaPath, metadataPath} {
 				if _, err := os.Stat(p); os.IsNotExist(err) {
 					if err = os.Mkdir(p, 0755); err != nil {
 						return err
@@ -83,6 +87,9 @@ func (c *ClICtrl) createLocalFolderForRemoteAlbums(ctx context.Context, account 
 			oldAlbumPath := filepath.Join(path, metaByID.FolderName)
 			log.Printf("Renaming path from %s to %s for album %s", oldAlbumPath, albumPath, album.AlbumName)
 			if err = os.Rename(oldAlbumPath, albumPath); err != nil {
+				return err
+			}
+			if err = migrateMetaToMetadataDir(albumPath); err != nil {
 				return err
 			}
 		}
@@ -101,6 +108,32 @@ func (c *ClICtrl) createLocalFolderForRemoteAlbums(ctx context.Context, account 
 		}
 		folderToMetaMap[albumFolderName] = &metaData
 		albumIDToMetaMap[albumID] = &metaData
+	}
+	return nil
+}
+
+// migrateMetaToMetadataDir creates the metadata/ directory if it doesn't exist and moves
+// any per-file JSON sidecars out of .meta/ into it. album_meta.json is left in .meta/.
+func migrateMetaToMetadataDir(albumPath string) error {
+	metadataPath := filepath.Join(albumPath, metadataFolder)
+	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+		if err = os.Mkdir(metadataPath, 0755); err != nil {
+			return err
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(albumPath, albumMetaFolder))
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == albumMetaFile || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		src := filepath.Join(albumPath, albumMetaFolder, entry.Name())
+		dst := filepath.Join(albumPath, metadataFolder, entry.Name())
+		if err = os.Rename(src, dst); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cli/pkg/remote_to_disk_file.go
+++ b/cli/pkg/remote_to_disk_file.go
@@ -197,7 +197,7 @@ func (c *ClICtrl) downloadEntry(ctx context.Context,
 			return err
 		}
 
-		err = writeJSONToFile(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, ".meta", diskMetaFileName), fileDiskMetadata)
+		err = writeJSONToFile(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, metadataFolder, diskMetaFileName), fileDiskMetadata)
 		if err != nil {
 			return err
 		}
@@ -213,7 +213,7 @@ func (c *ClICtrl) downloadEntry(ctx context.Context,
 func removeDiskFile(diskFileMeta *export.DiskFileMetadata, diskInfo *albumDiskInfo) error {
 	// remove the file from disk
 	log.Printf("Removing file %s from disk", diskFileMeta.MetaFileName)
-	err := os.Remove(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, ".meta", diskFileMeta.MetaFileName))
+	err := os.Remove(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, metadataFolder, diskFileMeta.MetaFileName))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -228,11 +228,11 @@ func removeDiskFile(diskFileMeta *export.DiskFileMetadata, diskInfo *albumDiskIn
 
 // readFolderMetadata reads the metadata of the files in the given path
 // For disk export, a particular albums files are stored in a folder named after the album.
-// Inside the folder, the files are stored at top level and its metadata is stored in a .meta folder
+// Inside the folder, the files are stored at top level and its metadata is stored in a metadata folder
 func readFilesMetadata(home string, albumMeta *export.AlbumMetadata) (*albumDiskInfo, error) {
-	albumMetadataFolder := filepath.Join(home, albumMeta.FolderName, albumMetaFolder)
+	albumMetadataFolder := filepath.Join(home, albumMeta.FolderName, metadataFolder)
 	albumPath := filepath.Join(home, albumMeta.FolderName)
-	// verify the both the album folder and the .meta folder exist
+	// verify both the album folder and the metadata folder exist
 	if _, err := os.Stat(albumMetadataFolder); err != nil {
 		return nil, err
 	}
@@ -260,9 +260,6 @@ func readFilesMetadata(home string, albumMeta *export.AlbumMetadata) (*albumDisk
 	for _, entry := range metaEntries {
 		if !entry.IsDir() {
 			fileName := entry.Name()
-			if fileName == albumMetaFile {
-				continue
-			}
 			if !strings.HasSuffix(fileName, ".json") {
 				log.Printf("Skipping file %s as it is not a JSON file", fileName)
 				continue

--- a/cli/pkg/remote_to_disk_file_test.go
+++ b/cli/pkg/remote_to_disk_file_test.go
@@ -1,0 +1,135 @@
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ente-io/cli/pkg/model/export"
+)
+
+func TestReadFilesMetadata_readsFromMetadataDir(t *testing.T) {
+	dir := t.TempDir()
+	albumFolderName := "TestAlbum"
+	albumPath := filepath.Join(dir, albumFolderName)
+	metaPath := filepath.Join(albumPath, albumMetaFolder)
+	metadataPath := filepath.Join(albumPath, metadataFolder)
+
+	for _, p := range []string{albumPath, metaPath, metadataPath} {
+		if err := os.Mkdir(p, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	// write a placeholder image file at the album root so FileNames is populated
+	imageFileName := "photo.jpg"
+	if err := os.WriteFile(filepath.Join(albumPath, imageFileName), []byte(""), 0644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	// write a sidecar JSON into metadata/
+	sidecarFileName := "photo.jpg.json"
+	sidecar := export.DiskFileMetadata{
+		Title:            "photo.jpg",
+		CreationTime:     time.Now(),
+		ModificationTime: time.Now(),
+		Info: &export.Info{
+			ID:        42,
+			OwnerID:   1,
+			FileNames: []string{imageFileName},
+		},
+	}
+	sidecarBytes, err := json.Marshal(sidecar)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(metadataPath, sidecarFileName), sidecarBytes, 0644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	diskInfo, err := readFilesMetadata(dir, &export.AlbumMetadata{
+		ID:         1,
+		FolderName: albumFolderName,
+		AlbumName:  "TestAlbum",
+	})
+	if err != nil {
+		t.Fatalf("readFilesMetadata() error = %v", err)
+	}
+
+	if _, ok := (*diskInfo.FileIdToDiskFileMap)[42]; !ok {
+		t.Errorf("file ID 42 not found in FileIdToDiskFileMap")
+	}
+	if _, ok := (*diskInfo.MetaFileNameToDiskFileMap)[strings.ToLower(sidecarFileName)]; !ok {
+		t.Errorf("%q not found in MetaFileNameToDiskFileMap", sidecarFileName)
+	}
+	if _, ok := (*diskInfo.FileNames)[strings.ToLower(imageFileName)]; !ok {
+		t.Errorf("%q not found in FileNames", imageFileName)
+	}
+}
+
+func TestReadFilesMetadata_failsWithoutMetadataDir(t *testing.T) {
+	dir := t.TempDir()
+	albumFolderName := "TestAlbum"
+	albumPath := filepath.Join(dir, albumFolderName)
+	metaPath := filepath.Join(albumPath, albumMetaFolder)
+
+	// create album and .meta but NOT metadata/
+	for _, p := range []string{albumPath, metaPath} {
+		if err := os.Mkdir(p, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	_, err := readFilesMetadata(dir, &export.AlbumMetadata{
+		ID:         1,
+		FolderName: albumFolderName,
+		AlbumName:  "TestAlbum",
+	})
+	if err == nil {
+		t.Error("expected error when metadata/ dir is absent, got nil")
+	}
+}
+
+func TestMigrateMetaToMetadataDir(t *testing.T) {
+	dir := t.TempDir()
+	metaPath := filepath.Join(dir, albumMetaFolder)
+	metadataPath := filepath.Join(dir, metadataFolder)
+
+	if err := os.Mkdir(metaPath, 0755); err != nil {
+		t.Fatalf("mkdir .meta: %v", err)
+	}
+
+	// write album_meta.json (should stay in .meta/) and two sidecars (should move)
+	files := map[string]string{
+		albumMetaFile: `{"id":1}`,
+		"photo.jpg.json":  `{"title":"photo.jpg"}`,
+		"video.mp4.json":  `{"title":"video.mp4"}`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(metaPath, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	if err := migrateMetaToMetadataDir(dir); err != nil {
+		t.Fatalf("migrateMetaToMetadataDir() error = %v", err)
+	}
+
+	// album_meta.json must remain in .meta/
+	if _, err := os.Stat(filepath.Join(metaPath, albumMetaFile)); err != nil {
+		t.Errorf("%s missing from .meta/: %v", albumMetaFile, err)
+	}
+
+	// sidecars must be in metadata/ and gone from .meta/
+	for _, name := range []string{"photo.jpg.json", "video.mp4.json"} {
+		if _, err := os.Stat(filepath.Join(metadataPath, name)); err != nil {
+			t.Errorf("%s missing from metadata/: %v", name, err)
+		}
+		if _, err := os.Stat(filepath.Join(metaPath, name)); err == nil {
+			t.Errorf("%s still present in .meta/ after migration", name)
+		}
+	}
+}


### PR DESCRIPTION
See #10358. This behavior may not be desired at all, and/or could be implemented more easily as a breaking change, but I thought I would working it up.

## Description

Replaces the previous `.meta/` location for per-file JSON sidecars with `metadata/`, matching the directory name used by the Ente desktop app. The `.meta/` folder is  retained solely for `album_meta.json` (CLI-internal album tracking).

On the next sync run, existing exports are migrated in place: `createLocalFolderForRemoteAlbums()` creates `metadata/` for any album folder that doesn't already have it  and moves all per-file sidecars out of `.meta/` into `metadata/`. `album_meta.json` is left in `.meta/`. No files are re-downloaded.

After migration, the `metadata/` directory contents are identical in structure to what the Ente desktop app produces. The only difference is the presence of `.meta/album_meta.json`, which is CLI-specific bookkeeping with no desktop equivalent.

## Tests

  - `TestFolderConstants` — verifies that `albumMetaFolder` and `metadataFolder` hold their expected string values, guarding against accidental constant changes that would silently break the export directory structure.
  - `TestReadFilesMetadata_readsFromMetadataDir` — integration test using a temp directory that verifies sidecars written to `metadata/` are correctly read back into the file tracking maps.
  - `TestReadFilesMetadata_failsWithoutMetadataDir` — verifies that `readFilesMetadata()` returns an error when `metadata/` is absent, confirming the sync will not silently proceed in a broken state.
  - `TestMigrateMetaToMetadataDir` — verifies that per-file sidecars are moved from `.meta/` into `metadata/` and that `album_meta.json` is left in place.