### PR TITLE
[mob][package] Add chip primitives to components

### DIFF
--- a/mobile/packages/ente_components/lib/components/buttons/icon_button_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/icon_button_component.dart
@@ -26,7 +26,8 @@ class IconButtonComponent extends StatefulWidget {
   const IconButtonComponent({
     super.key,
     required this.icon,
-    required this.onTap,
+    this.onTap,
+    this.onTapDown,
     this.variant = IconButtonComponentVariant.secondary,
     this.shouldSurfaceExecutionStates = true,
     this.shouldShowSuccessConfirmation = false,
@@ -35,6 +36,7 @@ class IconButtonComponent extends StatefulWidget {
 
   final Widget icon;
   final FutureOr<void> Function()? onTap;
+  final void Function(TapDownDetails details)? onTapDown;
   final IconButtonComponentVariant variant;
   final bool shouldSurfaceExecutionStates;
   final bool shouldShowSuccessConfirmation;
@@ -98,8 +100,8 @@ class _IconButtonComponentState extends State<IconButtonComponent>
         onExit: (_) => _setHovered(false),
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onTap: enabled ? _handleTap : null,
-          onTapDown: enabled ? (_) => _setPressed(true) : null,
+          onTap: enabled && widget.onTap != null ? _handleTap : null,
+          onTapDown: enabled ? _handleTapDown : null,
           onTapUp: enabled ? (_) => _setPressed(false) : null,
           onTapCancel: enabled ? () => _setPressed(false) : null,
           child: AnimatedScale(
@@ -181,8 +183,11 @@ class _IconButtonComponentState extends State<IconButtonComponent>
   }
 
   bool get _canHandleGestures {
-    return widget.onTap != null && !_isExecuting && !_isSuccessful;
+    return _hasGestureCallback && !_isExecuting && !_isSuccessful;
   }
+
+  bool get _hasGestureCallback =>
+      widget.onTap != null || widget.onTapDown != null;
 
   bool get _isExecuting =>
       _executionState == ComponentExecutionState.inProgress;
@@ -262,6 +267,11 @@ class _IconButtonComponentState extends State<IconButtonComponent>
     }
   }
 
+  void _handleTapDown(TapDownDetails details) {
+    widget.onTapDown?.call(details);
+    _setPressed(true);
+  }
+
   void _cancelLoadingTimer() {
     _loadingTimer?.cancel();
     _loadingTimer = null;
@@ -307,7 +317,7 @@ class _IconButtonComponentState extends State<IconButtonComponent>
         foreground: _foreground(context, isSuccess: true),
       );
     }
-    if (widget.onTap == null) {
+    if (!_hasGestureCallback) {
       return _ResolvedIconButtonColors(
         background: _disabledBackground(context),
         foreground: _foreground(context, isDisabled: true),

--- a/mobile/packages/ente_components/lib/components/chip_surface.dart
+++ b/mobile/packages/ente_components/lib/components/chip_surface.dart
@@ -1,0 +1,99 @@
+import 'package:ente_components/theme/motion.dart';
+import 'package:flutter/material.dart';
+
+class ChipSurface extends StatelessWidget {
+  const ChipSurface({
+    super.key,
+    required this.surfaceKey,
+    required this.enabled,
+    required this.selected,
+    required this.semanticLabel,
+    required this.height,
+    required this.padding,
+    required this.background,
+    required this.borderRadius,
+    required this.child,
+    this.minWidth,
+    this.onTap,
+    this.tooltip,
+  });
+
+  final Key surfaceKey;
+  final bool enabled;
+  final bool selected;
+  final String? semanticLabel;
+  final double height;
+  final double? minWidth;
+  final EdgeInsetsGeometry padding;
+  final Color background;
+  final BorderRadiusGeometry borderRadius;
+  final Widget child;
+  final VoidCallback? onTap;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget chip = MouseRegion(
+      cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: enabled ? onTap : null,
+        child: AnimatedContainer(
+          key: surfaceKey,
+          duration: Motion.quick,
+          curve: Curves.easeInOutCubic,
+          height: height,
+          constraints: minWidth == null
+              ? null
+              : BoxConstraints(minWidth: minWidth!),
+          padding: padding,
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: borderRadius,
+          ),
+          child: child,
+        ),
+      ),
+    );
+
+    if (tooltip != null) {
+      chip = Tooltip(message: tooltip!, child: chip);
+    }
+
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      selected: selected,
+      label: semanticLabel,
+      child: chip,
+    );
+  }
+}
+
+class ChipIconSlot extends StatelessWidget {
+  const ChipIconSlot({
+    required this.color,
+    required this.child,
+    required this.size,
+    required this.slotSize,
+    super.key,
+  });
+
+  final Color color;
+  final Widget child;
+  final double size;
+  final double slotSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: slotSize,
+      child: Center(
+        child: IconTheme.merge(
+          data: IconThemeData(color: color, size: size),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/packages/ente_components/lib/components/filter_chip_component.dart
+++ b/mobile/packages/ente_components/lib/components/filter_chip_component.dart
@@ -1,5 +1,5 @@
+import 'package:ente_components/components/chip_surface.dart';
 import 'package:ente_components/theme/icon_sizes.dart';
-import 'package:ente_components/theme/motion.dart';
 import 'package:ente_components/theme/radii.dart';
 import 'package:ente_components/theme/spacing.dart';
 import 'package:ente_components/theme/text_styles.dart';
@@ -46,41 +46,23 @@ class FilterChipComponent extends StatelessWidget {
     };
     final background = _selected ? colors.primaryLight : colors.fillLight;
 
-    Widget chip = MouseRegion(
-      cursor: _enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: _enabled ? () => onChanged!(!_selected) : null,
-        child: AnimatedContainer(
-          key: const ValueKey('filter-chip-surface'),
-          duration: Motion.quick,
-          curve: Curves.easeInOutCubic,
-          height: 40,
-          constraints: const BoxConstraints(minWidth: 40),
-          padding: _padding,
-          decoration: BoxDecoration(
-            color: background,
-            borderRadius: BorderRadius.circular(24),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: _children(textColor),
-          ),
-        ),
-      ),
-    );
-
-    if (tooltip != null) {
-      chip = Tooltip(message: tooltip!, child: chip);
-    }
-
-    return Semantics(
-      button: true,
+    return ChipSurface(
+      surfaceKey: const ValueKey('filter-chip-surface'),
       enabled: _enabled,
       selected: _selected,
-      label: tooltip ?? label,
-      child: chip,
+      semanticLabel: tooltip ?? label,
+      height: 40,
+      minWidth: 40,
+      padding: _padding,
+      background: background,
+      borderRadius: BorderRadius.circular(24),
+      onTap: _enabled ? () => onChanged!(!_selected) : null,
+      tooltip: tooltip,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: _children(textColor),
+      ),
     );
   }
 
@@ -105,7 +87,14 @@ class FilterChipComponent extends StatelessWidget {
 
     if (leading != null) {
       addGap();
-      children.add(_FilterChipIcon(color: color, child: leading!));
+      children.add(
+        ChipIconSlot(
+          color: color,
+          size: IconSizes.small,
+          slotSize: _iconSlotSize,
+          child: leading!,
+        ),
+      );
     }
 
     if (label != null) {
@@ -124,9 +113,12 @@ class FilterChipComponent extends StatelessWidget {
     if (trailing != null || selectedTrailing) {
       addGap();
       children.add(
-        _FilterChipIcon(
+        ChipIconSlot(
           color: color,
           size: selectedTrailing ? IconSizes.tiny : IconSizes.small,
+          slotSize: selectedTrailing
+              ? _selectedTrailingIconSlotSize
+              : _iconSlotSize,
           child: selectedTrailing ? const Icon(Icons.close_rounded) : trailing!,
         ),
       );
@@ -179,33 +171,6 @@ class FilterChipComponent extends StatelessWidget {
     }
 
     return const EdgeInsets.symmetric(horizontal: 18, vertical: Spacing.md);
-  }
-}
-
-class _FilterChipIcon extends StatelessWidget {
-  const _FilterChipIcon({
-    required this.color,
-    required this.child,
-    this.size = IconSizes.small,
-  });
-
-  final Color color;
-  final Widget child;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: size == IconSizes.tiny
-          ? _selectedTrailingIconSlotSize
-          : _iconSlotSize,
-      child: Center(
-        child: IconTheme.merge(
-          data: IconThemeData(color: color, size: size),
-          child: child,
-        ),
-      ),
-    );
   }
 }
 

--- a/mobile/packages/ente_components/lib/components/tag_chip_component.dart
+++ b/mobile/packages/ente_components/lib/components/tag_chip_component.dart
@@ -1,0 +1,129 @@
+import 'package:ente_components/components/chip_surface.dart';
+import 'package:ente_components/theme/radii.dart';
+import 'package:ente_components/theme/spacing.dart';
+import 'package:ente_components/theme/text_styles.dart';
+import 'package:ente_components/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+enum TagChipComponentState { selected, unselected, disabled }
+
+/// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=2482-6479&m=dev
+/// Section: Tag Chip
+/// Specs: 44px height, 16px radius, body text, selected/unselected/disabled states with one optional icon slot.
+class TagChipComponent extends StatelessWidget {
+  const TagChipComponent({
+    super.key,
+    required this.label,
+    this.leading,
+    this.trailing,
+    this.state = TagChipComponentState.unselected,
+    this.onTap,
+    this.tooltip,
+  }) : assert(leading == null || trailing == null);
+
+  final String label;
+  final Widget? leading;
+  final Widget? trailing;
+  final TagChipComponentState state;
+  final VoidCallback? onTap;
+  final String? tooltip;
+
+  bool get _selected => state == TagChipComponentState.selected;
+
+  bool get _enabled => state != TagChipComponentState.disabled && onTap != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    final contentColor = switch (state) {
+      TagChipComponentState.selected => colors.specialWhite,
+      TagChipComponentState.unselected => colors.textLight,
+      TagChipComponentState.disabled => colors.textLightest,
+    };
+    final background = _selected ? colors.primary : colors.fillLight;
+
+    return ChipSurface(
+      surfaceKey: const ValueKey('tag-chip-surface'),
+      enabled: _enabled,
+      selected: _selected,
+      semanticLabel: tooltip ?? label,
+      height: 44,
+      padding: _padding,
+      background: background,
+      borderRadius: BorderRadius.circular(Radii.lg),
+      onTap: _enabled ? onTap : null,
+      tooltip: tooltip,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: _children(contentColor),
+      ),
+    );
+  }
+
+  List<Widget> _children(Color color) {
+    final children = <Widget>[];
+
+    if (leading != null) {
+      children.add(
+        ChipIconSlot(
+          color: color,
+          size: _iconSlotSize,
+          slotSize: _iconSlotSize,
+          child: leading!,
+        ),
+      );
+      children.add(const SizedBox(width: Spacing.xs));
+    }
+
+    children.add(
+      Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyles.body.copyWith(color: color),
+      ),
+    );
+
+    if (trailing != null) {
+      children.add(const SizedBox(width: Spacing.xs));
+      children.add(
+        ChipIconSlot(
+          color: color,
+          size: _iconSlotSize,
+          slotSize: _iconSlotSize,
+          child: trailing!,
+        ),
+      );
+    }
+
+    return children;
+  }
+
+  EdgeInsets get _padding {
+    if (leading != null) {
+      return const EdgeInsets.fromLTRB(
+        Spacing.md,
+        Spacing.md,
+        Spacing.lg,
+        Spacing.md,
+      );
+    }
+
+    if (trailing != null) {
+      return const EdgeInsets.fromLTRB(
+        Spacing.lg,
+        Spacing.md,
+        Spacing.md,
+        Spacing.md,
+      );
+    }
+
+    return const EdgeInsets.symmetric(
+      horizontal: Spacing.xl,
+      vertical: Spacing.md,
+    );
+  }
+}
+
+const double _iconSlotSize = 20;

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -13,6 +13,7 @@ export 'components/selection_controls/radio_component.dart';
 export 'components/selection_controls/toggle_switch_component.dart';
 export 'components/slider_component.dart';
 export 'components/stepper_component.dart';
+export 'components/tag_chip_component.dart';
 export 'components/text_input_component.dart';
 export 'models/component_execution_state.dart';
 export 'theme/colors.dart';

--- a/mobile/packages/ente_components/test/components/button_test.dart
+++ b/mobile/packages/ente_components/test/components/button_test.dart
@@ -435,6 +435,30 @@ void main() {
     expect(tapCount, 1);
   });
 
+  testWidgets("IconButtonComponent can handle tap down without onTap", (
+    tester,
+  ) async {
+    TapDownDetails? tapDownDetails;
+
+    await tester.pumpWidget(
+      _wrap(
+        IconButtonComponent(
+          icon: const Icon(Icons.add),
+          onTapDown: (details) => tapDownDetails = details,
+        ),
+      ),
+    );
+
+    final surfaceFinder = find.byKey(const ValueKey('icon-button-surface'));
+    final gesture = await tester.startGesture(tester.getCenter(surfaceFinder));
+    await tester.pump();
+
+    expect(tapDownDetails, isNotNull);
+    expect(_iconButtonColor(tester), Colors.transparent);
+
+    await gesture.up();
+  });
+
   testWidgets("IconButtonComponent mutes disabled foreground", (tester) async {
     await tester.pumpWidget(
       _wrap(

--- a/mobile/packages/ente_components/test/components/tag_chip_component_test.dart
+++ b/mobile/packages/ente_components/test/components/tag_chip_component_test.dart
@@ -1,0 +1,132 @@
+import "package:ente_components/ente_components.dart";
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  testWidgets("TagChipComponent renders selected colors", (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const TagChipComponent(
+          label: "Faces",
+          leading: Icon(Icons.sell_outlined),
+          state: TagChipComponentState.selected,
+        ),
+      ),
+    );
+
+    _expectChipColors(
+      tester,
+      background: ColorTokens.light.primary,
+      content: ColorTokens.light.specialWhite,
+    );
+  });
+
+  testWidgets("TagChipComponent renders unselected colors", (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const TagChipComponent(
+          label: "Faces",
+          leading: Icon(Icons.sell_outlined),
+        ),
+      ),
+    );
+
+    _expectChipColors(
+      tester,
+      background: ColorTokens.light.fillLight,
+      content: ColorTokens.light.textLight,
+    );
+  });
+
+  testWidgets("TagChipComponent renders disabled colors", (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const TagChipComponent(
+          label: "Faces",
+          leading: Icon(Icons.sell_outlined),
+          state: TagChipComponentState.disabled,
+        ),
+      ),
+    );
+
+    _expectChipColors(
+      tester,
+      background: ColorTokens.light.fillLight,
+      content: ColorTokens.light.textLightest,
+    );
+  });
+
+  testWidgets("TagChipComponent invokes tap callback when enabled", (
+    tester,
+  ) async {
+    var taps = 0;
+
+    await tester.pumpWidget(
+      _wrap(TagChipComponent(label: "Albums", onTap: () => taps++)),
+    );
+
+    await tester.tap(find.byKey(const ValueKey("tag-chip-surface")));
+    await tester.pump();
+
+    expect(taps, 1);
+  });
+
+  testWidgets("TagChipComponent does not invoke tap callback when disabled", (
+    tester,
+  ) async {
+    var taps = 0;
+
+    await tester.pumpWidget(
+      _wrap(
+        TagChipComponent(
+          label: "Albums",
+          state: TagChipComponentState.disabled,
+          onTap: () => taps++,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey("tag-chip-surface")));
+    await tester.pump();
+
+    expect(taps, 0);
+  });
+
+  test("TagChipComponent allows only one icon slot", () {
+    expect(
+      () => TagChipComponent(
+        label: "People",
+        leading: const Icon(Icons.person_outline),
+        trailing: const Icon(Icons.close_rounded),
+      ),
+      throwsAssertionError,
+    );
+  });
+}
+
+void _expectChipColors(
+  WidgetTester tester, {
+  required Color background,
+  required Color content,
+}) {
+  final surfaceFinder = find.byKey(const ValueKey("tag-chip-surface"));
+  final surface = tester.widget<AnimatedContainer>(surfaceFinder);
+  final decoration = surface.decoration! as BoxDecoration;
+  final label = tester.widget<Text>(find.text("Faces"));
+  final iconTheme = IconTheme.of(
+    tester.element(find.byIcon(Icons.sell_outlined)),
+  );
+
+  expect(tester.getSize(surfaceFinder).height, 44);
+  expect(decoration.color, background);
+  expect(label.style?.color, content);
+  expect(iconTheme.color, content);
+  expect(find.byIcon(Icons.close_rounded), findsNothing);
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ComponentTheme.lightTheme(),
+    home: Scaffold(body: Center(child: child)),
+  );
+}


### PR DESCRIPTION
## Summary

- Add a shared `ChipSurface` primitive for component chip tap handling, semantics, tooltips, and animated surface styling.
- Add `TagChipComponent` for larger tag/category chips and export it from `ente_components`.
- Refactor `FilterChipComponent` to reuse the shared chip surface while preserving its compact filter behavior.
- Add `IconButtonComponent.onTapDown` support for menu/popup trigger use cases.

## Validation

- `flutter test test/components/tag_chip_component_test.dart test/components/selection_controls_test.dart`
