### PR TITLE
[mob][photos] Fix linter errors from freezed 3.x regeneration of location models

### DIFF
--- a/mobile/apps/photos/lib/models/location/location.dart
+++ b/mobile/apps/photos/lib/models/location/location.dart
@@ -4,7 +4,7 @@ part 'location.freezed.dart';
 part 'location.g.dart';
 
 @freezed
-class Location with _$Location {
+abstract class Location with _$Location {
   const factory Location({
     required double? latitude,
     required double? longitude,

--- a/mobile/apps/photos/lib/models/location/location.freezed.dart
+++ b/mobile/apps/photos/lib/models/location/location.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,162 +9,322 @@ part of 'location.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Location _$LocationFromJson(Map<String, dynamic> json) {
-  return _Location.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Location {
-  double? get latitude => throw _privateConstructorUsedError;
-  double? get longitude => throw _privateConstructorUsedError;
+  double? get latitude;
+  double? get longitude;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+  /// Create a copy of Location
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $LocationCopyWith<Location> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$LocationCopyWithImpl<Location>(this as Location, _$identity);
 
-/// @nodoc
-abstract class $LocationCopyWith<$Res> {
-  factory $LocationCopyWith(Location value, $Res Function(Location) then) =
-      _$LocationCopyWithImpl<$Res, Location>;
-  @useResult
-  $Res call({double? latitude, double? longitude});
-}
-
-/// @nodoc
-class _$LocationCopyWithImpl<$Res, $Val extends Location>
-    implements $LocationCopyWith<$Res> {
-  _$LocationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? latitude = freezed,
-    Object? longitude = freezed,
-  }) {
-    return _then(_value.copyWith(
-      latitude: freezed == latitude
-          ? _value.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double?,
-      longitude: freezed == longitude
-          ? _value.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$LocationImplCopyWith<$Res>
-    implements $LocationCopyWith<$Res> {
-  factory _$$LocationImplCopyWith(
-          _$LocationImpl value, $Res Function(_$LocationImpl) then) =
-      __$$LocationImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({double? latitude, double? longitude});
-}
-
-/// @nodoc
-class __$$LocationImplCopyWithImpl<$Res>
-    extends _$LocationCopyWithImpl<$Res, _$LocationImpl>
-    implements _$$LocationImplCopyWith<$Res> {
-  __$$LocationImplCopyWithImpl(
-      _$LocationImpl _value, $Res Function(_$LocationImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? latitude = freezed,
-    Object? longitude = freezed,
-  }) {
-    return _then(_$LocationImpl(
-      latitude: freezed == latitude
-          ? _value.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double?,
-      longitude: freezed == longitude
-          ? _value.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double?,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$LocationImpl implements _Location {
-  const _$LocationImpl({required this.latitude, required this.longitude});
-
-  factory _$LocationImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LocationImplFromJson(json);
-
-  @override
-  final double? latitude;
-  @override
-  final double? longitude;
-
-  @override
-  String toString() {
-    return 'Location(latitude: $latitude, longitude: $longitude)';
-  }
+  /// Serializes this Location to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LocationImpl &&
+            other is Location &&
             (identical(other.latitude, latitude) ||
                 other.latitude == latitude) &&
             (identical(other.longitude, longitude) ||
                 other.longitude == longitude));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, latitude, longitude);
 
-  @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$LocationImplCopyWith<_$LocationImpl> get copyWith =>
-      __$$LocationImplCopyWithImpl<_$LocationImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$LocationImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Location(latitude: $latitude, longitude: $longitude)';
   }
 }
 
-abstract class _Location implements Location {
-  const factory _Location(
-      {required final double? latitude,
-      required final double? longitude}) = _$LocationImpl;
-
-  factory _Location.fromJson(Map<String, dynamic> json) =
-      _$LocationImpl.fromJson;
-
-  @override
-  double? get latitude;
-  @override
-  double? get longitude;
-  @override
-  @JsonKey(ignore: true)
-  _$$LocationImplCopyWith<_$LocationImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+/// @nodoc
+abstract mixin class $LocationCopyWith<$Res> {
+  factory $LocationCopyWith(Location value, $Res Function(Location) _then) =
+      _$LocationCopyWithImpl;
+  @useResult
+  $Res call({double? latitude, double? longitude});
 }
+
+/// @nodoc
+class _$LocationCopyWithImpl<$Res> implements $LocationCopyWith<$Res> {
+  _$LocationCopyWithImpl(this._self, this._then);
+
+  final Location _self;
+  final $Res Function(Location) _then;
+
+  /// Create a copy of Location
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? latitude = freezed,
+    Object? longitude = freezed,
+  }) {
+    return _then(_self.copyWith(
+      latitude: freezed == latitude
+          ? _self.latitude
+          : latitude // ignore: cast_nullable_to_non_nullable
+              as double?,
+      longitude: freezed == longitude
+          ? _self.longitude
+          : longitude // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Location].
+extension LocationPatterns on Location {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Location value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Location() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Location value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Location():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Location value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Location() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(double? latitude, double? longitude)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Location() when $default != null:
+        return $default(_that.latitude, _that.longitude);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(double? latitude, double? longitude) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Location():
+        return $default(_that.latitude, _that.longitude);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(double? latitude, double? longitude)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Location() when $default != null:
+        return $default(_that.latitude, _that.longitude);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Location implements Location {
+  const _Location({required this.latitude, required this.longitude});
+  factory _Location.fromJson(Map<String, dynamic> json) =>
+      _$LocationFromJson(json);
+
+  @override
+  final double? latitude;
+  @override
+  final double? longitude;
+
+  /// Create a copy of Location
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LocationCopyWith<_Location> get copyWith =>
+      __$LocationCopyWithImpl<_Location>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$LocationToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Location &&
+            (identical(other.latitude, latitude) ||
+                other.latitude == latitude) &&
+            (identical(other.longitude, longitude) ||
+                other.longitude == longitude));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, latitude, longitude);
+
+  @override
+  String toString() {
+    return 'Location(latitude: $latitude, longitude: $longitude)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$LocationCopyWith<$Res>
+    implements $LocationCopyWith<$Res> {
+  factory _$LocationCopyWith(_Location value, $Res Function(_Location) _then) =
+      __$LocationCopyWithImpl;
+  @override
+  @useResult
+  $Res call({double? latitude, double? longitude});
+}
+
+/// @nodoc
+class __$LocationCopyWithImpl<$Res> implements _$LocationCopyWith<$Res> {
+  __$LocationCopyWithImpl(this._self, this._then);
+
+  final _Location _self;
+  final $Res Function(_Location) _then;
+
+  /// Create a copy of Location
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? latitude = freezed,
+    Object? longitude = freezed,
+  }) {
+    return _then(_Location(
+      latitude: freezed == latitude
+          ? _self.latitude
+          : latitude // ignore: cast_nullable_to_non_nullable
+              as double?,
+      longitude: freezed == longitude
+          ? _self.longitude
+          : longitude // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ));
+  }
+}
+
+// dart format on

--- a/mobile/apps/photos/lib/models/location/location.g.dart
+++ b/mobile/apps/photos/lib/models/location/location.g.dart
@@ -6,14 +6,12 @@ part of 'location.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$LocationImpl _$$LocationImplFromJson(Map<String, dynamic> json) =>
-    _$LocationImpl(
+_Location _$LocationFromJson(Map<String, dynamic> json) => _Location(
       latitude: (json['latitude'] as num?)?.toDouble(),
       longitude: (json['longitude'] as num?)?.toDouble(),
     );
 
-Map<String, dynamic> _$$LocationImplToJson(_$LocationImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$LocationToJson(_Location instance) => <String, dynamic>{
       'latitude': instance.latitude,
       'longitude': instance.longitude,
     };

--- a/mobile/apps/photos/lib/models/location_tag/location_tag.dart
+++ b/mobile/apps/photos/lib/models/location_tag/location_tag.dart
@@ -5,7 +5,7 @@ part 'location_tag.freezed.dart';
 part 'location_tag.g.dart';
 
 @freezed
-class LocationTag with _$LocationTag {
+abstract class LocationTag with _$LocationTag {
   const LocationTag._();
   const factory LocationTag({
     required String name,

--- a/mobile/apps/photos/lib/models/location_tag/location_tag.freezed.dart
+++ b/mobile/apps/photos/lib/models/location_tag/location_tag.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,34 +9,56 @@ part of 'location_tag.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-LocationTag _$LocationTagFromJson(Map<String, dynamic> json) {
-  return _LocationTag.fromJson(json);
-}
 
 /// @nodoc
 mixin _$LocationTag {
-  String get name => throw _privateConstructorUsedError;
-  double get radius => throw _privateConstructorUsedError;
-  double get aSquare => throw _privateConstructorUsedError;
-  double get bSquare => throw _privateConstructorUsedError;
-  Location get centerPoint => throw _privateConstructorUsedError;
+  String get name;
+  double get radius;
+  double get aSquare;
+  double get bSquare;
+  Location get centerPoint;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $LocationTagCopyWith<LocationTag> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$LocationTagCopyWithImpl<LocationTag>(this as LocationTag, _$identity);
+
+  /// Serializes this LocationTag to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is LocationTag &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.radius, radius) || other.radius == radius) &&
+            (identical(other.aSquare, aSquare) || other.aSquare == aSquare) &&
+            (identical(other.bSquare, bSquare) || other.bSquare == bSquare) &&
+            (identical(other.centerPoint, centerPoint) ||
+                other.centerPoint == centerPoint));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, name, radius, aSquare, bSquare, centerPoint);
+
+  @override
+  String toString() {
+    return 'LocationTag(name: $name, radius: $radius, aSquare: $aSquare, bSquare: $bSquare, centerPoint: $centerPoint)';
+  }
 }
 
 /// @nodoc
-abstract class $LocationTagCopyWith<$Res> {
+abstract mixin class $LocationTagCopyWith<$Res> {
   factory $LocationTagCopyWith(
-          LocationTag value, $Res Function(LocationTag) then) =
-      _$LocationTagCopyWithImpl<$Res, LocationTag>;
+          LocationTag value, $Res Function(LocationTag) _then) =
+      _$LocationTagCopyWithImpl;
   @useResult
   $Res call(
       {String name,
@@ -49,15 +71,14 @@ abstract class $LocationTagCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$LocationTagCopyWithImpl<$Res, $Val extends LocationTag>
-    implements $LocationTagCopyWith<$Res> {
-  _$LocationTagCopyWithImpl(this._value, this._then);
+class _$LocationTagCopyWithImpl<$Res> implements $LocationTagCopyWith<$Res> {
+  _$LocationTagCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final LocationTag _self;
+  final $Res Function(LocationTag) _then;
 
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -67,113 +88,219 @@ class _$LocationTagCopyWithImpl<$Res, $Val extends LocationTag>
     Object? bSquare = null,
     Object? centerPoint = null,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       radius: null == radius
-          ? _value.radius
+          ? _self.radius
           : radius // ignore: cast_nullable_to_non_nullable
               as double,
       aSquare: null == aSquare
-          ? _value.aSquare
+          ? _self.aSquare
           : aSquare // ignore: cast_nullable_to_non_nullable
               as double,
       bSquare: null == bSquare
-          ? _value.bSquare
+          ? _self.bSquare
           : bSquare // ignore: cast_nullable_to_non_nullable
               as double,
       centerPoint: null == centerPoint
-          ? _value.centerPoint
+          ? _self.centerPoint
           : centerPoint // ignore: cast_nullable_to_non_nullable
               as Location,
-    ) as $Val);
+    ));
   }
 
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $LocationCopyWith<$Res> get centerPoint {
-    return $LocationCopyWith<$Res>(_value.centerPoint, (value) {
-      return _then(_value.copyWith(centerPoint: value) as $Val);
+    return $LocationCopyWith<$Res>(_self.centerPoint, (value) {
+      return _then(_self.copyWith(centerPoint: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$LocationTagImplCopyWith<$Res>
-    implements $LocationTagCopyWith<$Res> {
-  factory _$$LocationTagImplCopyWith(
-          _$LocationTagImpl value, $Res Function(_$LocationTagImpl) then) =
-      __$$LocationTagImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String name,
-      double radius,
-      double aSquare,
-      double bSquare,
-      Location centerPoint});
+/// Adds pattern-matching-related methods to [LocationTag].
+extension LocationTagPatterns on LocationTag {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $LocationCopyWith<$Res> get centerPoint;
-}
-
-/// @nodoc
-class __$$LocationTagImplCopyWithImpl<$Res>
-    extends _$LocationTagCopyWithImpl<$Res, _$LocationTagImpl>
-    implements _$$LocationTagImplCopyWith<$Res> {
-  __$$LocationTagImplCopyWithImpl(
-      _$LocationTagImpl _value, $Res Function(_$LocationTagImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = null,
-    Object? radius = null,
-    Object? aSquare = null,
-    Object? bSquare = null,
-    Object? centerPoint = null,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_LocationTag value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(_$LocationTagImpl(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      radius: null == radius
-          ? _value.radius
-          : radius // ignore: cast_nullable_to_non_nullable
-              as double,
-      aSquare: null == aSquare
-          ? _value.aSquare
-          : aSquare // ignore: cast_nullable_to_non_nullable
-              as double,
-      bSquare: null == bSquare
-          ? _value.bSquare
-          : bSquare // ignore: cast_nullable_to_non_nullable
-              as double,
-      centerPoint: null == centerPoint
-          ? _value.centerPoint
-          : centerPoint // ignore: cast_nullable_to_non_nullable
-              as Location,
-    ));
+    final _that = this;
+    switch (_that) {
+      case _LocationTag() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_LocationTag value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LocationTag():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_LocationTag value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LocationTag() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String name, double radius, double aSquare, double bSquare,
+            Location centerPoint)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LocationTag() when $default != null:
+        return $default(_that.name, _that.radius, _that.aSquare, _that.bSquare,
+            _that.centerPoint);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String name, double radius, double aSquare, double bSquare,
+            Location centerPoint)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LocationTag():
+        return $default(_that.name, _that.radius, _that.aSquare, _that.bSquare,
+            _that.centerPoint);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String name, double radius, double aSquare,
+            double bSquare, Location centerPoint)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LocationTag() when $default != null:
+        return $default(_that.name, _that.radius, _that.aSquare, _that.bSquare,
+            _that.centerPoint);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$LocationTagImpl extends _LocationTag {
-  const _$LocationTagImpl(
+class _LocationTag extends LocationTag {
+  const _LocationTag(
       {required this.name,
       required this.radius,
       required this.aSquare,
       required this.bSquare,
       required this.centerPoint})
       : super._();
-
-  factory _$LocationTagImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LocationTagImplFromJson(json);
+  factory _LocationTag.fromJson(Map<String, dynamic> json) =>
+      _$LocationTagFromJson(json);
 
   @override
   final String name;
@@ -186,16 +313,26 @@ class _$LocationTagImpl extends _LocationTag {
   @override
   final Location centerPoint;
 
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'LocationTag(name: $name, radius: $radius, aSquare: $aSquare, bSquare: $bSquare, centerPoint: $centerPoint)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LocationTagCopyWith<_LocationTag> get copyWith =>
+      __$LocationTagCopyWithImpl<_LocationTag>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$LocationTagToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LocationTagImpl &&
+            other is _LocationTag &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.radius, radius) || other.radius == radius) &&
             (identical(other.aSquare, aSquare) || other.aSquare == aSquare) &&
@@ -204,49 +341,87 @@ class _$LocationTagImpl extends _LocationTag {
                 other.centerPoint == centerPoint));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, radius, aSquare, bSquare, centerPoint);
 
-  @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$LocationTagImplCopyWith<_$LocationTagImpl> get copyWith =>
-      __$$LocationTagImplCopyWithImpl<_$LocationTagImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$LocationTagImplToJson(
-      this,
-    );
+  String toString() {
+    return 'LocationTag(name: $name, radius: $radius, aSquare: $aSquare, bSquare: $bSquare, centerPoint: $centerPoint)';
   }
 }
 
-abstract class _LocationTag extends LocationTag {
-  const factory _LocationTag(
-      {required final String name,
-      required final double radius,
-      required final double aSquare,
-      required final double bSquare,
-      required final Location centerPoint}) = _$LocationTagImpl;
-  const _LocationTag._() : super._();
+/// @nodoc
+abstract mixin class _$LocationTagCopyWith<$Res>
+    implements $LocationTagCopyWith<$Res> {
+  factory _$LocationTagCopyWith(
+          _LocationTag value, $Res Function(_LocationTag) _then) =
+      __$LocationTagCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      double radius,
+      double aSquare,
+      double bSquare,
+      Location centerPoint});
 
-  factory _LocationTag.fromJson(Map<String, dynamic> json) =
-      _$LocationTagImpl.fromJson;
-
   @override
-  String get name;
-  @override
-  double get radius;
-  @override
-  double get aSquare;
-  @override
-  double get bSquare;
-  @override
-  Location get centerPoint;
-  @override
-  @JsonKey(ignore: true)
-  _$$LocationTagImplCopyWith<_$LocationTagImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  $LocationCopyWith<$Res> get centerPoint;
 }
+
+/// @nodoc
+class __$LocationTagCopyWithImpl<$Res> implements _$LocationTagCopyWith<$Res> {
+  __$LocationTagCopyWithImpl(this._self, this._then);
+
+  final _LocationTag _self;
+  final $Res Function(_LocationTag) _then;
+
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? name = null,
+    Object? radius = null,
+    Object? aSquare = null,
+    Object? bSquare = null,
+    Object? centerPoint = null,
+  }) {
+    return _then(_LocationTag(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      radius: null == radius
+          ? _self.radius
+          : radius // ignore: cast_nullable_to_non_nullable
+              as double,
+      aSquare: null == aSquare
+          ? _self.aSquare
+          : aSquare // ignore: cast_nullable_to_non_nullable
+              as double,
+      bSquare: null == bSquare
+          ? _self.bSquare
+          : bSquare // ignore: cast_nullable_to_non_nullable
+              as double,
+      centerPoint: null == centerPoint
+          ? _self.centerPoint
+          : centerPoint // ignore: cast_nullable_to_non_nullable
+              as Location,
+    ));
+  }
+
+  /// Create a copy of LocationTag
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $LocationCopyWith<$Res> get centerPoint {
+    return $LocationCopyWith<$Res>(_self.centerPoint, (value) {
+      return _then(_self.copyWith(centerPoint: value));
+    });
+  }
+}
+
+// dart format on

--- a/mobile/apps/photos/lib/models/location_tag/location_tag.g.dart
+++ b/mobile/apps/photos/lib/models/location_tag/location_tag.g.dart
@@ -6,8 +6,7 @@ part of 'location_tag.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$LocationTagImpl _$$LocationTagImplFromJson(Map<String, dynamic> json) =>
-    _$LocationTagImpl(
+_LocationTag _$LocationTagFromJson(Map<String, dynamic> json) => _LocationTag(
       name: json['name'] as String,
       radius: (json['radius'] as num).toDouble(),
       aSquare: (json['aSquare'] as num).toDouble(),
@@ -16,7 +15,7 @@ _$LocationTagImpl _$$LocationTagImplFromJson(Map<String, dynamic> json) =>
           Location.fromJson(json['centerPoint'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$LocationTagImplToJson(_$LocationTagImpl instance) =>
+Map<String, dynamic> _$LocationTagToJson(_LocationTag instance) =>
     <String, dynamic>{
       'name': instance.name,
       'radius': instance.radius,


### PR DESCRIPTION
## Description

Freezed 3.x generates abstract getters in the mixin instead of concrete throwing stubs, requiring the base class to be declared abstract.

