### PR TITLE
Fix video edit delete navigation

### DIFF
--- a/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
+++ b/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
@@ -40,8 +40,10 @@ Future<void> showSingleFileDeleteSheet(
       );
       return;
     }
-    await deleteFilesOnDeviceOnly(context, [file]);
-    if (onFileRemoved != null && (isLocalOnly || isLocalOnlyContext)) {
+    final deletedFiles = await deleteFilesOnDeviceOnly(context, [file]);
+    if (deletedFiles.isNotEmpty &&
+        onFileRemoved != null &&
+        (isLocalOnly || isLocalOnlyContext)) {
       onFileRemoved(file);
     }
     return;
@@ -105,11 +107,13 @@ Future<void> showSingleFileDeleteSheet(
         shouldSurfaceExecutionStates: false,
         isInAlert: true,
         onTap: () async {
-          await deleteFilesOnDeviceOnly(context, [file]);
+          final deletedFiles = await deleteFilesOnDeviceOnly(context, [file]);
           // Remove from viewer if:
           // 1. File is local-only (no remote copy), OR
           // 2. We're in a local-only context (device folder - file disappears from this view)
-          if (onFileRemoved != null && (isLocalOnly || isLocalOnlyContext)) {
+          if (deletedFiles.isNotEmpty &&
+              onFileRemoved != null &&
+              (isLocalOnly || isLocalOnlyContext)) {
             onFileRemoved(file);
           }
         },

--- a/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
@@ -590,7 +590,7 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
         SyncService.instance.sync().ignore();
 
         showShortToast(context, AppLocalizations.of(context).editsSaved);
-        final files = widget.detailPageConfig.files;
+        final files = List<EnteFile>.of(widget.detailPageConfig.files);
 
         // the index could be -1 if the files fetched doesn't contain the newly
         // edited files
@@ -598,8 +598,17 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
           (file) => file.generatedID == newFile.generatedID,
         );
         if (selectionIndex == -1) {
-          files.add(newFile);
-          selectionIndex = files.length - 1;
+          final fallbackIndex = min(
+            max(widget.detailPageConfig.selectedIndex, 0),
+            files.length,
+          );
+          final originalIndex = widget.file.generatedID == null
+              ? -1
+              : files.indexWhere(
+                  (file) => file.generatedID == widget.file.generatedID,
+                );
+          selectionIndex = originalIndex == -1 ? fallbackIndex : originalIndex;
+          files.insert(selectionIndex, newFile);
         }
         Navigator.of(dialogKey.currentContext!).pop('dialog');
 

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -197,7 +197,7 @@ Future<void> deleteFilesFromRemoteOnly(
   RemoteSyncService.instance.sync(silently: true);
 }
 
-Future<void> deleteFilesOnDeviceOnly(
+Future<List<EnteFile>> deleteFilesOnDeviceOnly(
   BuildContext context,
   List<EnteFile> files,
 ) async {
@@ -226,7 +226,7 @@ Future<void> deleteFilesOnDeviceOnly(
   if (hasLocalOnlyFiles && Platform.isAndroid && !isLocalGalleryMode) {
     final shouldProceed = await shouldProceedWithDeletion(context);
     if (!shouldProceed) {
-      return;
+      return const [];
     }
   }
   Set<String> deletedIDs = <String>{};
@@ -262,6 +262,7 @@ Future<void> deleteFilesOnDeviceOnly(
       ),
     );
   }
+  return deletedFiles;
 }
 
 Future<bool> deleteFromTrash(BuildContext context, List<EnteFile> files) async {


### PR DESCRIPTION
## Summary
- keep edited video copies adjacent to their source in the detail viewer instead of appending them to the end
- make device-only deletion report which files were actually removed
- only remove a single local file from the viewer after device deletion succeeds

## Validation
- `dart format mobile/apps/photos/lib/ui/actions/file/file_actions.dart mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart mobile/apps/photos/lib/utils/delete_file_util.dart`
- `flutter analyze lib/ui/actions/file/file_actions.dart lib/ui/tools/editor/video_editor_page.dart lib/utils/delete_file_util.dart`
- Full `flutter analyze` still fails on existing unrelated localization/Rust binding errors outside this diff.
