### PR TITLE
[mob][photos] Fix iOS Long Shot video crash

### DIFF
--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -2978,12 +2978,13 @@ packages:
     source: hosted
     version: "2.9.5"
   video_player_avfoundation:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: video_player_avfoundation
-      sha256: e5371e9c09a5f5d55b88fd552bb1192dd5805a5747388553a439a30b85851a6a
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/video_player/video_player_avfoundation"
+      ref: e6f7518a2ea4b31cf44e7bd6f44b35b1d66b2085
+      resolved-ref: e6f7518a2ea4b31cf44e7bd6f44b35b1d66b2085
+      url: "https://github.com/ente-io/packages.git"
+    source: git
     version: "2.9.5"
   video_player_platform_interface:
     dependency: transitive

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -296,6 +296,13 @@ dependency_overrides:
       url: https://github.com/deckerst/aves_panorama_motion_sensors.git
       ref: 4b11d59f4bda152627f701070272f657f8358e67
   protobuf: 3.1.0
+  # Fixes an iOS AVFoundation crash for videos whose minFrameDuration is zero.
+  # https://github.com/flutter/flutter/issues/151031
+  video_player_avfoundation:
+    git:
+      url: https://github.com/ente-io/packages.git
+      path: packages/video_player/video_player_avfoundation
+      ref: e6f7518a2ea4b31cf44e7bd6f44b35b1d66b2085
   watcher: 1.1.2
   win32: "5.10.1"
 

--- a/mobile/apps/photos/pubspec_overrides.yaml
+++ b/mobile/apps/photos/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: ente_cast,ente_crypto,ente_feature_flag,onnx_dart,ffi,flutter_sodium,intl,js,media_kit,media_kit_libs_ios_video,media_kit_libs_video,media_kit_video,protobuf,watcher,win32,log_viewer,native_video_editor,ente_qr_ui,ente_icons,ente_rust,ente_pure_utils,backup_exclusion,ente_contacts,ente_qr
+# melos_managed_dependency_overrides: ente_cast,ente_crypto,ente_feature_flag,onnx_dart,ffi,flutter_sodium,intl,js,media_kit,media_kit_libs_ios_video,media_kit_libs_video,media_kit_video,protobuf,video_player_avfoundation,watcher,win32,log_viewer,native_video_editor,ente_qr_ui,ente_icons,ente_rust,ente_pure_utils,backup_exclusion,ente_contacts,ente_qr
 dependency_overrides:
   cronet_http: 1.6.0
   ente_cast:
@@ -41,6 +41,11 @@ dependency_overrides:
       url: https://github.com/deckerst/aves_panorama_motion_sensors.git
       ref: 4b11d59f4bda152627f701070272f657f8358e67
   protobuf: 3.1.0
+  video_player_avfoundation:
+    git:
+      url: https://github.com/ente-io/packages.git
+      path: packages/video_player/video_player_avfoundation
+      ref: e6f7518a2ea4b31cf44e7bd6f44b35b1d66b2085
   watcher: 1.1.2
   win32: 5.10.1
   log_viewer:

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Fix iOS crash when playing Pixel Long Shot (.LS) videos
 
 Still behind internal flag:
 - Amrithesh: (I) ML/Pet recognition [Indexing]


### PR DESCRIPTION
## Summary
- Override `video_player_avfoundation` to the Ente packages fork that guards against zero `minFrameDuration` on iOS.
- Add the internal changelog entry for Pixel Long Shot (`.LS`) video playback crash fix.

## Testing
- `flutter pub get --enforce-lockfile`
- `flutter build ios --no-codesign`