### PR TITLE
[codex] Batch gallery download sync side effects

### DIFF
--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -10,12 +10,14 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/db/gallery_downloads_db.dart";
 import "package:photos/events/gallery_downloads_events.dart";
+import "package:photos/events/local_photos_updated_event.dart";
 import "package:photos/events/user_logged_out_event.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/module/download/manager.dart";
 import "package:photos/module/download/task.dart";
 import "package:photos/service_locator.dart";
+import "package:photos/services/sync/local_sync_service.dart";
 import "package:photos/utils/file_download_util.dart";
 
 class GalleryDownloadEnqueueResult {
@@ -40,15 +42,20 @@ class GalleryDownloadQueueService {
   final Set<int> _activeDownloads = {};
   final Map<int, StreamSubscription<DownloadTask>> _watchSubscriptions = {};
   final Map<int, EnteFile> _queuedFilesByID = {};
+  final List<EnteFile> _deferredGalleryUpdatedFiles = [];
 
   StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
   StreamSubscription<UserLoggedOutEvent>? _logoutSubscription;
   Timer? _completionCleanupTimer;
   Completer<void>? _initCompleter;
+  Future<void>? _deferredGallerySideEffectsStart;
+  Future<void>? _deferredGallerySideEffectsFlush;
 
   bool _isInitialized = false;
   bool _isBannerDismissedByUser = false;
   bool _showCompletionBanner = false;
+  bool _isDeferringGallerySideEffects = false;
+  bool _hasDeferredGallerySaves = false;
 
   GalleryDownloadQueueService._privateConstructor();
 
@@ -79,22 +86,22 @@ class GalleryDownloadQueueService {
       .length;
 
   bool get hasPausedDueToNoConnection => _tasks.values.any(
-        (task) =>
-            task.status == DownloadStatus.paused &&
-            task.error == DownloadManager.noConnectionError,
-      );
+    (task) =>
+        task.status == DownloadStatus.paused &&
+        task.error == DownloadManager.noConnectionError,
+  );
 
   bool get hasPausedDueToStorage => _tasks.values.any(
-        (task) =>
-            task.status == DownloadStatus.paused &&
-            task.error == DownloadManager.notEnoughStorageError,
-      );
+    (task) =>
+        task.status == DownloadStatus.paused &&
+        task.error == DownloadManager.notEnoughStorageError,
+  );
 
   bool get hasNonUnavailableErrors => _tasks.values.any(
-        (task) =>
-            task.status == DownloadStatus.error &&
-            task.error != DownloadManager.unavailableError,
-      );
+    (task) =>
+        task.status == DownloadStatus.error &&
+        task.error != DownloadManager.unavailableError,
+  );
 
   bool get isCompletionBannerVisible =>
       _showCompletionBanner &&
@@ -264,6 +271,7 @@ class GalleryDownloadQueueService {
       }
     }
     _activeDownloads.clear();
+    await _flushDeferredGallerySaveSideEffects(force: true);
     _tasks.clear();
     _queuedFilesByID.clear();
     _showCompletionBanner = false;
@@ -341,10 +349,12 @@ class GalleryDownloadQueueService {
 
   void _listenToConnectivity() {
     _connectivitySubscription?.cancel();
-    _connectivitySubscription =
-        Connectivity().onConnectivityChanged.listen((results) {
-      final hasConnection =
-          results.any((result) => result != ConnectivityResult.none);
+    _connectivitySubscription = Connectivity().onConnectivityChanged.listen((
+      results,
+    ) {
+      final hasConnection = results.any(
+        (result) => result != ConnectivityResult.none,
+      );
       if (!hasConnection) {
         return;
       }
@@ -397,6 +407,7 @@ class GalleryDownloadQueueService {
       _startTask(nextTask);
     }
     _maybeShowCompletionState();
+    _maybeFlushDeferredGallerySaveSideEffects();
     _emitUpdatedEvent();
   }
 
@@ -409,25 +420,27 @@ class GalleryDownloadQueueService {
       ),
     ).ignore();
     _watchSubscriptions[task.id]?.cancel();
-    _watchSubscriptions[task.id] =
-        downloadManager.watchDownload(task.id).listen(
-      (downloadTask) {
-        final existing = _tasks[task.id];
-        if (existing == null) {
-          return;
-        }
-        final updatedTask = existing.copyWith(
-          bytesDownloaded: downloadTask.bytesDownloaded,
-          filePath: downloadTask.filePath,
+    _watchSubscriptions[task.id] = downloadManager
+        .watchDownload(task.id)
+        .listen(
+          (downloadTask) {
+            final existing = _tasks[task.id];
+            if (existing == null) {
+              return;
+            }
+            final updatedTask = existing.copyWith(
+              bytesDownloaded: downloadTask.bytesDownloaded,
+              filePath: downloadTask.filePath,
+            );
+            _updateTask(updatedTask).ignore();
+          },
         );
-        _updateTask(updatedTask).ignore();
-      },
-    );
     _runTask(task.id).ignore();
   }
 
   Future<void> _runTask(int fileID) async {
     try {
+      await _ensureDeferredGallerySaveSideEffects();
       await _downloadAndSaveToGallery(fileID);
       final task = _tasks[fileID];
       if (task != null) {
@@ -481,15 +494,18 @@ class GalleryDownloadQueueService {
       throw DownloadUnavailableError();
     }
     file.fileSize ??= _tasks[fileID]?.totalBytes;
-    final fileToDownload =
-        file.isRemoteFile ? file.copyWith() : (file.copyWith()..localID = null);
-    await downloadToGallery(
+    final fileToDownload = file.isRemoteFile
+        ? file.copyWith()
+        : (file.copyWith()..localID = null);
+    final result = await downloadToGallery(
       fileToDownload,
       forceResumableDownload: true,
       persistToFilesDB: _deserializePersistToFilesDB(
         sourceFileJson ?? _tasks[fileID]?.sourceFileJson,
       ),
+      sideEffectMode: GalleryDownloadSideEffectMode.deferred,
     );
+    _recordDeferredGallerySave(result);
   }
 
   Future<void> _setPausedState(int fileID, String reason) async {
@@ -555,6 +571,95 @@ class GalleryDownloadQueueService {
     );
   }
 
+  Future<void> _ensureDeferredGallerySaveSideEffects() {
+    final existingStart = _deferredGallerySideEffectsStart;
+    if (existingStart != null) {
+      return existingStart;
+    }
+    _isDeferringGallerySideEffects = true;
+    final start = LocalSyncService.instance
+        .beginDeferredChangeSync()
+        .catchError(
+          (Object e, StackTrace s) {
+            _isDeferringGallerySideEffects = false;
+            _deferredGallerySideEffectsStart = null;
+            throw e;
+          },
+        );
+    _deferredGallerySideEffectsStart = start;
+    return start;
+  }
+
+  void _recordDeferredGallerySave(GalleryDownloadSaveResult result) {
+    if (!result.savedToGallery) {
+      return;
+    }
+    _hasDeferredGallerySaves = true;
+    final persistedFile = result.persistedFile;
+    if (persistedFile != null) {
+      _deferredGalleryUpdatedFiles.add(persistedFile);
+    }
+  }
+
+  void _maybeFlushDeferredGallerySaveSideEffects() {
+    if (_hasRunnableTasks) {
+      return;
+    }
+    if (!_isDeferringGallerySideEffects &&
+        !_hasDeferredGallerySaves &&
+        _deferredGalleryUpdatedFiles.isEmpty) {
+      return;
+    }
+    _deferredGallerySideEffectsFlush ??= _flushDeferredGallerySaveSideEffects()
+        .whenComplete(() {
+          _deferredGallerySideEffectsFlush = null;
+        });
+  }
+
+  Future<void> _flushDeferredGallerySaveSideEffects({
+    bool force = false,
+  }) async {
+    if (!force && _hasRunnableTasks) {
+      return;
+    }
+    final start = _deferredGallerySideEffectsStart;
+    if (start != null) {
+      await start;
+    }
+    if (!force && _hasRunnableTasks) {
+      return;
+    }
+
+    final updatedFiles = _deferredGalleryUpdatedFiles.toList(growable: false);
+    _deferredGalleryUpdatedFiles.clear();
+    final shouldSync = _hasDeferredGallerySaves;
+    _hasDeferredGallerySaves = false;
+
+    if (updatedFiles.isNotEmpty) {
+      Bus.instance.fire(
+        LocalPhotosUpdatedEvent(updatedFiles, source: "download"),
+      );
+    }
+    if (_isDeferringGallerySideEffects) {
+      _isDeferringGallerySideEffects = false;
+      _deferredGallerySideEffectsStart = null;
+      await LocalSyncService.instance.endDeferredChangeSync(
+        runDeferredSync: false,
+      );
+    }
+    if (shouldSync) {
+      LocalSyncService.instance.checkAndSync().ignore();
+    }
+  }
+
+  bool get _hasRunnableTasks =>
+      _activeDownloads.isNotEmpty ||
+      _tasks.values.any(
+        (task) =>
+            task.status == DownloadStatus.pending ||
+            task.status == DownloadStatus.downloading,
+      );
+
   bool get _allTasksAreTerminal =>
       _tasks.isNotEmpty &&
       _tasks.values.every((task) => _isTerminal(task.status));
@@ -588,8 +693,8 @@ class GalleryDownloadQueueService {
       if (await file.exists()) {
         await file.delete();
       }
-      final totalChunks =
-          (task.totalBytes / DownloadManager.downloadChunkSize).ceil();
+      final totalChunks = (task.totalBytes / DownloadManager.downloadChunkSize)
+          .ceil();
       for (int i = 1; i <= totalChunks; i++) {
         final chunk = File("$basePath.${i}_part");
         if (await chunk.exists()) {

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -44,6 +44,8 @@ class LocalSyncService {
   StreamSubscription<PermissionGrantedEvent>? _permissionGrantedSubscription;
   bool _isChangeCallbackRegistered = false;
   final Lock _lock = Lock();
+  int _deferredChangeSyncDepth = 0;
+  bool _hasDeferredChangeSyncRequest = false;
 
   static const kDbUpdationTimeKey = "db_updation_time";
   static const kHasCompletedFirstImportKey = "has_completed_firstImport";
@@ -64,15 +66,16 @@ class LocalSyncService {
       if (_permissionGrantedSubscription != null) {
         await _permissionGrantedSubscription!.cancel();
       }
-      _permissionGrantedSubscription =
-          Bus.instance.on<PermissionGrantedEvent>().listen((event) async {
-        _registerChangeCallback();
-        if (isLocalGalleryMode) {
-          // Local gallery onboarding grants permission without explicitly
-          // invoking SyncService, so trigger local import right away.
-          unawaited(checkAndSync());
-        }
-      });
+      _permissionGrantedSubscription = Bus.instance
+          .on<PermissionGrantedEvent>()
+          .listen((event) async {
+            _registerChangeCallback();
+            if (isLocalGalleryMode) {
+              // Local gallery onboarding grants permission without explicitly
+              // invoking SyncService, so trigger local import right away.
+              unawaited(checkAndSync());
+            }
+          });
     }
   }
 
@@ -82,8 +85,8 @@ class LocalSyncService {
       return;
     }
     if (Platform.isAndroid && AppLifecycleService.instance.isForeground) {
-      final permissionState =
-          await permissionService.requestPhotoMangerPermissions();
+      final permissionState = await permissionService
+          .requestPhotoMangerPermissions();
       if (permissionState != PermissionState.authorized) {
         _logger.warning(
           "Skipping local sync because Android gallery permission is "
@@ -197,8 +200,8 @@ class LocalSyncService {
     );
     final int ownerID = Configuration.instance.getUserIDV2();
     final existingLocalFileIDs = await _db.getExistingLocalFileIDs(ownerID);
-    final Map<String, Set<String>> pathToLocalIDs =
-        await _db.getDevicePathIDToLocalIDMap();
+    final Map<String, Set<String>> pathToLocalIDs = await _db
+        .getDevicePathIDToLocalIDMap();
 
     final localDiffResult = await getDiffFromExistingImport(
       localAssets,
@@ -245,16 +248,16 @@ class LocalSyncService {
     if (flagService.syncRecoveryDiagnostics) {
       final int newMappingCount =
           localDiffResult.newPathToLocalIDs?.values.fold<int>(
-                0,
-                (sum, ids) => sum + ids.length,
-              ) ??
-              0;
+            0,
+            (sum, ids) => sum + ids.length,
+          ) ??
+          0;
       final int deletedMappingCount =
           localDiffResult.deletePathToLocalIDs?.values.fold<int>(
-                0,
-                (sum, ids) => sum + ids.length,
-              ) ??
-              0;
+            0,
+            (sum, ids) => sum + ids.length,
+          ) ??
+          0;
       if (newMappingCount > 0 || deletedMappingCount > 0 || hasUnsyncedFiles) {
         final sampleRecovered = (localDiffResult.uniqueLocalFiles ?? [])
             .take(3)
@@ -299,6 +302,43 @@ class LocalSyncService {
 
   Lock getLock() {
     return _lock;
+  }
+
+  Future<void> beginDeferredChangeSync() async {
+    if (_deferredChangeSyncDepth > 0) {
+      _deferredChangeSyncDepth++;
+      return;
+    }
+    _deferredChangeSyncDepth = 1;
+    _hasDeferredChangeSyncRequest = false;
+    try {
+      await PhotoManager.stopChangeNotify();
+    } catch (_) {
+      _deferredChangeSyncDepth = 0;
+      rethrow;
+    }
+  }
+
+  Future<void> endDeferredChangeSync({bool runDeferredSync = true}) async {
+    if (_deferredChangeSyncDepth <= 0) {
+      _logger.warning("endDeferredChangeSync called without active deferral");
+      return;
+    }
+    if (_deferredChangeSyncDepth > 1) {
+      _deferredChangeSyncDepth--;
+      return;
+    }
+
+    try {
+      await PhotoManager.startChangeNotify();
+    } finally {
+      _deferredChangeSyncDepth = 0;
+    }
+    final shouldRunSync = runDeferredSync && _hasDeferredChangeSyncRequest;
+    _hasDeferredChangeSyncRequest = false;
+    if (shouldRunSync) {
+      unawaited(checkAndSync());
+    }
   }
 
   bool hasCompletedFirstImport() {
@@ -368,8 +408,10 @@ class LocalSyncService {
       _logger.info('Inserted ${files.length} out of ${allFiles.length} files');
       if (flagService.syncRecoveryDiagnostics &&
           allFiles.length != files.length) {
-        final sampleLocalIDs =
-            allFiles.take(3).map((file) => file.localID).toList();
+        final sampleLocalIDs = allFiles
+            .take(3)
+            .map((file) => file.localID)
+            .toList();
         _logger.info(
           "localSync partial materialization: "
           "from=$fromTime to=$toTime "
@@ -459,6 +501,10 @@ class LocalSyncService {
     // after file selection dialog is dismissed.
     PhotoManager.addChangeCallback((value) async {
       _logger.info("Something changed on disk");
+      if (_deferredChangeSyncDepth > 0) {
+        _hasDeferredChangeSyncRequest = true;
+        return;
+      }
       _changeCallbackDebouncer.run(() async {
         unawaited(checkAndSync());
       });

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -50,6 +50,21 @@ class DownloadUnavailableError extends DownloadFailedError {
   DownloadUnavailableError() : super("Unavailable");
 }
 
+enum GalleryDownloadSideEffectMode {
+  immediate,
+  deferred,
+}
+
+class GalleryDownloadSaveResult {
+  final bool savedToGallery;
+  final EnteFile? persistedFile;
+
+  const GalleryDownloadSaveResult({
+    required this.savedToGallery,
+    required this.persistedFile,
+  });
+}
+
 /// Use this instead of `file.displayName` directly for skip toasts.
 ///
 /// Rationale:
@@ -70,8 +85,9 @@ Future<String?> getExistingLocalFolderNameForDownloadSkipToast(
   if (asset == null || !(await asset.exists)) {
     return null;
   }
-  final folderNames =
-      await FilesDB.instance.getDeviceCollectionNamesForLocalID(file.localID!);
+  final folderNames = await FilesDB.instance.getDeviceCollectionNamesForLocalID(
+    file.localID!,
+  );
   if (folderNames.isNotEmpty) {
     return folderNames.last;
   }
@@ -91,16 +107,18 @@ Future<File?> downloadAndDecryptPublicFile(
   ProgressCallback? progressCallback,
 }) async {
   final String logPrefix = 'Public File-${file.uploadedFileID}:';
-  _logger
-      .info('$logPrefix starting download ${formatBytes(file.fileSize ?? 0)}');
+  _logger.info(
+    '$logPrefix starting download ${formatBytes(file.fileSize ?? 0)}',
+  );
 
   final String tempDir = Configuration.instance.getTempDirectory();
   final String encryptedFilePath = "$tempDir${file.uploadedFileID}.encrypted";
   final String decryptedFilePath = "$tempDir${file.uploadedFileID}.decrypted";
 
   try {
-    final headers =
-        CollectionsService.instance.publicCollectionHeaders(file.collectionID!);
+    final headers = CollectionsService.instance.publicCollectionHeaders(
+      file.collectionID!,
+    );
     final response = (await NetworkClient.instance.getDio().download(
       FileUrl.getUrl(file.uploadedFileID!, FileUrlType.publicDownload),
       encryptedFilePath,
@@ -139,8 +157,10 @@ Future<File?> downloadAndDecryptPublicFile(
       _logger.info('$logPrefix file saved at $decryptedFilePath');
     } catch (e, s) {
       fakeProgress?.stop();
-      final metadata =
-          await _getFileMetadataForLogging(file, encryptedFilePath);
+      final metadata = await _getFileMetadataForLogging(
+        file,
+        encryptedFilePath,
+      );
       _logger.severe("Critical: $logPrefix failed to decrypt, $metadata", e, s);
       return null;
     }
@@ -165,8 +185,9 @@ Future<File?> downloadAndDecrypt(
   }
 
   final String logPrefix = 'File-${file.uploadedFileID}:';
-  _logger
-      .info('$logPrefix starting download ${formatBytes(file.fileSize ?? 0)}');
+  _logger.info(
+    '$logPrefix starting download ${formatBytes(file.fileSize ?? 0)}',
+  );
   final String tempDir = Configuration.instance.getTempDirectory();
   String encryptedFilePath = "$tempDir${file.generatedID}.encrypted";
   File encryptedFile = File(encryptedFilePath);
@@ -249,12 +270,15 @@ Future<File?> downloadAndDecrypt(
         getFileKey(file),
       );
       fakeProgress?.stop();
-      _logger
-          .info('$logPrefix decryption completed (genID ${file.generatedID})');
+      _logger.info(
+        '$logPrefix decryption completed (genID ${file.generatedID})',
+      );
     } catch (e, s) {
       fakeProgress?.stop();
-      final metadata =
-          await _getFileMetadataForLogging(file, encryptedFilePath);
+      final metadata = await _getFileMetadataForLogging(
+        file,
+        encryptedFilePath,
+      );
       _logger.severe("Critical: $logPrefix failed to decrypt, $metadata", e, s);
       if (throwOnFailure) {
         throw DownloadFailedError("Failed to decrypt downloaded file");
@@ -325,11 +349,17 @@ Future<String> _getFileMetadataForLogging(
 // the in-memory EnteFile they hold is not updated with the saved localID and
 // LocalSyncService ingests the asset as a new local row rather than marking
 // the existing remote entry. Revisit if this surfaces as a user complaint.
-Future<void> downloadToGallery(
+Future<GalleryDownloadSaveResult> downloadToGallery(
   EnteFile file, {
   bool forceResumableDownload = false,
   bool persistToFilesDB = true,
+  GalleryDownloadSideEffectMode sideEffectMode =
+      GalleryDownloadSideEffectMode.immediate,
 }) async {
+  final runSideEffects =
+      sideEffectMode == GalleryDownloadSideEffectMode.immediate;
+  var savedToGallery = false;
+  EnteFile? persistedFile;
   try {
     final FileType type = file.fileType;
     final bool downloadLivePhotoOnDroid =
@@ -348,13 +378,19 @@ Future<void> downloadToGallery(
     await LocalSyncService.instance.getLock().synchronized(() async {
       //Disabling notifications for assets changing to insert the file into
       //files db before triggering a sync.
-      await PhotoManager.stopChangeNotify();
+      if (runSideEffects) {
+        await PhotoManager.stopChangeNotify();
+      }
       if (type == FileType.image) {
-        savedAsset = await PhotoManager.editor
-            .saveImageWithPath(fileToSave.path, title: file.title!);
+        savedAsset = await PhotoManager.editor.saveImageWithPath(
+          fileToSave.path,
+          title: file.title!,
+        );
       } else if (type == FileType.video) {
-        savedAsset =
-            await PhotoManager.editor.saveVideo(fileToSave, title: file.title!);
+        savedAsset = await PhotoManager.editor.saveVideo(
+          fileToSave,
+          title: file.title!,
+        );
       } else if (type == FileType.livePhoto) {
         final File? liveVideoFile = await getFileFromServer(
           file,
@@ -366,6 +402,7 @@ Future<void> downloadToGallery(
         }
         if (downloadLivePhotoOnDroid) {
           await _saveLivePhotoOnDroid(fileToSave, liveVideoFile, file);
+          savedToGallery = true;
         } else {
           savedAsset = await PhotoManager.editor.darwin.saveLivePhoto(
             imageFile: fileToSave,
@@ -376,23 +413,31 @@ Future<void> downloadToGallery(
       }
 
       if (savedAsset != null) {
+        savedToGallery = true;
         // Public-link downloads should be discovered by local sync so they are
         // materialized as true on-device files instead of remote/shared
         // entries in FilesDB.
         if (persistToFilesDB) {
           file.localID = savedAsset!.id;
           await FilesDB.instance.insert(file);
-          Bus.instance.fire(
-            LocalPhotosUpdatedEvent(
-              [file],
-              source: "download",
-            ),
-          );
+          persistedFile = file;
+          if (runSideEffects) {
+            Bus.instance.fire(
+              LocalPhotosUpdatedEvent(
+                [file],
+                source: "download",
+              ),
+            );
+          }
         }
       } else if (!downloadLivePhotoOnDroid && savedAsset == null) {
         _logger.severe('Failed to save assert of type $type');
       }
     });
+    return GalleryDownloadSaveResult(
+      savedToGallery: savedToGallery,
+      persistedFile: persistedFile,
+    );
   } catch (e) {
     if (forceResumableDownload && _isStorageError(e)) {
       _logger.severe("Failed to save file due to storage limit", e);
@@ -401,8 +446,10 @@ Future<void> downloadToGallery(
     _logger.severe("Failed to save file", e);
     rethrow;
   } finally {
-    await PhotoManager.startChangeNotify();
-    LocalSyncService.instance.checkAndSync().ignore();
+    if (runSideEffects) {
+      await PhotoManager.startChangeNotify();
+      LocalSyncService.instance.checkAndSync().ignore();
+    }
   }
 }
 
@@ -412,11 +459,13 @@ Future<void> _saveLivePhotoOnDroid(
   EnteFile enteFile,
 ) async {
   debugPrint("Downloading LivePhoto on Droid");
-  AssetEntity? savedAsset = await (PhotoManager.editor
-          .saveImageWithPath(image.path, title: enteFile.title!))
-      .catchError((err) {
-    throw Exception("Failed to save image of live photo: $err");
-  });
+  AssetEntity? savedAsset =
+      await (PhotoManager.editor.saveImageWithPath(
+        image.path,
+        title: enteFile.title!,
+      )).catchError((err) {
+        throw Exception("Failed to save image of live photo: $err");
+      });
   IgnoredFile ignoreVideoFile = IgnoredFile(
     savedAsset.id,
     savedAsset.title ?? '',
@@ -424,17 +473,19 @@ Future<void> _saveLivePhotoOnDroid(
     "remoteDownload",
   );
   await IgnoredFilesService.instance.cacheAndInsert([ignoreVideoFile]);
-  final videoTitle = file_path.basenameWithoutExtension(enteFile.title!) +
+  final videoTitle =
+      file_path.basenameWithoutExtension(enteFile.title!) +
       file_path.extension(video.path);
-  savedAsset = (await (PhotoManager.editor.saveVideo(
-    video,
-    title: videoTitle,
-  )).catchError(
-    (err) {
-      _logger.warning('Failed to save video $videoTitle of live photo');
-      throw Exception("Failed to save video of live photo: $err");
-    },
-  ));
+  savedAsset =
+      (await (PhotoManager.editor.saveVideo(
+        video,
+        title: videoTitle,
+      )).catchError(
+        (err) {
+          _logger.warning('Failed to save video $videoTitle of live photo');
+          throw Exception("Failed to save video of live photo: $err");
+        },
+      ));
 
   ignoreVideoFile = IgnoredFile(
     savedAsset.id,


### PR DESCRIPTION
## Summary

Batch gallery-download side effects for the queued download path so bulk saves do not trigger a local sync, remote sync, and gallery reload for every saved file.

## What changed

- Added a deferred side-effect mode to `downloadToGallery` while preserving immediate behavior for existing direct callers.
- Added local-sync deferral around PhotoManager change notifications so queued saves can coalesce change callbacks.
- Updated `GalleryDownloadQueueService` to collect saved files and flush one `LocalPhotosUpdatedEvent` plus one `checkAndSync()` when the queue goes idle or is cancelled.

## Impact

Bulk queued gallery downloads should avoid the repeated sync/gallery reload storm seen in exported logs. Single-file and non-queued download paths keep their existing immediate side effects.

## Validation

- `dart format mobile/apps/photos/lib/utils/file_download_util.dart mobile/apps/photos/lib/services/sync/local_sync_service.dart mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart`
- `flutter analyze lib/utils/file_download_util.dart lib/services/sync/local_sync_service.dart lib/module/download/gallery_download_queue_service.dart`