### PR TITLE
[mob][photos] Chunk offline file ID lookups

### DIFF
--- a/mobile/apps/photos/lib/db/offline_files_db.dart
+++ b/mobile/apps/photos/lib/db/offline_files_db.dart
@@ -9,14 +9,13 @@ class OfflineFilesDB with SqlDbBase {
   static final Logger _logger = Logger("OfflineFilesDB");
 
   static const _databaseName = "ente.offline_files.db";
+  static const _maxSqlBindParamsPerQuery = 500;
 
   OfflineFilesDB._privateConstructor();
 
   static final OfflineFilesDB instance = OfflineFilesDB._privateConstructor();
 
-  static const List<String> _migrationScripts = [
-    createOfflineFileKeyMapTable,
-  ];
+  static const List<String> _migrationScripts = [createOfflineFileKeyMapTable];
 
   Future<SqliteDatabase>? _sqliteAsyncDBFuture;
 
@@ -27,11 +26,15 @@ class OfflineFilesDB with SqlDbBase {
 
   Future<SqliteDatabase> _initSqliteAsyncDatabase() async {
     final documentsDirectory = await getApplicationDocumentsDirectory();
-    final String databaseDirectory =
-        join(documentsDirectory.path, _databaseName);
+    final String databaseDirectory = join(
+      documentsDirectory.path,
+      _databaseName,
+    );
     _logger.info("Opening offline files DB at $databaseDirectory");
-    final asyncDBConnection =
-        SqliteDatabase(path: databaseDirectory, maxReaders: 2);
+    final asyncDBConnection = SqliteDatabase(
+      path: databaseDirectory,
+      maxReaders: 2,
+    );
     await migrate(asyncDBConnection, _migrationScripts);
     return asyncDBConnection;
   }
@@ -69,18 +72,20 @@ class OfflineFilesDB with SqlDbBase {
   Future<Map<int, String>> getLocalIdsForIntIds(
     Iterable<int> localIntIds,
   ) async {
-    final ids = localIntIds.toList();
+    final ids = localIntIds.toSet().toList();
     if (ids.isEmpty) return {};
     final db = await asyncDB;
-    final inParam = List.filled(ids.length, '?').join(',');
-    final result = await db.getAll(
-      'SELECT $offlineFileKeyIntIdColumn, $offlineFileKeyLocalIdColumn FROM $offlineFileKeyMapTable WHERE $offlineFileKeyIntIdColumn IN ($inParam)',
-      ids,
-    );
     final mapping = <int, String>{};
-    for (final row in result) {
-      mapping[row[offlineFileKeyIntIdColumn] as int] =
-          row[offlineFileKeyLocalIdColumn] as String;
+    for (final chunk in _chunkSqlBindParams(ids)) {
+      final inParam = List.filled(chunk.length, '?').join(',');
+      final result = await db.getAll(
+        'SELECT $offlineFileKeyIntIdColumn, $offlineFileKeyLocalIdColumn FROM $offlineFileKeyMapTable WHERE $offlineFileKeyIntIdColumn IN ($inParam)',
+        chunk,
+      );
+      for (final row in result) {
+        mapping[row[offlineFileKeyIntIdColumn] as int] =
+            row[offlineFileKeyLocalIdColumn] as String;
+      }
     }
     return mapping;
   }
@@ -88,25 +93,25 @@ class OfflineFilesDB with SqlDbBase {
   Future<Map<String, int>> getLocalIntIdsForLocalIds(
     Iterable<String> localIds,
   ) async {
-    final ids = localIds.toList();
+    final ids = localIds.toSet().toList();
     if (ids.isEmpty) return {};
     final db = await asyncDB;
-    final inParam = List.filled(ids.length, '?').join(',');
-    final result = await db.getAll(
-      'SELECT $offlineFileKeyLocalIdColumn, $offlineFileKeyIntIdColumn FROM $offlineFileKeyMapTable WHERE $offlineFileKeyLocalIdColumn IN ($inParam)',
-      ids,
-    );
     final mapping = <String, int>{};
-    for (final row in result) {
-      mapping[row[offlineFileKeyLocalIdColumn] as String] =
-          row[offlineFileKeyIntIdColumn] as int;
+    for (final chunk in _chunkSqlBindParams(ids)) {
+      final inParam = List.filled(chunk.length, '?').join(',');
+      final result = await db.getAll(
+        'SELECT $offlineFileKeyLocalIdColumn, $offlineFileKeyIntIdColumn FROM $offlineFileKeyMapTable WHERE $offlineFileKeyLocalIdColumn IN ($inParam)',
+        chunk,
+      );
+      for (final row in result) {
+        mapping[row[offlineFileKeyLocalIdColumn] as String] =
+            row[offlineFileKeyIntIdColumn] as int;
+      }
     }
     return mapping;
   }
 
-  Future<Map<String, int>> ensureLocalIntIds(
-    Iterable<String> localIds,
-  ) async {
+  Future<Map<String, int>> ensureLocalIntIds(Iterable<String> localIds) async {
     final ids = localIds.toSet().toList();
     if (ids.isEmpty) return {};
     final existing = await getLocalIntIdsForLocalIds(ids);
@@ -122,5 +127,12 @@ class OfflineFilesDB with SqlDbBase {
       existing.addAll(inserted);
     }
     return existing;
+  }
+
+  Iterable<List<T>> _chunkSqlBindParams<T>(List<T> values) sync* {
+    for (var i = 0; i < values.length; i += _maxSqlBindParamsPerQuery) {
+      final end = i + _maxSqlBindParamsPerQuery;
+      yield values.sublist(i, end > values.length ? values.length : end);
+    }
   }
 }

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Fix smart memories and ML lookup failures for large offline galleries
 - Neeraj: Fix incorrect upload dates for photos with ISO-like metadata timestamps
 - Neeraj: Skip image EXIF parsing for videos
 - Neeraj: Fix iOS crash when playing Pixel Long Shot (.LS) videos

--- a/mobile/apps/photos/test/db/offline_files_db_test.dart
+++ b/mobile/apps/photos/test/db/offline_files_db_test.dart
@@ -1,0 +1,54 @@
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:path_provider_platform_interface/path_provider_platform_interface.dart";
+import "package:photos/db/offline_files_db.dart";
+
+void main() {
+  late Directory tempDir;
+  late PathProviderPlatform previousPathProvider;
+
+  setUpAll(() async {
+    previousPathProvider = PathProviderPlatform.instance;
+    tempDir = await Directory.systemTemp.createTemp("offline_files_db_test_");
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    PathProviderPlatform.instance = previousPathProvider;
+    await tempDir.delete(recursive: true);
+  });
+
+  test(
+    "handles local ID lookups larger than a single SQL bind batch",
+    () async {
+      final localIds = List.generate(1200, (index) => "local-id-$index");
+
+      final localIdToIntId = await OfflineFilesDB.instance.ensureLocalIntIds(
+        localIds,
+      );
+
+      expect(localIdToIntId, hasLength(localIds.length));
+      expect(localIdToIntId.keys, containsAll(localIds));
+
+      final localIntIds = localIdToIntId.values.toList();
+      final localIntIdToLocalId = await OfflineFilesDB.instance
+          .getLocalIdsForIntIds(localIntIds);
+
+      expect(localIntIdToLocalId, hasLength(localIds.length));
+      for (final localId in localIds) {
+        final localIntId = localIdToIntId[localId];
+        expect(localIntIdToLocalId[localIntId], localId);
+      }
+    },
+  );
+}
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}


### PR DESCRIPTION
## Description

Fixes PHOTOS-MOBILE-BFC.

Large smart memories / ML local-gallery flows can ask `OfflineFilesDB` to resolve thousands of local file IDs in one `WHERE IN (...)` query. That can exceed SQLite's bind-parameter limit and fail with `too many SQL variables`.

This chunks both offline file ID lookup directions into bounded SQL queries and adds a regression test covering more IDs than a single bind batch. It also adds an internal changes entry for large offline gallery lookup reliability.

## Tests

- [x] `flutter test test/db/offline_files_db_test.dart`
- [x] `flutter analyze .`
