### PR TITLE
Decouple Photos endpoint config from startup configuration

### DIFF
--- a/mobile/apps/photos/integration_test/ml_parity_shared.dart
+++ b/mobile/apps/photos/integration_test/ml_parity_shared.dart
@@ -285,16 +285,16 @@ Future<void> _ensureModelNetworkContext() async {
     return;
   }
 
-  await Configuration.instance.init();
   final prefs = await SharedPreferences.getInstance();
   final packageInfo = await PackageInfo.fromPlatform();
-  await NetworkClient.instance.init(packageInfo);
+  await NetworkClient.instance.init(packageInfo, prefs);
   ServiceLocator.instance.init(
     prefs,
     NetworkClient.instance.enteDio,
     NetworkClient.instance.getDio(),
     packageInfo,
   );
+  await Configuration.instance.init();
   _modelNetworkContextInitialized = true;
 }
 

--- a/mobile/apps/photos/integration_test/video_editor_test.dart
+++ b/mobile/apps/photos/integration_test/video_editor_test.dart
@@ -213,11 +213,8 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final packageInfo = await PackageInfo.fromPlatform();
 
-      // Configuration provides endpoint & secure storage (must precede network init).
-      await Configuration.instance.init();
-
       // Initialize network clients before service locator (mirrors app bootstrap).
-      await NetworkClient.instance.init(packageInfo);
+      await NetworkClient.instance.init(packageInfo, prefs);
 
       ServiceLocator.instance.init(
         prefs,
@@ -225,7 +222,7 @@ void main() {
         NetworkClient.instance.getDio(),
         packageInfo,
       );
-      // Configuration already initialized above.
+      await Configuration.instance.init();
 
       // Verify configuration
       expect(

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -26,7 +26,6 @@ import "package:photos/db/ml/db.dart";
 import 'package:photos/db/trash_db.dart';
 import 'package:photos/db/upload_locks_db.dart';
 import "package:photos/events/app_mode_changed_event.dart";
-import "package:photos/events/endpoint_updated_event.dart";
 import 'package:photos/events/signed_in_event.dart';
 import 'package:photos/events/user_logged_out_event.dart';
 import 'package:photos/gateways/users/models/key_attributes.dart';
@@ -55,10 +54,6 @@ class Configuration {
   Configuration._privateConstructor();
 
   static final Configuration instance = Configuration._privateConstructor();
-  static const endpoint = String.fromEnvironment(
-    "endpoint",
-    defaultValue: kDefaultProductionEndpoint,
-  );
 
   static const emailKey = "email";
   static const foldersToBackUpKey = "folders_to_back_up";
@@ -74,14 +69,12 @@ class Configuration {
   static const userIDKey = "user_id";
   static const hasMigratedSecureStorageKey = "has_migrated_secure_storage";
   static const anonymousUserIDKey = "anonymous_user_id";
-  static const endPointKey = "endpoint";
   static final _logger = Logger("Configuration");
 
   String? _cachedToken;
   late String _documentsDirectory;
   String? _key;
   late SharedPreferences _preferences;
-  bool _preferencesInitialized = false;
   String? _secretKey;
   late FlutterSecureStorage _secureStorage;
   late String _tempDocumentsDirPath;
@@ -91,16 +84,9 @@ class Configuration {
   late String _sharedDocumentsMediaDirectory;
   String? _volatilePassword;
 
-  void initPreferences(SharedPreferences preferences) {
-    _preferences = preferences;
-    _preferencesInitialized = true;
-  }
-
   Future<void> init() async {
     try {
-      if (!_preferencesInitialized) {
-        initPreferences(await SharedPreferences.getInstance());
-      }
+      _preferences = await SharedPreferences.getInstance();
       _secureStorage = const FlutterSecureStorage(
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,
@@ -528,26 +514,6 @@ class Configuration {
       secretKey,
     );
     await setToken(CryptoUtil.bin2base64(token, urlSafe: true));
-  }
-
-  String getHttpEndpoint() {
-    final savedEndpoint = _preferences.getString(endPointKey) ?? endpoint;
-    if (savedEndpoint == kLegacyProductionEndpoint) {
-      return kDefaultProductionEndpoint;
-    }
-    return savedEndpoint;
-  }
-
-  // isEnteProduction checks if the current endpoint is the default production
-  // endpoint. This is used to determine if the app is in production mode or
-  // not. The default production endpoint is set in the environment variable
-  bool isEnteProduction() {
-    return getHttpEndpoint() == kDefaultProductionEndpoint;
-  }
-
-  Future<void> setHttpEndpoint(String endpoint) async {
-    await _preferences.setString(endPointKey, endpoint);
-    Bus.instance.fire(EndpointUpdatedEvent());
   }
 
   String? getToken() {

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -81,6 +81,7 @@ class Configuration {
   late String _documentsDirectory;
   String? _key;
   late SharedPreferences _preferences;
+  bool _preferencesInitialized = false;
   String? _secretKey;
   late FlutterSecureStorage _secureStorage;
   late String _tempDocumentsDirPath;
@@ -90,9 +91,16 @@ class Configuration {
   late String _sharedDocumentsMediaDirectory;
   String? _volatilePassword;
 
+  void initPreferences(SharedPreferences preferences) {
+    _preferences = preferences;
+    _preferencesInitialized = true;
+  }
+
   Future<void> init() async {
     try {
-      _preferences = await SharedPreferences.getInstance();
+      if (!_preferencesInitialized) {
+        initPreferences(await SharedPreferences.getInstance());
+      }
       _secureStorage = const FlutterSecureStorage(
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,

--- a/mobile/apps/photos/lib/core/network/endpoint_config.dart
+++ b/mobile/apps/photos/lib/core/network/endpoint_config.dart
@@ -1,0 +1,44 @@
+import "package:photos/core/constants.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/event.dart";
+import "package:shared_preferences/shared_preferences.dart";
+
+class EndpointConfig {
+  EndpointConfig(this._preferences);
+
+  final SharedPreferences _preferences;
+
+  static const defaultEndpoint = String.fromEnvironment(
+    "endpoint",
+    defaultValue: kDefaultProductionEndpoint,
+  );
+  static const preferencesKey = "endpoint";
+
+  String get endpoint {
+    return _normalize(
+      _preferences.getString(preferencesKey) ?? defaultEndpoint,
+    );
+  }
+
+  bool get isProduction {
+    return endpoint == kDefaultProductionEndpoint;
+  }
+
+  Future<void> setEndpoint(String endpoint) async {
+    await _preferences.setString(preferencesKey, endpoint);
+    Bus.instance.fire(EndpointUpdatedEvent(this.endpoint));
+  }
+
+  static String _normalize(String endpoint) {
+    if (endpoint == kLegacyProductionEndpoint) {
+      return kDefaultProductionEndpoint;
+    }
+    return endpoint;
+  }
+}
+
+class EndpointUpdatedEvent extends Event {
+  EndpointUpdatedEvent(this.endpoint);
+
+  final String endpoint;
+}

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -7,10 +7,10 @@ import 'package:dio/io.dart';
 import 'package:dio_http2_adapter/dio_http2_adapter.dart';
 import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
+import "package:photos/core/network/endpoint_config.dart";
 import 'package:photos/core/network/ente_interceptor.dart';
-import "package:photos/events/endpoint_updated_event.dart";
+import "package:shared_preferences/shared_preferences.dart";
 import "package:ua_client_hints/ua_client_hints.dart";
 
 class NetworkClient {
@@ -22,9 +22,13 @@ class NetworkClient {
   static const kConnectTimeout = 15;
   static const _connectTimeout = Duration(seconds: kConnectTimeout);
 
-  Future<void> init(PackageInfo packageInfo) async {
+  Future<void> init(
+    PackageInfo packageInfo,
+    SharedPreferences preferences,
+  ) async {
+    final endpointConfig = EndpointConfig(preferences);
     final String ua = await userAgent();
-    final endpoint = Configuration.instance.getHttpEndpoint();
+    final endpoint = endpointConfig.endpoint;
     _dio = Dio(
       BaseOptions(
         connectTimeout: _connectTimeout,
@@ -57,16 +61,9 @@ class NetworkClient {
     }
     _endpointUpdatedSubscription =
         Bus.instance.on<EndpointUpdatedEvent>().listen((event) {
-      final endpoint = Configuration.instance.getHttpEndpoint();
-      _enteDio.options.baseUrl = endpoint;
-      _setupInterceptors(endpoint);
+      _enteDio.options.baseUrl = event.endpoint;
+      _setupInterceptors(event.endpoint);
     });
-  }
-
-  void refreshEndpoint() {
-    final endpoint = Configuration.instance.getHttpEndpoint();
-    _enteDio.options.baseUrl = endpoint;
-    _setupInterceptors(endpoint);
   }
 
   void _setupInterceptors(String endpoint) {

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -63,6 +63,12 @@ class NetworkClient {
     });
   }
 
+  void refreshEndpoint() {
+    final endpoint = Configuration.instance.getHttpEndpoint();
+    _enteDio.options.baseUrl = endpoint;
+    _setupInterceptors(endpoint);
+  }
+
   void _setupInterceptors(String endpoint) {
     _enteDio.interceptors.clear();
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));

--- a/mobile/apps/photos/lib/events/endpoint_updated_event.dart
+++ b/mobile/apps/photos/lib/events/endpoint_updated_event.dart
@@ -1,3 +1,0 @@
-import "package:photos/events/event.dart";
-
-class EndpointUpdatedEvent extends Event {}

--- a/mobile/apps/photos/lib/gateways/users/users_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/users/users_gateway.dart
@@ -1,6 +1,6 @@
 import "package:dio/dio.dart";
-import "package:photos/core/configuration.dart";
 import "package:photos/core/errors.dart";
+import "package:photos/core/network/endpoint_config.dart";
 import "package:photos/gateways/users/models/delete_account.dart";
 import "package:photos/gateways/users/models/key_attributes.dart";
 import "package:photos/gateways/users/models/sessions.dart";
@@ -15,9 +15,11 @@ import "package:photos/models/user_details.dart";
 class UsersGateway {
   final Dio _enteDio;
   final Dio _publicDio;
-  final Configuration _config;
+  final EndpointConfig _endpointConfig;
 
-  UsersGateway(this._enteDio, this._publicDio, this._config);
+  UsersGateway(this._enteDio, this._publicDio, this._endpointConfig);
+
+  String get _endpoint => _endpointConfig.endpoint;
 
   // ============================================================
   // Authentication & Email Verification
@@ -38,7 +40,7 @@ class UsersGateway {
     required bool isMobile,
   }) async {
     await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/ott",
+      "$_endpoint/users/ott",
       data: {
         "email": email,
         "purpose": isChangeEmail ? "change" : purpose ?? "",
@@ -65,7 +67,7 @@ class UsersGateway {
       data["source"] = source;
     }
     final response = await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/verify-email",
+      "$_endpoint/users/verify-email",
       data: data,
     );
     return response.data as Map<String, dynamic>;
@@ -340,7 +342,7 @@ class UsersGateway {
   Future<SrpAttributes> getSrpAttributes(String email) async {
     try {
       final response = await _publicDio.get(
-        "${_config.getHttpEndpoint()}/users/srp/attributes",
+        "$_endpoint/users/srp/attributes",
         queryParameters: {"email": email},
       );
       return SrpAttributes.fromMap(response.data);
@@ -413,7 +415,7 @@ class UsersGateway {
     required String srpA,
   }) async {
     final response = await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/srp/create-session",
+      "$_endpoint/users/srp/create-session",
       data: {
         "srpUserID": srpUserID,
         "srpA": srpA,
@@ -433,7 +435,7 @@ class UsersGateway {
     required String srpM1,
   }) async {
     final response = await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/srp/verify-session",
+      "$_endpoint/users/srp/verify-session",
       data: {
         "sessionID": sessionID,
         "srpUserID": srpUserID,
@@ -502,7 +504,7 @@ class UsersGateway {
     required String code,
   }) async {
     final response = await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/two-factor/verify",
+      "$_endpoint/users/two-factor/verify",
       data: {
         "sessionID": sessionID,
         "code": code,
@@ -523,7 +525,7 @@ class UsersGateway {
     required String twoFactorType,
   }) async {
     final response = await _publicDio.get(
-      "${_config.getHttpEndpoint()}/users/two-factor/recover",
+      "$_endpoint/users/two-factor/recover",
       queryParameters: {
         "sessionID": sessionID,
         "twoFactorType": twoFactorType,
@@ -543,7 +545,7 @@ class UsersGateway {
     required String twoFactorType,
   }) async {
     final response = await _publicDio.post(
-      "${_config.getHttpEndpoint()}/users/two-factor/remove",
+      "$_endpoint/users/two-factor/remove",
       data: {
         "sessionID": sessionID,
         "secret": secret,
@@ -564,7 +566,7 @@ class UsersGateway {
   ) async {
     try {
       final response = await _publicDio.get(
-        "${_config.getHttpEndpoint()}/users/two-factor/passkeys/get-token",
+        "$_endpoint/users/two-factor/passkeys/get-token",
         queryParameters: {"sessionID": sessionID},
       );
       return response.data as Map<String, dynamic>;
@@ -621,7 +623,7 @@ class UsersGateway {
     required String type,
   }) async {
     await _publicDio.post(
-      "${_config.getHttpEndpoint()}/anonymous/feedback",
+      "$_endpoint/anonymous/feedback",
       data: {"feedback": feedback, "type": type},
     );
   }

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -241,11 +241,25 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
   try {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     final SharedPreferences prefs = await SharedPreferences.getInstance();
+    Configuration.instance.initPreferences(prefs);
     await _scheduleHeartBeat(prefs, true);
     await _ensureRustInitialized(via: 'workmanager:$taskId');
 
+    _logger.info("[BG TASK] NetworkClient init $tlog");
+    await NetworkClient.instance.init(packageInfo);
+    _logger.info("[BG TASK] NetworkClient init done $tlog");
+
+    ServiceLocator.instance.init(
+      prefs,
+      NetworkClient.instance.enteDio,
+      NetworkClient.instance.getDio(),
+      packageInfo,
+    );
+    NotificationService.instance.init(prefs);
+
     _logger.info("(for debugging) Configuration init $tlog");
     await Configuration.instance.init();
+    NetworkClient.instance.refreshEndpoint();
     _logger.info("(for debugging) Configuration done $tlog");
 
     // App LifeCycle
@@ -258,16 +272,6 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     await Computer.shared().turnOn(workersCount: 4);
     CryptoUtil.init();
 
-    // Init Network Utils
-    await NetworkClient.instance.init(packageInfo);
-
-    // Global Services
-    ServiceLocator.instance.init(
-      prefs,
-      NetworkClient.instance.enteDio,
-      NetworkClient.instance.getDio(),
-      packageInfo,
-    );
     // Initialize early so thermal/battery listeners can warm up while the
     // rest of background services are being initialized.
     final controller = computeController;
@@ -286,7 +290,6 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
 
     // Misc Services
     await UserService.instance.init();
-    NotificationService.instance.init(prefs);
     SocialNotificationCoordinator.instance.init(prefs);
     await NotificationService.instance.initializeForBackground();
 
@@ -370,6 +373,7 @@ Future<void> _init(
     );
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    Configuration.instance.initPreferences(preferences);
     await _logFGHeartBeatInfo(preferences);
     _logger.info("_logFGHeartBeatInfo done $tlog");
     unawaited(_scheduleHeartBeat(preferences, isBackground));
@@ -387,13 +391,6 @@ Future<void> _init(
     Computer.shared().turnOn(workersCount: 4).ignore();
     CryptoUtil.init();
 
-    _logger.info("Lockscreen init $tlog");
-    unawaited(LockScreenSettings.instance.init(preferences));
-
-    _logger.info("Configuration init $tlog");
-    await Configuration.instance.init();
-    _logger.info("Configuration done $tlog");
-
     _logger.info("NetworkClient init $tlog");
     await NetworkClient.instance.init(packageInfo);
     _logger.info("NetworkClient init done $tlog");
@@ -404,6 +401,15 @@ Future<void> _init(
       NetworkClient.instance.getDio(),
       packageInfo,
     );
+
+    _logger.info("Lockscreen init $tlog");
+    unawaited(LockScreenSettings.instance.init(preferences));
+
+    _logger.info("Configuration init $tlog");
+    await Configuration.instance.init();
+    NetworkClient.instance.refreshEndpoint();
+    _logger.info("Configuration done $tlog");
+
     await MemoryShareService.instance.init();
 
     _logger.info("UserService init $tlog");

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -241,12 +241,11 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
   try {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     final SharedPreferences prefs = await SharedPreferences.getInstance();
-    Configuration.instance.initPreferences(prefs);
     await _scheduleHeartBeat(prefs, true);
     await _ensureRustInitialized(via: 'workmanager:$taskId');
 
     _logger.info("[BG TASK] NetworkClient init $tlog");
-    await NetworkClient.instance.init(packageInfo);
+    await NetworkClient.instance.init(packageInfo, prefs);
     _logger.info("[BG TASK] NetworkClient init done $tlog");
 
     ServiceLocator.instance.init(
@@ -259,7 +258,6 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
 
     _logger.info("(for debugging) Configuration init $tlog");
     await Configuration.instance.init();
-    NetworkClient.instance.refreshEndpoint();
     _logger.info("(for debugging) Configuration done $tlog");
 
     // App LifeCycle
@@ -373,7 +371,6 @@ Future<void> _init(
     );
     final SharedPreferences preferences = await SharedPreferences.getInstance();
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
-    Configuration.instance.initPreferences(preferences);
     await _logFGHeartBeatInfo(preferences);
     _logger.info("_logFGHeartBeatInfo done $tlog");
     unawaited(_scheduleHeartBeat(preferences, isBackground));
@@ -392,7 +389,7 @@ Future<void> _init(
     CryptoUtil.init();
 
     _logger.info("NetworkClient init $tlog");
-    await NetworkClient.instance.init(packageInfo);
+    await NetworkClient.instance.init(packageInfo, preferences);
     _logger.info("NetworkClient init done $tlog");
 
     ServiceLocator.instance.init(
@@ -407,7 +404,6 @@ Future<void> _init(
 
     _logger.info("Configuration init $tlog");
     await Configuration.instance.init();
-    NetworkClient.instance.refreshEndpoint();
     _logger.info("Configuration done $tlog");
 
     await MemoryShareService.instance.init();

--- a/mobile/apps/photos/lib/module/download/file_url.dart
+++ b/mobile/apps/photos/lib/module/download/file_url.dart
@@ -1,4 +1,3 @@
-import "package:photos/core/configuration.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/service_locator.dart";
 
@@ -12,7 +11,7 @@ enum FileUrlType {
 
 class FileUrl {
   static String getUrl(int fileID, FileUrlType type) {
-    final endpoint = Configuration.instance.getHttpEndpoint();
+    final endpoint = endpointConfig.endpoint;
     final disableWorker =
         endpoint != kDefaultProductionEndpoint || flagService.disableCFWorker;
 

--- a/mobile/apps/photos/lib/module/upload/service/multipart.dart
+++ b/mobile/apps/photos/lib/module/upload/service/multipart.dart
@@ -6,7 +6,6 @@ import "package:ente_feature_flag/ente_feature_flag.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
-import "package:photos/core/configuration.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/core/errors.dart";
 import "package:photos/db/upload_locks_db.dart";
@@ -78,7 +77,7 @@ class MultiPartUploader {
       !_featureFlagService.disableCFWorker &&
       (localSettings.cfUploadProxyEnabled ??
           _featureFlagService.cloudflareUploadWorker) &&
-      Configuration.instance.isEnteProduction();
+      endpointConfig.isProduction;
 
   int calculatePartCount(int fileSize) {
     // If the feature flag is disabled, return 1

--- a/mobile/apps/photos/lib/service_locator.dart
+++ b/mobile/apps/photos/lib/service_locator.dart
@@ -2,7 +2,7 @@ import "package:dio/dio.dart";
 import "package:ente_cast/ente_cast.dart";
 import "package:ente_feature_flag/ente_feature_flag.dart";
 import "package:package_info_plus/package_info_plus.dart";
-import "package:photos/core/configuration.dart";
+import "package:photos/core/network/endpoint_config.dart";
 import "package:photos/gateways/billing/billing_gateway.dart";
 import "package:photos/gateways/collections/collection_files_gateway.dart";
 import "package:photos/gateways/collections/collection_share_gateway.dart";
@@ -48,6 +48,7 @@ class ServiceLocator {
   late final Dio enteDio;
   late final Dio nonEnteDio;
   late final PackageInfo packageInfo;
+  late final EndpointConfig endpointConfig;
 
   // instance
   ServiceLocator._privateConstructor();
@@ -64,8 +65,11 @@ class ServiceLocator {
     this.enteDio = enteDio;
     this.nonEnteDio = nonEnteDio;
     this.packageInfo = packageInfo;
+    endpointConfig = EndpointConfig(prefs);
   }
 }
+
+EndpointConfig get endpointConfig => ServiceLocator.instance.endpointConfig;
 
 FlagService? _flagService;
 
@@ -366,7 +370,7 @@ UsersGateway get usersGateway {
   _usersGateway ??= UsersGateway(
     ServiceLocator.instance.enteDio,
     ServiceLocator.instance.nonEnteDio,
-    Configuration.instance,
+    endpointConfig,
   );
   return _usersGateway!;
 }

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -284,10 +284,10 @@ class UserService {
           // Token is already invalid (401 response)
           (e is DioException && e.response?.statusCode == 401) ||
               // Custom endpoints where server might be non-existent or unavailable
-              !_config.isEnteProduction();
+              !endpointConfig.isProduction;
 
       if (silentlyIgnoreError) {
-        if (!_config.isEnteProduction()) {
+        if (!endpointConfig.isProduction) {
           _logger.info(
             "Custom endpoint detected, proceeding with local logout despite server error",
           );

--- a/mobile/apps/photos/lib/services/photos_contacts_service.dart
+++ b/mobile/apps/photos/lib/services/photos_contacts_service.dart
@@ -292,7 +292,7 @@ class PhotosContactsService {
     }
     final packageInfo = ServiceLocator.instance.packageInfo;
     return contacts.ContactsSession(
-      baseUrl: config.getHttpEndpoint(),
+      baseUrl: endpointConfig.endpoint,
       authToken: token,
       userId: userId,
       accountKey: accountKey,

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -1110,7 +1110,7 @@ class VideoPreviewService {
     late final ({String encryptedData, String decryptionHeader}) fetchResult;
     if (collectionsService.isSharedPublicLink(file.collectionID!)) {
       fetchResult = await _fileDataGateway.fetchPublicFileData(
-        baseUrl: config.getHttpEndpoint(),
+        baseUrl: endpointConfig.endpoint,
         fileID: file.uploadedFileID!,
         type: "vid_preview",
         headers: collectionsService.publicCollectionHeaders(file.collectionID!),
@@ -1157,7 +1157,7 @@ class VideoPreviewService {
           file.fileType == FileType.video ? "vid_preview" : "img_preview";
       if (collectionsService.isSharedPublicLink(file.collectionID!)) {
         url = await _fileDataGateway.getPublicPreview(
-          baseUrl: config.getHttpEndpoint(),
+          baseUrl: endpointConfig.endpoint,
           fileID: file.uploadedFileID!,
           type: previewType,
           headers: collectionsService.publicCollectionHeaders(

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_settings_screen.dart
@@ -111,7 +111,7 @@ class BackupSettingsScreen extends StatelessWidget {
                           ),
                         ),
                       ],
-                      if (Configuration.instance.isEnteProduction()) ...[
+                      if (endpointConfig.isProduction) ...[
                         const SizedBox(height: 8),
                         MenuItemWidgetNew(
                           title: AppLocalizations.of(context).fasterUploads,

--- a/mobile/apps/photos/lib/ui/settings/developer_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/developer_settings_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/core/network/network.dart";
 import "package:photos/events/app_mode_changed_event.dart";
@@ -33,8 +32,9 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
     final textTheme = getEnteTextTheme(context);
+    final endpoint = endpointConfig.endpoint;
     _logger.info(
-      "Current endpoint is: ${Configuration.instance.getHttpEndpoint()}",
+      "Current endpoint is: $endpoint",
     );
     return Scaffold(
       resizeToAvoidBottomInset: true,
@@ -65,7 +65,7 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
               const SizedBox(height: 20),
               TextInputWidgetV2(
                 label: AppLocalizations.of(context).serverEndpoint,
-                hintText: Configuration.instance.getHttpEndpoint(),
+                hintText: endpoint,
                 textEditingController: _urlController,
                 autoCorrect: false,
                 autoFocus: true,
@@ -92,7 +92,7 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                     final uri = Uri.parse(url);
                     if ((uri.scheme == "http" || uri.scheme == "https")) {
                       await _ping(url);
-                      await Configuration.instance.setHttpEndpoint(url);
+                      await endpointConfig.setEndpoint(url);
                       showToast(
                         context,
                         AppLocalizations.of(context).endpointUpdatedMessage,

--- a/mobile/apps/photos/lib/ui/settings/developer_settings_widget.dart
+++ b/mobile/apps/photos/lib/ui/settings/developer_settings_widget.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-import "package:photos/core/configuration.dart";
 import "package:photos/generated/l10n.dart";
+import "package:photos/service_locator.dart";
 
 class DeveloperSettingsWidget extends StatelessWidget {
   const DeveloperSettingsWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
-    if (!Configuration.instance.isEnteProduction()) {
-      final endpoint = Configuration.instance.getHttpEndpoint();
+    if (!endpointConfig.isProduction) {
+      final endpoint = endpointConfig.endpoint;
       final endpointURI = Uri.parse(endpoint);
       return Padding(
         padding: const EdgeInsets.only(bottom: 20),

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -304,7 +304,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     if (Platform.isAndroid &&
         !localSettings.hasConfiguredInAppLinkPermissions() &&
         RemoteSyncService.instance.isFirstRemoteSyncDone() &&
-        Configuration.instance.isEnteProduction()) {
+        endpointConfig.isProduction) {
       PackageInfo.fromPlatform().then((packageInfo) {
         final packageName = packageInfo.packageName;
         if (packageName == 'io.ente.photos.independent' ||

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -1452,7 +1452,7 @@ class FileUploader {
       !flagService.disableCFWorker &&
       (localSettings.cfUploadProxyEnabled ??
           flagService.cloudflareUploadWorker) &&
-      Configuration.instance.isEnteProduction();
+      endpointConfig.isProduction;
 
   void _onStorageLimitExceeded() {
     clearQueue(StorageLimitExceededError());


### PR DESCRIPTION
## Summary

- Move Photos endpoint reads, writes, and production checks into EndpointConfig under core/network.
- Initialize NetworkClient and ServiceLocator before Configuration.init() in foreground, background, and integration bootstraps.
- Update endpoint consumers to use the service-locator endpoint config and propagate endpoint changes through the network event.