### PR TITLE
[locker] Fix missing header when self hosted

### DIFF
--- a/web/apps/locker/src/services/remote-read.ts
+++ b/web/apps/locker/src/services/remote-read.ts
@@ -2,7 +2,11 @@ import {
     ensureLocalUser,
     ensureUserKeyPair,
 } from "ente-accounts-rs/services/user";
-import { authenticatedRequestHeaders, ensureOk } from "ente-base/http";
+import {
+    authenticatedRequestHeaders,
+    ensureOk,
+    publicRequestHeaders,
+} from "ente-base/http";
 import log from "ente-base/log";
 import { apiURL, customAPIOrigin } from "ente-base/origins";
 import { ensureAuthToken } from "ente-base/token";
@@ -1044,7 +1048,9 @@ export const downloadLockerFile = async (
         if (customOrigin) {
             const token = await ensureAuthToken();
             const url = await apiURL(`/files/download/${fileID}`, { token });
-            response = await fetch(url);
+            response = await fetch(url, {
+                headers: publicRequestHeaders(),
+            });
         } else {
             response = await fetch(`https://files.ente.com/?fileID=${fileID}`, {
                 headers: await authenticatedRequestHeaders(),


### PR DESCRIPTION
## Description
Fix for the self hosted locker web app, see details [here](https://github.com/ente-io/ente/issues/10470)
