### PR TITLE
[mob][photos] Ignore missing iOS upload temp cleanup files

### DIFF
--- a/mobile/apps/photos/lib/services/local_file_update_service.dart
+++ b/mobile/apps/photos/lib/services/local_file_update_service.dart
@@ -13,6 +13,8 @@ import 'package:photos/utils/file_uploader_util.dart';
 import 'package:photos/utils/file_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const int _noSuchFileOrDirectoryErrorCode = 2;
+
 // LocalFileUpdateService tracks all the potential local file IDs which have
 // changed/modified on the device and needed to be uploaded again.
 class LocalFileUpdateService {
@@ -100,15 +102,13 @@ class LocalFileUpdateService {
     // invocation of this method. The limit act as a crude way to limit the
     // resource consumed by the method
     const int singleRunLimit = 10;
-    final localIDsToProcess =
-        await _fileUpdationDB.getLocalIDsForPotentialReUpload(
-      singleRunLimit,
-      FileUpdationDB.modificationTimeUpdated,
-    );
+    final localIDsToProcess = await _fileUpdationDB
+        .getLocalIDsForPotentialReUpload(
+          singleRunLimit,
+          FileUpdationDB.modificationTimeUpdated,
+        );
     if (localIDsToProcess.isNotEmpty) {
-      await _checkAndMarkFilesWithDifferentHashForFileUpdate(
-        localIDsToProcess,
-      );
+      await _checkAndMarkFilesWithDifferentHashForFileUpdate(localIDsToProcess);
       final eTime = DateTime.now().microsecondsSinceEpoch;
       final d = Duration(microseconds: eTime - sTime);
       _logger.info(
@@ -122,8 +122,9 @@ class LocalFileUpdateService {
     List<String> localIDsToProcess,
   ) async {
     final int userID = Configuration.instance.getUserID()!;
-    final List<EnteFile> result =
-        await FilesDB.instance.getLocalFiles(localIDsToProcess);
+    final List<EnteFile> result = await FilesDB.instance.getLocalFiles(
+      localIDsToProcess,
+    );
     final List<EnteFile> localFilesForUser = [];
     final Set<String> localIDsWithFile = {};
     for (EnteFile file in result) {
@@ -141,8 +142,10 @@ class LocalFileUpdateService {
         processedIDs.add(localID);
       }
     }
-    _logger.info("files to process ${localIDsToProcess.length} for reupload, "
-        "missing localFile cnt ${processedIDs.length}");
+    _logger.info(
+      "files to process ${localIDsToProcess.length} for reupload, "
+      "missing localFile cnt ${processedIDs.length}",
+    );
 
     for (EnteFile file in localFilesForUser) {
       if (processedIDs.contains(file.localID)) {
@@ -215,9 +218,7 @@ class LocalFileUpdateService {
     // delete the file from app's internal cache if it was copied to app
     // for upload. Shared Media should only be cleared when the upload
     // succeeds.
-    if (Platform.isIOS && mediaUploadData.sourceFile != null) {
-      await mediaUploadData.sourceFile?.delete();
-    }
+    await _deleteCopiedIOSUploadFile(mediaUploadData.sourceFile);
     return mediaUploadData;
   }
 
@@ -229,9 +230,27 @@ class LocalFileUpdateService {
     // delete the file from app's internal cache if it was copied to app
     // for upload. Shared Media should only be cleared when the upload
     // succeeds.
-    if (Platform.isIOS && mediaUploadData.sourceFile != null) {
-      await mediaUploadData.sourceFile?.delete();
-    }
+    await _deleteCopiedIOSUploadFile(mediaUploadData.sourceFile);
     return (mediaUploadData, size);
   }
+
+  Future<void> _deleteCopiedIOSUploadFile(File? sourceFile) async {
+    if (!Platform.isIOS || sourceFile == null) {
+      return;
+    }
+    try {
+      await sourceFile.delete();
+    } on FileSystemException catch (e) {
+      if (!_isPathMissing(e)) {
+        rethrow;
+      }
+      _logger.info(
+        "Copied upload temp file already missing: ${sourceFile.path}",
+      );
+    }
+  }
+
+  bool _isPathMissing(FileSystemException e) =>
+      e is PathNotFoundException ||
+      e.osError?.errorCode == _noSuchFileOrDirectoryErrorCode;
 }

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Avoid repeated iOS reupload checks when copied temp files are already cleaned up
 - Neeraj: Fix incorrect upload dates for photos with ISO-like metadata timestamps
 - Neeraj: Skip image EXIF parsing for videos
 - Neeraj: Fix iOS crash when playing Pixel Long Shot (.LS) videos


### PR DESCRIPTION
## Description

Fixes PHOTOS-MOBILE-7NC.

iOS local-file update checks copy media into a temporary PhotoKit path before hashing. Cleanup of that copied file can race with system/temp cleanup, and a missing temp file should be treated as already cleaned up instead of failing the hash check and retrying the same file.

This makes the copied iOS upload temp-file delete best-effort for missing-path errors while still rethrowing other filesystem failures. It also adds an internal changes entry for the production reupload reliability fix.

## Tests

- [x] `flutter analyze .`
