### PR TITLE
docs(photos): sync changelog for v1.3.44

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -7,6 +7,13 @@ description: Release notes of recent updates to Ente Photos mobile and desktop a
 
 A short summary list of changes to the Ente Photos mobile and desktop apps. For a more descriptive list with screenshots and blog post links, see the [news](https://ente.com/news).
 
+## v1.3.44 (mobile) - May 2026
+
+- Added support for selecting photos in 3rd party apps
+- Added support to review photos directly from camera apps
+- Fixed issue with HEIC photos rendering
+- Improvements in gallery scrolling performance
+
 ## v1.3.40 (mobile) - May 2026
 
 - Faster Memories loading


### PR DESCRIPTION
## Summary
- add the Ente Photos mobile changelog entry for v1.3.44

## Why
The public help changelog still stopped at v1.3.40 even though v1.3.44 is now released.

## Release notes synced
- Added support for selecting photos in 3rd party apps
- Added support to review photos directly from camera apps
- Fixed issue with HEIC photos rendering
- Improvements in gallery scrolling performance