### PR TITLE
[mob][auth] Hide HOTP share option

### DIFF
--- a/mobile/apps/auth/lib/models/code.dart
+++ b/mobile/apps/auth/lib/models/code.dart
@@ -328,6 +328,8 @@ enum Type {
   steam;
 
   bool get isTOTPCompatible => this == totp || this == steam;
+
+  bool get canShareCodes => this == totp || this == steam;
 }
 
 enum Algorithm {

--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -601,7 +601,7 @@ class _CodeWidgetState extends State<CodeWidget> {
   ) {
     if (widget.code.isTrashed) return;
 
-    if (widget.code.type.isTOTPCompatible) {
+    if (widget.code.type.canShareCodes) {
       entries.add(
         MenuItem(
           label: l10n.share,
@@ -949,6 +949,9 @@ class _CodeWidgetState extends State<CodeWidget> {
   }
 
   Future<void> _onSharePressed([bool? pop]) async {
+    if (!widget.code.type.canShareCodes) {
+      return;
+    }
     if (mounted && pop == true) {
       Navigator.of(context).pop();
     }

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -476,6 +476,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _onSharePressed(Code code) async {
+    if (!code.type.canShareCodes) {
+      return;
+    }
     bool isAuthSuccessful = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, context.l10n.authenticateGeneric);
     await PlatformUtil.refocusWindows();
@@ -566,16 +569,18 @@ class _HomePageState extends State<HomePage> {
               ),
             ),
             const SizedBox(width: 10),
-            _buildActionButton(
-              context.l10n.share,
-              () => _onSharePressed(code),
-              iconWidget: HugeIcon(
-                icon: HugeIcons.strokeRoundedNavigation03,
-                size: 21,
-                color: getEnteColorScheme(context).textBase,
+            if (code.type.canShareCodes) ...[
+              _buildActionButton(
+                context.l10n.share,
+                () => _onSharePressed(code),
+                iconWidget: HugeIcon(
+                  icon: HugeIcons.strokeRoundedNavigation03,
+                  size: 21,
+                  color: getEnteColorScheme(context).textBase,
+                ),
               ),
-            ),
-            const SizedBox(width: 10),
+              const SizedBox(width: 10),
+            ],
             _buildActionButton(
               context.l10n.qrCode,
               () => _onShowQrPressed(code),
@@ -2065,11 +2070,13 @@ class _HomePageState extends State<HomePage> {
       );
 
       if (singleCode != null) {
-        addButton(
-          context.l10n.share,
-          Icons.adaptive.share_outlined,
-          () => _onSharePressed(singleCode),
-        );
+        if (singleCode.type.canShareCodes) {
+          addButton(
+            context.l10n.share,
+            Icons.adaptive.share_outlined,
+            () => _onSharePressed(singleCode),
+          );
+        }
         addButton(
           context.l10n.qr,
           Icons.qr_code_2_outlined,

--- a/mobile/apps/auth/lib/ui/share/code_share.dart
+++ b/mobile/apps/auth/lib/ui/share/code_share.dart
@@ -143,6 +143,9 @@ class _ShareCodeDialogState extends State<ShareCodeDialog> {
 }
 
 void showShareDialog(BuildContext context, Code code) {
+  if (!code.type.canShareCodes) {
+    return;
+  }
   showDialog(
     context: context,
     builder: (BuildContext context) {

--- a/mobile/apps/auth/test/models/code_test.dart
+++ b/mobile/apps/auth/test/models/code_test.dart
@@ -33,6 +33,12 @@ void main() {
     expect(code.counter, 15);
   });
 
+  test("shareCodesSupport", () {
+    expect(Type.totp.canShareCodes, true);
+    expect(Type.steam.canShareCodes, true);
+    expect(Type.hotp.canShareCodes, false);
+  });
+
   test("validateDisplay", () {
     Code code = Code.fromOTPAuthUrl(
       "otpauth://hotp/testdata@ente.io?secret=ASKZNWOU6SVYAMVS&issuer=GitHub&counter=15",


### PR DESCRIPTION
## Summary
- Hide the Auth share action for HOTP entries across card context menus and selected-code action UIs.
- Add a shared `Type.canShareCodes` predicate and guard direct share-dialog entry points.
- Cover the shareability predicate in model tests.

## Testing
- `dart format mobile/apps/auth/lib/models/code.dart mobile/apps/auth/lib/ui/code_widget.dart mobile/apps/auth/lib/ui/home_page.dart mobile/apps/auth/lib/ui/share/code_share.dart mobile/apps/auth/test/models/code_test.dart`
- `flutter test test/models/code_test.dart`
- `flutter analyze` exits non-zero because `assets/simple-icons/icons/` and `assets/simple-icons/_data/` are missing from the local Auth asset tree.