### PR TITLE
[mob][auth] Compress native libs for APK flavors

### DIFF
--- a/mobile/apps/auth/android/app/build.gradle
+++ b/mobile/apps/auth/android/app/build.gradle
@@ -123,6 +123,20 @@ android {
     }
 }
 
+androidComponents {
+    onVariants(selector().withFlavor("default", "independent")) { variant ->
+        // Compress native libraries for direct APK distribution:
+        // https://developer.android.com/build/releases/agp-4-2-0-release-notes#compress-native-libs-dsl
+        variant.packaging.jniLibs.useLegacyPackaging.set(true)
+    }
+
+    onVariants(selector().withFlavor("default", "fdroid")) { variant ->
+        // Compress native libraries for direct APK distribution:
+        // https://developer.android.com/build/releases/agp-4-2-0-release-notes#compress-native-libs-dsl
+        variant.packaging.jniLibs.useLegacyPackaging.set(true)
+    }
+}
+
 flutter {
     source '../..'
 }


### PR DESCRIPTION
## Description

- Compress Auth native libraries only for APK-distribution flavors: `independent` and `fdroid`.
- Keep the default JNI packaging unchanged so the `playstore` AAB continues to use uncompressed native libraries.
- Keep existing ABI coverage, including `x86_64`, and do not add split APK artifacts.

## Validation

- [x] `flutter build apk --dart-define=cronetHttpNoPlay=true --release --flavor independent` with temporary local signing env vars.
- [x] Verified `independent` APK size: `54,416,711` bytes (`54.4 MB`).
- [x] Verified `independent` APK ABI set: `armeabi-v7a`, `arm64-v8a`, `x86_64`.
- [x] Verified all APK native libraries are compressed (`defN=27`).
- [x] Verified manifest has `extractNativeLibs=true` for the `independent` APK.
- [x] `git diff --check`.

## Note

The flavor-scoped compression follows the AGP native library packaging DSL documented here: https://developer.android.com/build/releases/agp-4-2-0-release-notes#compress-native-libs-dsl
