### PR TITLE
[mob][photos] Fix anonymous public comment names

### DIFF
--- a/mobile/apps/photos/lib/models/social/comment_author_utils.dart
+++ b/mobile/apps/photos/lib/models/social/comment_author_utils.dart
@@ -1,0 +1,84 @@
+import "package:photos/models/api/collection/user.dart";
+import "package:photos/models/social/comment.dart";
+
+class CommentAuthorResolver {
+  final Map<int, User> _registeredUserCache = {};
+
+  User resolve({
+    required Comment comment,
+    required Map<String, String> anonDisplayNames,
+    required User Function(int userID) registeredUserResolver,
+  }) {
+    if (comment.isAnonymous) {
+      return _anonymousUserForComment(comment, anonDisplayNames);
+    }
+
+    return _registeredUserCache.putIfAbsent(
+      comment.userID,
+      () => registeredUserResolver(comment.userID),
+    );
+  }
+
+  void clear() {
+    _registeredUserCache.clear();
+  }
+}
+
+User _anonymousUserForComment(
+  Comment comment,
+  Map<String, String> anonDisplayNames,
+) {
+  final anonID = _normalizedAnonID(comment);
+  final displayName =
+      anonID != null ? (anonDisplayNames[anonID] ?? anonID) : "Anonymous";
+  return User(
+    id: comment.userID,
+    email: "${anonID ?? "anonymous"}@unknown.com",
+    name: displayName,
+  );
+}
+
+class MissingAnonProfileSyncTracker {
+  final Map<int, Set<String>> _attemptedIDsByCollection = {};
+
+  Set<String> nextIDsToSync({
+    required int collectionID,
+    required Iterable<Comment> comments,
+    required Map<String, String> anonDisplayNames,
+  }) {
+    final missingIDs = _missingAnonDisplayNameIDs(comments, anonDisplayNames);
+    if (missingIDs.isEmpty) {
+      return const <String>{};
+    }
+
+    final attemptedIDs = _attemptedIDsByCollection.putIfAbsent(
+      collectionID,
+      () => <String>{},
+    );
+    final nextIDs = missingIDs.difference(attemptedIDs);
+    attemptedIDs.addAll(nextIDs);
+    return nextIDs;
+  }
+}
+
+Set<String> _missingAnonDisplayNameIDs(
+  Iterable<Comment> comments,
+  Map<String, String> anonDisplayNames,
+) {
+  final missing = <String>{};
+  for (final comment in comments) {
+    final anonID = _normalizedAnonID(comment);
+    if (anonID != null && !anonDisplayNames.containsKey(anonID)) {
+      missing.add(anonID);
+    }
+  }
+  return missing;
+}
+
+String? _normalizedAnonID(Comment comment) {
+  if (!comment.isAnonymous) {
+    return null;
+  }
+  final anonID = comment.anonUserID?.trim();
+  return anonID == null || anonID.isEmpty ? null : anonID;
+}

--- a/mobile/apps/photos/lib/models/social/social_data_provider.dart
+++ b/mobile/apps/photos/lib/models/social/social_data_provider.dart
@@ -103,6 +103,11 @@ class SocialDataProvider {
     return SocialSyncService.instance.syncFileSocialData(collectionID, fileID);
   }
 
+  /// Syncs anonymous profiles for a collection.
+  Future<void> syncAnonProfiles(int collectionID) {
+    return SocialSyncService.instance.syncAnonProfiles(collectionID);
+  }
+
   // ============ Comment mutation methods ============
 
   /// Adds a comment via API, then stores locally.

--- a/mobile/apps/photos/lib/ui/social/comments_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/comments_screen.dart
@@ -10,6 +10,7 @@ import "package:photos/generated/l10n.dart";
 import "package:photos/models/api/collection/user.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/social/comment.dart";
+import "package:photos/models/social/comment_author_utils.dart";
 import "package:photos/models/social/reaction.dart";
 import "package:photos/models/social/social_data_provider.dart";
 import "package:photos/services/collections_service.dart";
@@ -133,7 +134,9 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
   Timer? _sendLoadingTimer;
   bool _hasMoreComments = true;
   int _offset = 0;
-  final Map<int, User> _userCache = {};
+  final CommentAuthorResolver _commentAuthorResolver = CommentAuthorResolver();
+  final MissingAnonProfileSyncTracker _anonProfileSyncTracker =
+      MissingAnonProfileSyncTracker();
   Map<String, String> _anonDisplayNames = {};
   String? _highlightedCommentID;
   bool _hasScrolledToHighlight = false;
@@ -275,6 +278,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       _hasMoreComments = comments.length == _pageSize;
       _isLoading = false;
     });
+    unawaited(_syncMissingAnonDisplayNamesFor(comments));
 
     // Scroll to highlighted comment if specified
     _scrollToHighlightedComment();
@@ -292,22 +296,31 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
 
       if (!mounted) return;
 
-      // Reload comments after sync
-      final freshComments =
-          await SocialDataProvider.instance.getCommentsForFilePaginated(
-        widget.fileID,
-        collectionID: _selectedCollectionID,
-        limit: _pageSize,
-        offset: 0,
-      );
+      // Reload comments and any already-synced anonymous names after sync.
+      final results = await Future.wait([
+        SocialDataProvider.instance.getCommentsForFilePaginated(
+          widget.fileID,
+          collectionID: _selectedCollectionID,
+          limit: _pageSize,
+          offset: 0,
+        ),
+        SocialDataProvider.instance.getAnonDisplayNamesForCollection(
+          _selectedCollectionID,
+        ),
+      ]);
+
+      final freshComments = results[0] as List<Comment>;
+      final anonNames = results[1] as Map<String, String>;
 
       if (mounted) {
         setState(() {
           _comments.clear();
           _comments.addAll(freshComments);
+          _anonDisplayNames = anonNames;
           _offset = freshComments.length;
           _hasMoreComments = freshComments.length == _pageSize;
         });
+        unawaited(_syncMissingAnonDisplayNamesFor(freshComments));
       }
     } catch (_) {
       // Ignore sync errors, local data is already displayed
@@ -333,6 +346,31 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       _hasMoreComments = comments.length == _pageSize;
       _isLoadingMore = false;
     });
+    unawaited(_syncMissingAnonDisplayNamesFor(comments));
+  }
+
+  Future<void> _syncMissingAnonDisplayNamesFor(List<Comment> comments) async {
+    final collectionID = _selectedCollectionID;
+    final missingIDs = _anonProfileSyncTracker.nextIDsToSync(
+      collectionID: collectionID,
+      comments: comments,
+      anonDisplayNames: _anonDisplayNames,
+    );
+    if (missingIDs.isEmpty) {
+      return;
+    }
+
+    try {
+      await SocialDataProvider.instance.syncAnonProfiles(collectionID);
+      final anonNames = await SocialDataProvider.instance
+          .getAnonDisplayNamesForCollection(collectionID);
+      if (!mounted || _selectedCollectionID != collectionID) {
+        return;
+      }
+      setState(() => _anonDisplayNames = anonNames);
+    } catch (_) {
+      // Missing anonymous names should not block showing comments.
+    }
   }
 
   void _onScroll() {
@@ -450,7 +488,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       _comments.clear();
       _offset = 0;
       _hasMoreComments = true;
-      _userCache.clear();
+      _commentAuthorResolver.clear();
       _anonDisplayNames = {};
     });
     _loadInitialComments();
@@ -470,27 +508,12 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
   }
 
   User _getUserForComment(Comment comment) {
-    if (_userCache.containsKey(comment.userID)) {
-      return _userCache[comment.userID]!;
-    }
-
-    if (comment.isAnonymous) {
-      final anonID = comment.anonUserID;
-      final displayName =
-          anonID != null ? (_anonDisplayNames[anonID] ?? anonID) : "Anonymous";
-      final user = User(
-        id: comment.userID,
-        email: "${anonID ?? "anonymous"}@unknown.com",
-        name: displayName,
-      );
-      _userCache[comment.userID] = user;
-      return user;
-    }
-
-    final user = CollectionsService.instance
-        .getFileOwner(comment.userID, _selectedCollectionID);
-    _userCache[comment.userID] = user;
-    return user;
+    return _commentAuthorResolver.resolve(
+      comment: comment,
+      anonDisplayNames: _anonDisplayNames,
+      registeredUserResolver: (userID) => CollectionsService.instance
+          .getFileOwner(userID, _selectedCollectionID),
+    );
   }
 
   void _dismissReply() {

--- a/mobile/apps/photos/test/models/social/comment_author_utils_test.dart
+++ b/mobile/apps/photos/test/models/social/comment_author_utils_test.dart
@@ -1,0 +1,113 @@
+import "package:photos/models/api/collection/user.dart";
+import "package:photos/models/social/comment.dart";
+import "package:photos/models/social/comment_author_utils.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CommentAuthorResolver", () {
+    test("does not reuse names for anonymous comments with same userID", () {
+      final resolver = CommentAuthorResolver();
+      final first = _comment(id: "comment-1", userID: -1, anonUserID: "anon-a");
+      final second = _comment(
+        id: "comment-2",
+        userID: -1,
+        anonUserID: "anon-b",
+      );
+      final anonDisplayNames = {"anon-a": "Alice", "anon-b": "Bob"};
+
+      final firstUser = resolver.resolve(
+        comment: first,
+        anonDisplayNames: anonDisplayNames,
+        registeredUserResolver: _registeredUser,
+      );
+      final secondUser = resolver.resolve(
+        comment: second,
+        anonDisplayNames: anonDisplayNames,
+        registeredUserResolver: _registeredUser,
+      );
+
+      expect(firstUser.id, secondUser.id);
+      expect(firstUser.toMap()["name"], "Alice");
+      expect(secondUser.toMap()["name"], "Bob");
+    });
+
+    test("falls back to anonUserID when display name is missing", () {
+      final resolver = CommentAuthorResolver();
+      final user = resolver.resolve(
+        comment: _comment(id: "comment-1", userID: -1, anonUserID: "anon-a"),
+        anonDisplayNames: const {},
+        registeredUserResolver: _registeredUser,
+      );
+
+      expect(user.toMap()["name"], "anon-a");
+      expect(user.email, "anon-a@unknown.com");
+    });
+  });
+
+  group("MissingAnonProfileSyncTracker", () {
+    test(
+      "requests sync only for missing anonymous IDs not already attempted",
+      () {
+        final tracker = MissingAnonProfileSyncTracker();
+        final comments = [
+          _comment(id: "comment-1", userID: -1, anonUserID: "anon-a"),
+          _comment(id: "comment-2", userID: -1, anonUserID: "anon-b"),
+          _comment(id: "comment-3", userID: 7),
+        ];
+
+        expect(
+          tracker.nextIDsToSync(
+            collectionID: 10,
+            comments: comments,
+            anonDisplayNames: const {"anon-a": "Alice"},
+          ),
+          {"anon-b"},
+        );
+        expect(
+          tracker.nextIDsToSync(
+            collectionID: 10,
+            comments: comments,
+            anonDisplayNames: const {"anon-a": "Alice"},
+          ),
+          isEmpty,
+        );
+        expect(
+          tracker.nextIDsToSync(
+            collectionID: 10,
+            comments: [
+              ...comments,
+              _comment(id: "comment-4", userID: -1, anonUserID: "anon-c"),
+            ],
+            anonDisplayNames: const {"anon-a": "Alice", "anon-b": "Bob"},
+          ),
+          {"anon-c"},
+        );
+      },
+    );
+  });
+}
+
+Comment _comment({
+  required String id,
+  required int userID,
+  String? anonUserID,
+}) {
+  return Comment(
+    id: id,
+    collectionID: 10,
+    fileID: 20,
+    data: "hello",
+    userID: userID,
+    anonUserID: anonUserID,
+    createdAt: 1,
+    updatedAt: 1,
+  );
+}
+
+User _registeredUser(int userID) {
+  return User(
+    id: userID,
+    email: "user-$userID@example.com",
+    name: "User $userID",
+  );
+}


### PR DESCRIPTION
## Description

- Fixes #10389.
- Resolve public anonymous comment authors by anonUserID instead of caching them by the shared anonymous numeric userID.
- Fetch anonymous profiles only when visible comments reference missing local anon display names.
- Add a regression test for two anonymous comments with the same userID and different anonUserID so this exact case does not regress.

## Tests

- [x] `flutter test test/models/social/comment_author_utils_test.dart`
- [x] `dart analyze lib/models/social/comment_author_utils.dart lib/models/social/social_data_provider.dart lib/ui/social/comments_screen.dart`
- [ ] `flutter analyze .` (fails locally on existing generated localization/decodeToJpeg errors outside this change)