### PR TITLE
[mob][photos] Update ffmpeg-kit Android AAR

### DIFF
--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -749,8 +749,8 @@ packages:
     dependency: "direct main"
     description:
       path: "flutter/flutter"
-      ref: b5d560ca9417ee92cd04546c651dcf2889a817d6
-      resolved-ref: b5d560ca9417ee92cd04546c651dcf2889a817d6
+      ref: "15afc08775a75fe9c12de3366fa99e39bf171ccc"
+      resolved-ref: "15afc08775a75fe9c12de3366fa99e39bf171ccc"
       url: "https://github.com/ente-io/ffmpeg-kit"
     source: git
     version: "6.0.3"
@@ -758,8 +758,8 @@ packages:
     dependency: transitive
     description:
       path: "flutter/flutter_platform_interface"
-      ref: b5d560ca9417ee92cd04546c651dcf2889a817d6
-      resolved-ref: b5d560ca9417ee92cd04546c651dcf2889a817d6
+      ref: "15afc08775a75fe9c12de3366fa99e39bf171ccc"
+      resolved-ref: "15afc08775a75fe9c12de3366fa99e39bf171ccc"
       url: "https://github.com/ente-io/ffmpeg-kit"
     source: git
     version: "0.2.1"

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
     git:
       url: https://github.com/ente-io/ffmpeg-kit
       path: flutter/flutter
-      ref: b5d560ca9417ee92cd04546c651dcf2889a817d6
+      ref: 15afc08775a75fe9c12de3366fa99e39bf171ccc
   figma_squircle: 0.6.3
   file_saver: 0.2.14
   firebase_core: 3.15.1

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -5,6 +5,7 @@ Still behind internal flag:
 - Aman: (I) Use Rust HEIC decoder for Android photo viewer when dimensions are known
 - Laurens: (I) Generate and compress face thumbnails in rust
 - Laurens: (I) Use cloudflare worker for upload for internal users
+- Neeraj: Fix Android video preview/export generation by restoring ffmpeg x264 support
 - Neeraj: (I) Add internal-only resumable gallery download queue with persistence/restart fixes and completion banner updates
 - Neeraj: (i) Save Contact
 - Prateek: (i) Enable BG sync notifications by default for internal users on iOS

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,5 +1,7 @@
 Latest changes:
 - Neeraj: Fix Android video preview/export generation by restoring ffmpeg x264 support
+- Neeraj: Fix video edit delete navigation
+- Neeraj: Fix grey screen after single-memory delete or favorite actions
 - Aman: Flutter upgrade
 
 Still behind internal flag:

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,11 +1,13 @@
 Latest changes:
+- Neeraj: Fix Android video preview/export generation by restoring ffmpeg x264 support
+- Aman: Flutter upgrade
 
 Still behind internal flag:
 - Amrithesh: (I) ML/Pet recognition [Indexing]
 - Aman: (I) Use Rust HEIC decoder for Android photo viewer when dimensions are known
 - Laurens: (I) Generate and compress face thumbnails in rust
 - Laurens: (I) Use cloudflare worker for upload for internal users
-- Neeraj: Fix Android video preview/export generation by restoring ffmpeg x264 support
+
 - Neeraj: (I) Add internal-only resumable gallery download queue with persistence/restart fixes and completion banner updates
 - Neeraj: (i) Save Contact
 - Prateek: (i) Enable BG sync notifications by default for internal users on iOS


### PR DESCRIPTION
## Description

- Update `ffmpeg_kit_flutter` from `b5d560c` to `15afc087`.
- Pull in the CI-built Android ffmpeg AAR from ente-io/ffmpeg-kit#4.
- Restore Android `libx264` support for video transcodes.
- Keep `zimg`/`zscale` support for HDR/video processing paths.

The previous Android AAR did not include `libx264`, causing ffmpeg failures such as:

```text
Unknown encoder 'libx264'
```

The updated dependency points to the merged ente-io/ffmpeg-kit fix and uses the CI-built AAR.

## Tests

- [x] `flutter pub get`
- [x] `flutter analyze .`
- [x] `flutter build apk --dart-define=cronetHttpNoPlay=true --release --flavor independent --target-platform android-arm,android-arm64`
- [x] Installed and launched the independent release APK on `SM_M305F`
- [x] Verified arm64 ffmpeg libs include `libx264` and `zimg`/`zscale`, with native `LOAD` alignment `>= 0x4000`
