### PR TITLE
[mob][photos] Use file-derived dimensions for large images

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -239,7 +239,8 @@ class EnteFile {
         // This is done because many times the fileTimeStamp will only give us
         // the date, not time value but the photo_manager's creation time will
         // contain the time.
-        final bool useFileTimeStamp = creationTime == null ||
+        final bool useFileTimeStamp =
+            creationTime == null ||
             !areFromSameDay(
               creationTime!,
               timeFromFileName.microsecondsSinceEpoch,
@@ -306,6 +307,22 @@ class EnteFile {
 
   int get width {
     return pubMagicMetadata?.w ?? 0;
+  }
+
+  int get rawHeight {
+    return pubMagicMetadata?.rh ?? 0;
+  }
+
+  int get rawWidth {
+    return pubMagicMetadata?.rw ?? 0;
+  }
+
+  int get rotationDegrees {
+    return pubMagicMetadata?.rot ?? 0;
+  }
+
+  bool get hasRawDimensions {
+    return rawHeight > 0 && rawWidth > 0;
   }
 
   bool get hasDimensions {

--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -239,8 +239,7 @@ class EnteFile {
         // This is done because many times the fileTimeStamp will only give us
         // the date, not time value but the photo_manager's creation time will
         // contain the time.
-        final bool useFileTimeStamp =
-            creationTime == null ||
+        final bool useFileTimeStamp = creationTime == null ||
             !areFromSameDay(
               creationTime!,
               timeFromFileName.microsecondsSinceEpoch,
@@ -309,20 +308,12 @@ class EnteFile {
     return pubMagicMetadata?.w ?? 0;
   }
 
-  int get rawHeight {
-    return pubMagicMetadata?.rh ?? 0;
+  int? get rotationDegrees {
+    return pubMagicMetadata?.rot;
   }
 
-  int get rawWidth {
-    return pubMagicMetadata?.rw ?? 0;
-  }
-
-  int get rotationDegrees {
-    return pubMagicMetadata?.rot ?? 0;
-  }
-
-  bool get hasRawDimensions {
-    return rawHeight > 0 && rawWidth > 0;
+  bool get hasRotationDegrees {
+    return pubMagicMetadata?.rot != null;
   }
 
   bool get hasDimensions {

--- a/mobile/apps/photos/lib/models/metadata/file_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/file_magic.dart
@@ -9,6 +9,9 @@ const captionKey = "caption";
 const uploaderNameKey = "uploaderName";
 const widthKey = 'w';
 const heightKey = 'h';
+const rawWidthKey = 'rw';
+const rawHeightKey = 'rh';
+const rotationDegreesKey = 'rot';
 const streamVersionKey = 'sv';
 const mediaTypeKey = 'mediaType';
 const latKey = "lat";
@@ -48,6 +51,9 @@ class PubMagicMetadata {
   String? uploaderName;
   int? w;
   int? h;
+  int? rw;
+  int? rh;
+  int? rot;
   double? lat;
   double? long;
   String? cameraMake;
@@ -85,6 +91,9 @@ class PubMagicMetadata {
     this.uploaderName,
     this.w,
     this.h,
+    this.rw,
+    this.rh,
+    this.rot,
     this.lat,
     this.long,
     this.cameraMake,
@@ -113,6 +122,9 @@ class PubMagicMetadata {
       uploaderName: map[uploaderNameKey],
       w: safeParseInt(map[widthKey], widthKey),
       h: safeParseInt(map[heightKey], heightKey),
+      rw: safeParseInt(map[rawWidthKey], rawWidthKey),
+      rh: safeParseInt(map[rawHeightKey], rawHeightKey),
+      rot: safeParseInt(map[rotationDegreesKey], rotationDegreesKey),
       lat: safeParseDouble(map[latKey], latKey),
       long: safeParseDouble(map[longKey], longKey),
       cameraMake: map[cameraMakeKey],

--- a/mobile/apps/photos/lib/models/metadata/file_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/file_magic.dart
@@ -9,8 +9,6 @@ const captionKey = "caption";
 const uploaderNameKey = "uploaderName";
 const widthKey = 'w';
 const heightKey = 'h';
-const rawWidthKey = 'rw';
-const rawHeightKey = 'rh';
 const rotationDegreesKey = 'rot';
 const streamVersionKey = 'sv';
 const mediaTypeKey = 'mediaType';
@@ -51,8 +49,6 @@ class PubMagicMetadata {
   String? uploaderName;
   int? w;
   int? h;
-  int? rw;
-  int? rh;
   int? rot;
   double? lat;
   double? long;
@@ -91,8 +87,6 @@ class PubMagicMetadata {
     this.uploaderName,
     this.w,
     this.h,
-    this.rw,
-    this.rh,
     this.rot,
     this.lat,
     this.long,
@@ -122,8 +116,6 @@ class PubMagicMetadata {
       uploaderName: map[uploaderNameKey],
       w: safeParseInt(map[widthKey], widthKey),
       h: safeParseInt(map[heightKey], heightKey),
-      rw: safeParseInt(map[rawWidthKey], rawWidthKey),
-      rh: safeParseInt(map[rawHeightKey], rawHeightKey),
       rot: safeParseInt(map[rotationDegreesKey], rotationDegreesKey),
       lat: safeParseDouble(map[latKey], latKey),
       long: safeParseDouble(map[longKey], longKey),

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -18,7 +18,9 @@ import "package:photos/events/reset_zoom_of_photo_view_event.dart";
 import "package:photos/events/retry_failed_image_load_event.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
+import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/service_locator.dart" show flagService;
+import "package:photos/services/file_magic_service.dart";
 import "package:photos/src/rust/api/image_processing_api.dart" as rust_image;
 import "package:photos/states/detail_page_state.dart";
 import "package:photos/theme/colors.dart";
@@ -28,6 +30,7 @@ import 'package:photos/ui/common/loading_widget.dart';
 import 'package:photos/ui/viewer/file/thumbnail_widget.dart';
 import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
+import "package:photos/utils/image_dimension_util.dart";
 import 'package:photos/utils/image_util.dart';
 import "package:photos/utils/ram_check_util.dart";
 import 'package:photos/utils/thumbnail_util.dart';
@@ -77,6 +80,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
   // soon as any presentable frame lands (small/large thumb or final), so
   // the timer isn't gated on the full original download.
   bool _firedOnReady = false;
+  bool _dimensionMetadataBackfillQueued = false;
   ValueChanged<PhotoViewScaleState>? _scaleStateChangedCallback;
   bool _isZooming = false;
   PhotoViewController _photoViewController = PhotoViewController();
@@ -87,20 +91,28 @@ class _ZoomableImageState extends State<ZoomableImage> {
   // is at its contained size. ZoomTransform.scale is reported relative to this.
   double? _initialScale;
   late final StreamSubscription<FileCaptionUpdatedEvent>
-      _captionUpdatedSubscription;
+  _captionUpdatedSubscription;
   late final StreamSubscription<ResetZoomOfPhotoView> _resetZoomSubscription;
   late final StreamSubscription<RetryFailedImageLoadEvent>
-      _retryFailedLoadSubscription;
+  _retryFailedLoadSubscription;
 
   // This is to prevent the app from crashing when loading 200MP images
   // https://github.com/flutter/flutter/issues/110331
   static const int _defaultMaxPixels = 100000000; // 100MP
   static const int _lowRamMaxPixels = 24000000; // 24MP
+  static const int _largeImageBackfillMinPixels = 100000000; // 100MP
 
   int get _maxImagePixels =>
       hasLessThan5GBRAM ? _lowRamMaxPixels : _defaultMaxPixels;
 
   bool get isTooLargeImage => _photo.width * _photo.height > _maxImagePixels;
+
+  String get _photoLogID =>
+      "fileID=${_photo.uploadedFileID}, generatedID=${_photo.generatedID}";
+
+  bool _isTooLargeDisplayImage(ImageDimensionMetadata dimensions) {
+    return dimensions.width * dimensions.height > _maxImagePixels;
+  }
 
   @override
   void initState() {
@@ -112,7 +124,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
     // flash the spinner while the async load resolves.
     final cachedThumbnail =
         ThumbnailInMemoryLruCache.get(_photo, thumbnailLargeSize) ??
-            ThumbnailInMemoryLruCache.get(_photo, thumbnailSmallSize);
+        ThumbnailInMemoryLruCache.get(_photo, thumbnailSmallSize);
     if (cachedThumbnail != null) {
       _imageProvider = Image.memory(cachedThumbnail).image;
       _loadedSmallThumbnail = true;
@@ -133,17 +145,19 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
     _subscribeToZoomStream();
 
-    _captionUpdatedSubscription =
-        Bus.instance.on<FileCaptionUpdatedEvent>().listen((event) {
-      if (event.fileGeneratedID == _photo.generatedID) {
-        if (mounted) {
-          setState(() {});
-        }
-      }
-    });
+    _captionUpdatedSubscription = Bus.instance
+        .on<FileCaptionUpdatedEvent>()
+        .listen((event) {
+          if (event.fileGeneratedID == _photo.generatedID) {
+            if (mounted) {
+              setState(() {});
+            }
+          }
+        });
 
-    _resetZoomSubscription =
-        Bus.instance.on<ResetZoomOfPhotoView>().listen((event) {
+    _resetZoomSubscription = Bus.instance.on<ResetZoomOfPhotoView>().listen((
+      event,
+    ) {
       if (event.isSamePhoto(
         uploadedFileID: widget.photo.uploadedFileID,
         localID: widget.photo.localID,
@@ -152,24 +166,26 @@ class _ZoomableImageState extends State<ZoomableImage> {
       }
     });
 
-    _retryFailedLoadSubscription =
-        Bus.instance.on<RetryFailedImageLoadEvent>().listen((_) {
-      if (!mounted || _loadedFinalImage) return;
-      if (!_loadedSmallThumbnail && _photo.isRemoteFile) {
-        // Evict the stale in-flight thumbnail so the rebuild's
-        // getThumbnailFromServer doesn't dedupe against the dead completer.
-        removePendingGetThumbnailRequestIfAny(_photo);
-      }
-      if (_loadingFinalImage) {
-        _pendingFinalImageRetry = true;
-      }
-      setState(() {});
-    });
+    _retryFailedLoadSubscription = Bus.instance
+        .on<RetryFailedImageLoadEvent>()
+        .listen((_) {
+          if (!mounted || _loadedFinalImage) return;
+          if (!_loadedSmallThumbnail && _photo.isRemoteFile) {
+            // Evict the stale in-flight thumbnail so the rebuild's
+            // getThumbnailFromServer doesn't dedupe against the dead completer.
+            removePendingGetThumbnailRequestIfAny(_photo);
+          }
+          if (_loadingFinalImage) {
+            _pendingFinalImageRetry = true;
+          }
+          setState(() {});
+        });
   }
 
   void _subscribeToZoomStream() {
-    _zoomStreamSubscription =
-        _photoViewController.outputStateStream.listen((value) {
+    _zoomStreamSubscription = _photoViewController.outputStateStream.listen((
+      value,
+    ) {
       final state = InheritedDetailPageState.maybeOf(context);
       if (value.scale == null) return;
       if (!_isZooming) {
@@ -257,9 +273,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
                 height: screenRelativeImageHeight,
                 child: widget.isFromMemories
                     ? const _DelayedLoadingIndicator()
-                    : const EnteLoadingWidget(
-                        color: Colors.white,
-                      ),
+                    : const EnteLoadingWidget(color: Colors.white),
               ),
             );
           },
@@ -277,27 +291,23 @@ class _ZoomableImageState extends State<ZoomableImage> {
     } else {
       content = widget.isFromMemories
           ? const _DelayedLoadingIndicator()
-          : const EnteLoadingWidget(
-              color: Colors.white,
-            );
+          : const EnteLoadingWidget(color: Colors.white);
     }
 
     final GestureDragUpdateCallback? verticalDragCallback =
         _isZooming || widget.isGuestView
-            ? null
-            : (d) => {
-                  if (!_isZooming)
-                    {
-                      if (d.delta.dy > dragSensitivity)
-                        {
-                          {Navigator.of(context).pop()},
-                        }
-                      else if (d.delta.dy < (dragSensitivity * -1))
-                        {
-                          showDetailsSheet(context, widget.photo),
-                        },
-                    },
-                };
+        ? null
+        : (d) => {
+            if (!_isZooming)
+              {
+                if (d.delta.dy > dragSensitivity)
+                  {
+                    {Navigator.of(context).pop()},
+                  }
+                else if (d.delta.dy < (dragSensitivity * -1))
+                  {showDetailsSheet(context, widget.photo)},
+              },
+          };
     return GestureDetector(
       onVerticalDragUpdate: verticalDragCallback,
       child: widget.photo.caption?.isNotEmpty ?? false
@@ -310,8 +320,10 @@ class _ZoomableImageState extends State<ZoomableImage> {
                   left: 0,
                   right: 0,
                   child: ValueListenableBuilder<bool>(
-                    valueListenable: InheritedDetailPageState.maybeOf(context)
-                            ?.enableFullScreenNotifier ??
+                    valueListenable:
+                        InheritedDetailPageState.maybeOf(
+                          context,
+                        )?.enableFullScreenNotifier ??
                         ValueNotifier(false),
                     builder: (context, doNotShowCaption, _) {
                       return AnimatedOpacity(
@@ -342,11 +354,9 @@ class _ZoomableImageState extends State<ZoomableImage> {
                                           widget.photo.caption!,
                                           maxLines: 3,
                                           overflow: TextOverflow.ellipsis,
-                                          style: getEnteTextTheme(context)
-                                              .mini
-                                              .copyWith(
-                                                color: textBaseDark,
-                                              ),
+                                          style: getEnteTextTheme(
+                                            context,
+                                          ).mini.copyWith(color: textBaseDark),
                                         ),
                                       ),
                                     ),
@@ -386,53 +396,59 @@ class _ZoomableImageState extends State<ZoomableImage> {
         _loadedSmallThumbnail = true;
         _notifyReadyOnce();
       } else {
-        getThumbnailFromServer(_photo).then((file) {
-          final imageProvider = Image.memory(file).image;
-          if (mounted) {
-            precacheImage(imageProvider, context).then((value) {
+        getThumbnailFromServer(_photo)
+            .then((file) {
+              final imageProvider = Image.memory(file).image;
               if (mounted) {
-                setState(() {
-                  _imageProvider = imageProvider;
-                  _loadedSmallThumbnail = true;
-                });
-                _notifyReadyOnce();
+                precacheImage(imageProvider, context)
+                    .then((value) {
+                      if (mounted) {
+                        setState(() {
+                          _imageProvider = imageProvider;
+                          _loadedSmallThumbnail = true;
+                        });
+                        _notifyReadyOnce();
+                      }
+                    })
+                    .catchError((e) {
+                      _logger.severe(
+                        "Could not load image " + _photo.toString(),
+                      );
+                      _loadedSmallThumbnail = true;
+                    });
               }
-            }).catchError((e) {
-              _logger.severe("Could not load image " + _photo.toString());
-              _loadedSmallThumbnail = true;
+            })
+            .catchError((e, s) {
+              _logger.warning(
+                "Failed to fetch thumbnail from server for ${_photo.tag}",
+                e,
+                s,
+              );
             });
-          }
-        }).catchError((e, s) {
-          _logger.warning(
-            "Failed to fetch thumbnail from server for ${_photo.tag}",
-            e,
-            s,
-          );
-        });
       }
     }
     if (!_loadedFinalImage && !_loadingFinalImage) {
       _loadingFinalImage = true;
-      getFileFromServer(_photo).then((file) {
-        if (file != null) {
-          _onFileLoaded(
-            file,
-          );
-        } else {
-          // getFileFromServer resolves null (not throw) on most network
-          // failures because downloadAndDecrypt is called with
-          // throwOnFailure=false here — route through the same helper as
-          // catchError below.
-          _onFinalImageFetchFailed();
-        }
-      }).catchError((e, s) {
-        _logger.warning(
-          "Failed to fetch final image from server for ${_photo.tag}",
-          e,
-          s,
-        );
-        _onFinalImageFetchFailed();
-      });
+      getFileFromServer(_photo)
+          .then((file) {
+            if (file != null) {
+              _onFileLoaded(file);
+            } else {
+              // getFileFromServer resolves null (not throw) on most network
+              // failures because downloadAndDecrypt is called with
+              // throwOnFailure=false here — route through the same helper as
+              // catchError below.
+              _onFinalImageFetchFailed();
+            }
+          })
+          .catchError((e, s) {
+            _logger.warning(
+              "Failed to fetch final image from server for ${_photo.tag}",
+              e,
+              s,
+            );
+            _onFinalImageFetchFailed();
+          });
     }
   }
 
@@ -440,8 +456,10 @@ class _ZoomableImageState extends State<ZoomableImage> {
     if (!_loadedSmallThumbnail &&
         !_loadedLargeThumbnail &&
         !_loadedFinalImage) {
-      final cachedThumbnail =
-          ThumbnailInMemoryLruCache.get(_photo, thumbnailSmallSize);
+      final cachedThumbnail = ThumbnailInMemoryLruCache.get(
+        _photo,
+        thumbnailSmallSize,
+      );
       if (cachedThumbnail != null) {
         _imageProvider = Image.memory(cachedThumbnail).image;
         _loadedSmallThumbnail = true;
@@ -453,8 +471,11 @@ class _ZoomableImageState extends State<ZoomableImage> {
         !_loadedLargeThumbnail &&
         !_loadedFinalImage) {
       _loadingLargeThumbnail = true;
-      getThumbnailFromLocal(_photo, size: thumbnailLargeSize, quality: 100)
-          .then((cachedThumbnail) {
+      getThumbnailFromLocal(
+        _photo,
+        size: thumbnailLargeSize,
+        quality: 100,
+      ).then((cachedThumbnail) {
         if (cachedThumbnail != null) {
           _onLargeThumbnailLoaded(Image.memory(cachedThumbnail).image, context);
         }
@@ -465,13 +486,12 @@ class _ZoomableImageState extends State<ZoomableImage> {
       _loadingFinalImage = true;
       getFile(
         _photo,
-        isOrigin: Platform.isIOS &&
+        isOrigin:
+            Platform.isIOS &&
             _isGIF(), // since on iOS GIFs playback only when origin-files are loaded
       ).then((file) {
         if (file != null && file.existsSync()) {
-          _onFileLoaded(
-            file,
-          );
+          _onFileLoaded(file);
         } else {
           _logger.info("File was deleted " + _photo.toString());
           if (_photo.uploadedFileID != null) {
@@ -520,7 +540,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
       return;
     }
 
-    _loadWithPlatformDecoder(file);
+    unawaited(_loadWithPlatformDecoder(file));
   }
 
   Future<void> _loadAndroidHeic(File file) async {
@@ -543,64 +563,204 @@ class _ZoomableImageState extends State<ZoomableImage> {
       return;
     }
 
-    _loadWithPlatformDecoder(file);
+    unawaited(_loadWithPlatformDecoder(file));
   }
 
   Future<bool> _heicNeedsExifRotation(File file) async {
     try {
       final exif = await readExifAsync(file);
-      final orientation =
-          exif['Image Orientation']?.values.firstAsInt() ?? 1;
+      final orientation = exif['Image Orientation']?.values.firstAsInt() ?? 1;
       return orientation > 1;
     } catch (e, s) {
-      _logger.warning(
-        "Failed to read EXIF orientation for ${_photo.displayName}",
-        e,
-        s,
-      );
+      _logger.warning("Failed to read EXIF orientation for $_photoLogID", e, s);
       return false;
     }
   }
 
-  void _loadWithPlatformDecoder(File file) {
-    ImageProvider imageProvider;
-    if (isTooLargeImage) {
-      _logger.info(
-        "Handling very large image (${_photo.width}x${_photo.height}) by decreasing resolution to ${_maxImagePixels ~/ 1000000}MP to prevent crash",
+  // Some Android providers report display dimensions through MediaStore, then
+  // EXIF correction swaps them again at upload. For decode-size requests, trust
+  // the file's own dimensions and orientation so Flutter preserves aspect ratio.
+  Future<ImageDimensionMetadata> _readDisplayDimensions(File file) async {
+    if (!flagService.useFileDerivedImageDimensions) {
+      return ImageDimensionMetadata.displayOnly(
+        width: _photo.width,
+        height: _photo.height,
       );
-      final aspectRatio = _photo.width / _photo.height;
-      final maxPixels = min(50000000, _maxImagePixels);
-      final targetHeight = sqrt(maxPixels / aspectRatio);
-      final targetWidth = aspectRatio * targetHeight;
+    }
+
+    if (_photo.hasRawDimensions) {
+      final dimensions = ImageDimensionMetadata.fromRawDimensions(
+        rawWidth: _photo.rawWidth,
+        rawHeight: _photo.rawHeight,
+        rotationDegrees: _photo.rotationDegrees,
+      );
+      _logger.fine(
+        "Using stored raw dimensions for $_photoLogID: raw=${dimensions.rawWidth}x${dimensions.rawHeight}, rot=${dimensions.rotationDegrees}, display=${dimensions.width}x${dimensions.height}",
+      );
+      _backfillDimensionMetadataIfNeeded(dimensions);
+      return dimensions;
+    }
+
+    final dimensions = await tryReadImageDimensionMetadata(file);
+    if (dimensions != null) {
+      _logger.fine(
+        "Read file-backed dimensions for $_photoLogID: raw=${dimensions.rawWidth}x${dimensions.rawHeight}, rot=${dimensions.rotationDegrees}, display=${dimensions.width}x${dimensions.height}",
+      );
+      _backfillDimensionMetadataIfNeeded(dimensions);
+      return dimensions;
+    }
+
+    _logger.info(
+      "Could not read file-backed dimensions for $_photoLogID; falling back to stored dimensions ${_photo.width}x${_photo.height}",
+    );
+    return ImageDimensionMetadata.displayOnly(
+      width: _photo.width,
+      height: _photo.height,
+    );
+  }
+
+  Future<ImageDimensionMetadata> _displayDimensionsForDecode(File file) async {
+    final shouldReadFileBackedDimensions =
+        flagService.useFileDerivedImageDimensions &&
+        (!_photo.hasDimensions || _photo.hasRawDimensions || isTooLargeImage);
+    if (shouldReadFileBackedDimensions) {
+      return _readDisplayDimensions(file);
+    }
+
+    return ImageDimensionMetadata.displayOnly(
+      width: _photo.width,
+      height: _photo.height,
+    );
+  }
+
+  void _backfillDimensionMetadataIfNeeded(ImageDimensionMetadata dimensions) {
+    if (_dimensionMetadataBackfillQueued) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: already queued",
+      );
+      return;
+    }
+    if (!flagService.useFileDerivedImageDimensions) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: feature flag disabled",
+      );
+      return;
+    }
+    final displayPixels = dimensions.width * dimensions.height;
+    if (displayPixels <= _largeImageBackfillMinPixels) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: display dimensions ${dimensions.width}x${dimensions.height} are not above 100MP",
+      );
+      return;
+    }
+    if (!dimensions.hasRawDimensions) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: raw dimensions unavailable",
+      );
+      return;
+    }
+    if (!_photo.canEditMetaInfo) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: current user cannot edit file metadata",
+      );
+      return;
+    }
+
+    final updates = <String, dynamic>{};
+    if (_photo.rawWidth != dimensions.rawWidth) {
+      updates[rawWidthKey] = dimensions.rawWidth;
+    }
+    if (_photo.rawHeight != dimensions.rawHeight) {
+      updates[rawHeightKey] = dimensions.rawHeight;
+    }
+    if (_photo.rotationDegrees != (dimensions.rotationDegrees ?? 0)) {
+      updates[rotationDegreesKey] = dimensions.rotationDegrees ?? 0;
+    }
+    if (_photo.width != dimensions.width) {
+      updates[widthKey] = dimensions.width;
+    }
+    if (_photo.height != dimensions.height) {
+      updates[heightKey] = dimensions.height;
+    }
+    if (updates.isEmpty) {
+      _logger.fine(
+        "Skipping image dimension backfill for $_photoLogID: metadata already up to date",
+      );
+      return;
+    }
+
+    _dimensionMetadataBackfillQueued = true;
+    _logger.info("Backfilling image dimensions for $_photoLogID: $updates");
+    unawaited(
+      FileMagicService.instance
+          .updatePublicMagicMetadata([_photo], updates)
+          .then((_) {
+            _logger.info("Backfilled image dimensions for $_photoLogID");
+          })
+          .catchError((e, s) {
+            _logger.warning(
+              "Failed to backfill image dimensions for $_photoLogID",
+              e,
+              s,
+            );
+          }),
+    );
+  }
+
+  ImageDimensionMetadata _targetDimensionsForMaxPixels(
+    ImageDimensionMetadata dimensions,
+  ) {
+    final aspectRatio = dimensions.width / dimensions.height;
+    final maxPixels = min(50000000, _maxImagePixels);
+    final targetHeight = sqrt(maxPixels / aspectRatio);
+    final targetWidth = aspectRatio * targetHeight;
+
+    return ImageDimensionMetadata.displayOnly(
+      width: max(1, targetWidth.round()),
+      height: max(1, targetHeight.round()),
+    );
+  }
+
+  Future<void> _loadWithPlatformDecoder(File file) async {
+    ImageProvider imageProvider;
+    final displayDimensions = await _displayDimensionsForDecode(file);
+    if (!mounted) {
+      return;
+    }
+    final tooLargeImage = _isTooLargeDisplayImage(displayDimensions);
+    if (tooLargeImage) {
+      final targetDimensions = _targetDimensionsForMaxPixels(displayDimensions);
+      _logger.info(
+        "Handling very large image (${displayDimensions.width}x${displayDimensions.height}) by decreasing resolution to ${targetDimensions.width}x${targetDimensions.height} to prevent crash",
+      );
 
       imageProvider = Image.file(
         file,
         gaplessPlayback: true,
-        cacheWidth: targetWidth.round(),
-        cacheHeight: targetHeight.round(),
+        cacheWidth: targetDimensions.width,
+        cacheHeight: targetDimensions.height,
       ).image;
     } else {
-      imageProvider = Image.file(
-        file,
-        gaplessPlayback: true,
-      ).image;
+      imageProvider = Image.file(file, gaplessPlayback: true).image;
     }
 
     if (mounted) {
-      precacheImage(
-        imageProvider,
-        context,
-        onError: (exception, s) async {
-          _logger.warning(
-            "Failed to load image ${_photo.displayName} with error: $exception, attempting fallback",
-          );
-          unawaited(_loadInSupportedFormat(file, exception));
-        },
-      ).then((value) {
-        if (mounted && !_loadedFinalImage && !_convertToSupportedFormat) {
-          _updateViewWithFinalImage(imageProvider);
-        }
-      });
+      unawaited(
+        precacheImage(
+          imageProvider,
+          context,
+          onError: (exception, s) async {
+            _logger.warning(
+              "Failed to load image $_photoLogID with error: $exception, attempting fallback",
+            );
+            unawaited(_loadInSupportedFormat(file, exception));
+          },
+        ).then((value) {
+          if (mounted && !_loadedFinalImage && !_convertToSupportedFormat) {
+            unawaited(_updateViewWithFinalImage(imageProvider));
+          }
+        }),
+      );
     }
   }
 
@@ -613,9 +773,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
   }
 
   Future<void> _loadHeicWithRust(File file) async {
-    final imageProvider = await _tryDecodeHeicWithRust(
-      file,
-    );
+    final imageProvider = await _tryDecodeHeicWithRust(file);
     if (imageProvider != null) {
       await _tryDisplayRustDecodedImage(
         file,
@@ -651,7 +809,8 @@ class _ZoomableImageState extends State<ZoomableImage> {
     required ImageProvider? previewImageProvider,
     required ImageProvider finalImageProvider,
   }) async {
-    final bool shouldFixPosition = previewImageProvider != null &&
+    final bool shouldFixPosition =
+        previewImageProvider != null &&
         _isZooming &&
         _photoViewController.scale != null;
     ImageInfo? finalImageInfo;
@@ -662,7 +821,8 @@ class _ZoomableImageState extends State<ZoomableImage> {
       final previousRelativeScale = _initialScale != null && _initialScale! > 0
           ? previousScale / _initialScale!
           : null;
-      final scale = previousScale /
+      final scale =
+          previousScale /
           (finalImageInfo.image.width / prevImageInfo.image.width);
       final currentPosition = _photoViewController.value.position;
       unawaited(_zoomStreamSubscription?.cancel());
@@ -753,13 +913,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
         "Flutter failed to decode Rust JPEG bytes for ${_photo.generatedID}: $e",
       );
       if (fallbackToSupportedFormatOnFailure) {
-        unawaited(
-          _loadInSupportedFormat(
-            file,
-            e,
-            skipRustDecoder: true,
-          ),
-        );
+        unawaited(_loadInSupportedFormat(file, e, skipRustDecoder: true));
       }
       return false;
     }
@@ -784,31 +938,32 @@ class _ZoomableImageState extends State<ZoomableImage> {
     // and will crash. Go directly to thumbnail fallback.
     if (_isRawFile()) {
       _logger.info(
-        "Skipping compression for RAW file ${_photo.displayName}, using thumbnail fallback",
+        "Skipping compression for RAW file $_photoLogID, using thumbnail fallback",
       );
       _convertToSupportedFormat = true;
       if (mounted) {
         setState(() {
           _showingThumbnailFallback = true;
         });
-        InheritedDetailPageState.maybeOf(context)
-            ?.showingThumbnailFallbackNotifier
-            .value = detailPageFileIdentifier(_photo);
+        InheritedDetailPageState.maybeOf(
+          context,
+        )?.showingThumbnailFallbackNotifier.value = detailPageFileIdentifier(
+          _photo,
+        );
         _notifyReadyOnce();
       }
       return;
     }
 
     _logger.info(
-      "Compressing ${_photo.displayName} to viewable format due to $unsupportedErr",
+      "Compressing $_photoLogID to viewable format due to $unsupportedErr",
     );
     _convertToSupportedFormat = true;
 
     if (!skipRustDecoder) {
-      final imageProvider = await _tryDecodeHeicWithRust(
-        file,
-      );
-      final didDisplayRustImage = imageProvider != null &&
+      final imageProvider = await _tryDecodeHeicWithRust(file);
+      final didDisplayRustImage =
+          imageProvider != null &&
           await _tryDisplayRustDecodedImage(
             file,
             imageProvider,
@@ -821,19 +976,21 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
     // Fallback to FlutterImageCompress (platform-based decoder).
     Uint8List? compressedFile;
-    if (isTooLargeImage) {
+    final displayDimensions = await _displayDimensionsForDecode(file);
+    if (!mounted) {
+      return;
+    }
+    final tooLargeImage = _isTooLargeDisplayImage(displayDimensions);
+    if (tooLargeImage) {
+      final targetDimensions = _targetDimensionsForMaxPixels(displayDimensions);
       _logger.info(
-        "Compressing very large image (${_photo.width}x${_photo.height}) more aggressively down to ${_maxImagePixels ~/ 1000000}MP",
+        "Compressing very large image (${displayDimensions.width}x${displayDimensions.height}) more aggressively down to ${targetDimensions.width}x${targetDimensions.height}",
       );
-      final aspectRatio = _photo.width / _photo.height;
-      final maxPixels = min(50000000, _maxImagePixels);
-      final targetHeight = sqrt(maxPixels / aspectRatio);
-      final targetWidth = aspectRatio * targetHeight;
 
       compressedFile = await FlutterImageCompress.compressWithFile(
         file.path,
-        minWidth: targetWidth.round(),
-        minHeight: targetHeight.round(),
+        minWidth: targetDimensions.width,
+        minHeight: targetDimensions.height,
         quality: 85,
       );
     } else {
@@ -860,15 +1017,17 @@ class _ZoomableImageState extends State<ZoomableImage> {
       );
     } else {
       _logger.severe(
-        "Failed to compress image ${_photo.displayName} to viewable format",
+        "Failed to compress image $_photoLogID to viewable format",
       );
       if (mounted) {
         setState(() {
           _showingThumbnailFallback = true;
         });
-        InheritedDetailPageState.maybeOf(context)
-            ?.showingThumbnailFallbackNotifier
-            .value = detailPageFileIdentifier(_photo);
+        InheritedDetailPageState.maybeOf(
+          context,
+        )?.showingThumbnailFallbackNotifier.value = detailPageFileIdentifier(
+          _photo,
+        );
         _notifyReadyOnce();
       }
     }

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -91,10 +91,10 @@ class _ZoomableImageState extends State<ZoomableImage> {
   // is at its contained size. ZoomTransform.scale is reported relative to this.
   double? _initialScale;
   late final StreamSubscription<FileCaptionUpdatedEvent>
-  _captionUpdatedSubscription;
+      _captionUpdatedSubscription;
   late final StreamSubscription<ResetZoomOfPhotoView> _resetZoomSubscription;
   late final StreamSubscription<RetryFailedImageLoadEvent>
-  _retryFailedLoadSubscription;
+      _retryFailedLoadSubscription;
 
   // This is to prevent the app from crashing when loading 200MP images
   // https://github.com/flutter/flutter/issues/110331
@@ -124,7 +124,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
     // flash the spinner while the async load resolves.
     final cachedThumbnail =
         ThumbnailInMemoryLruCache.get(_photo, thumbnailLargeSize) ??
-        ThumbnailInMemoryLruCache.get(_photo, thumbnailSmallSize);
+            ThumbnailInMemoryLruCache.get(_photo, thumbnailSmallSize);
     if (cachedThumbnail != null) {
       _imageProvider = Image.memory(cachedThumbnail).image;
       _loadedSmallThumbnail = true;
@@ -145,15 +145,14 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
     _subscribeToZoomStream();
 
-    _captionUpdatedSubscription = Bus.instance
-        .on<FileCaptionUpdatedEvent>()
-        .listen((event) {
-          if (event.fileGeneratedID == _photo.generatedID) {
-            if (mounted) {
-              setState(() {});
-            }
-          }
-        });
+    _captionUpdatedSubscription =
+        Bus.instance.on<FileCaptionUpdatedEvent>().listen((event) {
+      if (event.fileGeneratedID == _photo.generatedID) {
+        if (mounted) {
+          setState(() {});
+        }
+      }
+    });
 
     _resetZoomSubscription = Bus.instance.on<ResetZoomOfPhotoView>().listen((
       event,
@@ -166,20 +165,19 @@ class _ZoomableImageState extends State<ZoomableImage> {
       }
     });
 
-    _retryFailedLoadSubscription = Bus.instance
-        .on<RetryFailedImageLoadEvent>()
-        .listen((_) {
-          if (!mounted || _loadedFinalImage) return;
-          if (!_loadedSmallThumbnail && _photo.isRemoteFile) {
-            // Evict the stale in-flight thumbnail so the rebuild's
-            // getThumbnailFromServer doesn't dedupe against the dead completer.
-            removePendingGetThumbnailRequestIfAny(_photo);
-          }
-          if (_loadingFinalImage) {
-            _pendingFinalImageRetry = true;
-          }
-          setState(() {});
-        });
+    _retryFailedLoadSubscription =
+        Bus.instance.on<RetryFailedImageLoadEvent>().listen((_) {
+      if (!mounted || _loadedFinalImage) return;
+      if (!_loadedSmallThumbnail && _photo.isRemoteFile) {
+        // Evict the stale in-flight thumbnail so the rebuild's
+        // getThumbnailFromServer doesn't dedupe against the dead completer.
+        removePendingGetThumbnailRequestIfAny(_photo);
+      }
+      if (_loadingFinalImage) {
+        _pendingFinalImageRetry = true;
+      }
+      setState(() {});
+    });
   }
 
   void _subscribeToZoomStream() {
@@ -296,18 +294,18 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
     final GestureDragUpdateCallback? verticalDragCallback =
         _isZooming || widget.isGuestView
-        ? null
-        : (d) => {
-            if (!_isZooming)
-              {
-                if (d.delta.dy > dragSensitivity)
-                  {
-                    {Navigator.of(context).pop()},
-                  }
-                else if (d.delta.dy < (dragSensitivity * -1))
-                  {showDetailsSheet(context, widget.photo)},
-              },
-          };
+            ? null
+            : (d) => {
+                  if (!_isZooming)
+                    {
+                      if (d.delta.dy > dragSensitivity)
+                        {
+                          {Navigator.of(context).pop()},
+                        }
+                      else if (d.delta.dy < (dragSensitivity * -1))
+                        {showDetailsSheet(context, widget.photo)},
+                    },
+                };
     return GestureDetector(
       onVerticalDragUpdate: verticalDragCallback,
       child: widget.photo.caption?.isNotEmpty ?? false
@@ -320,8 +318,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
                   left: 0,
                   right: 0,
                   child: ValueListenableBuilder<bool>(
-                    valueListenable:
-                        InheritedDetailPageState.maybeOf(
+                    valueListenable: InheritedDetailPageState.maybeOf(
                           context,
                         )?.enableFullScreenNotifier ??
                         ValueNotifier(false),
@@ -396,59 +393,53 @@ class _ZoomableImageState extends State<ZoomableImage> {
         _loadedSmallThumbnail = true;
         _notifyReadyOnce();
       } else {
-        getThumbnailFromServer(_photo)
-            .then((file) {
-              final imageProvider = Image.memory(file).image;
+        getThumbnailFromServer(_photo).then((file) {
+          final imageProvider = Image.memory(file).image;
+          if (mounted) {
+            precacheImage(imageProvider, context).then((value) {
               if (mounted) {
-                precacheImage(imageProvider, context)
-                    .then((value) {
-                      if (mounted) {
-                        setState(() {
-                          _imageProvider = imageProvider;
-                          _loadedSmallThumbnail = true;
-                        });
-                        _notifyReadyOnce();
-                      }
-                    })
-                    .catchError((e) {
-                      _logger.severe(
-                        "Could not load image " + _photo.toString(),
-                      );
-                      _loadedSmallThumbnail = true;
-                    });
+                setState(() {
+                  _imageProvider = imageProvider;
+                  _loadedSmallThumbnail = true;
+                });
+                _notifyReadyOnce();
               }
-            })
-            .catchError((e, s) {
-              _logger.warning(
-                "Failed to fetch thumbnail from server for ${_photo.tag}",
-                e,
-                s,
+            }).catchError((e) {
+              _logger.severe(
+                "Could not load image " + _photo.toString(),
               );
+              _loadedSmallThumbnail = true;
             });
+          }
+        }).catchError((e, s) {
+          _logger.warning(
+            "Failed to fetch thumbnail from server for ${_photo.tag}",
+            e,
+            s,
+          );
+        });
       }
     }
     if (!_loadedFinalImage && !_loadingFinalImage) {
       _loadingFinalImage = true;
-      getFileFromServer(_photo)
-          .then((file) {
-            if (file != null) {
-              _onFileLoaded(file);
-            } else {
-              // getFileFromServer resolves null (not throw) on most network
-              // failures because downloadAndDecrypt is called with
-              // throwOnFailure=false here — route through the same helper as
-              // catchError below.
-              _onFinalImageFetchFailed();
-            }
-          })
-          .catchError((e, s) {
-            _logger.warning(
-              "Failed to fetch final image from server for ${_photo.tag}",
-              e,
-              s,
-            );
-            _onFinalImageFetchFailed();
-          });
+      getFileFromServer(_photo).then((file) {
+        if (file != null) {
+          _onFileLoaded(file);
+        } else {
+          // getFileFromServer resolves null (not throw) on most network
+          // failures because downloadAndDecrypt is called with
+          // throwOnFailure=false here — route through the same helper as
+          // catchError below.
+          _onFinalImageFetchFailed();
+        }
+      }).catchError((e, s) {
+        _logger.warning(
+          "Failed to fetch final image from server for ${_photo.tag}",
+          e,
+          s,
+        );
+        _onFinalImageFetchFailed();
+      });
     }
   }
 
@@ -486,8 +477,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
       _loadingFinalImage = true;
       getFile(
         _photo,
-        isOrigin:
-            Platform.isIOS &&
+        isOrigin: Platform.isIOS &&
             _isGIF(), // since on iOS GIFs playback only when origin-files are loaded
       ).then((file) {
         if (file != null && file.existsSync()) {
@@ -588,19 +578,6 @@ class _ZoomableImageState extends State<ZoomableImage> {
       );
     }
 
-    if (_photo.hasRawDimensions) {
-      final dimensions = ImageDimensionMetadata.fromRawDimensions(
-        rawWidth: _photo.rawWidth,
-        rawHeight: _photo.rawHeight,
-        rotationDegrees: _photo.rotationDegrees,
-      );
-      _logger.fine(
-        "Using stored raw dimensions for $_photoLogID: raw=${dimensions.rawWidth}x${dimensions.rawHeight}, rot=${dimensions.rotationDegrees}, display=${dimensions.width}x${dimensions.height}",
-      );
-      _backfillDimensionMetadataIfNeeded(dimensions);
-      return dimensions;
-    }
-
     final dimensions = await tryReadImageDimensionMetadata(file);
     if (dimensions != null) {
       _logger.fine(
@@ -622,7 +599,8 @@ class _ZoomableImageState extends State<ZoomableImage> {
   Future<ImageDimensionMetadata> _displayDimensionsForDecode(File file) async {
     final shouldReadFileBackedDimensions =
         flagService.useFileDerivedImageDimensions &&
-        (!_photo.hasDimensions || _photo.hasRawDimensions || isTooLargeImage);
+            (!_photo.hasDimensions ||
+                (isTooLargeImage && !_photo.hasRotationDegrees));
     if (shouldReadFileBackedDimensions) {
       return _readDisplayDimensions(file);
     }
@@ -653,12 +631,6 @@ class _ZoomableImageState extends State<ZoomableImage> {
       );
       return;
     }
-    if (!dimensions.hasRawDimensions) {
-      _logger.fine(
-        "Skipping image dimension backfill for $_photoLogID: raw dimensions unavailable",
-      );
-      return;
-    }
     if (!_photo.canEditMetaInfo) {
       _logger.fine(
         "Skipping image dimension backfill for $_photoLogID: current user cannot edit file metadata",
@@ -667,14 +639,9 @@ class _ZoomableImageState extends State<ZoomableImage> {
     }
 
     final updates = <String, dynamic>{};
-    if (_photo.rawWidth != dimensions.rawWidth) {
-      updates[rawWidthKey] = dimensions.rawWidth;
-    }
-    if (_photo.rawHeight != dimensions.rawHeight) {
-      updates[rawHeightKey] = dimensions.rawHeight;
-    }
-    if (_photo.rotationDegrees != (dimensions.rotationDegrees ?? 0)) {
-      updates[rotationDegreesKey] = dimensions.rotationDegrees ?? 0;
+    final rotationDegrees = dimensions.rotationDegrees;
+    if (rotationDegrees != null && _photo.rotationDegrees != rotationDegrees) {
+      updates[rotationDegreesKey] = rotationDegrees;
     }
     if (_photo.width != dimensions.width) {
       updates[widthKey] = dimensions.width;
@@ -693,17 +660,15 @@ class _ZoomableImageState extends State<ZoomableImage> {
     _logger.info("Backfilling image dimensions for $_photoLogID: $updates");
     unawaited(
       FileMagicService.instance
-          .updatePublicMagicMetadata([_photo], updates)
-          .then((_) {
-            _logger.info("Backfilled image dimensions for $_photoLogID");
-          })
-          .catchError((e, s) {
-            _logger.warning(
-              "Failed to backfill image dimensions for $_photoLogID",
-              e,
-              s,
-            );
-          }),
+          .updatePublicMagicMetadata([_photo], updates).then((_) {
+        _logger.info("Backfilled image dimensions for $_photoLogID");
+      }).catchError((e, s) {
+        _logger.warning(
+          "Failed to backfill image dimensions for $_photoLogID",
+          e,
+          s,
+        );
+      }),
     );
   }
 
@@ -809,8 +774,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
     required ImageProvider? previewImageProvider,
     required ImageProvider finalImageProvider,
   }) async {
-    final bool shouldFixPosition =
-        previewImageProvider != null &&
+    final bool shouldFixPosition = previewImageProvider != null &&
         _isZooming &&
         _photoViewController.scale != null;
     ImageInfo? finalImageInfo;
@@ -821,8 +785,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
       final previousRelativeScale = _initialScale != null && _initialScale! > 0
           ? previousScale / _initialScale!
           : null;
-      final scale =
-          previousScale /
+      final scale = previousScale /
           (finalImageInfo.image.width / prevImageInfo.image.width);
       final currentPosition = _photoViewController.value.position;
       unawaited(_zoomStreamSubscription?.cancel());
@@ -962,8 +925,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
     if (!skipRustDecoder) {
       final imageProvider = await _tryDecodeHeicWithRust(file);
-      final didDisplayRustImage =
-          imageProvider != null &&
+      final didDisplayRustImage = imageProvider != null &&
           await _tryDisplayRustDecodedImage(
             file,
             imageProvider,

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -99,9 +99,8 @@ class FileUploader {
 
   Future<void> init(SharedPreferences preferences, bool isBackground) async {
     _prefs = preferences;
-    _processType = isBackground
-        ? ProcessType.background
-        : ProcessType.foreground;
+    _processType =
+        isBackground ? ProcessType.background : ProcessType.foreground;
     final currentTime = DateTime.now().microsecondsSinceEpoch;
     await _uploadLocks.releaseLocksAcquiredByOwnerBefore(
       _processType.toString(),
@@ -144,27 +143,26 @@ class FileUploader {
     if (_localPhotosUpdatedSubscription != null) {
       await _localPhotosUpdatedSubscription!.cancel();
     }
-    _localPhotosUpdatedSubscription = Bus.instance
-        .on<LocalPhotosUpdatedEvent>()
-        .listen((event) {
-          if (event.type == EventType.deletedFromDevice ||
-              event.type == EventType.deletedFromEverywhere) {
-            removeFromQueueWhere(
-              (file) {
-                for (final updatedFile in event.updatedFiles) {
-                  if (file.generatedID == updatedFile.generatedID) {
-                    return true;
-                  }
-                }
-                return false;
-              },
-              InvalidFileError(
-                "File already deleted",
-                InvalidReason.assetDeletedEvent,
-              ),
-            );
-          }
-        });
+    _localPhotosUpdatedSubscription =
+        Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {
+      if (event.type == EventType.deletedFromDevice ||
+          event.type == EventType.deletedFromEverywhere) {
+        removeFromQueueWhere(
+          (file) {
+            for (final updatedFile in event.updatedFiles) {
+              if (file.generatedID == updatedFile.generatedID) {
+                return true;
+              }
+            }
+            return false;
+          },
+          InvalidFileError(
+            "File already deleted",
+            InvalidReason.assetDeletedEvent,
+          ),
+        );
+      }
+    });
   }
 
   // upload future will return null as File when the file entry is deleted
@@ -210,10 +208,9 @@ class FileUploader {
       );
 
       return CollectionsService.instance
-          .addOrCopyToCollection(collectionID, [uploadedFile])
-          .then((aVoid) {
-            return uploadedFile;
-          });
+          .addOrCopyToCollection(collectionID, [uploadedFile]).then((aVoid) {
+        return uploadedFile;
+      });
     });
   }
 
@@ -226,8 +223,8 @@ class FileUploader {
     _queue.entries
         .where((entry) => entry.value.status == UploadStatus.notStarted)
         .forEach((pendingUpload) {
-          uploadsToBeRemoved.add(pendingUpload.key);
-        });
+      uploadsToBeRemoved.add(pendingUpload.key);
+    });
     for (final id in uploadsToBeRemoved) {
       _queue.remove(id)?.completer.completeError(reason);
       _allBackups[id] = _allBackups[id]!.copyWith(
@@ -270,10 +267,10 @@ class FileUploader {
     _queue.entries
         .where((entry) => entry.value.status == UploadStatus.notStarted)
         .forEach((pendingUpload) {
-          if (fn(pendingUpload.value.file)) {
-            uploadsToBeRemoved.add(pendingUpload.key);
-          }
-        });
+      if (fn(pendingUpload.value.file)) {
+        uploadsToBeRemoved.add(pendingUpload.key);
+      }
+    });
     for (final id in uploadsToBeRemoved) {
       _queue.remove(id)?.completer.completeError(reason);
       _allBackups[id] = _allBackups[id]!.copyWith(
@@ -321,8 +318,8 @@ class FileUploader {
         pendingEntry.status = UploadStatus.inProgress;
         _allBackups[pendingEntry.file.localID!] =
             _allBackups[pendingEntry.file.localID]!.copyWith(
-              status: BackupItemStatus.uploading,
-            );
+          status: BackupItemStatus.uploading,
+        );
         Bus.instance.fire(BackupUpdatedEvent(_allBackups));
         _encryptAndUploadFileToCollection(
           pendingEntry.file,
@@ -343,14 +340,14 @@ class FileUploader {
     }
     final localID = file.localID!;
     try {
-      final uploadedFile = await _tryToUpload(file, collectionID, forcedUpload)
-          .timeout(
-            kFileUploadTimeout,
-            onTimeout: () {
-              final message = "Upload timed out for file " + file.toString();
-              throw TimeoutException(message);
-            },
-          );
+      final uploadedFile =
+          await _tryToUpload(file, collectionID, forcedUpload).timeout(
+        kFileUploadTimeout,
+        onTimeout: () {
+          final message = "Upload timed out for file " + file.toString();
+          throw TimeoutException(message);
+        },
+      );
       _queue.remove(localID)!.completer.complete(uploadedFile);
       _allBackups[localID] = _allBackups[localID]!.copyWith(
         status: BackupItemStatus.uploaded,
@@ -399,8 +396,8 @@ class FileUploader {
       });
       if (filesToDelete.isNotEmpty) {
         _logger.info('Deleting ${filesToDelete.length} stale upload files ');
-        final fileNameToLastAttempt = await _uploadLocks
-            .getFileNameToLastAttemptedAtMap();
+        final fileNameToLastAttempt =
+            await _uploadLocks.getFileNameToLastAttemptedAtMap();
         for (final file in filesToDelete) {
           final fileName = file.path.split('/').last;
           final lastAttemptTime = fileNameToLastAttempt[fileName] != null
@@ -426,8 +423,8 @@ class FileUploader {
         if (sharedFiles.isNotEmpty) {
           _logger.info('Shared media directory cleanup ${sharedFiles.length}');
           final int ownerID = Configuration.instance.getUserID()!;
-          final existingLocalFileIDs = await FilesDB.instance
-              .getExistingLocalFileIDs(ownerID);
+          final existingLocalFileIDs =
+              await FilesDB.instance.getExistingLocalFileIDs(ownerID);
           final Set<String> trackedSharedFilePaths = {};
           for (String localID in existingLocalFileIDs) {
             if (localID.contains(sharedMediaIdentifier)) {
@@ -518,8 +515,7 @@ class FileUploader {
     await checkNetworkForUpload(isForceUpload: forcedUpload);
     if (!forcedUpload) {
       final fileOnDisk = await FilesDB.instance.getFile(file.generatedID!);
-      final wasAlreadyUploaded =
-          fileOnDisk != null &&
+      final wasAlreadyUploaded = fileOnDisk != null &&
           fileOnDisk.uploadedFileID != null &&
           (fileOnDisk.updationTime ?? -1) != -1 &&
           (fileOnDisk.collectionID ?? -1) == collectionID;
@@ -586,12 +582,12 @@ class FileUploader {
 
     final String? existingMultipartEncFileName =
         mediaUploadData.hashData?.fileHash != null
-        ? await _uploadLocks.getEncryptedFileName(
-            lockKey,
-            mediaUploadData.hashData!.fileHash!,
-            collectionID,
-          )
-        : null;
+            ? await _uploadLocks.getEncryptedFileName(
+                lockKey,
+                mediaUploadData.hashData!.fileHash!,
+                collectionID,
+              )
+            : null;
     final sourceLength = await mediaUploadData.sourceFile!.length();
     final bool hasExistingMultiPart = existingMultipartEncFileName != null;
     final tempDirectory = Configuration.instance.getTempDirectory();
@@ -660,8 +656,7 @@ class FileUploader {
             'multiPartResume: encryptedFile missing',
           );
         }
-        final bool updateWithDiffKey =
-            isUpdatedFile &&
+        final bool updateWithDiffKey = isUpdatedFile &&
             multiPartFileEncResult != null &&
             !listEquals(key, multiPartFileEncResult.key);
         if (updateWithDiffKey) {
@@ -772,16 +767,15 @@ class FileUploader {
           if (partMd5s == null || partMd5s.isEmpty) {
             throw MultiPartError("Missing part MD5s for multipart upload");
           }
-          final multipartPartLength =
-              fileAttributes.partSize ??
+          final multipartPartLength = fileAttributes.partSize ??
               _multiPartUploader.multipartPartSizeForUpload;
-          final fileUploadURLs = await _multiPartUploader
-              .getMultipartUploadURLs(
-                count: count,
-                contentLength: encFileSize,
-                partLength: multipartPartLength,
-                partMd5s: partMd5s,
-              );
+          final fileUploadURLs =
+              await _multiPartUploader.getMultipartUploadURLs(
+            count: count,
+            contentLength: encFileSize,
+            partLength: multipartPartLength,
+            partMd5s: partMd5s,
+          );
           final encFileName = encryptedFile.path.split('/').last;
           await _multiPartUploader.createTableEntry(
             lockKey,
@@ -991,12 +985,9 @@ class FileUploader {
       pubMetadata[widthKey] = mediaUploadData.width;
       pubMetadata[mediaTypeKey] = mediaUploadData.isPanorama == true ? 1 : 0;
     }
-    if (flagService.useFileDerivedImageDimensions &&
-        (mediaUploadData.rawHeight ?? 0) != 0 &&
-        (mediaUploadData.rawWidth ?? 0) != 0) {
-      pubMetadata[rawHeightKey] = mediaUploadData.rawHeight;
-      pubMetadata[rawWidthKey] = mediaUploadData.rawWidth;
-      pubMetadata[rotationDegreesKey] = mediaUploadData.rotationDegrees ?? 0;
+    final rotationDegrees = mediaUploadData.rotationDegrees;
+    if (flagService.useFileDerivedImageDimensions && rotationDegrees != null) {
+      pubMetadata[rotationDegreesKey] = rotationDegrees;
     }
     if (mediaUploadData.motionPhotoStartIndex != null) {
       pubMetadata[motionVideoIndexKey] = mediaUploadData.motionPhotoStartIndex;
@@ -1066,24 +1057,24 @@ class FileUploader {
     }
     final bool isSandBoxFile = fileToUpload.isSharedMediaToAppSandbox;
 
-    final List<EnteFile> existingUploadedFiles = await FilesDB.instance
-        .getUploadedFilesWithHashes(
-          mediaUploadData.hashData!,
-          fileToUpload.fileType,
-          Configuration.instance.getUserID()!,
-        );
+    final List<EnteFile> existingUploadedFiles =
+        await FilesDB.instance.getUploadedFilesWithHashes(
+      mediaUploadData.hashData!,
+      fileToUpload.fileType,
+      Configuration.instance.getUserID()!,
+    );
     if (existingUploadedFiles.isEmpty) {
       // continueUploading this file
       return Tuple2(false, fileToUpload);
     }
 
     // case a
-    final EnteFile? sameLocalSameCollection = existingUploadedFiles
-        .firstWhereOrNull(
-          (e) =>
-              e.collectionID == toCollectionID &&
-              (e.localID == fileToUpload.localID || isSandBoxFile),
-        );
+    final EnteFile? sameLocalSameCollection =
+        existingUploadedFiles.firstWhereOrNull(
+      (e) =>
+          e.collectionID == toCollectionID &&
+          (e.localID == fileToUpload.localID || isSandBoxFile),
+    );
     if (sameLocalSameCollection != null) {
       _logger.info(
         "sameLocalSameCollection: toUpload  ${fileToUpload.tag} "
@@ -1137,12 +1128,12 @@ class FileUploader {
     }
 
     // case c
-    final EnteFile? fileExistsButDifferentCollection = existingUploadedFiles
-        .firstWhereOrNull(
-          (e) =>
-              e.collectionID != toCollectionID &&
-              (e.localID == fileToUpload.localID || isSandBoxFile),
-        );
+    final EnteFile? fileExistsButDifferentCollection =
+        existingUploadedFiles.firstWhereOrNull(
+      (e) =>
+          e.collectionID != toCollectionID &&
+          (e.localID == fileToUpload.localID || isSandBoxFile),
+    );
     if (fileExistsButDifferentCollection != null) {
       _logger.info(
         "fileExistsButDifferentCollection: toUpload  ${fileToUpload.tag} "
@@ -1150,10 +1141,10 @@ class FileUploader {
       );
       final linkedFile = await CollectionsService.instance
           .linkLocalFileToExistingUploadedFileInAnotherCollection(
-            toCollectionID,
-            localFileToUpload: fileToUpload,
-            existingUploadedFile: fileExistsButDifferentCollection,
-          );
+        toCollectionID,
+        localFileToUpload: fileToUpload,
+        existingUploadedFile: fileExistsButDifferentCollection,
+      );
       return Tuple2(true, linkedFile);
     }
     final Set<String> matchLocalIDs = existingUploadedFiles
@@ -1215,8 +1206,8 @@ class FileUploader {
    */
   Future<void> _checkIfWithinStorageLimit(File fileToBeUploaded) async {
     try {
-      final UserDetails? userDetails = UserService.instance
-          .getCachedUserDetails();
+      final UserDetails? userDetails =
+          UserService.instance.getCachedUserDetails();
       if (userDetails == null) {
         return;
       }
@@ -1252,8 +1243,7 @@ class FileUploader {
 
   Future _onInvalidFileError(EnteFile file, InvalidFileError e) async {
     try {
-      final bool canIgnoreFile =
-          file.localID != null &&
+      final bool canIgnoreFile = file.localID != null &&
           file.deviceFolder != null &&
           file.title != null &&
           !file.isSharedMediaToAppSandbox;

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -99,15 +99,17 @@ class FileUploader {
 
   Future<void> init(SharedPreferences preferences, bool isBackground) async {
     _prefs = preferences;
-    _processType =
-        isBackground ? ProcessType.background : ProcessType.foreground;
+    _processType = isBackground
+        ? ProcessType.background
+        : ProcessType.foreground;
     final currentTime = DateTime.now().microsecondsSinceEpoch;
     await _uploadLocks.releaseLocksAcquiredByOwnerBefore(
       _processType.toString(),
       currentTime,
     );
-    await _uploadLocks
-        .releaseAllLocksAcquiredBefore(currentTime - kSafeBufferForLockExpiry);
+    await _uploadLocks.releaseAllLocksAcquiredBefore(
+      currentTime - kSafeBufferForLockExpiry,
+    );
     if (!isBackground) {
       await _prefs.reload();
       final lastBGTaskHeartBeatTime =
@@ -142,26 +144,27 @@ class FileUploader {
     if (_localPhotosUpdatedSubscription != null) {
       await _localPhotosUpdatedSubscription!.cancel();
     }
-    _localPhotosUpdatedSubscription =
-        Bus.instance.on<LocalPhotosUpdatedEvent>().listen((event) {
-      if (event.type == EventType.deletedFromDevice ||
-          event.type == EventType.deletedFromEverywhere) {
-        removeFromQueueWhere(
-          (file) {
-            for (final updatedFile in event.updatedFiles) {
-              if (file.generatedID == updatedFile.generatedID) {
-                return true;
-              }
-            }
-            return false;
-          },
-          InvalidFileError(
-            "File already deleted",
-            InvalidReason.assetDeletedEvent,
-          ),
-        );
-      }
-    });
+    _localPhotosUpdatedSubscription = Bus.instance
+        .on<LocalPhotosUpdatedEvent>()
+        .listen((event) {
+          if (event.type == EventType.deletedFromDevice ||
+              event.type == EventType.deletedFromEverywhere) {
+            removeFromQueueWhere(
+              (file) {
+                for (final updatedFile in event.updatedFiles) {
+                  if (file.generatedID == updatedFile.generatedID) {
+                    return true;
+                  }
+                }
+                return false;
+              },
+              InvalidFileError(
+                "File already deleted",
+                InvalidReason.assetDeletedEvent,
+              ),
+            );
+          }
+        });
   }
 
   // upload future will return null as File when the file entry is deleted
@@ -207,9 +210,10 @@ class FileUploader {
       );
 
       return CollectionsService.instance
-          .addOrCopyToCollection(collectionID, [uploadedFile]).then((aVoid) {
-        return uploadedFile;
-      });
+          .addOrCopyToCollection(collectionID, [uploadedFile])
+          .then((aVoid) {
+            return uploadedFile;
+          });
     });
   }
 
@@ -222,8 +226,8 @@ class FileUploader {
     _queue.entries
         .where((entry) => entry.value.status == UploadStatus.notStarted)
         .forEach((pendingUpload) {
-      uploadsToBeRemoved.add(pendingUpload.key);
-    });
+          uploadsToBeRemoved.add(pendingUpload.key);
+        });
     for (final id in uploadsToBeRemoved) {
       _queue.remove(id)?.completer.completeError(reason);
       _allBackups[id] = _allBackups[id]!.copyWith(
@@ -266,14 +270,16 @@ class FileUploader {
     _queue.entries
         .where((entry) => entry.value.status == UploadStatus.notStarted)
         .forEach((pendingUpload) {
-      if (fn(pendingUpload.value.file)) {
-        uploadsToBeRemoved.add(pendingUpload.key);
-      }
-    });
+          if (fn(pendingUpload.value.file)) {
+            uploadsToBeRemoved.add(pendingUpload.key);
+          }
+        });
     for (final id in uploadsToBeRemoved) {
       _queue.remove(id)?.completer.completeError(reason);
-      _allBackups[id] = _allBackups[id]!
-          .copyWith(status: BackupItemStatus.retry, error: reason);
+      _allBackups[id] = _allBackups[id]!.copyWith(
+        status: BackupItemStatus.retry,
+        error: reason,
+      );
       Bus.instance.fire(BackupUpdatedEvent(_allBackups));
     }
     _logger.info(
@@ -314,8 +320,9 @@ class FileUploader {
       if (pendingEntry != null) {
         pendingEntry.status = UploadStatus.inProgress;
         _allBackups[pendingEntry.file.localID!] =
-            _allBackups[pendingEntry.file.localID]!
-                .copyWith(status: BackupItemStatus.uploading);
+            _allBackups[pendingEntry.file.localID]!.copyWith(
+              status: BackupItemStatus.uploading,
+            );
         Bus.instance.fire(BackupUpdatedEvent(_allBackups));
         _encryptAndUploadFileToCollection(
           pendingEntry.file,
@@ -336,30 +343,34 @@ class FileUploader {
     }
     final localID = file.localID!;
     try {
-      final uploadedFile =
-          await _tryToUpload(file, collectionID, forcedUpload).timeout(
-        kFileUploadTimeout,
-        onTimeout: () {
-          final message = "Upload timed out for file " + file.toString();
-          throw TimeoutException(message);
-        },
-      );
+      final uploadedFile = await _tryToUpload(file, collectionID, forcedUpload)
+          .timeout(
+            kFileUploadTimeout,
+            onTimeout: () {
+              final message = "Upload timed out for file " + file.toString();
+              throw TimeoutException(message);
+            },
+          );
       _queue.remove(localID)!.completer.complete(uploadedFile);
-      _allBackups[localID] =
-          _allBackups[localID]!.copyWith(status: BackupItemStatus.uploaded);
+      _allBackups[localID] = _allBackups[localID]!.copyWith(
+        status: BackupItemStatus.uploaded,
+      );
       Bus.instance.fire(BackupUpdatedEvent(_allBackups));
       return uploadedFile;
     } catch (e) {
       if (e is LockAlreadyAcquiredError) {
         _queue[localID]!.status = UploadStatus.inBackground;
-        _allBackups[localID] = _allBackups[localID]!
-            .copyWith(status: BackupItemStatus.inBackground);
+        _allBackups[localID] = _allBackups[localID]!.copyWith(
+          status: BackupItemStatus.inBackground,
+        );
         Bus.instance.fire(BackupUpdatedEvent(_allBackups));
         return _queue[localID]!.completer.future;
       } else {
         _queue.remove(localID)!.completer.completeError(e);
-        _allBackups[localID] = _allBackups[localID]!
-            .copyWith(status: BackupItemStatus.retry, error: e);
+        _allBackups[localID] = _allBackups[localID]!.copyWith(
+          status: BackupItemStatus.retry,
+          error: e,
+        );
         Bus.instance.fire(BackupUpdatedEvent(_allBackups));
         return null;
       }
@@ -374,9 +385,7 @@ class FileUploader {
 
   Future<void> removeStaleFiles() async {
     if (_hasInitiatedForceUpload) {
-      _logger.info(
-        "Force upload was initiated, skipping stale file cleanup",
-      );
+      _logger.info("Force upload was initiated, skipping stale file cleanup");
       return;
     }
     try {
@@ -390,8 +399,8 @@ class FileUploader {
       });
       if (filesToDelete.isNotEmpty) {
         _logger.info('Deleting ${filesToDelete.length} stale upload files ');
-        final fileNameToLastAttempt =
-            await _uploadLocks.getFileNameToLastAttemptedAtMap();
+        final fileNameToLastAttempt = await _uploadLocks
+            .getFileNameToLastAttemptedAtMap();
         for (final file in filesToDelete) {
           final fileName = file.path.split('/').last;
           final lastAttemptTime = fileNameToLastAttempt[fileName] != null
@@ -417,13 +426,14 @@ class FileUploader {
         if (sharedFiles.isNotEmpty) {
           _logger.info('Shared media directory cleanup ${sharedFiles.length}');
           final int ownerID = Configuration.instance.getUserID()!;
-          final existingLocalFileIDs =
-              await FilesDB.instance.getExistingLocalFileIDs(ownerID);
+          final existingLocalFileIDs = await FilesDB.instance
+              .getExistingLocalFileIDs(ownerID);
           final Set<String> trackedSharedFilePaths = {};
           for (String localID in existingLocalFileIDs) {
             if (localID.contains(sharedMediaIdentifier)) {
-              trackedSharedFilePaths
-                  .add(getSharedMediaPathFromLocalID(localID));
+              trackedSharedFilePaths.add(
+                getSharedMediaPathFromLocalID(localID),
+              );
             }
           }
           for (final file in sharedFiles) {
@@ -508,7 +518,8 @@ class FileUploader {
     await checkNetworkForUpload(isForceUpload: forcedUpload);
     if (!forcedUpload) {
       final fileOnDisk = await FilesDB.instance.getFile(file.generatedID!);
-      final wasAlreadyUploaded = fileOnDisk != null &&
+      final wasAlreadyUploaded =
+          fileOnDisk != null &&
           fileOnDisk.uploadedFileID != null &&
           (fileOnDisk.updationTime ?? -1) != -1 &&
           (fileOnDisk.collectionID ?? -1) == collectionID;
@@ -530,9 +541,7 @@ class FileUploader {
       return file;
     }
     if (!CollectionsService.instance.allowUpload(collectionID)) {
-      _logger.warning(
-        'Upload not allowed for collection $collectionID',
-      );
+      _logger.warning('Upload not allowed for collection $collectionID');
       if (!file.isUploaded && file.generatedID != null) {
         _logger.info("Deleting file entry for " + file.toString());
         await FilesDB.instance.deleteByGeneratedID(file.generatedID!);
@@ -557,7 +566,12 @@ class FileUploader {
 
     MediaUploadData? mediaUploadData;
     try {
-      mediaUploadData = await getUploadDataFromEnteFile(file, parseExif: true);
+      mediaUploadData = await getUploadDataFromEnteFile(
+        file,
+        parseExif: true,
+        useFileDerivedImageDimensions:
+            flagService.useFileDerivedImageDimensions,
+      );
     } catch (e) {
       // This additional try catch block is added because for resumable upload,
       // we need to compute the hash before the next step. Previously, this
@@ -572,12 +586,12 @@ class FileUploader {
 
     final String? existingMultipartEncFileName =
         mediaUploadData.hashData?.fileHash != null
-            ? await _uploadLocks.getEncryptedFileName(
-                lockKey,
-                mediaUploadData.hashData!.fileHash!,
-                collectionID,
-              )
-            : null;
+        ? await _uploadLocks.getEncryptedFileName(
+            lockKey,
+            mediaUploadData.hashData!.fileHash!,
+            collectionID,
+          )
+        : null;
     final sourceLength = await mediaUploadData.sourceFile!.length();
     final bool hasExistingMultiPart = existingMultipartEncFileName != null;
     final tempDirectory = Configuration.instance.getTempDirectory();
@@ -646,13 +660,12 @@ class FileUploader {
             'multiPartResume: encryptedFile missing',
           );
         }
-        final bool updateWithDiffKey = isUpdatedFile &&
+        final bool updateWithDiffKey =
+            isUpdatedFile &&
             multiPartFileEncResult != null &&
             !listEquals(key, multiPartFileEncResult.key);
         if (updateWithDiffKey) {
-          throw MultiPartError(
-            'multiPart update resumed with differentKey',
-          );
+          throw MultiPartError('multiPart update resumed with differentKey');
         }
       } else if (encryptedFileExists) {
         // otherwise just delete the file for singlepart upload
@@ -665,8 +678,9 @@ class FileUploader {
       // Calculate the number of parts to determine if we need MD5
       // Use source length to estimate encrypted size for part count decision
       final estimatedEncSize = CryptoUtil.estimateEncryptedSize(sourceLength);
-      final estimatedCount =
-          _multiPartUploader.calculatePartCount(estimatedEncSize);
+      final estimatedCount = _multiPartUploader.calculatePartCount(
+        estimatedEncSize,
+      );
 
       FileEncryptResult? fileAttributes = multiPartFileEncResult;
       String? fileMd5 = fileAttributes?.fileMd5;
@@ -702,16 +716,14 @@ class FileUploader {
       }
 
       final EncryptionResult encryptedThumbnailData =
-          await CryptoUtil.encryptChaCha(
-        thumbnailData!,
-        fileAttributes.key,
-      );
+          await CryptoUtil.encryptChaCha(thumbnailData!, fileAttributes.key);
       if (File(encryptedThumbnailPath).existsSync()) {
         await File(encryptedThumbnailPath).delete();
       }
       final encryptedThumbnailFile = File(encryptedThumbnailPath);
-      await encryptedThumbnailFile
-          .writeAsBytes(encryptedThumbnailData.encryptedData!);
+      await encryptedThumbnailFile.writeAsBytes(
+        encryptedThumbnailData.encryptedData!,
+      );
       encThumbSize = await encryptedThumbnailFile.length();
       final thumbnailMd5 = await computeMd5(encryptedThumbnailPath);
 
@@ -760,15 +772,16 @@ class FileUploader {
           if (partMd5s == null || partMd5s.isEmpty) {
             throw MultiPartError("Missing part MD5s for multipart upload");
           }
-          final multipartPartLength = fileAttributes.partSize ??
+          final multipartPartLength =
+              fileAttributes.partSize ??
               _multiPartUploader.multipartPartSizeForUpload;
-          final fileUploadURLs =
-              await _multiPartUploader.getMultipartUploadURLs(
-            count: count,
-            contentLength: encFileSize,
-            partLength: multipartPartLength,
-            partMd5s: partMd5s,
-          );
+          final fileUploadURLs = await _multiPartUploader
+              .getMultipartUploadURLs(
+                count: count,
+                contentLength: encFileSize,
+                partLength: multipartPartLength,
+                partMd5s: partMd5s,
+              );
           final encFileName = encryptedFile.path.split('/').last;
           await _multiPartUploader.createTableEntry(
             lockKey,
@@ -810,26 +823,32 @@ class FileUploader {
         mediaUploadData.exifData,
       );
       file.metadataVersion = EnteFile.kCurrentMetadataVersion;
-      final metadata =
-          await file.getMetadataForUpload(mediaUploadData, exifTime);
+      final metadata = await file.getMetadataForUpload(
+        mediaUploadData,
+        exifTime,
+      );
 
       final encryptedMetadataResult = await CryptoUtil.encryptChaCha(
         utf8.encode(jsonEncode(metadata)),
         fileAttributes.key,
       );
       final fileDecryptionHeader = CryptoUtil.bin2base64(fileAttributes.header);
-      final thumbnailDecryptionHeader =
-          CryptoUtil.bin2base64(encryptedThumbnailData.header!);
+      final thumbnailDecryptionHeader = CryptoUtil.bin2base64(
+        encryptedThumbnailData.header!,
+      );
       final encryptedMetadata = CryptoUtil.bin2base64(
         encryptedMetadataResult.encryptedData!,
       );
-      final metadataDecryptionHeader =
-          CryptoUtil.bin2base64(encryptedMetadataResult.header!);
+      final metadataDecryptionHeader = CryptoUtil.bin2base64(
+        encryptedMetadataResult.header!,
+      );
       if (SyncService.instance.shouldStopSync()) {
         throw SyncStopRequestedError();
       }
-      final stillLocked =
-          await _uploadLocks.isLocked(lockKey, _processType.toString());
+      final stillLocked = await _uploadLocks.isLocked(
+        lockKey,
+        _processType.toString(),
+      );
       if (!stillLocked) {
         _logger.warning('file ${file.tag} report paused is missing');
         throw LockFreedError();
@@ -865,12 +884,16 @@ class FileUploader {
           fileAttributes.key,
           CollectionsService.instance.getCollectionKey(collectionID),
         );
-        final encryptedKey =
-            CryptoUtil.bin2base64(encryptedFileKeyData.encryptedData!);
-        final keyDecryptionNonce =
-            CryptoUtil.bin2base64(encryptedFileKeyData.nonce!);
-        final Map<String, dynamic> pubMetadata =
-            _buildPublicMagicData(mediaUploadData, exifTime);
+        final encryptedKey = CryptoUtil.bin2base64(
+          encryptedFileKeyData.encryptedData!,
+        );
+        final keyDecryptionNonce = CryptoUtil.bin2base64(
+          encryptedFileKeyData.nonce!,
+        );
+        final Map<String, dynamic> pubMetadata = _buildPublicMagicData(
+          mediaUploadData,
+          exifTime,
+        );
         MetadataRequest? pubMetadataRequest;
         if (pubMetadata.isNotEmpty) {
           pubMetadataRequest = await getPubMetadataRequest(
@@ -913,10 +936,7 @@ class FileUploader {
       await UploadLocksDB.instance.deleteMultipartTrack(lockKey);
 
       Bus.instance.fire(
-        LocalPhotosUpdatedEvent(
-          [remoteFile],
-          source: "uploadCompleted",
-        ),
+        LocalPhotosUpdatedEvent([remoteFile], source: "uploadCompleted"),
       );
       _logger.info("File upload complete for " + remoteFile.toString());
       uploadCompleted = true;
@@ -970,6 +990,13 @@ class FileUploader {
       pubMetadata[heightKey] = mediaUploadData.height;
       pubMetadata[widthKey] = mediaUploadData.width;
       pubMetadata[mediaTypeKey] = mediaUploadData.isPanorama == true ? 1 : 0;
+    }
+    if (flagService.useFileDerivedImageDimensions &&
+        (mediaUploadData.rawHeight ?? 0) != 0 &&
+        (mediaUploadData.rawWidth ?? 0) != 0) {
+      pubMetadata[rawHeightKey] = mediaUploadData.rawHeight;
+      pubMetadata[rawWidthKey] = mediaUploadData.rawWidth;
+      pubMetadata[rotationDegreesKey] = mediaUploadData.rotationDegrees ?? 0;
     }
     if (mediaUploadData.motionPhotoStartIndex != null) {
       pubMetadata[motionVideoIndexKey] = mediaUploadData.motionPhotoStartIndex;
@@ -1034,31 +1061,29 @@ class FileUploader {
     if (fileToUpload.uploadedFileID != null) {
       // ideally this should never happen, but because the code below this case
       // can do unexpected mapping, we are adding this additional check
-      _logger.severe(
-        'Critical: file is already uploaded, skipped mapping',
-      );
+      _logger.severe('Critical: file is already uploaded, skipped mapping');
       return Tuple2(false, fileToUpload);
     }
     final bool isSandBoxFile = fileToUpload.isSharedMediaToAppSandbox;
 
-    final List<EnteFile> existingUploadedFiles =
-        await FilesDB.instance.getUploadedFilesWithHashes(
-      mediaUploadData.hashData!,
-      fileToUpload.fileType,
-      Configuration.instance.getUserID()!,
-    );
+    final List<EnteFile> existingUploadedFiles = await FilesDB.instance
+        .getUploadedFilesWithHashes(
+          mediaUploadData.hashData!,
+          fileToUpload.fileType,
+          Configuration.instance.getUserID()!,
+        );
     if (existingUploadedFiles.isEmpty) {
       // continueUploading this file
       return Tuple2(false, fileToUpload);
     }
 
     // case a
-    final EnteFile? sameLocalSameCollection =
-        existingUploadedFiles.firstWhereOrNull(
-      (e) =>
-          e.collectionID == toCollectionID &&
-          (e.localID == fileToUpload.localID || isSandBoxFile),
-    );
+    final EnteFile? sameLocalSameCollection = existingUploadedFiles
+        .firstWhereOrNull(
+          (e) =>
+              e.collectionID == toCollectionID &&
+              (e.localID == fileToUpload.localID || isSandBoxFile),
+        );
     if (sameLocalSameCollection != null) {
       _logger.info(
         "sameLocalSameCollection: toUpload  ${fileToUpload.tag} "
@@ -1112,12 +1137,12 @@ class FileUploader {
     }
 
     // case c
-    final EnteFile? fileExistsButDifferentCollection =
-        existingUploadedFiles.firstWhereOrNull(
-      (e) =>
-          e.collectionID != toCollectionID &&
-          (e.localID == fileToUpload.localID || isSandBoxFile),
-    );
+    final EnteFile? fileExistsButDifferentCollection = existingUploadedFiles
+        .firstWhereOrNull(
+          (e) =>
+              e.collectionID != toCollectionID &&
+              (e.localID == fileToUpload.localID || isSandBoxFile),
+        );
     if (fileExistsButDifferentCollection != null) {
       _logger.info(
         "fileExistsButDifferentCollection: toUpload  ${fileToUpload.tag} "
@@ -1125,16 +1150,14 @@ class FileUploader {
       );
       final linkedFile = await CollectionsService.instance
           .linkLocalFileToExistingUploadedFileInAnotherCollection(
-        toCollectionID,
-        localFileToUpload: fileToUpload,
-        existingUploadedFile: fileExistsButDifferentCollection,
-      );
+            toCollectionID,
+            localFileToUpload: fileToUpload,
+            existingUploadedFile: fileExistsButDifferentCollection,
+          );
       return Tuple2(true, linkedFile);
     }
     final Set<String> matchLocalIDs = existingUploadedFiles
-        .where(
-          (e) => e.localID != null,
-        )
+        .where((e) => e.localID != null)
         .map((e) => e.localID!)
         .toSet();
     _logger.info(
@@ -1192,8 +1215,8 @@ class FileUploader {
    */
   Future<void> _checkIfWithinStorageLimit(File fileToBeUploaded) async {
     try {
-      final UserDetails? userDetails =
-          UserService.instance.getCachedUserDetails();
+      final UserDetails? userDetails = UserService.instance
+          .getCachedUserDetails();
       if (userDetails == null) {
         return;
       }
@@ -1201,8 +1224,10 @@ class FileUploader {
       final num freeStorage = userDetails.getFreeStorage() + k20MBStorageBuffer;
       final int fileSize = await fileToBeUploaded.length();
       if (fileSize > freeStorage) {
-        _logger.warning('Storage limit exceeded fileSize $fileSize and '
-            'freeStorage $freeStorage');
+        _logger.warning(
+          'Storage limit exceeded fileSize $fileSize and '
+          'freeStorage $freeStorage',
+        );
         throw StorageLimitExceededError();
       }
       final estimatedEncryptedSize = CryptoUtil.estimateEncryptedSize(fileSize);
@@ -1227,7 +1252,8 @@ class FileUploader {
 
   Future _onInvalidFileError(EnteFile file, InvalidFileError e) async {
     try {
-      final bool canIgnoreFile = file.localID != null &&
+      final bool canIgnoreFile =
+          file.localID != null &&
           file.deviceFolder != null &&
           file.title != null &&
           !file.isSharedMediaToAppSandbox;
@@ -1303,8 +1329,9 @@ class FileUploader {
         _onStorageLimitExceeded();
       } else if (attempt < kMaximumUploadAttempts && statusCode == -1) {
         // retry when DioException contains no response/status code
-        _logger
-            .info("Upload file (${file.tag}) failed, will retry in 3 seconds");
+        _logger.info(
+          "Upload file (${file.tag}) failed, will retry in 3 seconds",
+        );
         await Future.delayed(const Duration(seconds: 3));
         return _uploadFile(
           file,
@@ -1365,8 +1392,9 @@ class FileUploader {
       if (statusCode == 426) {
         _onStorageLimitExceeded();
       } else if (attempt < kMaximumUploadAttempts && statusCode == -1) {
-        _logger
-            .info("Update file (${file.tag}) failed, will retry in 3 seconds");
+        _logger.info(
+          "Update file (${file.tag}) failed, will retry in 3 seconds",
+        );
         await Future.delayed(const Duration(seconds: 3));
         return _updateFile(
           file,
@@ -1427,8 +1455,10 @@ class FileUploader {
   UploadURL _registerUploadURLUsage(UploadURL uploadURL) {
     // Atomic check-and-set to prevent race conditions in parallel uploads
     final now = DateTime.now();
-    final existingTimestamp =
-        _usedUploadURLs.putIfAbsent(uploadURL.url, () => now);
+    final existingTimestamp = _usedUploadURLs.putIfAbsent(
+      uploadURL.url,
+      () => now,
+    );
 
     if (existingTimestamp != now) {
       throw DuplicateUploadURLError(
@@ -1485,9 +1515,7 @@ class FileUploader {
       await _dio.put(
         useUploadProxy ? "$kUploadProxyEndpoint/file-upload" : uploadURL.url,
         data: file.openRead(),
-        options: Options(
-          headers: headers,
-        ),
+        options: Options(headers: headers),
         onSendProgress: (sent, total) {
           bytesSent = sent;
         },
@@ -1547,15 +1575,17 @@ class FileUploader {
       );
       if (!isStillLocked) {
         final completer = _queue.remove(upload.key)?.completer;
-        final dbFile =
-            await FilesDB.instance.getFile(upload.value.file.generatedID!);
+        final dbFile = await FilesDB.instance.getFile(
+          upload.value.file.generatedID!,
+        );
         if (dbFile?.uploadedFileID != null) {
           _logger.info(
             "Background upload success detected ${upload.value.file.tag}",
           );
           completer?.complete(dbFile);
-          _allBackups[upload.key] = _allBackups[upload.key]!
-              .copyWith(status: BackupItemStatus.uploaded);
+          _allBackups[upload.key] = _allBackups[upload.key]!.copyWith(
+            status: BackupItemStatus.uploaded,
+          );
         } else {
           _logger.info(
             "Background upload failure detected ${upload.value.file.tag}",
@@ -1599,7 +1629,4 @@ class FileUploadItem {
 
 enum UploadStatus { notStarted, inProgress, inBackground, completed }
 
-enum ProcessType {
-  background,
-  foreground,
-}
+enum ProcessType { background, foreground }

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -27,6 +27,7 @@ import "package:photos/services/sync/local_sync_service.dart";
 import "package:photos/src/rust/api/motion_photo_api.dart";
 import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
+import "package:photos/utils/image_dimension_util.dart";
 import "package:uuid/uuid.dart";
 import 'package:video_thumbnail/video_thumbnail.dart';
 
@@ -40,6 +41,9 @@ class MediaUploadData {
   final FileHashData? hashData;
   final int? height;
   final int? width;
+  final int? rawHeight;
+  final int? rawWidth;
+  final int? rotationDegrees;
   final String? cameraMake;
   final String? cameraModel;
 
@@ -58,6 +62,9 @@ class MediaUploadData {
     this.hashData, {
     this.height,
     this.width,
+    this.rawHeight,
+    this.rawWidth,
+    this.rotationDegrees,
     this.cameraMake,
     this.cameraModel,
     this.motionPhotoStartIndex,
@@ -92,17 +99,27 @@ String? _extractPrintableExifValue(IfdTag? tag) {
 Future<MediaUploadData> getUploadDataFromEnteFile(
   EnteFile file, {
   bool parseExif = false,
+  bool useFileDerivedImageDimensions = false,
 }) async {
   if (file.isSharedMediaToAppSandbox) {
-    return await _getMediaUploadDataFromAppCache(file, parseExif);
+    return await _getMediaUploadDataFromAppCache(
+      file,
+      parseExif,
+      useFileDerivedImageDimensions,
+    );
   } else {
-    return await _getMediaUploadDataFromAssetFile(file, parseExif);
+    return await _getMediaUploadDataFromAssetFile(
+      file,
+      parseExif,
+      useFileDerivedImageDimensions,
+    );
   }
 }
 
 Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   EnteFile file,
   bool parseExif,
+  bool useFileDerivedImageDimensions,
 ) async {
   File? sourceFile;
   Uint8List? thumbnailData;
@@ -117,13 +134,13 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   final asset = await file.getAsset
       .timeout(const Duration(seconds: 3))
       .catchError((e) async {
-    if (e is TimeoutException) {
-      _logger.info("Asset fetch timed out for " + file.toString());
-      return await file.getAsset;
-    } else {
-      throw e;
-    }
-  });
+        if (e is TimeoutException) {
+          _logger.info("Asset fetch timed out for " + file.toString());
+          return await file.getAsset;
+        } else {
+          throw e;
+        }
+      });
   if (asset == null) {
     throw InvalidFileError("", InvalidReason.assetDeleted);
   }
@@ -134,13 +151,13 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   sourceFile = await asset.originFile
       .timeout(const Duration(seconds: 15))
       .catchError((e) async {
-    if (e is TimeoutException) {
-      _logger.info("Origin file fetch timed out for " + file.tag);
-      return await asset.originFile;
-    } else {
-      throw e;
-    }
-  });
+        if (e is TimeoutException) {
+          _logger.info("Origin file fetch timed out for " + file.tag);
+          return await asset.originFile;
+        } else {
+          throw e;
+        }
+      });
   if (sourceFile == null || !sourceFile.existsSync()) {
     throw InvalidFileError(
       "id: ${file.localID}",
@@ -166,8 +183,9 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
       _logger.severe(errMsg);
       throw InvalidFileError(errMsg, InvalidReason.livePhotoVideoMissing);
     }
-    final String livePhotoVideoHash =
-        CryptoUtil.bin2base64(await CryptoUtil.getHash(videoUrl));
+    final String livePhotoVideoHash = CryptoUtil.bin2base64(
+      await CryptoUtil.getHash(videoUrl),
+    );
     // imgHash:vidHash
     fileHash = '$fileHash$kLivePhotoHashSeparator$livePhotoVideoHash';
     final tempPath = Configuration.instance.getTempDirectory();
@@ -191,23 +209,32 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
 
   thumbnailData = await _getThumbnailForUpload(asset, file);
   isDeleted = !(await asset.exists);
-  int? h, w;
-  if (asset.width != 0 && asset.height != 0) {
-    w = asset.width;
-    h = asset.height;
-    if (Platform.isAndroid &&
-        file.fileType == FileType.image &&
-        _shouldSwapDimensionsForExifOrientation(exifData)) {
-      final temp = w;
-      w = h;
-      h = temp;
-    }
+  final fallbackWidth = asset.width == 0 ? null : asset.width;
+  final fallbackHeight = asset.height == 0 ? null : asset.height;
+  ImageDimensionMetadata? imageDimensions;
+  int? width = fallbackWidth;
+  int? height = fallbackHeight;
+  if (useFileDerivedImageDimensions && file.fileType == FileType.image) {
+    imageDimensions = imageDimensionMetadataFromExifOrFallback(
+      exifData,
+      fallbackWidth: fallbackWidth,
+      fallbackHeight: fallbackHeight,
+      applyExifOrientationToFallback: Platform.isAndroid,
+    );
+    width = imageDimensions?.width ?? fallbackWidth;
+    height = imageDimensions?.height ?? fallbackHeight;
+  } else if (Platform.isAndroid &&
+      file.fileType == FileType.image &&
+      _shouldSwapDimensionsForExifOrientation(exifData)) {
+    width = fallbackHeight;
+    height = fallbackWidth;
   }
   int? motionPhotoStartingIndex;
   if (Platform.isAndroid && asset.type == AssetType.image) {
     try {
-      motionPhotoStartingIndex =
-          await motionVideoIndex({'path': sourceFile.path});
+      motionPhotoStartingIndex = await motionVideoIndex({
+        'path': sourceFile.path,
+      });
     } catch (e) {
       _logger.severe('error while detecthing motion photo start index', e);
     }
@@ -217,8 +244,11 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     thumbnailData,
     isDeleted,
     FileHashData(fileHash, zipHash: zipHash),
-    height: h,
-    width: w,
+    height: height,
+    width: width,
+    rawHeight: imageDimensions?.rawHeight,
+    rawWidth: imageDimensions?.rawWidth,
+    rotationDegrees: imageDimensions?.rotationDegrees,
     cameraMake: cameraMake,
     cameraModel: cameraModel,
     motionPhotoStartIndex: motionPhotoStartingIndex,
@@ -256,11 +286,7 @@ Future<void> zip({
 }) {
   return Computer.shared().compute(
     _computeZip,
-    param: {
-      'zipPath': zipPath,
-      'imagePath': imagePath,
-      'videoPath': videoPath,
-    },
+    param: {'zipPath': zipPath, 'imagePath': imagePath, 'videoPath': videoPath},
     taskName: 'zip',
   );
 }
@@ -289,8 +315,9 @@ Future<Uint8List?> _getThumbnailForUpload(
         compressionAttempts < kMaximumThumbnailCompressionAttempts) {
       _logger.info("Thumbnail size " + thumbnailData.length.toString());
       thumbnailData = await compressThumbnail(thumbnailData);
-      _logger
-          .info("Compressed thumbnail size " + thumbnailData.length.toString());
+      _logger.info(
+        "Compressed thumbnail size " + thumbnailData.length.toString(),
+      );
       compressionAttempts++;
     }
     return thumbnailData;
@@ -343,8 +370,10 @@ Future<void> _decorateEnteFileData(
   if (file.location == null ||
       (file.location!.latitude == 0 && file.location!.longitude == 0)) {
     final latLong = await asset.latlngAsync();
-    file.location =
-        Location(latitude: latLong.latitude, longitude: latLong.longitude);
+    file.location = Location(
+      latitude: latLong.latitude,
+      longitude: latLong.longitude,
+    );
   }
   if (!file.hasLocation && file.isVideo && Platform.isAndroid) {
     final FFProbeProps? props = await getVideoPropsAsync(sourceFile);
@@ -377,8 +406,9 @@ Future<MetadataRequest> getPubMetadataRequest(
   Map<String, dynamic> newData,
   Uint8List fileKey,
 ) async {
-  final Map<String, dynamic> jsonToUpdate =
-      jsonDecode(file.pubMmdEncodedJson ?? '{}');
+  final Map<String, dynamic> jsonToUpdate = jsonDecode(
+    file.pubMmdEncodedJson ?? '{}',
+  );
   newData.forEach((key, value) {
     jsonToUpdate[key] = value;
   });
@@ -401,6 +431,7 @@ Future<MetadataRequest> getPubMetadataRequest(
 Future<MediaUploadData> _getMediaUploadDataFromAppCache(
   EnteFile file,
   bool parseExif,
+  bool useFileDerivedImageDimensions,
 ) async {
   File sourceFile;
   Uint8List? thumbnailData;
@@ -419,12 +450,21 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(
   }
   try {
     thumbnailData = await getThumbnailFromInAppCacheFile(file);
-    final fileHash =
-        CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
+    final fileHash = CryptoUtil.bin2base64(
+      await CryptoUtil.getHash(sourceFile),
+    );
     Map<String, int>? dimensions;
+    ImageDimensionMetadata? imageDimensions;
     if (file.fileType == FileType.image) {
       dimensions = await getImageHeightAndWith(imagePath: localPath);
       exifData = await tryExifFromFile(sourceFile);
+      if (useFileDerivedImageDimensions) {
+        imageDimensions = imageDimensionMetadataFromExifOrFallback(
+          exifData,
+          fallbackWidth: dimensions?['width'],
+          fallbackHeight: dimensions?['height'],
+        );
+      }
       if (exifData != null) {
         cameraMake = _extractPrintableExifValue(exifData['Image Make']);
         cameraModel = _extractPrintableExifValue(exifData['Image Model']);
@@ -458,8 +498,11 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(
       thumbnailData,
       isDeleted,
       FileHashData(fileHash),
-      height: dimensions?['height'],
-      width: dimensions?['width'],
+      height: imageDimensions?.height ?? dimensions?['height'],
+      width: imageDimensions?.width ?? dimensions?['width'],
+      rawHeight: imageDimensions?.rawHeight,
+      rawWidth: imageDimensions?.rawWidth,
+      rotationDegrees: imageDimensions?.rotationDegrees,
       cameraMake: cameraMake,
       cameraModel: cameraModel,
       exifData: exifData,
@@ -493,10 +536,7 @@ Future<Map<String, int>?> getImageHeightAndWith({
     if (frameInfo.image.width == 0 || frameInfo.image.height == 0) {
       return null;
     } else {
-      return {
-        "width": frameInfo.image.width,
-        "height": frameInfo.image.height,
-      };
+      return {"width": frameInfo.image.width, "height": frameInfo.image.height};
     }
   } catch (e) {
     _logger.severe("Failed to get image size", e);
@@ -530,8 +570,9 @@ Future<Uint8List?> getThumbnailFromInAppCacheFile(EnteFile file) async {
       compressionAttempts < kMaximumThumbnailCompressionAttempts) {
     _logger.info("Thumbnail size " + thumbnailData.length.toString());
     thumbnailData = await compressThumbnail(thumbnailData);
-    _logger
-        .info("Compressed thumbnail size " + thumbnailData.length.toString());
+    _logger.info(
+      "Compressed thumbnail size " + thumbnailData.length.toString(),
+    );
     compressionAttempts++;
   }
   return thumbnailData;

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -41,8 +41,6 @@ class MediaUploadData {
   final FileHashData? hashData;
   final int? height;
   final int? width;
-  final int? rawHeight;
-  final int? rawWidth;
   final int? rotationDegrees;
   final String? cameraMake;
   final String? cameraModel;
@@ -62,8 +60,6 @@ class MediaUploadData {
     this.hashData, {
     this.height,
     this.width,
-    this.rawHeight,
-    this.rawWidth,
     this.rotationDegrees,
     this.cameraMake,
     this.cameraModel,
@@ -134,13 +130,13 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   final asset = await file.getAsset
       .timeout(const Duration(seconds: 3))
       .catchError((e) async {
-        if (e is TimeoutException) {
-          _logger.info("Asset fetch timed out for " + file.toString());
-          return await file.getAsset;
-        } else {
-          throw e;
-        }
-      });
+    if (e is TimeoutException) {
+      _logger.info("Asset fetch timed out for " + file.toString());
+      return await file.getAsset;
+    } else {
+      throw e;
+    }
+  });
   if (asset == null) {
     throw InvalidFileError("", InvalidReason.assetDeleted);
   }
@@ -151,13 +147,13 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   sourceFile = await asset.originFile
       .timeout(const Duration(seconds: 15))
       .catchError((e) async {
-        if (e is TimeoutException) {
-          _logger.info("Origin file fetch timed out for " + file.tag);
-          return await asset.originFile;
-        } else {
-          throw e;
-        }
-      });
+    if (e is TimeoutException) {
+      _logger.info("Origin file fetch timed out for " + file.tag);
+      return await asset.originFile;
+    } else {
+      throw e;
+    }
+  });
   if (sourceFile == null || !sourceFile.existsSync()) {
     throw InvalidFileError(
       "id: ${file.localID}",
@@ -246,8 +242,6 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     FileHashData(fileHash, zipHash: zipHash),
     height: height,
     width: width,
-    rawHeight: imageDimensions?.rawHeight,
-    rawWidth: imageDimensions?.rawWidth,
     rotationDegrees: imageDimensions?.rotationDegrees,
     cameraMake: cameraMake,
     cameraModel: cameraModel,
@@ -500,8 +494,6 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(
       FileHashData(fileHash),
       height: imageDimensions?.height ?? dimensions?['height'],
       width: imageDimensions?.width ?? dimensions?['width'],
-      rawHeight: imageDimensions?.rawHeight,
-      rawWidth: imageDimensions?.rawWidth,
       rotationDegrees: imageDimensions?.rotationDegrees,
       cameraMake: cameraMake,
       cameraModel: cameraModel,

--- a/mobile/apps/photos/lib/utils/image_dimension_util.dart
+++ b/mobile/apps/photos/lib/utils/image_dimension_util.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import "package:exif_reader/exif_reader.dart";
+import "package:photos/utils/exif_util.dart";
+
+class ImageDimensionMetadata {
+  final int width;
+  final int height;
+  final int? rawWidth;
+  final int? rawHeight;
+  final int? rotationDegrees;
+
+  const ImageDimensionMetadata({
+    required this.width,
+    required this.height,
+    this.rawWidth,
+    this.rawHeight,
+    this.rotationDegrees,
+  });
+
+  factory ImageDimensionMetadata.fromRawDimensions({
+    required int rawWidth,
+    required int rawHeight,
+    required int rotationDegrees,
+  }) {
+    final normalizedRotation = normalizeRotationDegrees(rotationDegrees);
+    final shouldSwap = isSidewaysRotation(normalizedRotation);
+    return ImageDimensionMetadata(
+      width: shouldSwap ? rawHeight : rawWidth,
+      height: shouldSwap ? rawWidth : rawHeight,
+      rawWidth: rawWidth,
+      rawHeight: rawHeight,
+      rotationDegrees: normalizedRotation,
+    );
+  }
+
+  factory ImageDimensionMetadata.displayOnly({
+    required int width,
+    required int height,
+  }) {
+    return ImageDimensionMetadata(width: width, height: height);
+  }
+
+  bool get hasRawDimensions => (rawWidth ?? 0) > 0 && (rawHeight ?? 0) > 0;
+}
+
+int normalizeRotationDegrees(int degrees) {
+  final normalized = degrees % 360;
+  return normalized < 0 ? normalized + 360 : normalized;
+}
+
+bool isSidewaysRotation(int degrees) {
+  final normalized = normalizeRotationDegrees(degrees);
+  return normalized == 90 || normalized == 270;
+}
+
+int rotationDegreesFromExifOrientation(int orientation) {
+  switch (orientation) {
+    case 3:
+    case 4:
+      return 180;
+    case 5:
+      return 270;
+    case 6:
+    case 7:
+      return 90;
+    case 8:
+      return 270;
+    default:
+      return 0;
+  }
+}
+
+ImageDimensionMetadata? imageDimensionMetadataFromExifOrFallback(
+  Map<String, IfdTag>? exifData, {
+  int? fallbackWidth,
+  int? fallbackHeight,
+  bool applyExifOrientationToFallback = false,
+}) {
+  final exifDimensions = imageDimensionMetadataFromExif(exifData);
+  if (exifDimensions != null) {
+    return exifDimensions;
+  }
+  if ((fallbackWidth ?? 0) > 0 && (fallbackHeight ?? 0) > 0) {
+    final displayWidth = fallbackWidth!;
+    final displayHeight = fallbackHeight!;
+    final orientation = exifData?['Image Orientation']?.values.firstAsInt();
+    if (applyExifOrientationToFallback && orientation != null) {
+      final rotationDegrees = rotationDegreesFromExifOrientation(orientation);
+      final shouldSwap = isSidewaysRotation(rotationDegrees);
+      return ImageDimensionMetadata.displayOnly(
+        width: shouldSwap ? displayHeight : displayWidth,
+        height: shouldSwap ? displayWidth : displayHeight,
+      );
+    }
+    return ImageDimensionMetadata.displayOnly(
+      width: displayWidth,
+      height: displayHeight,
+    );
+  }
+  return null;
+}
+
+ImageDimensionMetadata? imageDimensionMetadataFromExif(
+  Map<String, IfdTag>? exifData,
+) {
+  final rawWidth = firstPositiveExifDimension(exifData, const [
+    'EXIF ExifImageWidth',
+    'Image ImageWidth',
+  ]);
+  final rawHeight = firstPositiveExifDimension(exifData, const [
+    'EXIF ExifImageLength',
+    'Image ImageLength',
+  ]);
+  if (rawWidth == null || rawHeight == null) {
+    return null;
+  }
+  final orientation = exifData?['Image Orientation']?.values.firstAsInt() ?? 1;
+  return ImageDimensionMetadata.fromRawDimensions(
+    rawWidth: rawWidth,
+    rawHeight: rawHeight,
+    rotationDegrees: rotationDegreesFromExifOrientation(orientation),
+  );
+}
+
+Future<ImageDimensionMetadata?> tryReadImageDimensionMetadata(File file) async {
+  try {
+    return imageDimensionMetadataFromExif(await readExifAsync(file));
+  } catch (_) {
+    return null;
+  }
+}
+
+int? firstPositiveExifDimension(
+  Map<String, IfdTag>? exifData,
+  List<String> keys,
+) {
+  if (exifData == null) {
+    return null;
+  }
+  for (final key in keys) {
+    final value = exifData[key]?.values.firstAsInt();
+    if (value != null && value > 0) {
+      return value;
+    }
+  }
+  return null;
+}

--- a/mobile/apps/photos/lib/utils/image_dimension_util.dart
+++ b/mobile/apps/photos/lib/utils/image_dimension_util.dart
@@ -37,8 +37,15 @@ class ImageDimensionMetadata {
   factory ImageDimensionMetadata.displayOnly({
     required int width,
     required int height,
+    int? rotationDegrees,
   }) {
-    return ImageDimensionMetadata(width: width, height: height);
+    return ImageDimensionMetadata(
+      width: width,
+      height: height,
+      rotationDegrees: rotationDegrees == null
+          ? null
+          : normalizeRotationDegrees(rotationDegrees),
+    );
   }
 
   bool get hasRawDimensions => (rawWidth ?? 0) > 0 && (rawHeight ?? 0) > 0;
@@ -91,6 +98,7 @@ ImageDimensionMetadata? imageDimensionMetadataFromExifOrFallback(
       return ImageDimensionMetadata.displayOnly(
         width: shouldSwap ? displayHeight : displayWidth,
         height: shouldSwap ? displayWidth : displayHeight,
+        rotationDegrees: rotationDegrees,
       );
     }
     return ImageDimensionMetadata.displayOnly(

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -118,6 +118,8 @@ class FlagService {
 
   bool get useRustForHeicDecoder => internalUser;
 
+  bool get useFileDerivedImageDimensions => internalUser;
+
   bool get petEnabled => internalUser;
 
   bool get qrFeatureEnabled => true;

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -4,6 +4,7 @@ Latest changes:
 Still behind internal flag:
 - Amrithesh: (I) ML/Pet recognition [Indexing]
 - Aman: (I) Use Rust HEIC decoder for Android photo viewer when dimensions are known
+- Aman: (I) Use file-derived image dimensions for large image preview and metadata backfill
 - Laurens: (I) Generate and compress face thumbnails in rust
 - Laurens: (I) Use cloudflare worker for upload for internal users
 - Neeraj: (I) Add internal-only resumable gallery download queue with persistence/restart fixes and completion banner updates

--- a/mobile/apps/photos/test/models/metadata/file_magic_test.dart
+++ b/mobile/apps/photos/test/models/metadata/file_magic_test.dart
@@ -4,21 +4,15 @@ import "package:test/test.dart";
 
 void main() {
   group("PubMagicMetadata", () {
-    test("parses raw dimensions and rotation metadata", () {
-      final metadata =
-          PubMagicMetadata.fromMap({
-                widthKey: "12240",
-                heightKey: 16320,
-                rawWidthKey: "16320",
-                rawHeightKey: 12240,
-                rotationDegreesKey: "90",
-              })
-              as PubMagicMetadata;
+    test("parses display dimensions and rotation metadata", () {
+      final metadata = PubMagicMetadata.fromMap({
+        widthKey: "12240",
+        heightKey: 16320,
+        rotationDegreesKey: "90",
+      }) as PubMagicMetadata;
 
       expect(metadata.w, 12240);
       expect(metadata.h, 16320);
-      expect(metadata.rw, 16320);
-      expect(metadata.rh, 12240);
       expect(metadata.rot, 90);
     });
 
@@ -29,22 +23,22 @@ void main() {
 
       expect(metadata.w, 4000);
       expect(metadata.h, 3000);
-      expect(metadata.rw, isNull);
-      expect(metadata.rh, isNull);
       expect(metadata.rot, isNull);
     });
   });
 
-  group("EnteFile raw dimensions", () {
-    test("requires positive raw dimensions", () {
+  group("EnteFile rotation metadata", () {
+    test("tracks whether rotation metadata exists", () {
       final file = EnteFile()
-        ..pubMagicMetadata = PubMagicMetadata(rw: -16320, rh: 12240);
+        ..pubMagicMetadata = PubMagicMetadata(w: 12240, h: 16320);
 
-      expect(file.hasRawDimensions, isFalse);
+      expect(file.rotationDegrees, isNull);
+      expect(file.hasRotationDegrees, isFalse);
 
-      file.pubMagicMetadata = PubMagicMetadata(rw: 16320, rh: 12240);
+      file.pubMagicMetadata = PubMagicMetadata(w: 12240, h: 16320, rot: 90);
 
-      expect(file.hasRawDimensions, isTrue);
+      expect(file.rotationDegrees, 90);
+      expect(file.hasRotationDegrees, isTrue);
     });
   });
 }

--- a/mobile/apps/photos/test/models/metadata/file_magic_test.dart
+++ b/mobile/apps/photos/test/models/metadata/file_magic_test.dart
@@ -1,0 +1,50 @@
+import "package:photos/models/file/file.dart";
+import "package:photos/models/metadata/file_magic.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PubMagicMetadata", () {
+    test("parses raw dimensions and rotation metadata", () {
+      final metadata =
+          PubMagicMetadata.fromMap({
+                widthKey: "12240",
+                heightKey: 16320,
+                rawWidthKey: "16320",
+                rawHeightKey: 12240,
+                rotationDegreesKey: "90",
+              })
+              as PubMagicMetadata;
+
+      expect(metadata.w, 12240);
+      expect(metadata.h, 16320);
+      expect(metadata.rw, 16320);
+      expect(metadata.rh, 12240);
+      expect(metadata.rot, 90);
+    });
+
+    test("keeps legacy metadata valid when raw dimensions are missing", () {
+      final metadata =
+          PubMagicMetadata.fromMap({widthKey: 4000, heightKey: 3000})
+              as PubMagicMetadata;
+
+      expect(metadata.w, 4000);
+      expect(metadata.h, 3000);
+      expect(metadata.rw, isNull);
+      expect(metadata.rh, isNull);
+      expect(metadata.rot, isNull);
+    });
+  });
+
+  group("EnteFile raw dimensions", () {
+    test("requires positive raw dimensions", () {
+      final file = EnteFile()
+        ..pubMagicMetadata = PubMagicMetadata(rw: -16320, rh: 12240);
+
+      expect(file.hasRawDimensions, isFalse);
+
+      file.pubMagicMetadata = PubMagicMetadata(rw: 16320, rh: 12240);
+
+      expect(file.hasRawDimensions, isTrue);
+    });
+  });
+}

--- a/mobile/apps/photos/test/utils/image_dimension_util_test.dart
+++ b/mobile/apps/photos/test/utils/image_dimension_util_test.dart
@@ -124,6 +124,7 @@ void main() {
       expect(dimensions, isNotNull);
       expect(dimensions!.width, 12240);
       expect(dimensions.height, 16320);
+      expect(dimensions.rotationDegrees, 90);
       expect(dimensions.hasRawDimensions, isFalse);
     });
 

--- a/mobile/apps/photos/test/utils/image_dimension_util_test.dart
+++ b/mobile/apps/photos/test/utils/image_dimension_util_test.dart
@@ -1,0 +1,175 @@
+import "package:exif_reader/exif_reader.dart";
+import "package:photos/utils/image_dimension_util.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ImageDimensionMetadata", () {
+    test("derives display dimensions from raw rotated dimensions", () {
+      final dimensions = ImageDimensionMetadata.fromRawDimensions(
+        rawWidth: 16320,
+        rawHeight: 12240,
+        rotationDegrees: 90,
+      );
+
+      expect(dimensions.width, 12240);
+      expect(dimensions.height, 16320);
+      expect(dimensions.rawWidth, 16320);
+      expect(dimensions.rawHeight, 12240);
+      expect(dimensions.rotationDegrees, 90);
+    });
+
+    test("keeps display dimensions for non-sideways rotations", () {
+      final dimensions = ImageDimensionMetadata.fromRawDimensions(
+        rawWidth: 16320,
+        rawHeight: 12240,
+        rotationDegrees: 180,
+      );
+
+      expect(dimensions.width, 16320);
+      expect(dimensions.height, 12240);
+      expect(dimensions.rotationDegrees, 180);
+    });
+
+    test("normalizes rotation before deriving display dimensions", () {
+      final dimensions = ImageDimensionMetadata.fromRawDimensions(
+        rawWidth: 16320,
+        rawHeight: 12240,
+        rotationDegrees: 450,
+      );
+
+      expect(dimensions.width, 12240);
+      expect(dimensions.height, 16320);
+      expect(dimensions.rotationDegrees, 90);
+    });
+
+    test("tracks when only display dimensions are known", () {
+      final dimensions = ImageDimensionMetadata.displayOnly(
+        width: 4000,
+        height: 3000,
+      );
+
+      expect(dimensions.width, 4000);
+      expect(dimensions.height, 3000);
+      expect(dimensions.rawWidth, isNull);
+      expect(dimensions.rawHeight, isNull);
+      expect(dimensions.rotationDegrees, isNull);
+      expect(dimensions.hasRawDimensions, isFalse);
+    });
+  });
+
+  group("rotationDegreesFromExifOrientation", () {
+    test("maps EXIF orientation variants to normalized rotation degrees", () {
+      expect(rotationDegreesFromExifOrientation(1), 0);
+      expect(rotationDegreesFromExifOrientation(2), 0);
+      expect(rotationDegreesFromExifOrientation(3), 180);
+      expect(rotationDegreesFromExifOrientation(4), 180);
+      expect(rotationDegreesFromExifOrientation(5), 270);
+      expect(rotationDegreesFromExifOrientation(6), 90);
+      expect(rotationDegreesFromExifOrientation(7), 90);
+      expect(rotationDegreesFromExifOrientation(8), 270);
+    });
+
+    test("normalizes arbitrary rotation degrees", () {
+      expect(normalizeRotationDegrees(0), 0);
+      expect(normalizeRotationDegrees(360), 0);
+      expect(normalizeRotationDegrees(450), 90);
+      expect(normalizeRotationDegrees(-90), 270);
+    });
+  });
+
+  group("imageDimensionMetadataFromExifOrFallback", () {
+    test("prefers EXIF raw dimensions over fallback dimensions", () {
+      final dimensions = imageDimensionMetadataFromExifOrFallback(
+        {
+          'EXIF ExifImageWidth': _intTag(16320),
+          'EXIF ExifImageLength': _intTag(12240),
+          'Image Orientation': _intTag(6),
+        },
+        fallbackWidth: 16320,
+        fallbackHeight: 12240,
+      );
+
+      expect(dimensions, isNotNull);
+      expect(dimensions!.width, 12240);
+      expect(dimensions.height, 16320);
+      expect(dimensions.rawWidth, 16320);
+      expect(dimensions.rawHeight, 12240);
+      expect(dimensions.rotationDegrees, 90);
+    });
+
+    test(
+      "returns display-only metadata when EXIF dimensions are unavailable",
+      () {
+        final dimensions = imageDimensionMetadataFromExifOrFallback(
+          null,
+          fallbackWidth: 4000,
+          fallbackHeight: 3000,
+        );
+
+        expect(dimensions, isNotNull);
+        expect(dimensions!.width, 4000);
+        expect(dimensions.height, 3000);
+        expect(dimensions.hasRawDimensions, isFalse);
+      },
+    );
+
+    test("can apply EXIF orientation to fallback dimensions", () {
+      final dimensions = imageDimensionMetadataFromExifOrFallback(
+        {'Image Orientation': _intTag(6)},
+        fallbackWidth: 16320,
+        fallbackHeight: 12240,
+        applyExifOrientationToFallback: true,
+      );
+
+      expect(dimensions, isNotNull);
+      expect(dimensions!.width, 12240);
+      expect(dimensions.height, 16320);
+      expect(dimensions.hasRawDimensions, isFalse);
+    });
+
+    test(
+      "does not apply EXIF orientation to fallback dimensions by default",
+      () {
+        final dimensions = imageDimensionMetadataFromExifOrFallback(
+          {'Image Orientation': _intTag(6)},
+          fallbackWidth: 16320,
+          fallbackHeight: 12240,
+        );
+
+        expect(dimensions, isNotNull);
+        expect(dimensions!.width, 16320);
+        expect(dimensions.height, 12240);
+        expect(dimensions.hasRawDimensions, isFalse);
+      },
+    );
+
+    test(
+      "returns null when neither EXIF nor fallback dimensions are available",
+      () {
+        final dimensions = imageDimensionMetadataFromExifOrFallback(null);
+
+        expect(dimensions, isNull);
+      },
+    );
+
+    test("ignores incomplete fallback dimensions", () {
+      expect(
+        imageDimensionMetadataFromExifOrFallback(null, fallbackWidth: 4000),
+        isNull,
+      );
+      expect(
+        imageDimensionMetadataFromExifOrFallback(null, fallbackHeight: 3000),
+        isNull,
+      );
+    });
+  });
+}
+
+IfdTag _intTag(int value) {
+  return IfdTag(
+    tag: 0,
+    tagType: "LONG",
+    printable: value.toString(),
+    values: IfdInts([value]),
+  );
+}


### PR DESCRIPTION
## Issue

Some Samsung Galaxy S24/S25 Ultra 200MP portrait photos can render squished in the mobile Photos viewer.

The viewer already avoids full-resolution decode for very large images to prevent Flutter OOMs. That path passes `cacheWidth` and `cacheHeight` to `Image.file`. For affected portrait images, the stored `w/h` metadata can be wrong or missing, so the viewer computes a landscape-shaped decode target for a portrait image.

Observed cases:

- Stored dimensions are swapped, e.g. `16320x12240` instead of display `12240x16320`.
- Stored dimensions are missing, so app-side dimensions resolve to `0x0`.
- `0x0` bypasses the large-image guard and can attempt a full-resolution decode.

## Root Cause

Android MediaStore/photo manager dimensions are not always a reliable source of display dimensions for rotated media. On affected Samsung files, MediaStore can already report display-oriented dimensions, and then the Android upload path applies another EXIF-orientation swap.

For normal images this usually goes unnoticed. For 200MP images, the viewer takes the large-image path and uses stored dimensions to compute `cacheWidth/cacheHeight`. If those dimensions are wrong, Flutter decodes/scales with the wrong aspect ratio and the image appears squished.

## Fix

This adds an internal-only path to derive image dimensions from the file itself instead of relying only on stored MediaStore dimensions.

Behind `useFileDerivedImageDimensions`:

- Read raw image dimensions and EXIF orientation from the file.
- Derive display dimensions from raw dimensions + rotation.
- Store display dimensions as existing `w/h`.
- Store raw dimensions and rotation as new public magic metadata keys:
  - `rw`
  - `rh`
  - `rot`
- Use file-derived dimensions in the viewer when stored dimensions are missing, raw dimensions are available, or the image is very large.
- Lazily backfill corrected metadata for owned images above 100MP.
- Skip backfill for shared/read-only files, while still correcting viewer decode locally.

## How It Works

For new uploads, the upload path now prefers EXIF/file-derived dimensions when the internal flag is enabled.

Example Samsung 200MP portrait:

```text
raw pixels:      16320x12240
EXIF rotation:   90
display size:    12240x16320
```

The uploaded public metadata becomes:

```json
{
  "w": 12240,
  "h": 16320,
  "rw": 16320,
  "rh": 12240,
  "rot": 90
}
```

If EXIF raw dimension tags are unavailable, we fall back to the previous asset dimensions. On Android, if EXIF orientation is still available, we apply the same orientation swap behavior to the fallback dimensions so the existing behavior does not regress.

For existing files, the viewer resolves dimensions in this order:

1. Use stored raw dimensions + rotation if available.
2. Else read dimensions from the local file EXIF.
3. Else fall back to stored `w/h`.

For large images, the viewer computes `cacheWidth/cacheHeight` from the resolved display dimensions, so portrait images stay portrait-shaped during reduced-resolution decode.

Backfill is intentionally conservative:

- only behind the internal flag
- only for images above 100MP
- only when raw dimensions are available
- only when the current user can edit metadata
- only writes keys that are missing or different

Shared files are not mutated by viewers.

## Tests

- [x] `flutter test test/utils/image_dimension_util_test.dart test/models/metadata/file_magic_test.dart`
- [x] `flutter analyze`
- [x] `git diff --check`

Note: the clean PR branch is based on `main`, which expects Flutter 3.32.8. Local validation was done on the Flutter-up branch where the current local Flutter SDK resolves.

## References

- Flutter large-image crash: https://github.com/flutter/flutter/issues/110331
- Aves MediaStore size/rotation handling: https://github.com/deckerst/aves/blob/develop/lib/model/entry/entry.dart#L268
- Aves HEIC reported-size note: https://github.com/deckerst/aves/blob/develop/android/app/src/main/kotlin/deckers/thibault/aves/model/provider/MediaStoreImageProvider.kt#L284
- Aves issue on Android MediaStore wrong size: https://github.com/deckerst/aves/issues/896
- Aves issue on Samsung HEIF dimension swap: https://github.com/deckerst/aves/issues/1784
- photo_manager Samsung orientation issue: https://github.com/fluttercandies/flutter_photo_manager/issues/1139
- photo_manager inverse width/height issue: https://github.com/fluttercandies/flutter_photo_manager/issues/209
