### PR TITLE
[server] Alert on storage warning login blocks

### DIFF
--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -410,6 +410,21 @@ func storageWarningDeletionScheduledError() error {
 	}, "storage warning deletion scheduled")
 }
 
+func (c *UserController) alertStorageWarningDeletionScheduledLoginBlock(userID int64, app ente.App) {
+	log.WithFields(log.Fields{
+		"user_id": userID,
+		"app":     app,
+		"code":    StorageWarningDeletionScheduledCode,
+	}).Warn("blocked login due to storage warning scheduled deletion")
+
+	if c.DiscordController != nil {
+		c.DiscordController.NotifyThrottled(
+			fmt.Sprintf("Storage warning login block hit: user_id=%d app=%s", userID, app),
+			15*t.Minute,
+		)
+	}
+}
+
 func (c *UserController) ensureStorageWarningDeletionLoginAllowed(userID int64, app ente.App) error {
 	if c.NotificationHistoryRepo == nil || !shouldEnforceStorageWarningDeletionLoginBlock(app) {
 		return nil
@@ -419,6 +434,7 @@ func (c *UserController) ensureStorageWarningDeletionLoginAllowed(userID int64, 
 		return stacktrace.Propagate(err, "failed to read storage warning deletion state")
 	}
 	if deletionScheduled {
+		c.alertStorageWarningDeletionScheduledLoginBlock(userID, app)
 		return storageWarningDeletionScheduledError()
 	}
 	return nil

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -419,7 +419,7 @@ func (c *UserController) alertStorageWarningDeletionScheduledLoginBlock(userID i
 
 	if c.DiscordController != nil {
 		c.DiscordController.NotifyThrottled(
-			fmt.Sprintf("Storage warning login block hit: user_id=%d app=%s", userID, app),
+			fmt.Sprintf("🔒 Storage warning login block hit: user_id=%d app=%s", userID, app),
 			15*t.Minute,
 		)
 	}

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -418,7 +418,8 @@ func (c *UserController) alertStorageWarningDeletionScheduledLoginBlock(userID i
 	}).Warn("blocked login due to storage warning scheduled deletion")
 
 	if c.DiscordController != nil {
-		c.DiscordController.NotifyThrottled(
+		discordController := c.DiscordController
+		go discordController.NotifyThrottled(
 			fmt.Sprintf("🔒 Storage warning login block hit: user_id=%d app=%s", userID, app),
 			15*t.Minute,
 		)

--- a/server/pkg/controller/user/userauth_storage_warning_test.go
+++ b/server/pkg/controller/user/userauth_storage_warning_test.go
@@ -1,0 +1,32 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/ente-io/museum/ente"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestAlertStorageWarningDeletionScheduledLoginBlockLogsUserIDAndApp(t *testing.T) {
+	hook := logtest.NewGlobal()
+	t.Cleanup(hook.Reset)
+
+	(&UserController{}).alertStorageWarningDeletionScheduledLoginBlock(123, ente.Photos)
+
+	entry := hook.LastEntry()
+	if entry == nil {
+		t.Fatal("expected a log entry")
+	}
+	if entry.Message != "blocked login due to storage warning scheduled deletion" {
+		t.Fatalf("log message = %q, want storage warning login block message", entry.Message)
+	}
+	if got := entry.Data["user_id"]; got != int64(123) {
+		t.Fatalf("user_id field = %v, want 123", got)
+	}
+	if got := entry.Data["app"]; got != ente.Photos {
+		t.Fatalf("app field = %v, want %s", got, ente.Photos)
+	}
+	if got := entry.Data["code"]; got != StorageWarningDeletionScheduledCode {
+		t.Fatalf("code field = %v, want %s", got, StorageWarningDeletionScheduledCode)
+	}
+}


### PR DESCRIPTION
## Summary
- Emit a structured server warning when storage-warning scheduled deletion blocks Photos or Locker login
- Include `user_id`, app, and the stable `ACCOUNT_SCHEDULED_FOR_DELETION` code in the log
- Send a throttled `🔒` Discord notification asynchronously when a Discord controller is available
- Add unit coverage for the alert log fields

## Tests
- `cd server && go test ./pkg/controller/user -run TestAlertStorageWarningDeletionScheduledLoginBlockLogsUserIDAndApp`
- `git diff --check`
