### PR TITLE
[mob][photos] Fix for gcam-services-provider opening on gallery instead of photo viewer

### DIFF
--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -1698,8 +1698,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "9561bd13f0b5f1f7efe5ba7d2867d4ffacf8c8ee"
-      resolved-ref: "9561bd13f0b5f1f7efe5ba7d2867d4ffacf8c8ee"
+      ref: "7dfca297926ad113780e8151d58262bf5f8c8e9c"
+      resolved-ref: "7dfca297926ad113780e8151d58262bf5f8c8e9c"
       url: "https://github.com/ente-io/media_extension.git"
     source: git
     version: "1.0.2"

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -149,7 +149,7 @@ dependencies:
   media_extension:
     git:
       url: https://github.com/ente-io/media_extension.git
-      ref: 9561bd13f0b5f1f7efe5ba7d2867d4ffacf8c8ee
+      ref: 7dfca297926ad113780e8151d58262bf5f8c8e9c
   media_kit:
     git:
       url: https://github.com/media-kit/media-kit


### PR DESCRIPTION
## Description

Fix for gcam-services-provider opening on gallery instead of photo viewer, through [this commit](https://github.com/ente-io/media_extension/commit/7dfca297926ad113780e8151d58262bf5f8c8e9c) in our media-extension package.
