### PR TITLE
Stop reporting expected logs to Sentry

### DIFF
--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -85,9 +85,9 @@ class LocalSyncService {
       final permissionState =
           await permissionService.requestPhotoMangerPermissions();
       if (permissionState != PermissionState.authorized) {
-        _logger.severe(
-          "sync requested with invalid permission",
-          permissionState.toString(),
+        _logger.warning(
+          "Skipping local sync because Android gallery permission is "
+          "$permissionState",
         );
         return;
       }

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -47,6 +47,8 @@ import "package:photos/utils/gzip.dart";
 import "package:photos/utils/network_util.dart";
 
 const _maxRetryCount = 3;
+const _maxFfmpegOutputLines = 24;
+const _maxFfmpegOutputChars = 4000;
 
 class VideoPreviewService {
   final _logger = Logger("VideoPreviewService");
@@ -668,11 +670,12 @@ class VideoPreviewService {
         }
       } else {
         final output = playlistGenResult["output"] as String?;
-        _logger.shout(
-          "FFmpeg command failed with return code $playlistGenReturnCode",
-          output ?? "Error not found",
+        _logger.warning(
+          "FFmpeg command failed with return code $playlistGenReturnCode\n"
+          "${_summarizeFfmpegOutput(output)}",
         );
-        error = "Failed to generate video preview\nError: $output";
+        error =
+            "Failed to generate video preview (return code $playlistGenReturnCode)";
       }
 
       if (error == null) {
@@ -1440,4 +1443,30 @@ class VideoPreviewService {
       }
     });
   }
+}
+
+String _summarizeFfmpegOutput(String? output) {
+  final trimmedOutput = output?.trim();
+  if (trimmedOutput == null || trimmedOutput.isEmpty) {
+    return "FFmpeg output unavailable";
+  }
+
+  final lines = const LineSplitter()
+      .convert(trimmedOutput)
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .toList();
+  final summarizedLines = lines.length > _maxFfmpegOutputLines
+      ? lines.sublist(lines.length - _maxFfmpegOutputLines)
+      : lines;
+  var summary = summarizedLines.join("\n");
+  if (summary.length > _maxFfmpegOutputChars) {
+    summary = summary.substring(summary.length - _maxFfmpegOutputChars);
+  }
+
+  final wasTruncated = lines.length > summarizedLines.length ||
+      trimmedOutput.length > _maxFfmpegOutputChars;
+  return wasTruncated
+      ? "FFmpeg output (truncated):\n$summary"
+      : "FFmpeg output:\n$summary";
 }


### PR DESCRIPTION
## Summary
- Log Android local sync permission skips without passing the permission state as an error object.
- Log failed FFmpeg preview generation output as a capped message instead of reporting stdout/stderr as an exception.
- Keep video preview retry/failure state concise instead of persisting full FFmpeg output blobs.

## Root cause
`SuperLogging` forwards any log record with `rec.error != null` to Sentry. The permission skip path passed `PermissionState.denied` / `PermissionState.limited` as the error argument, and the video preview path passed full FFmpeg output as the error argument. Both became noisy `String` exception groups instead of actionable app failures.

Sentry issue: PHOTOS-MOBILE-581

## Validation
- `git diff --check upstream/main...HEAD`
- `cd mobile/apps/photos && flutter analyze lib/services/sync/local_sync_service.dart lib/services/video_preview_service.dart`