### PR TITLE
Clean up temporary Auth import files

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
@@ -12,6 +11,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_ui/components/progress_dialog.dart';
@@ -87,9 +87,7 @@ Future<int?> _processAegisExportFile(
   String path,
   final ProgressDialog dialog,
 ) async {
-  File file = File(path);
-
-  final jsonString = await file.readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
   final decodedJson = jsonDecode(jsonString);
   final isEncrypted = decodedJson['header']['slots'] != null;
   Map? aegisDB;

--- a/mobile/apps/auth/lib/ui/settings/data/import/andotp_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/andotp_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -10,6 +9,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_ui/components/progress_dialog.dart';
@@ -95,12 +95,11 @@ Future<int?> _processAndOTPFile(
   String path,
   ProgressDialog dialog,
 ) async {
-  File file = File(path);
   List<dynamic> entries;
 
   // Try to detect if file is encrypted or plain text
   // Plain text files are valid JSON arrays, encrypted files are binary
-  final Uint8List fileBytes = await file.readAsBytes();
+  final Uint8List fileBytes = await readPickedImportFileAsBytes(path);
 
   try {
     // Try to parse as JSON (plain text format)

--- a/mobile/apps/auth/lib/ui/settings/data/import/bitwarden_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/bitwarden_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -10,6 +9,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:file_picker/file_picker.dart';
@@ -77,8 +77,7 @@ Future<int?> _processBitwardenExportFile(
   BuildContext context,
   String path,
 ) async {
-  File file = File(path);
-  final jsonString = await file.readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
   final data = jsonDecode(jsonString);
   List<dynamic> jsonArray = data['items'];
   final Map<String, String> folderIdToName = {};

--- a/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -10,6 +9,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_auth/utils/toast_util.dart';
@@ -133,8 +133,8 @@ Future<void> _pickEnteJsonFile(BuildContext context) async {
   }
 
   try {
-    File file = File(result.files.single.path!);
-    final jsonString = await file.readAsString();
+    final jsonString =
+        await readPickedImportFileAsString(result.files.single.path!);
     EnteAuthExport exportedData =
         EnteAuthExport.fromJson(jsonDecode(jsonString));
     await _decryptExportData(context, exportedData);

--- a/mobile/apps/auth/lib/ui/settings/data/import/import_file_cleanup.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/import_file_cleanup.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+final _logger = Logger('ImportFileCleanup');
+
+Future<String> readPickedImportFileAsString(String path) async {
+  try {
+    return await File(path).readAsString();
+  } finally {
+    await deletePickedImportFileIfAppOwned(path);
+  }
+}
+
+Future<Uint8List> readPickedImportFileAsBytes(String path) async {
+  try {
+    return await File(path).readAsBytes();
+  } finally {
+    await deletePickedImportFileIfAppOwned(path);
+  }
+}
+
+Future<void> deletePickedImportFileIfAppOwned(String path) async {
+  if (!await isAppOwnedPickedImportFile(path)) {
+    return;
+  }
+
+  try {
+    final file = File(path);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  } catch (e, s) {
+    _logger.warning('Failed to delete picked import file copy', e, s);
+  }
+}
+
+Future<bool> isAppOwnedPickedImportFile(String path) async {
+  if (!Platform.isIOS && !Platform.isAndroid) {
+    return false;
+  }
+
+  final candidatePath = await _canonicalFilePath(path);
+  final appOwnedRoots = await _appOwnedPickedFileRoots();
+
+  for (final root in appOwnedRoots) {
+    final rootPath = await _canonicalDirectoryPath(root);
+    if (p.isWithin(rootPath, candidatePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Future<List<String>> _appOwnedPickedFileRoots() async {
+  final roots = <String>[];
+
+  if (Platform.isIOS) {
+    roots.add(Directory.systemTemp.path);
+    await _addDirectoryRoot(roots, getApplicationCacheDirectory);
+  } else if (Platform.isAndroid) {
+    await _addDirectoryRoot(
+      roots,
+      getApplicationCacheDirectory,
+      child: 'file_picker',
+    );
+    await _addDirectoryRoot(
+      roots,
+      getTemporaryDirectory,
+      child: 'file_picker',
+    );
+  }
+
+  return roots.toSet().toList();
+}
+
+Future<void> _addDirectoryRoot(
+  List<String> roots,
+  Future<Directory> Function() directoryProvider, {
+  String? child,
+}) async {
+  try {
+    final directory = await directoryProvider();
+    roots.add(child == null ? directory.path : p.join(directory.path, child));
+  } catch (e, s) {
+    _logger.fine('Failed to resolve app-owned import cleanup root', e, s);
+  }
+}
+
+Future<String> _canonicalFilePath(String path) async {
+  try {
+    return await File(path).resolveSymbolicLinks();
+  } catch (_) {
+    return p.normalize(p.absolute(path));
+  }
+}
+
+Future<String> _canonicalDirectoryPath(String path) async {
+  try {
+    return await Directory(path).resolveSymbolicLinks();
+  } catch (_) {
+    return p.normalize(p.absolute(path));
+  }
+}

--- a/mobile/apps/auth/lib/ui/settings/data/import/lastpass_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/lastpass_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -9,6 +8,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:file_picker/file_picker.dart';
@@ -76,8 +76,7 @@ Future<int?> _processLastpassExportFile(
   BuildContext context,
   String path,
 ) async {
-  File file = File(path);
-  final jsonString = await file.readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
   Map<String, dynamic> jsonData = json.decode(jsonString);
   List<dynamic> accounts = jsonData["accounts"];
   final parsedCodes = [];

--- a/mobile/apps/auth/lib/ui/settings/data/import/plain_text_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/plain_text_import.dart
@@ -7,6 +7,7 @@ import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
 import 'package:ente_auth/store/code_store.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:file_picker/file_picker.dart';
@@ -105,8 +106,7 @@ Future<void> _pickImportFile(BuildContext context) async {
   await progressDialog.show();
   try {
     final parsedCodes = [];
-    File file = File(result.files.single.path!);
-    final codes = await file.readAsString();
+    final codes = await readPickedImportFileAsString(result.files.single.path!);
 
     if (codes.startsWith('otpauth://')) {
       List<String> splitCodes = codes.split(",");

--- a/mobile/apps/auth/lib/ui/settings/data/import/proton_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/proton_import.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
@@ -7,6 +6,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/ui/settings/data/import/proton_import_parser.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
@@ -81,7 +81,7 @@ Future<int?> _processProtonExportFile(
   String path,
   ProgressDialog dialog,
 ) async {
-  final jsonString = await File(path).readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
 
   Map<String, dynamic> decodedJson;
   try {

--- a/mobile/apps/auth/lib/ui/settings/data/import/raivo_plain_text_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/raivo_plain_text_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
@@ -9,6 +8,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:file_picker/file_picker.dart';
@@ -73,8 +73,8 @@ Future<void> _pickRaivoJsonFile(BuildContext context) async {
 }
 
 Future<int?> _processRaivoExportFile(BuildContext context, String path) async {
-  File file = File(path);
   if (path.endsWith('.zip')) {
+    await deletePickedImportFileIfAppOwned(path);
     await showErrorDialog(
       context,
       context.l10n.sorry,
@@ -82,7 +82,7 @@ Future<int?> _processRaivoExportFile(BuildContext context, String path) async {
     );
     return null;
   }
-  final jsonString = await file.readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
   List<dynamic> jsonArray = jsonDecode(jsonString);
   final parsedCodes = [];
   for (var item in jsonArray) {

--- a/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:ente_auth/l10n/l10n.dart';
@@ -11,6 +10,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/components/dialog_widget.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
+import 'package:ente_auth/ui/settings/data/import/import_file_cleanup.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_ui/components/progress_dialog.dart';
@@ -83,9 +83,7 @@ Future<int?> _process2FasExportFile(
   String path,
   final ProgressDialog dialog,
 ) async {
-  File file = File(path);
-
-  final jsonString = await file.readAsString();
+  final jsonString = await readPickedImportFileAsString(path);
   final decodedJson = jsonDecode(jsonString);
   int version = (decodedJson['schemaVersion'] ?? 0) as int;
   if (version != 3 && version != 4) {

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -1,4 +1,4 @@
-- Added custom icons for Art Fight, BJ-Share, CatRealm, eClinicalWorks, RustDesk, Smogon, Zabbix, and Zyxel Nebula
+- Added custom icons for Art Fight, BJ-Share, CatRealm, eClinicalWorks, Racket Coach, RustDesk, Smogon, Zabbix, and Zyxel Nebula
 - Updated the Availity custom icon
 - Fixed several multi-color custom icons rendering as single-color masks
 - Preserved maximized window state across desktop app launches
@@ -6,4 +6,5 @@
 - Migrated Auth app API, sharing, billing, web access, and exported HTML asset links to ente.com domains
 - Added Android and iOS web credential associations for ente.com Ente properties to improve password autofill/passkey handoff
 - Reduced direct-distribution Android APK size by filtering supported ABIs and compressing native libraries
+- Cleaned up temporary files created while importing Auth exports from other apps
 - Updated Estonian and Lithuanian translations


### PR DESCRIPTION
## Summary

- Delete app-owned temporary/cache copies created when Auth imports picked files after reading them into memory.
- Apply the cleanup across plain text, Ente encrypted, Raivo, Aegis, 2FAS, andOTP, Bitwarden, LastPass, and Proton imports.
- Guard cleanup to iOS/Android picker-owned paths so desktop user-selected files are left untouched.
- Update Auth internal changes for the import cleanup and the recent Racket Coach custom icon.

Fixes #2742
