### PR TITLE
[server] Reduce file fetch DB latency

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -591,9 +591,9 @@ func main() {
 	privateAPI.POST("/files/upload-url", fileHandler.GetUploadURLV2)
 	privateAPI.POST("/files/multipart-upload-url", fileHandler.GetMultipartUploadURLV2)
 	privateAPI.GET("/files/download/:fileID", fileHandler.Get)
-	privateAPI.GET("/files/download/v2/:fileID", fileHandler.Get)
+	privateAPI.GET("/files/download/v2/:fileID", fileHandler.GetUsingFusedLookup)
 	privateAPI.GET("/files/preview/:fileID", fileHandler.GetThumbnail)
-	privateAPI.GET("/files/preview/v2/:fileID", fileHandler.GetThumbnail)
+	privateAPI.GET("/files/preview/v2/:fileID", fileHandler.GetThumbnailUsingFusedLookup)
 
 	privateAPI.POST("/files/share-url", fileHandler.ShareUrl)
 	privateAPI.GET("/files/share-url", fileHandler.GetUrls)

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1178,7 +1178,7 @@ func setupLatencySensitiveDatabase() *sql.DB {
 	log.Println("Pinged latency sensitive DB")
 
 	db.SetMaxIdleConns(20)
-	db.SetMaxOpenConns(20)
+	db.SetMaxOpenConns(40)
 	db.SetConnMaxLifetime(30 * time.Minute)
 	db.SetConnMaxIdleTime(10 * time.Minute)
 

--- a/server/migrations/123_temp_objects_expiration_time_idx.down.sql
+++ b/server/migrations/123_temp_objects_expiration_time_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS temp_objects_expiration_time_idx;

--- a/server/migrations/123_temp_objects_expiration_time_idx.up.sql
+++ b/server/migrations/123_temp_objects_expiration_time_idx.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS temp_objects_expiration_time_idx
+    ON temp_objects (expiration_time);

--- a/server/pkg/api/file.go
+++ b/server/pkg/api/file.go
@@ -223,6 +223,19 @@ func (h *FileHandler) Get(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, url)
 }
 
+// GetUsingFusedLookup redirects the request to the file location using a temporary
+// fused access-check and object lookup path.
+func (h *FileHandler) GetUsingFusedLookup(c *gin.Context) {
+	userID, fileID := getUserAndFileIDs(c)
+	url, err := h.Controller.GetFileURLUsingFusedLookup(c, userID, fileID)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	h.logBadRedirect(c)
+	c.Redirect(http.StatusTemporaryRedirect, url)
+}
+
 // GetV2 returns the URL of the file to client
 func (h *FileHandler) GetV2(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
@@ -240,6 +253,19 @@ func (h *FileHandler) GetV2(c *gin.Context) {
 func (h *FileHandler) GetThumbnail(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
 	url, err := h.Controller.GetThumbnailURL(c, userID, fileID)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	h.logBadRedirect(c)
+	c.Redirect(http.StatusTemporaryRedirect, url)
+}
+
+// GetThumbnailUsingFusedLookup redirects the request to the file's thumbnail
+// location using a temporary fused access-check and object lookup path.
+func (h *FileHandler) GetThumbnailUsingFusedLookup(c *gin.Context) {
+	userID, fileID := getUserAndFileIDs(c)
+	url, err := h.Controller.GetThumbnailURLUsingFusedLookup(c, userID, fileID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/api/file_test.go
+++ b/server/pkg/api/file_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestFusedLookupV2FileRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := &FileHandler{}
+	router := gin.New()
+	router.GET("/files/download/:fileID", handler.Get)
+	router.GET("/files/download/v2/:fileID", handler.GetUsingFusedLookup)
+	router.GET("/files/preview/:fileID", handler.GetThumbnail)
+	router.GET("/files/preview/v2/:fileID", handler.GetThumbnailUsingFusedLookup)
+
+	routes := router.Routes()
+	assertRouteUsesHandler(t, routes, "/files/download/v2/:fileID", "GetUsingFusedLookup")
+	assertRouteUsesHandler(t, routes, "/files/preview/v2/:fileID", "GetThumbnailUsingFusedLookup")
+}
+
+func assertRouteUsesHandler(t *testing.T, routes gin.RoutesInfo, path string, handlerName string) {
+	t.Helper()
+
+	for _, route := range routes {
+		if route.Method == http.MethodGet && route.Path == path {
+			if !strings.Contains(route.Handler, handlerName) {
+				t.Fatalf("route %s uses handler %q, want %q", path, route.Handler, handlerName)
+			}
+			return
+		}
+	}
+	t.Fatalf("route %s was not registered", path)
+}

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -419,6 +419,18 @@ func (c *FileController) GetThumbnailURL(ctx *gin.Context, userID int64, fileID 
 	return url, nil
 }
 
+// GetFileURLUsingFusedLookup verifies permissions and returns a presigned URL
+// using the temporary fused access-check and object lookup path.
+func (c *FileController) GetFileURLUsingFusedLookup(ctx *gin.Context, userID int64, fileID int64) (string, error) {
+	return c.getSignedURLForAccessibleObject(ctx, userID, fileID, ente.FILE)
+}
+
+// GetThumbnailURLUsingFusedLookup verifies permissions and returns a presigned
+// URL using the temporary fused access-check and object lookup path.
+func (c *FileController) GetThumbnailURLUsingFusedLookup(ctx *gin.Context, userID int64, fileID int64) (string, error) {
+	return c.getSignedURLForAccessibleObject(ctx, userID, fileID, ente.THUMBNAIL)
+}
+
 func (c *FileController) CleanUpStaleCollectionFiles(userID int64, fileID int64) {
 	logger := log.WithFields(log.Fields{
 		"userID": userID,
@@ -485,6 +497,27 @@ func (c *FileController) getSignedURLForType(ctx *gin.Context, fileID int64, obj
 	return c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
 }
 
+func (c *FileController) getSignedURLForAccessibleObject(ctx *gin.Context, userID int64, fileID int64, objType ente.ObjectType) (string, error) {
+	var url string
+	var err error
+	if isCliRequest(ctx) {
+		url, err = c.getWasabiSignedUrlForAccessibleObject(ctx, userID, fileID, objType)
+	} else {
+		var s3Object ente.S3ObjectKey
+		s3Object, err = c.ObjectRepo.GetAccessibleObject(ctx, fileID, userID, objType)
+		if err == nil {
+			url, err = c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+		}
+	}
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			go c.CleanUpStaleCollectionFiles(userID, fileID)
+		}
+		return "", stacktrace.Propagate(err, "")
+	}
+	return url, nil
+}
+
 // ignore lint unused inspection
 func isCliRequest(ctx *gin.Context) bool {
 	// check if user-agent contains go-resty
@@ -496,6 +529,19 @@ func isCliRequest(ctx *gin.Context) bool {
 // if the file is not found in wasabi, it will return signed url from B2
 func (c *FileController) getWasabiSignedUrlIfAvailable(fileID int64, objType ente.ObjectType) (string, error) {
 	s3Object, dcs, err := c.ObjectRepo.GetObjectWithDCs(fileID, objType)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
+	for _, dc := range dcs {
+		if dc == c.S3Config.GetHotWasabiDC() {
+			return c.getPreSignedURLForDC(s3Object.ObjectKey, dc, objType)
+		}
+	}
+	return c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+}
+
+func (c *FileController) getWasabiSignedUrlForAccessibleObject(ctx *gin.Context, userID int64, fileID int64, objType ente.ObjectType) (string, error) {
+	s3Object, dcs, err := c.ObjectRepo.GetAccessibleObjectWithDCs(ctx, fileID, userID, objType)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/repo/object.go
+++ b/server/pkg/repo/object.go
@@ -82,6 +82,72 @@ func (repo *ObjectRepository) GetObjectWithDCs(fileID int64, objType ente.Object
 	return s3ObjectKey, datacenters, stacktrace.Propagate(err, "")
 }
 
+// GetAccessibleObject verifies actor access and returns the S3 object key in a
+// single latency-sensitive DB query.
+func (repo *ObjectRepository) GetAccessibleObject(ctx context.Context, fileID int64, actorUserID int64, objType ente.ObjectType) (ente.S3ObjectKey, error) {
+	s3ObjectKey, _, err := repo.GetAccessibleObjectWithDCs(ctx, fileID, actorUserID, objType)
+	return s3ObjectKey, err
+}
+
+// GetAccessibleObjectWithDCs verifies actor access and returns the S3 object
+// key along with replicated datacenters in a single latency-sensitive DB query.
+func (repo *ObjectRepository) GetAccessibleObjectWithDCs(ctx context.Context, fileID int64, actorUserID int64, objType ente.ObjectType) (ente.S3ObjectKey, []string, error) {
+	row := repo.objectLookupDB().QueryRowContext(ctx, `
+		SELECT
+			f.file_id,
+			CASE
+				WHEN f.owner_id = $2 THEN TRUE
+				ELSE EXISTS (
+					SELECT 1
+					FROM collection_files cf
+					JOIN collection_shares cs ON cs.collection_id = cf.collection_id
+					WHERE cf.file_id = f.file_id
+						AND cf.is_deleted = FALSE
+						AND cs.is_deleted = FALSE
+						AND (cs.to_user_id = $2 OR cs.from_user_id = $2)
+				)
+			END AS can_access,
+			ok.object_key,
+			ok.size,
+			ok.o_type::text,
+			COALESCE(ok.datacenters, '{}'::s3region[])
+		FROM files f
+		LEFT JOIN object_keys ok
+			ON ok.file_id = f.file_id
+			AND ok.o_type = $3::object_type
+			AND ok.is_deleted = FALSE
+		WHERE f.file_id = $1`,
+		fileID, actorUserID, objType)
+
+	var s3ObjectKey ente.S3ObjectKey
+	var canAccess bool
+	var objectKey sql.NullString
+	var fileSize sql.NullInt64
+	var objectType sql.NullString
+	datacenters := make([]string, 0)
+	err := row.Scan(
+		&s3ObjectKey.FileID,
+		&canAccess,
+		&objectKey,
+		&fileSize,
+		&objectType,
+		pq.Array(&datacenters),
+	)
+	if err != nil {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(err, "")
+	}
+	if !canAccess {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(ente.ErrPermissionDenied, "access denied")
+	}
+	if !objectKey.Valid || !fileSize.Valid || !objectType.Valid {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(sql.ErrNoRows, "")
+	}
+	s3ObjectKey.ObjectKey = objectKey.String
+	s3ObjectKey.FileSize = fileSize.Int64
+	s3ObjectKey.Type = ente.ObjectType(objectType.String)
+	return s3ObjectKey, datacenters, nil
+}
+
 func (repo *ObjectRepository) GetAllFileObjectsByObjectKey(objectKey string) ([]ente.S3ObjectKey, error) {
 	rows, err := repo.DB.Query(`SELECT file_id, o_type, object_key, size from object_keys where file_id in 
                                                                 (select file_id from object_keys where object_key= $1) 

--- a/server/pkg/repo/object_test.go
+++ b/server/pkg/repo/object_test.go
@@ -1,8 +1,14 @@
 package repo
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"testing"
+
+	"github.com/ente-io/museum/ente"
+	"github.com/ente-io/museum/internal/testutil"
+	"github.com/lib/pq"
 )
 
 func TestObjectLookupDBUsesLatencySensitiveDBWhenPresent(t *testing.T) {
@@ -21,5 +27,271 @@ func TestObjectLookupDBFallsBackToPrimaryDB(t *testing.T) {
 
 	if got := repository.objectLookupDB(); got != primaryDB {
 		t.Fatal("expected object lookup DB to fall back to DB")
+	}
+}
+
+func TestGetAccessibleObjectAllowsOwnerFileAndThumbnail(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owner-object@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "owner-file-object", 100, []string{"b2-eu-cen"})
+	insertObjectTestKey(t, db, fileID, ente.THUMBNAIL, "owner-thumbnail-object", 10, []string{"b2-eu-cen"})
+
+	fileObject, err := repository.GetAccessibleObject(context.Background(), fileID, ownerID, ente.FILE)
+	if err != nil {
+		t.Fatalf("GetAccessibleObject(file) error = %v", err)
+	}
+	if fileObject.ObjectKey != "owner-file-object" || fileObject.FileSize != 100 || fileObject.Type != ente.FILE {
+		t.Fatalf("unexpected file object: %+v", fileObject)
+	}
+
+	thumbnailObject, err := repository.GetAccessibleObject(context.Background(), fileID, ownerID, ente.THUMBNAIL)
+	if err != nil {
+		t.Fatalf("GetAccessibleObject(thumbnail) error = %v", err)
+	}
+	if thumbnailObject.ObjectKey != "owner-thumbnail-object" || thumbnailObject.FileSize != 10 || thumbnailObject.Type != ente.THUMBNAIL {
+		t.Fatalf("unexpected thumbnail object: %+v", thumbnailObject)
+	}
+}
+
+func TestGetAccessibleObjectAllowsSharedFile(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "shared-owner-object@ente.com",
+		CreationTime: 1,
+	})
+	actorID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "shared-actor-object@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	insertObjectTestCollectionShare(t, db, collectionID, ownerID, actorID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "shared-file-object", 100, []string{"b2-eu-cen"})
+
+	fileObject, err := repository.GetAccessibleObject(context.Background(), fileID, actorID, ente.FILE)
+	if err != nil {
+		t.Fatalf("GetAccessibleObject(shared file) error = %v", err)
+	}
+	if fileObject.ObjectKey != "shared-file-object" {
+		t.Fatalf("unexpected shared file object: %+v", fileObject)
+	}
+}
+
+func TestGetAccessibleObjectRejectsUnsharedForeignFile(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "unshared-owner-object@ente.com",
+		CreationTime: 1,
+	})
+	actorID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "unshared-actor-object@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "unshared-file-object", 100, []string{"b2-eu-cen"})
+
+	_, err := repository.GetAccessibleObject(context.Background(), fileID, actorID, ente.FILE)
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
+func TestGetAccessibleObjectReturnsNoRowsForAllowedFileWithMissingObject(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "missing-object-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+
+	_, err := repository.GetAccessibleObject(context.Background(), fileID, ownerID, ente.FILE)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetAccessibleObjectReturnsNoRowsForMissingFile(t *testing.T) {
+	repository, _ := setupAccessibleObjectTest(t)
+
+	_, err := repository.GetAccessibleObject(context.Background(), 404, 1, ente.FILE)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetAccessibleObjectReturnsNoRowsForDeletedObject(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "deleted-object-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "deleted-file-object", 100, []string{"b2-eu-cen"})
+	if _, err := db.Exec(`UPDATE object_keys SET is_deleted = TRUE WHERE file_id = $1 AND o_type = $2`, fileID, ente.FILE); err != nil {
+		t.Fatalf("failed to mark object deleted: %v", err)
+	}
+
+	_, err := repository.GetAccessibleObject(context.Background(), fileID, ownerID, ente.FILE)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetAccessibleObjectWithDCsReturnsDatacenters(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "dcs-owner-object@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	wantDCs := []string{"b2-eu-cen", "wasabi-eu-central-2-v3"}
+	insertObjectTestKey(t, db, fileID, ente.FILE, "dcs-file-object", 100, wantDCs)
+
+	fileObject, gotDCs, err := repository.GetAccessibleObjectWithDCs(context.Background(), fileID, ownerID, ente.FILE)
+	if err != nil {
+		t.Fatalf("GetAccessibleObjectWithDCs() error = %v", err)
+	}
+	if fileObject.ObjectKey != "dcs-file-object" {
+		t.Fatalf("unexpected object: %+v", fileObject)
+	}
+	if len(gotDCs) != len(wantDCs) {
+		t.Fatalf("unexpected datacenters: got %v want %v", gotDCs, wantDCs)
+	}
+	for i := range wantDCs {
+		if gotDCs[i] != wantDCs[i] {
+			t.Fatalf("unexpected datacenters: got %v want %v", gotDCs, wantDCs)
+		}
+	}
+}
+
+func setupAccessibleObjectTest(t *testing.T) (*ObjectRepository, *sql.DB) {
+	t.Helper()
+
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		testutil.ResetTables(t, db)
+	})
+
+	return &ObjectRepository{DB: db, LatencySensitiveDB: db}, db
+}
+
+func insertObjectTestFile(t *testing.T, db *sql.DB, ownerID int64) int64 {
+	t.Helper()
+
+	var fileID int64
+	err := db.QueryRow(
+		`INSERT INTO files(owner_id, file_decryption_header, thumbnail_decryption_header, metadata_decryption_header, encrypted_metadata, updation_time, info)
+		 VALUES($1, $2, $3, $4, $5, $6, $7::jsonb)
+		 RETURNING file_id`,
+		ownerID,
+		"file-header",
+		"thumbnail-header",
+		"metadata-header",
+		"encrypted-metadata",
+		int64(1),
+		"{}",
+	).Scan(&fileID)
+	if err != nil {
+		t.Fatalf("failed to insert file for owner %d: %v", ownerID, err)
+	}
+	return fileID
+}
+
+func insertObjectTestKey(t *testing.T, db *sql.DB, fileID int64, objType ente.ObjectType, objectKey string, size int64, datacenters []string) {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO object_keys(file_id, o_type, object_key, size, datacenters)
+		 VALUES($1, $2, $3, $4, $5)`,
+		fileID,
+		objType,
+		objectKey,
+		size,
+		pq.StringArray(datacenters),
+	)
+	if err != nil {
+		t.Fatalf("failed to insert object key for file %d: %v", fileID, err)
+	}
+}
+
+func insertObjectTestCollection(t *testing.T, db *sql.DB, ownerID int64) int64 {
+	t.Helper()
+
+	var collectionID int64
+	err := db.QueryRow(
+		`INSERT INTO collections(owner_id, encrypted_key, key_decryption_nonce, name, type, attributes, updation_time, app)
+		 VALUES($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+		 RETURNING collection_id`,
+		ownerID,
+		"encrypted-key",
+		"key-nonce",
+		"Test collection",
+		"album",
+		"{}",
+		int64(1),
+		string(ente.Photos),
+	).Scan(&collectionID)
+	if err != nil {
+		t.Fatalf("failed to insert collection for owner %d: %v", ownerID, err)
+	}
+	return collectionID
+}
+
+func insertObjectTestCollectionShare(t *testing.T, db *sql.DB, collectionID int64, fromUserID int64, toUserID int64) {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO collection_shares(collection_id, from_user_id, to_user_id, encrypted_key, updation_time, role_type, shared_at)
+		 VALUES($1, $2, $3, $4, $5, $6, $7)`,
+		collectionID,
+		fromUserID,
+		toUserID,
+		"share-key",
+		int64(1),
+		string(ente.VIEWER),
+		int64(1),
+	)
+	if err != nil {
+		t.Fatalf("failed to insert collection share for collection %d: %v", collectionID, err)
+	}
+}
+
+func linkObjectTestFileToCollection(t *testing.T, db *sql.DB, collectionID int64, fileID int64, ownerID int64) {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO collection_files(collection_id, file_id, encrypted_key, key_decryption_nonce, updation_time, c_owner_id, f_owner_id)
+		 VALUES($1, $2, $3, $4, $5, $6, $7)`,
+		collectionID,
+		fileID,
+		"collection-file-key",
+		"collection-file-nonce",
+		int64(1),
+		ownerID,
+		ownerID,
+	)
+	if err != nil {
+		t.Fatalf("failed to link file %d to collection %d: %v", fileID, collectionID, err)
 	}
 }


### PR DESCRIPTION
## Summary
- Route private file download and preview v2 endpoints through a fused access-check/object lookup path.
- Add an expiration-time index for `temp_objects` cleanup scans.
- Increase latency-sensitive DB max open connections from 20 to 40 while keeping idle connections at 20.

## Tests
- `go test ./pkg/api`
- `go test ./pkg/repo`
- `ENV=test go test ./pkg/repo -run 'TestGetAccessibleObject' -count=1`
- `ENV=test go test ./pkg/repo -count=1`
- `go test ./cmd/museum`