### PR TITLE
[codex] Update ente component color tokens

### DIFF
--- a/mobile/packages/ente_components/lib/components/buttons/button_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/button_component.dart
@@ -509,8 +509,10 @@ class _ButtonComponentState extends State<ButtonComponent>
     final colors = _componentColors(context);
     return switch (widget.variant) {
       ButtonComponentVariant.primary => colors.specialWhite,
-      ButtonComponentVariant.secondary =>
-        isPressed ? colors.primaryDarker : colors.primaryDark,
+      ButtonComponentVariant.secondary => _secondaryForeground(
+        colors,
+        isPressed: isPressed,
+      ),
       ButtonComponentVariant.neutral => colors.textReverse,
       ButtonComponentVariant.critical => colors.specialWhite,
       ButtonComponentVariant.tertiaryCritical =>
@@ -526,6 +528,13 @@ class _ButtonComponentState extends State<ButtonComponent>
             ? colors.primaryDark
             : colors.primary,
     };
+  }
+
+  Color _secondaryForeground(ColorTokens colors, {required bool isPressed}) {
+    if (colors.primary == colors.blue || colors.primary == colors.purple) {
+      return colors.primary;
+    }
+    return isPressed ? colors.primaryDarker : colors.primaryDark;
   }
 
   ColorTokens _componentColors(BuildContext context) {

--- a/mobile/packages/ente_components/lib/theme/colors.dart
+++ b/mobile/packages/ente_components/lib/theme/colors.dart
@@ -453,20 +453,20 @@ const Color greenDarkerLight = Color.fromRGBO(5, 124, 24, 1);
 const Color greenDarkerDark = Color.fromRGBO(5, 124, 24, 1);
 
 // Purple Colors
-const Color purpleLightLight = Color.fromRGBO(248, 243, 254, 1);
-const Color purpleLightDark = Color.fromRGBO(41, 41, 41, 1);
+const Color purpleLightLight = Color.fromRGBO(244, 231, 252, 1);
+const Color purpleLightDark = Color.fromRGBO(39, 28, 50, 1);
 
 const Color purpleLightHoverLight = Color.fromRGBO(232, 210, 250, 1);
-const Color purpleLightHoverDark = Color.fromRGBO(61, 27, 92, 1);
+const Color purpleLightHoverDark = Color.fromRGBO(47, 31, 63, 1);
 
 const Color purpleLightPressedLight = Color.fromRGBO(217, 188, 241, 1);
-const Color purpleLightPressedDark = Color.fromRGBO(79, 40, 115, 1);
+const Color purpleLightPressedDark = Color.fromRGBO(37, 23, 52, 1);
 
 const Color purpleStrokeLight = Color.fromRGBO(216, 181, 244, 1);
 const Color purpleStrokeDark = Color.fromRGBO(61, 27, 92, 1);
 
-const Color purpleDefaultLight = Color.fromRGBO(138, 56, 245, 1);
-const Color purpleDefaultDark = Color.fromRGBO(138, 56, 245, 1);
+const Color purpleDefaultLight = Color.fromRGBO(150, 16, 214, 1);
+const Color purpleDefaultDark = Color.fromRGBO(150, 16, 214, 1);
 
 const Color purpleDarkLight = Color.fromRGBO(122, 12, 174, 1);
 const Color purpleDarkDark = Color.fromRGBO(122, 12, 174, 1);
@@ -482,7 +482,7 @@ const Color blueLightHoverLight = Color.fromRGBO(216, 228, 244, 1);
 const Color blueLightHoverDark = Color.fromRGBO(26, 38, 56, 1);
 
 const Color blueLightPressedLight = Color.fromRGBO(194, 210, 232, 1);
-const Color blueLightPressedDark = Color.fromRGBO(42, 59, 85, 1);
+const Color blueLightPressedDark = Color.fromRGBO(17, 30, 49, 1);
 
 const Color blueStrokeLight = Color.fromRGBO(16, 113, 255, 1);
 const Color blueStrokeDark = Color.fromRGBO(16, 113, 255, 1);
@@ -533,7 +533,7 @@ const Color textLighterLight = Color.fromRGBO(150, 150, 150, 1);
 const Color textLighterDark = Color.fromRGBO(150, 150, 150, 1);
 
 const Color textLightestLight = Color.fromRGBO(222, 222, 222, 1);
-const Color textLightestDark = Color.fromRGBO(10, 10, 10, 1);
+const Color textLightestDark = Color.fromRGBO(65, 65, 65, 1);
 
 const Color textReverseLight = Color.fromRGBO(255, 255, 255, 1);
 const Color textReverseDark = Color.fromRGBO(0, 0, 0, 1);
@@ -543,7 +543,7 @@ const Color iconColorLight = Color.fromRGBO(0, 0, 0, 0.75);
 const Color iconColorDark = Color.fromRGBO(255, 255, 255, 1);
 
 // Background Colors
-const Color backgroundBaseLight = Color.fromRGBO(250, 250, 250, 1);
+const Color backgroundBaseLight = Color.fromRGBO(244, 244, 244, 1);
 const Color backgroundBaseDark = Color.fromRGBO(22, 22, 22, 1);
 
 // Fill Colors
@@ -553,7 +553,7 @@ const Color fillLightDark = Color.fromRGBO(33, 33, 33, 1);
 const Color fillBaseLight = Color.fromRGBO(0, 0, 0, 1);
 const Color fillBaseDark = Color.fromRGBO(255, 255, 255, 1);
 
-const Color fillDarkLight = Color.fromRGBO(245, 245, 245, 1);
+const Color fillDarkLight = Color.fromRGBO(234, 234, 234, 1);
 const Color fillDarkDark = Color.fromRGBO(10, 10, 10, 1);
 
 const Color fillDarkerLight = Color.fromRGBO(233, 233, 233, 1);

--- a/mobile/packages/ente_components/test/components/button_test.dart
+++ b/mobile/packages/ente_components/test/components/button_test.dart
@@ -262,6 +262,10 @@ void main() {
 
       expect(find.text("No callback"), findsOneWidget);
       expect(find.text("Disabled"), findsOneWidget);
+      expect(
+        _buttonContainerColor(tester, "Disabled"),
+        ColorTokens.light.fillDark,
+      );
       await tester.tap(find.text("Disabled"));
       await tester.pump();
 
@@ -320,6 +324,55 @@ void main() {
     );
 
     expect(tester.getSize(find.byType(AnimatedContainer)).height, 52);
+  });
+
+  testWidgets("Secondary button foreground follows app-specific Figma tokens", (
+    tester,
+  ) async {
+    Future<void> pumpSecondary({
+      required String label,
+      required ComponentApp app,
+      Brightness brightness = Brightness.light,
+    }) {
+      return tester.pumpWidget(
+        _wrap(
+          ButtonComponent(
+            label: label,
+            variant: ButtonComponentVariant.secondary,
+            size: ButtonComponentSize.large,
+            onTap: () {},
+          ),
+          app: app,
+          brightness: brightness,
+        ),
+      );
+    }
+
+    await pumpSecondary(label: "Photos", app: ComponentApp.photos);
+    expect(_textColor(tester, "Photos"), greenDarkLight);
+
+    await pumpSecondary(label: "Locker", app: ComponentApp.locker);
+    expect(_textColor(tester, "Locker"), blueDefaultLight);
+
+    await pumpSecondary(label: "Auth", app: ComponentApp.auth);
+    expect(_textColor(tester, "Auth"), purpleDefaultLight);
+
+    await pumpSecondary(
+      label: "Auth dark",
+      app: ComponentApp.auth,
+      brightness: Brightness.dark,
+    );
+    expect(_textColor(tester, "Auth dark"), purpleDefaultDark);
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text("Auth dark")),
+    );
+    await tester.pump();
+
+    expect(_containerColor(tester), purpleLightPressedDark);
+    expect(_textColor(tester, "Auth dark"), purpleDefaultDark);
+
+    await gesture.up();
   });
 
   testWidgets("IconButtonComponent renders Figma size and pressed state", (
@@ -489,9 +542,14 @@ void main() {
   });
 }
 
-Widget _wrap(Widget child) {
+Widget _wrap(
+  Widget child, {
+  ComponentApp app = ComponentApp.photos,
+  Brightness brightness = Brightness.light,
+}) {
   return MaterialApp(
-    theme: ComponentTheme.lightTheme(),
+    themeAnimationDuration: Duration.zero,
+    theme: ComponentTheme.themeForApp(app, brightness: brightness),
     home: Scaffold(body: Center(child: child)),
   );
 }
@@ -503,9 +561,24 @@ Color _containerColor(WidgetTester tester) {
   return (container.decoration! as BoxDecoration).color!;
 }
 
+Color _buttonContainerColor(WidgetTester tester, String label) {
+  final container = tester.widget<AnimatedContainer>(
+    find.ancestor(
+      of: find.text(label),
+      matching: find.byType(AnimatedContainer),
+    ),
+  );
+  return (container.decoration! as BoxDecoration).color!;
+}
+
 Color _iconButtonColor(WidgetTester tester) {
   final container = tester.widget<AnimatedContainer>(
     find.byKey(const ValueKey('icon-button-surface')),
   );
   return (container.decoration! as BoxDecoration).color!;
+}
+
+Color _textColor(WidgetTester tester, String label) {
+  final text = tester.widget<Text>(find.text(label));
+  return text.style!.color!;
 }

--- a/mobile/packages/ente_components/test/theme/theme_tokens_test.dart
+++ b/mobile/packages/ente_components/test/theme/theme_tokens_test.dart
@@ -37,7 +37,7 @@ void main() {
     test("expose light and dark semantic color values", () {
       expect(ColorTokens.light.primary, const Color(0xFF08C225));
       expect(ColorTokens.light.warning, const Color(0xFFF63A3A));
-      expect(ColorTokens.light.backgroundBase, const Color(0xFFFAFAFA));
+      expect(ColorTokens.light.backgroundBase, const Color(0xFFF4F4F4));
       expect(ColorTokens.light.textBase, const Color(0xFF000000));
       expect(ColorTokens.light.textReverse, const Color(0xFFFFFFFF));
       expect(ColorTokens.light.iconColor, const Color.fromRGBO(0, 0, 0, 0.75));
@@ -85,6 +85,8 @@ void main() {
 
       expect(authDark.primary, purpleDefaultDark);
       expect(authDark.primaryLight, purpleLightDark);
+      expect(authDark.primaryLightHover, purpleLightHoverDark);
+      expect(authDark.primaryLightPressed, purpleLightPressedDark);
 
       expect(authLight.backgroundBase, ColorTokens.light.backgroundBase);
       expect(authLight.warning, ColorTokens.light.warning);
@@ -104,11 +106,11 @@ void main() {
         "greens/green": Color.fromRGBO(8, 194, 37, 1),
         "greens/green-dark": Color.fromRGBO(6, 157, 30, 1),
         "greens/green-darker": Color.fromRGBO(5, 124, 24, 1),
-        "purples/purple-light": Color.fromRGBO(248, 243, 254, 1),
+        "purples/purple-light": Color.fromRGBO(244, 231, 252, 1),
         "purples/purple-light-hover": Color.fromRGBO(232, 210, 250, 1),
         "purples/purple-light-pressed": Color.fromRGBO(217, 188, 241, 1),
         "purples/purple-stroke": Color.fromRGBO(216, 181, 244, 1),
-        "purples/purple": Color.fromRGBO(138, 56, 245, 1),
+        "purples/purple": Color.fromRGBO(150, 16, 214, 1),
         "purples/purple-dark": Color.fromRGBO(122, 12, 174, 1),
         "purples/purple-darker": Color.fromRGBO(93, 8, 132, 1),
         "blues/blue-light": Color.fromRGBO(231, 239, 250, 1),
@@ -127,16 +129,16 @@ void main() {
         "greens/green": Color.fromRGBO(8, 194, 37, 1),
         "greens/green-dark": Color.fromRGBO(6, 157, 30, 1),
         "greens/green-darker": Color.fromRGBO(5, 124, 24, 1),
-        "purples/purple-light": Color.fromRGBO(41, 41, 41, 1),
-        "purples/purple-light-hover": Color.fromRGBO(61, 27, 92, 1),
-        "purples/purple-light-pressed": Color.fromRGBO(79, 40, 115, 1),
+        "purples/purple-light": Color.fromRGBO(39, 28, 50, 1),
+        "purples/purple-light-hover": Color.fromRGBO(47, 31, 63, 1),
+        "purples/purple-light-pressed": Color.fromRGBO(37, 23, 52, 1),
         "purples/purple-stroke": Color.fromRGBO(61, 27, 92, 1),
-        "purples/purple": Color.fromRGBO(138, 56, 245, 1),
+        "purples/purple": Color.fromRGBO(150, 16, 214, 1),
         "purples/purple-dark": Color.fromRGBO(122, 12, 174, 1),
         "purples/purple-darker": Color.fromRGBO(93, 8, 132, 1),
         "blues/blue-light": Color.fromRGBO(41, 41, 41, 1),
         "blues/blue-light-hover": Color.fromRGBO(26, 38, 56, 1),
-        "blues/blue-light-pressed": Color.fromRGBO(42, 59, 85, 1),
+        "blues/blue-light-pressed": Color.fromRGBO(17, 30, 49, 1),
         "blues/blue-stroke": Color.fromRGBO(16, 113, 255, 1),
         "blues/blue": Color.fromRGBO(16, 113, 255, 1),
         "blues/blue-dark": Color.fromRGBO(14, 95, 217, 1),
@@ -155,11 +157,11 @@ void main() {
         "accent/pink-light": Color.fromRGBO(253, 246, 251, 1),
         "accent/teal": Color.fromRGBO(95, 183, 187, 1),
         "accent/teal-light": Color.fromRGBO(245, 251, 251, 1),
-        "background/base": Color.fromRGBO(250, 250, 250, 1),
+        "background/base": Color.fromRGBO(244, 244, 244, 1),
         "caution/default": Color.fromRGBO(240, 138, 30, 1),
         "caution/light": Color.fromRGBO(250, 244, 235, 1),
         "fill/base": Color.fromRGBO(0, 0, 0, 1),
-        "fill/dark": Color.fromRGBO(245, 245, 245, 1),
+        "fill/dark": Color.fromRGBO(234, 234, 234, 1),
         "fill/darker": Color.fromRGBO(233, 233, 233, 1),
         "fill/darkest": Color.fromRGBO(210, 210, 210, 1),
         "fill/light": Color.fromRGBO(255, 255, 255, 1),
@@ -221,7 +223,7 @@ void main() {
         "text/darker": Color.fromRGBO(204, 204, 204, 1),
         "text/light": Color.fromRGBO(153, 153, 153, 1),
         "text/lighter": Color.fromRGBO(150, 150, 150, 1),
-        "text/lightest": Color.fromRGBO(10, 10, 10, 1),
+        "text/lightest": Color.fromRGBO(65, 65, 65, 1),
         "text/reverse": Color.fromRGBO(0, 0, 0, 1),
         "warning/dark": Color.fromRGBO(221, 52, 52, 1),
         "warning/darker": Color.fromRGBO(197, 46, 46, 1),


### PR DESCRIPTION
## Summary
- Update ente component color tokens for the latest Figma values, including purple states, blue dark pressed, background base, disabled fill, and dark text-lightest.
- Keep secondary button text behavior app-aware without adding button-specific color tokens: Locker/Auth use primary, Photos keeps the existing dark/darker green behavior.
- Add component tests for disabled button fill and app-specific secondary button foreground states.

## Validation
- `flutter test`
- `flutter analyze`
- `flutter build ios --simulator`