### PR TITLE
[mob][photos] Skip EXIF reader for videos

### DIFF
--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -102,8 +102,11 @@ class OfflineImportMetadataService {
       }
 
       final fileSize = await originFile.length();
-      final exifData = await tryExifFromFile(originFile);
-      final exifTime = await tryParseExifDateTime(null, exifData);
+      final exifData = shouldReadExif(file)
+          ? await tryExifFromFile(originFile)
+          : null;
+      final exifTime =
+          exifData != null ? await tryParseExifDateTime(null, exifData) : null;
 
       await _updateLocationForOfflineFile(file, originFile, exifData);
 

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import "package:photos/models/ffmpeg/ffprobe_props.dart";
 import 'package:photos/models/file/file.dart';
+import "package:photos/models/file/file_type.dart";
 import "package:photos/models/location/location.dart";
 import "package:photos/services/isolated_ffmpeg_service.dart";
 import "package:photos/services/location_service.dart";
@@ -26,8 +27,15 @@ const kEmptyExifDateTime = "0000:00:00 00:00:00";
 
 final _logger = Logger("ExifUtil");
 
+bool shouldReadExif(EnteFile file) {
+  return file.fileType == FileType.image || file.fileType == FileType.livePhoto;
+}
+
 Future<Map<String, IfdTag>> getExif(EnteFile file) async {
   try {
+    if (!shouldReadExif(file)) {
+      return <String, IfdTag>{};
+    }
     final File? originFile = await getFile(file, isOrigin: true);
     if (originFile == null) {
       throw Exception("Failed to fetch origin file");

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -805,10 +805,9 @@ class FileUploader {
           contentMd5: thumbnailMd5,
         );
       }
-      final ParsedExifDateTime? exifTime = await tryParseExifDateTime(
-        null,
-        mediaUploadData.exifData,
-      );
+      final ParsedExifDateTime? exifTime = mediaUploadData.exifData != null
+          ? await tryParseExifDateTime(null, mediaUploadData.exifData)
+          : null;
       file.metadataVersion = EnteFile.kCurrentMetadataVersion;
       final metadata =
           await file.getMetadataForUpload(mediaUploadData, exifTime);

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -147,7 +147,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
       InvalidReason.sourceFileMissing,
     );
   }
-  if (parseExif) {
+  if (parseExif && shouldReadExif(file)) {
     exifData = await tryExifFromFile(sourceFile);
     if (exifData != null) {
       cameraMake = _extractPrintableExifValue(exifData['Image Make']);

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Skip image EXIF parsing for videos
 - Neeraj: Fix iOS crash when playing Pixel Long Shot (.LS) videos
 - Neeraj: Fix Android video preview/export generation by restoring ffmpeg x264 support
 - Neeraj: Fix video edit delete navigation


### PR DESCRIPTION
## Summary
- skip image EXIF parsing for videos in Photos mobile
- keep image and live-photo EXIF behavior unchanged
- keep video metadata/location handling on the existing ffprobe paths
- update Photos internal changes

## Root cause
Some video paths were sharing the image EXIF parsing flow, so videos could be sent through `exif_reader` before the existing video metadata handling ran.

## Validation
- `git diff --check`
- `cd mobile/apps/photos && flutter analyze .`
- `dart format --output=none --set-exit-if-changed <changed Dart files>` reports the formatter would rewrite the four touched Dart files; those unrelated formatter-only rewrites were intentionally not applied to keep this PR scoped.
