### PR TITLE
Document Auth offline mode guide

### DIFF
--- a/docs/docs/.vitepress/sidebar.ts
+++ b/docs/docs/.vitepress/sidebar.ts
@@ -329,6 +329,10 @@ export const sidebar = [
             { text: "Introduction", link: "/auth/" },
             { text: "Features", link: "/auth/features/" },
             {
+                text: "Offline mode",
+                link: "/auth/features/offline-mode",
+            },
+            {
                 text: "FAQ",
                 collapsed: true,
                 items: [

--- a/docs/docs/auth/features/index.md
+++ b/docs/docs/auth/features/index.md
@@ -96,6 +96,13 @@ login screen. In this mode, your codes are stored locally on your device.
 Unlike when using an account, data is not synced or backed up to the cloud. You
 are responsible for manually backing up your codes.
 
+The local vault is encrypted using a key protected by your device's secure
+storage. Device transfers and OS backups are not supported recovery methods for
+offline-mode codes. Create an encrypted export or local backup and keep the
+backup password safe.
+
+Learn more about [using offline mode safely](offline-mode).
+
 ### Display options
 
 Customize how your codes are displayed for optimal usability.
@@ -118,6 +125,9 @@ following lock methods:
 
 Additionally, configure **Auto lock** to automatically lock the app after a
 specified period of time (options: Immediately, 5s, 15s, 1m, 5m, 30m).
+
+App lock protects access to the app UI. It is not a recovery password for your
+codes and does not re-encrypt the stored Auth data.
 
 ### Import / Export
 

--- a/docs/docs/auth/features/offline-mode.md
+++ b/docs/docs/auth/features/offline-mode.md
@@ -1,0 +1,40 @@
+---
+title: Using offline mode safely - Auth
+description: Guidelines for backing up and recovering Ente Auth codes when using offline mode
+---
+
+# Using offline mode safely
+
+Ente Auth can be used without an account by choosing **Use without backups**. In
+offline mode, your codes are stored only on that device. They are not synced to
+Ente and cannot be restored from Ente's servers.
+
+## How offline storage works
+
+The local vault is encrypted using a key protected by the device's secure
+storage, such as the OS keychain, keyring, credential store, or secure storage
+service. If that secure-storage key becomes unavailable, Ente cannot recover the
+offline vault from the local database alone.
+
+Device transfers and OS backups are not supported recovery methods for
+offline-mode codes. They may not include the secure-storage key, or the restored
+key may not be usable on the new system.
+
+## Before device or OS changes
+
+If you use Ente Auth in offline mode, create an encrypted export or local backup
+before resetting credentials, reinstalling your OS, transferring devices,
+restoring a device backup, or making major system changes. Verify that you know
+the backup password, and store the backup or export file in a separate location
+you can access after the change.
+
+## App lock is not a recovery password
+
+App lock protects access to the app UI. It is not a recovery password for your
+codes and does not re-encrypt the stored Auth data.
+
+## Back up your codes
+
+Open `Settings > Data > Local backup` to enable automatic local backups, or
+create an encrypted export from the Data settings. Keep your backup or export
+files and password somewhere safe.

--- a/docs/docs/auth/migration/export.md
+++ b/docs/docs/auth/migration/export.md
@@ -86,14 +86,20 @@ automatically.
 - **Automatic daily backups:** When enabled, Ente Auth creates one local backup
   per day when you open the app.
 - **Password-protected:** All local backups are encrypted with a password you
-  set. This password is stored securely on your device.
+  set. Keep this password safe, because Ente cannot recover it for you.
 - **Custom backup location:** Choose where to store your backups on your device.
 - **Backup retention:** The app keeps up to 5 most recent backups and
   automatically removes older ones.
 
+If you use Ente Auth in offline mode, encrypted exports and local backups are
+the supported recovery path. Device transfers and OS backups should not be
+treated as a backup for offline codes. Store the backup or export file in a
+separate location you can access after a reset or device change. Learn more
+about [using offline mode safely](/auth/features/offline-mode).
+
 **Setting up local backups:**
 
-1. Go to **Settings → Data → Local backup**.
+1. Open `Settings > Data > Local backup`.
 2. Enable **Automatic backups**.
 3. Set a backup password (minimum 8 characters).
 4. Select a folder where backups will be stored.


### PR DESCRIPTION
## Summary
- add a dedicated Auth page for using offline mode safely
- clarify that offline vault recovery depends on exports/local backups, not device transfers or OS backups
- document that app lock is not a recovery password or vault re-encryption layer

## Validation
- cd docs && yarn build
- cd docs && ./node_modules/.bin/prettier -c docs/auth/features/offline-mode.md docs/auth/features/index.md docs/auth/migration/export.md docs/.vitepress/sidebar.ts