### PR TITLE
Fix noisy stack trace logging

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -340,6 +340,10 @@ class SuperLogging {
     LogRecord? rec,
   }) async {
     try {
+      if (kDebugMode && error is StackTrace) {
+        _reportInvalidLoggerUsageInDebug(rec, error);
+      }
+
       if (_shouldSkipSentry(error)) {
         return;
       }
@@ -373,6 +377,27 @@ class SuperLogging {
       $.info('Sending report to sentry failed: $e');
       $.info('Original error: $error');
     }
+  }
+
+  static void _reportInvalidLoggerUsageInDebug(
+    LogRecord? rec,
+    StackTrace stack,
+  ) {
+    assert(() {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: StateError(
+            "Logger call passed a StackTrace as the error argument. "
+            "Use logger.warning(message, error, stackTrace) or "
+            "logger.severe(message, error, stackTrace)."
+            "${rec == null ? '' : ' Logger: ${rec.loggerName}.'}",
+          ),
+          stack: stack,
+          library: "SuperLogging",
+        ),
+      );
+      return true;
+    }());
   }
 
   /// Determine execution context from prefix

--- a/mobile/apps/photos/lib/emergency/recover_others_account.dart
+++ b/mobile/apps/photos/lib/emergency/recover_others_account.dart
@@ -288,7 +288,7 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
       );
       Navigator.of(context).pop();
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to recover account", e, s);
       await dialog.hide();
       showGenericErrorBottomSheet(context: context, error: e).ignore();
     }

--- a/mobile/apps/photos/lib/services/account/billing_service.dart
+++ b/mobile/apps/photos/lib/services/account/billing_service.dart
@@ -84,7 +84,7 @@ class BillingService {
             paymentProvider ?? (Platform.isAndroid ? "playstore" : "appstore"),
       );
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to verify subscription", e, s);
       rethrow;
     }
   }
@@ -93,7 +93,7 @@ class BillingService {
     try {
       return await _gateway.getSubscription();
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to fetch subscription", e, s);
       rethrow;
     }
   }
@@ -102,7 +102,7 @@ class BillingService {
     try {
       return await _gateway.cancelStripeSubscription();
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to cancel Stripe subscription", e, s);
       rethrow;
     }
   }
@@ -111,7 +111,7 @@ class BillingService {
     try {
       return await _gateway.activateStripeSubscription();
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to activate Stripe subscription", e, s);
       rethrow;
     }
   }
@@ -124,7 +124,7 @@ class BillingService {
         redirectURL: kWebPaymentRedirectUrl,
       );
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to fetch Stripe customer portal URL", e, s);
       rethrow;
     }
   }

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -188,7 +188,7 @@ class UserService {
       }
     } catch (e, s) {
       await dialog.hide();
-      _logger.severe(e, s);
+      _logger.severe("Failed to send OTT", e, s);
       unawaited(showGenericErrorBottomSheet(context: context, error: e));
     }
   }
@@ -1081,7 +1081,7 @@ class UserService {
       return true;
     } catch (e, s) {
       await dialog.hide();
-      _logger.severe(e, s);
+      _logger.severe("Failed to enable 2FA", e, s);
       if (e is DioException) {
         if (e.response != null && e.response!.statusCode == 401) {
           // ignore: unawaited_futures
@@ -1168,7 +1168,7 @@ class UserService {
         await dialog.hide();
       } catch (e, s) {
         await dialog.hide();
-        _logger.severe(e, s);
+        _logger.severe("Failed to create recovery key", e, s);
         rethrow;
       }
     }

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -1455,7 +1455,7 @@ class CollectionsService {
       }
       return collections;
     } catch (e, s) {
-      _logger.warning(e, s);
+      _logger.warning("Failed to fetch collections", e, s);
       if (e is DioException && e.response?.statusCode == 401) {
         throw UnauthorizedError();
       }
@@ -1648,7 +1648,7 @@ class CollectionsService {
       );
       return null;
     } catch (e, s) {
-      _logger.warning(e, s);
+      _logger.warning("Failed to fetch public collection", e, s);
       _logger.severe("Failed to fetch public collection");
       await showGenericErrorDialog(context: context, error: e);
       rethrow;

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart
@@ -206,7 +206,7 @@ class FaceClusteringService extends SuperIsolate {
         return clusterResult;
       }
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Face clustering prediction failed", e, s);
       rethrow;
     }
   }
@@ -268,7 +268,7 @@ class FaceClusteringService extends SuperIsolate {
       );
       return faceIdToCluster;
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Linear face clustering failed", e, s);
       rethrow;
     }
   }
@@ -316,7 +316,7 @@ class FaceClusteringService extends SuperIsolate {
       );
       return clusteringResult;
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Complete face clustering failed", e, s);
       rethrow;
     }
   }

--- a/mobile/apps/photos/lib/services/sync/diff_fetcher.dart
+++ b/mobile/apps/photos/lib/services/sync/diff_fetcher.dart
@@ -253,7 +253,7 @@ class DiffFetcher {
           'diff items ( ${updatedFiles.length} updated) in ${DateTime.now().difference(startTime).inMilliseconds}ms');
       return Diff(updatedFiles, deletedFiles, hasMore, latestUpdatedAtTime);
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to parse collection diff", e, s);
       rethrow;
     }
   }

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -234,7 +234,7 @@ class TrashSyncService {
         latestUpdatedAtTime,
       );
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to parse trash diff", e, s);
       rethrow;
     }
   }

--- a/mobile/apps/photos/lib/ui/account/password_entry_page.dart
+++ b/mobile/apps/photos/lib/ui/account/password_entry_page.dart
@@ -351,7 +351,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
         Navigator.of(context).popUntil((route) => route.isFirst);
       }
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to change password", e, s);
       await dialog.hide();
       await showGenericErrorBottomSheet(context: context, error: e);
     }
@@ -409,7 +409,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
             (route) => route.isFirst,
           );
         } catch (e, s) {
-          _logger.severe(e, s);
+          _logger.severe("Failed to configure account", e, s);
           await dialog.hide();
           await showGenericErrorBottomSheet(context: context, error: e);
         }

--- a/mobile/apps/photos/lib/ui/actions/collection/collection_file_actions.dart
+++ b/mobile/apps/photos/lib/ui/actions/collection/collection_file_actions.dart
@@ -317,7 +317,7 @@ extension CollectionFileActions on CollectionActions {
           .updateFavorites(context, files, markAsFavorite);
       return true;
     } catch (e, s) {
-      logger.severe(e, s);
+      logger.severe("Failed to update favorites", e, s);
       showShortToast(
         context,
         markAsFavorite

--- a/mobile/apps/photos/lib/ui/tools/collage/collage_creator_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/collage/collage_creator_page.dart
@@ -88,7 +88,7 @@ class _CollageCreatorPageState extends State<CollageCreatorPage> {
         result: true,
       );
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to create collage", e, s);
       showShortToast(
         context,
         AppLocalizations.of(context).somethingWentWrong,

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -135,7 +135,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     } catch (e, s) {
       await dialog.hide();
       showToast(context, AppLocalizations.of(context).oopsCouldNotSaveEdits);
-      _logger.severe(e, s);
+      _logger.severe("Failed to save image edits", e, s);
     } finally {
       await PhotoManager.startChangeNotify();
     }

--- a/mobile/apps/photos/lib/ui/tools/lock_screen.dart
+++ b/mobile/apps/photos/lib/ui/tools/lock_screen.dart
@@ -377,7 +377,7 @@ class _LockScreenState extends State<LockScreen>
       }
     } catch (e, s) {
       _isShowingLockScreen = false;
-      _logger.severe(e, s);
+      _logger.severe("Failed to show lock screen", e, s);
     }
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/file_details/albums_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/albums_item_widget.dart
@@ -67,7 +67,7 @@ class AlbumsItemWidget extends StatelessWidget {
       }
       return chipButtons;
     } catch (e, s) {
-      Logger("AlbumsItemWidget").info(e, s);
+      Logger("AlbumsItemWidget").info("Failed to build owned album chips", e, s);
       return [];
     }
   }
@@ -125,7 +125,7 @@ class AlbumsItemWidget extends StatelessWidget {
 
       return chipButtons;
     } catch (e, s) {
-      Logger("AlbumsItemWidget").info(e, s);
+      Logger("AlbumsItemWidget").info("Failed to build shared album chips", e, s);
       return [];
     }
   }

--- a/mobile/apps/photos/lib/ui/viewer/file_details/favorite_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/favorite_widget.dart
@@ -121,7 +121,7 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
         );
         _stateMachine?.trigger("Filled")?.fire();
       } catch (e, s) {
-        _logger.severe(e, s);
+        _logger.severe("Failed to add file to favorites", e, s);
         hasError = true;
         showToast(
           context,
@@ -139,7 +139,7 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
           widget.file.copyWith(),
         );
       } catch (e, s) {
-        _logger.severe(e, s);
+        _logger.severe("Failed to remove file from favorites", e, s);
         hasError = true;
         showToast(
           context,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -1013,7 +1013,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
         );
       }
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to open share collection dialog", e, s);
       await showGenericErrorDialog(context: context, error: e);
     }
   }
@@ -1050,7 +1050,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
         await showAddPhotosSheet(bContext, collection!);
       }
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to show add photo dialog", e, s);
       await showGenericErrorDialog(context: bContext, error: e);
     }
   }

--- a/mobile/packages/accounts/lib/pages/password_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_entry_page.dart
@@ -455,7 +455,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
         Navigator.of(context).popUntil((route) => route.isFirst);
       }
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to change password", e, s);
       await dialog.hide();
       // ignore: unawaited_futures
       showGenericErrorDialog(
@@ -551,7 +551,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
             (route) => false,
           );
         } catch (e, s) {
-          _logger.severe(e, s);
+          _logger.severe("Failed to configure account", e, s);
           await dialog.hide();
           // ignore: unawaited_futures
           showGenericErrorDialog(

--- a/mobile/packages/legacy/lib/pages/recover_others_account.dart
+++ b/mobile/packages/legacy/lib/pages/recover_others_account.dart
@@ -344,7 +344,7 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
       );
       Navigator.of(context).pop();
     } catch (e, s) {
-      _logger.severe(e, s);
+      _logger.severe("Failed to recover account", e, s);
       await dialog.hide();
       await showGenericErrorDialog(context: context, error: e);
     }

--- a/mobile/packages/lock_screen/lib/ui/lock_screen.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen.dart
@@ -10,7 +10,6 @@ import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:logging/logging.dart';
 
@@ -365,7 +364,7 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
       }
     } catch (e, s) {
       _isShowingLockScreen = false;
-      _logger.severe(e, s);
+      _logger.severe("Failed to show lock screen", e, s);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix logger calls that passed the caught `StackTrace` as the error argument.
- Add a debug-only SuperLogging alert when a StackTrace is captured as the error object.
- Use operation-specific log messages so Sentry groups on the real underlying exception.

## Root cause
Some calls used `logger.warning(e, s)` or `logger.severe(e, s)`, which Dart logging treats as `message = e` and `error = s`. That caused Sentry to receive `_StackTrace` as the captured exception instead of the original error.

Sentry issue: PHOTOS-MOBILE-54T

## Validation
- `git diff --check`
- Targeted `flutter analyze` for touched Photos files
- Targeted `flutter analyze` for touched `accounts`, `legacy`, and `lock_screen` package files

Full Photos `flutter analyze` is still blocked by unrelated baseline errors on `main`.