### PR TITLE
[mob][photos] Initialize ServiceLocator before Configuration main init

### DIFF
--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -81,6 +81,7 @@ class Configuration {
   late String _documentsDirectory;
   String? _key;
   late SharedPreferences _preferences;
+  bool _preferencesInitialized = false;
   String? _secretKey;
   late FlutterSecureStorage _secureStorage;
   late String _tempDocumentsDirPath;
@@ -90,9 +91,16 @@ class Configuration {
   late String _sharedDocumentsMediaDirectory;
   String? _volatilePassword;
 
+  void initPreferences(SharedPreferences preferences) {
+    _preferences = preferences;
+    _preferencesInitialized = true;
+  }
+
   Future<void> init() async {
     try {
-      _preferences = await SharedPreferences.getInstance();
+      if (!_preferencesInitialized) {
+        initPreferences(await SharedPreferences.getInstance());
+      }
       _secureStorage = const FlutterSecureStorage(
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -63,6 +63,12 @@ class NetworkClient {
     });
   }
 
+  void refreshEndpoint() {
+    final endpoint = Configuration.instance.getHttpEndpoint();
+    _enteDio.options.baseUrl = endpoint;
+    _setupInterceptors(endpoint);
+  }
+
   void _setupInterceptors(String endpoint) {
     _enteDio.interceptors.clear();
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -241,11 +241,25 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
   try {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     final SharedPreferences prefs = await SharedPreferences.getInstance();
+    Configuration.instance.initPreferences(prefs);
     await _scheduleHeartBeat(prefs, true);
     await _ensureRustInitialized(via: 'workmanager:$taskId');
 
+    _logger.info("[BG TASK] NetworkClient init $tlog");
+    await NetworkClient.instance.init(packageInfo);
+    _logger.info("[BG TASK] NetworkClient init done $tlog");
+
+    ServiceLocator.instance.init(
+      prefs,
+      NetworkClient.instance.enteDio,
+      NetworkClient.instance.getDio(),
+      packageInfo,
+    );
+    NotificationService.instance.init(prefs);
+
     _logger.info("(for debugging) Configuration init $tlog");
     await Configuration.instance.init();
+    NetworkClient.instance.refreshEndpoint();
     _logger.info("(for debugging) Configuration done $tlog");
 
     // App LifeCycle
@@ -258,16 +272,6 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     await Computer.shared().turnOn(workersCount: 4);
     CryptoUtil.init();
 
-    // Init Network Utils
-    await NetworkClient.instance.init(packageInfo);
-
-    // Global Services
-    ServiceLocator.instance.init(
-      prefs,
-      NetworkClient.instance.enteDio,
-      NetworkClient.instance.getDio(),
-      packageInfo,
-    );
     // Initialize early so thermal/battery listeners can warm up while the
     // rest of background services are being initialized.
     final controller = computeController;
@@ -286,7 +290,6 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
 
     // Misc Services
     await UserService.instance.init();
-    NotificationService.instance.init(prefs);
     SocialNotificationCoordinator.instance.init(prefs);
     await NotificationService.instance.initializeForBackground();
 
@@ -370,6 +373,7 @@ Future<void> _init(
     );
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    Configuration.instance.initPreferences(preferences);
     await _logFGHeartBeatInfo(preferences);
     _logger.info("_logFGHeartBeatInfo done $tlog");
     unawaited(_scheduleHeartBeat(preferences, isBackground));
@@ -387,13 +391,6 @@ Future<void> _init(
     Computer.shared().turnOn(workersCount: 4).ignore();
     CryptoUtil.init();
 
-    _logger.info("Lockscreen init $tlog");
-    unawaited(LockScreenSettings.instance.init(preferences));
-
-    _logger.info("Configuration init $tlog");
-    await Configuration.instance.init();
-    _logger.info("Configuration done $tlog");
-
     _logger.info("NetworkClient init $tlog");
     await NetworkClient.instance.init(packageInfo);
     _logger.info("NetworkClient init done $tlog");
@@ -404,6 +401,15 @@ Future<void> _init(
       NetworkClient.instance.getDio(),
       packageInfo,
     );
+
+    _logger.info("Lockscreen init $tlog");
+    unawaited(LockScreenSettings.instance.init(preferences));
+
+    _logger.info("Configuration init $tlog");
+    await Configuration.instance.init();
+    NetworkClient.instance.refreshEndpoint();
+    _logger.info("Configuration done $tlog");
+
     await MemoryShareService.instance.init();
 
     _logger.info("UserService init $tlog");


### PR DESCRIPTION
## Description

This fixes a startup ordering issue where Configuration.init() could trigger auto-logout before ServiceLocator was initialized. The app now bootstraps configuration preferences first, initializes networking and the service locator, and only then runs the full configuration init that may perform cleanup.