### PR TITLE
[web] Show friendly error for deleted or expired Locker share links

### DIFF
--- a/web/apps/share/src/services/file-share.ts
+++ b/web/apps/share/src/services/file-share.ts
@@ -91,6 +91,18 @@ export const fetchFileInfo = async (
         if (await isDeviceLimitExceededResponse(response)) {
             throw new Error(deviceLimitExceededMessage);
         }
+        if (response.status === 410) {
+            let errorBody: { error?: string } | undefined;
+            try {
+                errorBody = (await response.json()) as { error?: string };
+            } catch {
+                // Ignore JSON parsing errors and use generic message
+            }
+            if (errorBody?.error === "expired token") {
+                throw new Error("This link has expired.");
+            }
+            throw new Error("This link has been deleted by the owner.");
+        }
         throw new Error(`Failed to fetch file`);
     }
 


### PR DESCRIPTION
## Summary

- When a Locker share link has been deleted by the owner, the share page now shows a clear message: **"This link has been deleted by the owner."** instead of a generic error.
- When the link token has expired (HTTP 410 with `"expired token"` in the response body), the page shows: **"This link has expired."**
- Previously, both cases fell through to a generic `"Failed to fetch file"` error that gave the viewer no useful context.

## Changes

- `web/apps/share/src/services/file-share.ts`: Handle HTTP 410 responses in `fetchFileInfo` by inspecting the response body and throwing a user-friendly error message.

## Test plan

- [ ] Open a Locker share link that has been deleted by the owner — confirm "This link has been deleted by the owner." is displayed.
- [ ] Open an expired Locker share link (410 with `expired token` body) — confirm "This link has expired." is displayed.
- [ ] Open a valid Locker share link — confirm normal behavior is unaffected.

## Before
<img width="1870" height="982" alt="image" src="https://github.com/user-attachments/assets/aca061a8-f7a3-48d2-8f7c-b876e02d38d0" />

## After
<img width="1870" height="982" alt="image" src="https://github.com/user-attachments/assets/7ccacf7c-83e1-4afd-8ca2-e5443a7ed129" />
