### PR TITLE
[server] Add latency-sensitive DB pool for access and object lookups

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -138,6 +138,8 @@ func main() {
 
 	db := setupDatabase()
 	defer db.Close()
+	latencySensitiveDB := setupLatencySensitiveDatabase()
+	defer latencySensitiveDB.Close()
 
 	hostName, err := os.Hostname()
 	if err != nil {
@@ -181,7 +183,7 @@ func main() {
 
 	notificationHistoryRepo := &repo.NotificationHistoryRepository{DB: db}
 	queueRepo := &repo.QueueRepository{DB: db}
-	objectRepo := &repo.ObjectRepository{DB: db, QueueRepo: queueRepo}
+	objectRepo := &repo.ObjectRepository{DB: db, LatencySensitiveDB: latencySensitiveDB, QueueRepo: queueRepo}
 	objectCleanupRepo := &repo.ObjectCleanupRepository{DB: db}
 	contactRepository := &contactRepo.Repository{
 		DB:                  db,
@@ -203,6 +205,9 @@ func main() {
 
 	collectionRepo := &repo.CollectionRepository{DB: db, FileRepo: fileRepo, CollectionLinkRepo: collectionLinkRepo,
 		TrashRepo: trashRepo, SecretEncryptionKey: secretEncryptionKeyBytes, QueueRepo: queueRepo, LatencyLogger: latencyLogger}
+	accessCollectionLinkRepo := public.NewCollectionLinkRepository(latencySensitiveDB, viper.GetString("apps.public-albums"))
+	accessCollectionRepo := &repo.CollectionRepository{DB: latencySensitiveDB, CollectionLinkRepo: accessCollectionLinkRepo}
+	accessFileRepo := &repo.FileRepository{DB: latencySensitiveDB}
 	pushRepo := &repo.PushTokenRepository{DB: db}
 	collectionActionRepo := &repo.CollectionActionsRepository{
 		DB: db,
@@ -288,7 +293,7 @@ func main() {
 		UploadResultCache: make(map[int64]bool),
 	}
 
-	accessCtrl := access.NewAccessController(collectionRepo, fileRepo)
+	accessCtrl := access.NewAccessController(accessCollectionRepo, accessFileRepo)
 	commentsRepo := &socialrepo.CommentsRepository{DB: db}
 	reactionsRepo := &socialrepo.ReactionsRepository{DB: db}
 	anonUsersRepo := &socialrepo.AnonUsersRepository{DB: db}
@@ -1152,6 +1157,31 @@ func setupDatabase() *sql.DB {
 	db.SetConnMaxIdleTime(10 * time.Minute)
 
 	log.Println("Database was configured successfully.")
+
+	return db
+}
+
+func setupLatencySensitiveDatabase() *sql.DB {
+	log.Println("Setting up latency sensitive db")
+	db, err := sql.Open("postgres", config.GetPGInfo())
+
+	if err != nil {
+		log.Panic(err)
+		panic(err)
+	}
+	log.Println("Connected to latency sensitive DB")
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+	log.Println("Pinged latency sensitive DB")
+
+	db.SetMaxIdleConns(20)
+	db.SetMaxOpenConns(20)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(10 * time.Minute)
+
+	log.Println("Latency sensitive database was configured successfully.")
 
 	return db
 }

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1050,10 +1050,11 @@ func main() {
 		trashController, pushController, objectController, dataCleanupController, storageBonusCtrl, emergencyCtrl,
 		embeddingController, healthCheckHandler, castDb, inactiveUserOrchestrator)
 
-	// Create a new collector, the name will be used as a label on the metrics
-	collector := sqlstats.NewStatsCollector("prod_db", db)
-	// Register it with Prometheus
-	prometheus.MustRegister(collector)
+	// Create new collectors, the names will be used as labels on the metrics
+	primaryDBCollector := sqlstats.NewStatsCollector("prod_db", db)
+	latencySensitiveDBCollector := sqlstats.NewStatsCollector("latency_sensitive_db", latencySensitiveDB)
+	// Register them with Prometheus
+	prometheus.MustRegister(primaryDBCollector, latencySensitiveDBCollector)
 
 	http.Handle("/metrics", promhttp.Handler())
 	go http.ListenAndServe(":2112", nil)

--- a/server/pkg/repo/object.go
+++ b/server/pkg/repo/object.go
@@ -13,8 +13,16 @@ import (
 )
 
 type ObjectRepository struct {
-	DB        *sql.DB
-	QueueRepo *QueueRepository
+	DB                 *sql.DB
+	LatencySensitiveDB *sql.DB
+	QueueRepo          *QueueRepository
+}
+
+func (repo *ObjectRepository) objectLookupDB() *sql.DB {
+	if repo.LatencySensitiveDB != nil {
+		return repo.LatencySensitiveDB
+	}
+	return repo.DB
 }
 
 func (repo *ObjectRepository) GetObjectsMissingInDC(dc string, limit int, random bool) ([]ente.S3ObjectKey, error) {
@@ -56,7 +64,7 @@ func (repo *ObjectRepository) GetObjectsForFileIDs(fileIDs []int64) ([]ente.S3Ob
 // GetObject returns the ente.S3ObjectKey key for a file id and type
 func (repo *ObjectRepository) GetObject(fileID int64, objType ente.ObjectType) (ente.S3ObjectKey, error) {
 	// todo: handling of deleted objects
-	row := repo.DB.QueryRow(`SELECT object_key, size, o_type FROM object_keys WHERE file_id = $1 AND o_type = $2 AND is_deleted=false`,
+	row := repo.objectLookupDB().QueryRow(`SELECT object_key, size, o_type FROM object_keys WHERE file_id = $1 AND o_type = $2 AND is_deleted=false`,
 		fileID, objType)
 	var s3ObjectKey ente.S3ObjectKey
 	s3ObjectKey.FileID = fileID
@@ -65,7 +73,7 @@ func (repo *ObjectRepository) GetObject(fileID int64, objType ente.ObjectType) (
 }
 
 func (repo *ObjectRepository) GetObjectWithDCs(fileID int64, objType ente.ObjectType) (ente.S3ObjectKey, []string, error) {
-	row := repo.DB.QueryRow(`SELECT object_key, size, o_type, datacenters FROM object_keys WHERE file_id = $1 AND o_type = $2 AND is_deleted=false`,
+	row := repo.objectLookupDB().QueryRow(`SELECT object_key, size, o_type, datacenters FROM object_keys WHERE file_id = $1 AND o_type = $2 AND is_deleted=false`,
 		fileID, objType)
 	var s3ObjectKey ente.S3ObjectKey
 	var datacenters []string

--- a/server/pkg/repo/object_test.go
+++ b/server/pkg/repo/object_test.go
@@ -1,0 +1,25 @@
+package repo
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestObjectLookupDBUsesLatencySensitiveDBWhenPresent(t *testing.T) {
+	primaryDB := &sql.DB{}
+	latencySensitiveDB := &sql.DB{}
+	repository := &ObjectRepository{DB: primaryDB, LatencySensitiveDB: latencySensitiveDB}
+
+	if got := repository.objectLookupDB(); got != latencySensitiveDB {
+		t.Fatal("expected object lookup DB to use LatencySensitiveDB")
+	}
+}
+
+func TestObjectLookupDBFallsBackToPrimaryDB(t *testing.T) {
+	primaryDB := &sql.DB{}
+	repository := &ObjectRepository{DB: primaryDB}
+
+	if got := repository.objectLookupDB(); got != primaryDB {
+		t.Fatal("expected object lookup DB to fall back to DB")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a separate latency-sensitive PostgreSQL pool capped at 20 connections.
- Route AccessCtrl file/collection access-check queries through the new pool.
- Route ObjectRepository.GetObject and GetObjectWithDCs through the new pool with primary DB fallback.
- Publish primary and latency-sensitive DB pool metrics separately through existing sqlstats labels.
- Keep migrations, writes, replication, cleanup, and other object queries on the primary pool.

## Testing

- go test ./pkg/repo -run TestObjectLookupDB -count=1
- go test ./cmd/museum -count=1
- go test ./... -count=1
