### PR TITLE
[mob][photos] Quiet inline OCR pre-check timeouts

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
@@ -185,9 +185,14 @@ class _InlineTextDetectionState extends State<InlineTextDetection> {
             .hasText(imagePath: localFile.path)
             .timeout(const Duration(seconds: 5));
         _logger.info("hasText result: $hasText");
+      } on TimeoutException {
+        // A slow pre-check is expected on some devices. Fall back to the full
+        // detector path without reporting an app error.
+        hasText = true;
+        _logger.info("hasText timed out, falling back to optimistic");
       } catch (error, stackTrace) {
-        // On error or timeout, optimistically assume text may be present
-        // so the full detection pipeline can make the final determination.
+        // On error, optimistically assume text may be present so the full
+        // detection pipeline can make the final determination.
         hasText = true;
         _logger.warning(
           "hasText failed, falling back to optimistic",

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,5 +1,6 @@
 Latest changes:
 - Neeraj: Fix smart memories and ML lookup failures for large offline galleries [Sentry]
+- Neeraj: Stop reporting inline OCR pre-check timeouts as errors [Sentry]
 - Neeraj: Avoid repeated iOS reupload checks when copied temp files are already cleaned up [Sentry]
 - Neeraj: Fix incorrect upload dates for photos with ISO-like metadata timestamps [Sentry]
 - Neeraj: Skip image EXIF parsing for videos


### PR DESCRIPTION
## Summary
- treat inline OCR hasText timeouts as the existing optimistic fallback instead of warning telemetry
- keep unexpected OCR pre-check errors reported with stack traces
- update Photos internal changes

Fixes PHOTOS-MOBILE-C48

## Validation
- git diff --check
- flutter analyze lib/ui/viewer/file/inline_text_detection.dart

Full app analyze is blocked in this fresh worktree because generated localization and Rust binding files are absent.