### PR TITLE
[auth] Add custom icon for Racket Coach

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -46,8 +46,8 @@
       "hex": "0000ff"
     },
     {
-      "title":"Ahrefs",
-      "slug":"ahrefs"
+      "title": "Ahrefs",
+      "slug": "ahrefs"
     },
     {
       "title": "Airtable"
@@ -64,7 +64,7 @@
     {
       "title": "aliyun",
       "altNames": [
-        "阿里云"
+        "\u963f\u91cc\u4e91"
       ]
     },
     {
@@ -99,7 +99,7 @@
       "title": "Ankara University",
       "slug": "ankara_university",
       "altNames": [
-        "Ankara Üniversitesi"
+        "Ankara \u00dcniversitesi"
       ]
     },
     {
@@ -186,7 +186,7 @@
       "title": "BaiduCloud",
       "slug": "baidu_cloud",
       "altNames": [
-        "百度云",
+        "\u767e\u5ea6\u4e91",
         "baiduyun"
       ]
     },
@@ -228,7 +228,7 @@
       "title": "Binance",
       "slug": "binance_exchange",
       "altNames": [
-        "币安"
+        "\u5e01\u5b89"
       ]
     },
     {
@@ -367,10 +367,10 @@
       "title": "Bugzilla"
     },
     {
-      "title": "Bundesagentur für Arbeit",
+      "title": "Bundesagentur f\u00fcr Arbeit",
       "slug": "bundesagentur_fur_arbeit",
       "altNames": [
-        "Agentur für Arbeit"
+        "Agentur f\u00fcr Arbeit"
       ]
     },
     {
@@ -846,7 +846,7 @@
       "slug": "fzj",
       "hex": "023d6b",
       "altNames": [
-        "Forschungszentrum Jülich",
+        "Forschungszentrum J\u00fclich",
         "FZJ IdP",
         "iffLogin"
       ]
@@ -888,7 +888,7 @@
       "title": "Gosuslugi",
       "slug": "gosuslugi",
       "altNames": [
-        "Госуслуги"
+        "\u0413\u043e\u0441\u0443\u0441\u043b\u0443\u0433\u0438"
       ]
     },
     {
@@ -1070,7 +1070,7 @@
     {
       "title": "jianguoyun",
       "altNames": [
-        "坚果云"
+        "\u575a\u679c\u4e91"
       ]
     },
     {
@@ -1162,7 +1162,7 @@
       "title": "Lark",
       "slug": "lark",
       "altNames": [
-        "飞书"
+        "\u98de\u4e66"
       ]
     },
     {
@@ -1317,7 +1317,7 @@
         "MyFigureCollection.net",
         "MFC"
       ]
-    },    
+    },
     {
       "title": "microsoft"
     },
@@ -1426,7 +1426,7 @@
       "title": "NeteaseMail",
       "slug": "netease_mail",
       "altNames": [
-        "网易邮箱",
+        "\u7f51\u6613\u90ae\u7bb1",
         "Mail.163"
       ]
     },
@@ -1463,7 +1463,7 @@
       "title": "nintendo",
       "hex": "ffffff",
       "altNames": [
-        "任天堂",
+        "\u4efb\u5929\u5802",
         "Nintendo Account"
       ]
     },
@@ -1524,7 +1524,7 @@
       "title": "okx",
       "hex": "000000",
       "altNames": [
-        "欧易"
+        "\u6b27\u6613"
       ]
     },
     {
@@ -1618,7 +1618,7 @@
       "title": "Peking University",
       "slug": "peking_university",
       "altNames": [
-        "北京大学",
+        "\u5317\u4eac\u5927\u5b66",
         "PKU",
         "Peking Univ"
       ]
@@ -1730,7 +1730,7 @@
     {
       "title": "qiniuyun",
       "altNames": [
-        "七牛云",
+        "\u4e03\u725b\u4e91",
         "qiniu"
       ]
     },
@@ -1744,6 +1744,15 @@
       "altNames": [
         "R10",
         "r10.net"
+      ]
+    },
+    {
+      "title": "Racket Coach",
+      "slug": "racket_coach",
+      "hex": "16a34a",
+      "altNames": [
+        "racketcoach",
+        "racketcoach.app"
       ]
     },
     {
@@ -1880,7 +1889,7 @@
         "sei",
         "sei!",
         "SEI!",
-        "Sistema Eletrônico de Informações",
+        "Sistema Eletr\u00f4nico de Informa\u00e7\u00f5es",
         "SEI/SEDE"
       ]
     },
@@ -2053,7 +2062,7 @@
       "title": "tencent cloud",
       "slug": "tencent_cloud",
       "altNames": [
-        "腾讯云",
+        "\u817e\u8baf\u4e91",
         "tencentcloud"
       ]
     },
@@ -2061,7 +2070,7 @@
       "title": "tencent cloud",
       "slug": "tencent_cloud",
       "altNames": [
-        "腾讯云",
+        "\u817e\u8baf\u4e91",
         "tencentcloud"
       ]
     },
@@ -2103,7 +2112,7 @@
     {
       "title": "tianyiyun",
       "altNames": [
-        "天翼云"
+        "\u5929\u7ffc\u4e91"
       ]
     },
     {
@@ -2162,7 +2171,7 @@
       "title": "TU Dresden",
       "slug": "tu_dresden",
       "altNames": [
-        "Technische Universität Dresden",
+        "Technische Universit\u00e4t Dresden",
         "Dresden University of Technology"
       ],
       "hex": "00305d"
@@ -2257,7 +2266,7 @@
       "title": "VGN",
       "slug": "vgn",
       "altNames": [
-        "Ver­kehrs­ver­bund Groß­raum Nürn­berg"
+        "Ver\u00adkehrs\u00adver\u00adbund Gro\u00df\u00adraum N\u00fcrn\u00adberg"
       ]
     },
     {
@@ -2283,7 +2292,7 @@
     {
       "title": "volcengine",
       "altNames": [
-        "火山引擎"
+        "\u706b\u5c71\u5f15\u64ce"
       ]
     },
     {
@@ -2322,9 +2331,9 @@
       "title": "WHMCS"
     },
     {
-       "title": "Wick"
+      "title": "Wick"
     },
-    {     
+    {
       "title": "Windscribe"
     },
     {
@@ -2391,7 +2400,7 @@
       "slug": "yandex",
       "altNames": [
         "Ya",
-        "Яндекс"
+        "\u042f\u043d\u0434\u0435\u043a\u0441"
       ]
     },
     {

--- a/mobile/apps/auth/assets/custom-icons/icons/racket_coach.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/racket_coach.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Racket Coach">
+  <title>Racket Coach</title>
+  <!-- Brand green: #16a34a. Single-colour silhouette so it sits well in
+       both light and dark themes; Ente Auth pairs the fill with the
+       theme background. -->
+  <g fill="#16a34a">
+    <!-- Racket head: filled rim with hollow centre (using fill-rule
+         evenodd to subtract the inner ellipse). -->
+    <path fill-rule="evenodd" d="M9 1.5a7 7 0 1 0 0 14A7 7 0 0 0 9 1.5Zm0 2a5 5 0 1 1 0 10A5 5 0 0 1 9 3.5Z"/>
+    <!-- Stringbed: 2 horizontal + 2 vertical lines, slim rectangles. -->
+    <rect x="4.2"  y="8.4" width="9.6" height="0.5" rx="0.25"/>
+    <rect x="4.2"  y="9.6" width="9.6" height="0.5" rx="0.25"/>
+    <rect x="8.4"  y="4.2" width="0.5" height="9.6" rx="0.25"/>
+    <rect x="9.6"  y="4.2" width="0.5" height="9.6" rx="0.25"/>
+    <!-- Handle/throat going to bottom-right at 45 deg. Two parts: short
+         throat connecting the rim to the grip, and a longer grip. -->
+    <path d="M13.05 13.05 L14.5 11.6 L21.4 18.5 L18.5 21.4 L11.6 14.5 Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
Issuer: `Racket Coach` (racketcoach.app — UK SaaS booking platform for racket-sport coaches).

Brand colour: `#16a34a`. Single-colour SVG tennis-racket silhouette, 1.1 KB — well under the 20 KB ceiling. Added `altNames` for `racketcoach` and `racketcoach.app` so the matcher catches both the space-stripped issuer and the full domain that some clients use.

JSON entry inserted alphabetically between `RackNerd` and `RaiderIO`.