### PR TITLE
[mob][photos] Ignore missing stale upload cleanup files

### DIFF
--- a/mobile/apps/photos/lib/services/local_file_update_service.dart
+++ b/mobile/apps/photos/lib/services/local_file_update_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:io';
 
+import 'package:ente_pure_utils/ente_pure_utils.dart'
+    show deleteFileSystemEntityIfPresent;
 import 'package:logging/logging.dart';
 import "package:photos/core/configuration.dart";
 import 'package:photos/core/errors.dart';
@@ -12,8 +14,6 @@ import 'package:photos/models/file/file_type.dart';
 import 'package:photos/utils/file_uploader_util.dart';
 import 'package:photos/utils/file_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-const int _noSuchFileOrDirectoryErrorCode = 2;
 
 // LocalFileUpdateService tracks all the potential local file IDs which have
 // changed/modified on the device and needed to be uploaded again.
@@ -238,19 +238,11 @@ class LocalFileUpdateService {
     if (!Platform.isIOS || sourceFile == null) {
       return;
     }
-    try {
-      await sourceFile.delete();
-    } on FileSystemException catch (e) {
-      if (!_isPathMissing(e)) {
-        rethrow;
-      }
+    final deleted = await deleteFileSystemEntityIfPresent(sourceFile);
+    if (!deleted) {
       _logger.info(
         "Copied upload temp file already missing: ${sourceFile.path}",
       );
     }
   }
-
-  bool _isPathMissing(FileSystemException e) =>
-      e is PathNotFoundException ||
-      e.osError?.errorCode == _noSuchFileOrDirectoryErrorCode;
 }

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -401,7 +401,7 @@ class FileUploader {
               : null;
           if (lastAttemptTime == null ||
               DateTime.now().difference(lastAttemptTime).inDays > 1) {
-            await file.delete();
+            await _deleteStaleFileIfPresent(file);
           } else {
             _logger.info(
               'Skipping file $fileName as it was attempted recently on $lastAttemptTime',
@@ -429,13 +429,20 @@ class FileUploader {
           for (final file in sharedFiles) {
             if (!trackedSharedFilePaths.contains(file.path)) {
               _logger.info('Deleting stale shared media file ${file.path}');
-              await file.delete();
+              await _deleteStaleFileIfPresent(file);
             }
           }
         }
       }
     } catch (e, s) {
       _logger.severe("Failed to remove stale files", e, s);
+    }
+  }
+
+  Future<void> _deleteStaleFileIfPresent(FileSystemEntity file) async {
+    final deleted = await deleteFileSystemEntityIfPresent(file);
+    if (!deleted) {
+      _logger.info("Stale file already missing during cleanup: ${file.path}");
     }
   }
 

--- a/mobile/apps/photos/lib/utils/thumbnail_util.dart
+++ b/mobile/apps/photos/lib/utils/thumbnail_util.dart
@@ -5,6 +5,8 @@ import "dart:typed_data";
 
 import 'package:dio/dio.dart';
 import 'package:ente_crypto/ente_crypto.dart';
+import 'package:ente_pure_utils/ente_pure_utils.dart'
+    show isFileSystemPathMissing;
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/cache/thumbnail_in_memory_cache.dart';
@@ -23,7 +25,6 @@ final _logger = Logger("ThumbnailUtil");
 final _uploadIDToDownloadItem = <int, FileDownloadItem>{};
 final _downloadQueue = Queue<int>();
 const int kMaximumConcurrentDownloads = 500;
-const int _noSuchFileOrDirectoryErrorCode = 2;
 
 class FileDownloadItem {
   final EnteFile file;
@@ -298,7 +299,7 @@ Future<Uint8List?> _readCachedThumbnailIfPresent(
     ThumbnailInMemoryLruCache.put(file, data, size);
     return data;
   } on FileSystemException catch (e) {
-    if (_isPathMissing(e)) {
+    if (isFileSystemPathMissing(e)) {
       _logger.info(
         "Thumbnail cache file missing during read; treating as cache miss: "
         "${cachedThumbnail.path}",
@@ -318,7 +319,7 @@ Future<bool> _writeCachedThumbnail(
     await cachedThumbnail.writeAsBytes(data, flush: flush);
     return true;
   } on FileSystemException catch (e) {
-    if (!_isPathMissing(e)) {
+    if (!isFileSystemPathMissing(e)) {
       rethrow;
     }
     _logger.info(
@@ -330,7 +331,7 @@ Future<bool> _writeCachedThumbnail(
       await cachedThumbnail.writeAsBytes(data, flush: flush);
       return true;
     } on FileSystemException catch (retryError) {
-      if (_isPathMissing(retryError)) {
+      if (isFileSystemPathMissing(retryError)) {
         _logger.info(
           "Thumbnail cache path still missing after recreate; skipping write: "
           "${cachedThumbnail.path}",
@@ -341,10 +342,6 @@ Future<bool> _writeCachedThumbnail(
     }
   }
 }
-
-bool _isPathMissing(FileSystemException e) =>
-    e is PathNotFoundException ||
-    e.osError?.errorCode == _noSuchFileOrDirectoryErrorCode;
 
 File cachedThumbnailPath(EnteFile file) {
   final thumbnailCacheDirectory =

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 Latest changes:
+- Neeraj: Ignore missing files during stale upload cleanup [Sentry]
 - Neeraj: Fix smart memories and ML lookup failures for large offline galleries [Sentry]
 - Neeraj: Stop reporting inline OCR pre-check timeouts as errors [Sentry]
 - Neeraj: Avoid repeated iOS reupload checks when copied temp files are already cleaned up [Sentry]

--- a/mobile/packages/ente_pure_utils/lib/src/directory_content_util.dart
+++ b/mobile/packages/ente_pure_utils/lib/src/directory_content_util.dart
@@ -18,6 +18,7 @@ class DirectoryStat {
 
 const int _oneMB = 1048576;
 const int _tenMB = 10485760;
+const int _noSuchFileOrDirectoryErrorCode = 2;
 
 String prettyPrintDirectoryStat(
   DirectoryStat dirStat,
@@ -113,22 +114,38 @@ Future<DirectoryStat> getDirectoryStat(
 }
 
 Future<void> deleteDirectoryContents(String directoryPath) async {
-  // Mark variables as final if they don't need to be modified
   final directory = Directory(directoryPath);
   if (!(await directory.exists())) {
     return;
   }
   final contents = await directory.list().toList();
 
-  // Iterate through the list and delete each file or directory
   for (final fileOrDirectory in contents) {
-    if (fileOrDirectory is Directory) {
-      await fileOrDirectory.delete(recursive: true);
-    } else {
-      await fileOrDirectory.delete();
-    }
+    await deleteFileSystemEntityIfPresent(
+      fileOrDirectory,
+      recursive: fileOrDirectory is Directory,
+    );
   }
 }
+
+Future<bool> deleteFileSystemEntityIfPresent(
+  FileSystemEntity entity, {
+  bool recursive = false,
+}) async {
+  try {
+    await entity.delete(recursive: recursive);
+    return true;
+  } on FileSystemException catch (e) {
+    if (!isFileSystemPathMissing(e)) {
+      rethrow;
+    }
+    return false;
+  }
+}
+
+bool isFileSystemPathMissing(FileSystemException e) =>
+    e is PathNotFoundException ||
+    e.osError?.errorCode == _noSuchFileOrDirectoryErrorCode;
 
 Future<int> getFileSize(String path) async {
   final file = File(path);

--- a/mobile/packages/ente_pure_utils/test/directory_content_util_test.dart
+++ b/mobile/packages/ente_pure_utils/test/directory_content_util_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:ente_pure_utils/ente_pure_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('deleteFileSystemEntityIfPresent', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'ente_pure_utils_directory_content_util_test_',
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('deletes an existing file', () async {
+      final file = File(p.join(tempDir.path, 'file.txt'));
+      await file.writeAsString('content');
+
+      final deleted = await deleteFileSystemEntityIfPresent(file);
+
+      expect(deleted, isTrue);
+      expect(await file.exists(), isFalse);
+    });
+
+    test('returns false when the path is already missing', () async {
+      final missingFile = File(p.join(tempDir.path, 'missing.txt'));
+
+      final deleted = await deleteFileSystemEntityIfPresent(missingFile);
+
+      expect(deleted, isFalse);
+    });
+
+    test('identifies missing path file system errors', () async {
+      final missingFile = File(p.join(tempDir.path, 'missing.txt'));
+
+      try {
+        await missingFile.delete();
+        fail('delete should fail for a missing file');
+      } on FileSystemException catch (e) {
+        expect(isFileSystemPathMissing(e), isTrue);
+      }
+    });
+
+    test('deletes a directory recursively', () async {
+      final directory = Directory(p.join(tempDir.path, 'nested'));
+      await directory.create();
+      await File(p.join(directory.path, 'file.txt')).writeAsString('content');
+
+      final deleted = await deleteFileSystemEntityIfPresent(
+        directory,
+        recursive: true,
+      );
+
+      expect(deleted, isTrue);
+      expect(await directory.exists(), isFalse);
+    });
+  });
+
+  group('deleteDirectoryContents', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'ente_pure_utils_directory_content_util_test_',
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('deletes files and directories while preserving the root', () async {
+      await File(p.join(tempDir.path, 'file.txt')).writeAsString('content');
+      final directory = Directory(p.join(tempDir.path, 'nested'));
+      await directory.create();
+      await File(p.join(directory.path, 'file.txt')).writeAsString('content');
+
+      await deleteDirectoryContents(tempDir.path);
+
+      expect(await tempDir.exists(), isTrue);
+      expect(await tempDir.list().toList(), isEmpty);
+    });
+
+    test('ignores a missing root directory', () async {
+      final missingDirectory = Directory(p.join(tempDir.path, 'missing'));
+
+      await deleteDirectoryContents(missingDirectory.path);
+
+      expect(await missingDirectory.exists(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add shared missing filesystem path/delete helpers in ente_pure_utils
- use the shared delete helper for stale upload cleanup while keeping unexpected delete errors visible
- refactor copied iOS temp cleanup and thumbnail cache missing-path checks to the shared helper/predicate
- make deleteDirectoryContents tolerant of list/delete races and add pure-utils regression tests
- update Photos internal changes

Fixes PHOTOS-MOBILE-7K3
Fixes PHOTOS-MOBILE-7N6

## Validation
- dart format -o none --set-exit-if-changed mobile/packages/ente_pure_utils/lib/src/directory_content_util.dart mobile/packages/ente_pure_utils/test/directory_content_util_test.dart
- git diff --check
- flutter test test/directory_content_util_test.dart (mobile/packages/ente_pure_utils)
- flutter test (mobile/packages/ente_pure_utils)
- flutter analyze lib/src/directory_content_util.dart test/directory_content_util_test.dart (mobile/packages/ente_pure_utils)
- flutter analyze . (mobile/packages/ente_pure_utils)
- flutter analyze lib/utils/file_uploader.dart lib/services/local_file_update_service.dart lib/utils/thumbnail_util.dart (mobile/apps/photos)

Full Photos app analyze is covered by CI; local full app analyze is blocked in this fresh worktree because generated localization and Rust binding files are absent.