### PR TITLE
Improve Ensu release Discord notes

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const [changesDir, previousRef] = process.argv.slice(2);
+
+if (!changesDir) {
+    console.error("Usage: node .github/scripts/release-notes.mjs <changes-dir> [previous-ref]");
+    process.exit(2);
+}
+
+function git(args) {
+    const result = spawnSync("git", args, { encoding: "utf8" });
+    return result.status === 0 ? result.stdout : "";
+}
+
+function readMarkdown(file) {
+    return fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n").replace(/\n?$/, "\n");
+}
+
+function changesetFiles(dir) {
+    return fs
+        .readdirSync(dir)
+        .filter((name) => name.endsWith(".md") && name !== "README.md")
+        .sort()
+        .map((name) => path.join(dir, name));
+}
+
+function changesetFilesAtRef(dir, ref) {
+    const prefix = dir.replace(/^\.\//, "").replace(/\/$/, "");
+    return git(["ls-tree", "-r", "--name-only", ref, "--", prefix])
+        .split("\n")
+        .filter((file) => path.dirname(file) === prefix)
+        .filter((file) => file.endsWith(".md") && path.basename(file) !== "README.md")
+        .sort();
+}
+
+function currentBody() {
+    return changesetFiles(changesDir).map(readMarkdown).join("").trim();
+}
+
+function previousBody() {
+    if (!previousRef) return "";
+    return changesetFilesAtRef(changesDir, previousRef)
+        .map((file) => git(["show", `${previousRef}:${file}`]).replace(/\r\n/g, "\n").replace(/\n?$/, "\n"))
+        .join("")
+        .trim();
+}
+
+function groupedBody(body, previous) {
+    const previousLines = new Set(previous.split("\n").filter(Boolean));
+    if (!previousLines.size) return body;
+
+    const latest = [];
+    const previousAgain = [];
+    for (const line of body.split("\n").filter(Boolean)) {
+        (previousLines.has(line) ? previousAgain : latest).push(line);
+    }
+
+    if (!previousAgain.length) return body;
+    return [
+        latest.length ? `Latest changes:\n\n${latest.join("\n")}` : "",
+        `Previous changes:\n${previousAgain.join("\n")}`,
+    ]
+        .filter(Boolean)
+        .join("\n\n");
+}
+
+function output(name, value) {
+    console.log(`${name}<<EOF`);
+    console.log(value);
+    console.log("EOF");
+}
+
+const body = currentBody();
+
+output("release_body", body);
+output("release_body_grouped", groupedBody(body, previousBody()));

--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -61,7 +61,7 @@ function groupedBody(body, previous) {
 
     if (!previousAgain.length) return body;
     return [
-        latest.length ? `Latest changes:\n\n${latest.join("\n")}` : "",
+        latest.length ? `New changes:\n\n${latest.join("\n")}` : "",
         `Previous changes:\n${previousAgain.join("\n")}`,
     ]
         .filter(Boolean)

--- a/.github/workflows/ensu-build.yml
+++ b/.github/workflows/ensu-build.yml
@@ -33,6 +33,7 @@ jobs:
             release_tag: ${{ steps.prepare.outputs.release_tag }}
             release_title: ${{ steps.prepare.outputs.release_title }}
             release_body: ${{ steps.prepare.outputs.release_body }}
+            release_body_grouped: ${{ steps.prepare.outputs.release_body_grouped }}
 
         steps:
             - name: Checkout code
@@ -77,17 +78,14 @@ jobs:
                   fi
 
                   commit_sha="$(git rev-parse HEAD)"
+                  git fetch --force --depth=1 --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}" || true
 
                   echo "should_build=true" >> "${GITHUB_OUTPUT}"
                   echo "commit_sha=${commit_sha}" >> "${GITHUB_OUTPUT}"
                   echo "build_number=${build_number}" >> "${GITHUB_OUTPUT}"
                   echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
                   echo "release_title=${release_title}" >> "${GITHUB_OUTPUT}"
-                  {
-                      echo "release_body<<EOF"
-                      find rust/apps/ensu/changes -maxdepth 1 -type f -name '*.md' ! -name README.md | sort | xargs awk 1
-                      echo "EOF"
-                  } >> "${GITHUB_OUTPUT}"
+                  node .github/scripts/release-notes.mjs rust/apps/ensu/changes "${release_tag}" >> "${GITHUB_OUTPUT}"
 
     build-desktop:
         needs: build-metadata
@@ -406,14 +404,19 @@ jobs:
               continue-on-error: true
               env:
                   DISCORD_WEBHOOK: ${{ secrets.DISCORD_INTERNAL_RELEASE_WEBHOOK }}
-                  RELEASE_BODY: ${{ needs.build-metadata.outputs.release_body }}
+                  RELEASE_BODY_GROUPED: ${{ needs.build-metadata.outputs.release_body_grouped }}
                   RELEASE_TAG: ${{ needs.build-metadata.outputs.release_tag }}
               run: |
                   download_line="-# Download: [Play Store](https://play.google.com/store/apps/details?id=io.ente.ensu) | [TestFlight](https://appstoreconnect.apple.com/apps/6758197006/testflight/ios) | [GitHub Release](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
+                  release_body_discord="$(awk '
+                      /^Previous changes:$/ { previous = 1 }
+                      previous && NF { print "-# " $0; next }
+                      { print }
+                  ' <<< "${RELEASE_BODY_GROUPED}")"
 
                   jq -n \
                       --arg title "${{ needs.build-metadata.outputs.release_title }}" \
-                      --arg body "${RELEASE_BODY}" \
+                      --arg body "${release_body_discord}" \
                       --arg download_line "${download_line}" \
                       '{embeds: [{title: $title, description: ($body + "\n\n" + $download_line), color: 16633363}]}' \
                       | curl -fsSL -H 'Content-Type: application/json' -d @- "${DISCORD_WEBHOOK}"

--- a/.github/workflows/ensu-build.yml
+++ b/.github/workflows/ensu-build.yml
@@ -67,14 +67,14 @@ jobs:
                           exit 1
                       fi
                       release_tag="ensu-v${release_version}-rc"
-                      release_title="🤖  Ensu release candidate · ${release_version} (build ${build_number})"
+                      release_title="🤖   Ensu release candidate · ${release_version} (build ${build_number})"
                   else
                       if [[ "${version}" != "${release_version}-beta" ]]; then
                           echo "::error::${GITHUB_REF_NAME} is ${version}, expected ${release_version}-beta"
                           exit 1
                       fi
                       release_tag="ensu-v${release_version}-beta"
-                      release_title="🤖  Ensu nightly · ${version} (build ${build_number})"
+                      release_title="🤖   Ensu nightly · ${version} (build ${build_number})"
                   fi
 
                   commit_sha="$(git rev-parse HEAD)"
@@ -418,5 +418,5 @@ jobs:
                       --arg title "${{ needs.build-metadata.outputs.release_title }}" \
                       --arg body "${release_body_discord}" \
                       --arg download_line "${download_line}" \
-                      '{embeds: [{title: $title, description: ($body + "\n\n" + $download_line), color: 16633363}]}' \
+                      '{embeds: [{title: $title, description: $body, fields: [{name: "\u200B", value: $download_line, inline: false}], color: 16633363}]}' \
                       | curl -fsSL -H 'Content-Type: application/json' -d @- "${DISCORD_WEBHOOK}"


### PR DESCRIPTION
## Summary
- add a reusable release-notes script for Ensu changesets
- generate grouped release notes so Discord can mute previous changes
- move Ensu Discord downloads into an embed field and adjust title spacing

## Tests
- `git diff --check`
- `node --check .github/scripts/release-notes.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ensu-build.yml'); puts 'ok'"`
- `bash -n` on the edited workflow shell blocks