### PR TITLE
Remove hardcoded accounts URL fallbacks

### DIFF
--- a/cli/internal/api/login_type.go
+++ b/cli/internal/api/login_type.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/google/uuid"
 )
 
@@ -42,6 +45,19 @@ type AuthorizationResponse struct {
 	// SrpM2 is sent only if the user is logging via SRP
 	// SrpM2 is the SRP M2 value aka the proof that the server has the verifier
 	SrpM2 *string `json:"srpM2,omitempty"`
+}
+
+func (a *AuthorizationResponse) UnmarshalJSON(data []byte) error {
+	type authorizationResponse AuthorizationResponse
+	var decoded authorizationResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.PassKeySessionID != "" && decoded.AccountsUrl == "" {
+		return fmt.Errorf("accountsUrl is required when passkeySessionID is present")
+	}
+	*a = AuthorizationResponse(decoded)
+	return nil
 }
 
 func (a *AuthorizationResponse) IsMFARequired() bool {

--- a/cli/internal/api/login_type_test.go
+++ b/cli/internal/api/login_type_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestAuthorizationResponseRequiresAccountsURLOnlyForPasskey(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "plain login response may omit accounts URL",
+			body: `{"id":1,"encryptedToken":"token"}`,
+		},
+		{
+			name:    "passkey response requires accounts URL",
+			body:    `{"id":1,"passkeySessionID":"passkey-session"}`,
+			wantErr: true,
+		},
+		{
+			name: "passkey response accepts museum accounts URL",
+			body: `{"id":1,"passkeySessionID":"passkey-session","accountsUrl":"https://accounts.example.org"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response AuthorizationResponse
+			err := json.Unmarshal([]byte(tt.body), &response)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected missing accounts URL to be rejected")
+				}
+				if !strings.Contains(err.Error(), "accountsUrl is required") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifySRPSessionRejectsPasskeyResponseWithoutAccountsURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users/srp/verify-session" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"passkeySessionID":"passkey-session"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Params{Host: server.URL})
+	ctx := context.WithValue(context.Background(), "app", string(AppPhotos))
+
+	_, err := client.VerifySRPSession(ctx, uuid.New(), uuid.New(), "client-m1")
+	if err == nil {
+		t.Fatal("expected response parsing to reject missing accounts URL")
+	}
+	if !strings.Contains(err.Error(), "accountsUrl is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/pkg/sign_in.go
+++ b/cli/pkg/sign_in.go
@@ -8,7 +8,6 @@ import (
 	eCrypto "github.com/ente-io/cli/internal/crypto"
 	"github.com/ente-io/cli/pkg/model"
 	"github.com/ente-io/cli/utils/browser"
-	"github.com/ente-io/cli/utils/constants"
 	"github.com/ente-io/cli/utils/encoding"
 	"log"
 
@@ -145,11 +144,7 @@ func (c *ClICtrl) verifyPassKey(ctx context.Context, authResp *api.Authorization
 	if !authResp.IsPasskeyRequired() {
 		return authResp, nil
 	}
-	baseAccountUrl := constants.EnteAccountUrl
-	if authResp.AccountsUrl != "" {
-		baseAccountUrl = authResp.AccountsUrl
-	}
-	passkeyAuthUrl := fmt.Sprintf("%s/passkeys/verify?passkeySessionID=%s&redirect=ente-cli://passkey&clientPackage=%s", baseAccountUrl, authResp.PassKeySessionID, app.ClientPkg())
+	passkeyAuthUrl := fmt.Sprintf("%s/passkeys/verify?passkeySessionID=%s&redirect=ente-cli://passkey&clientPackage=%s", authResp.AccountsUrl, authResp.PassKeySessionID, app.ClientPkg())
 	fmt.Printf("Open this url in browser to verify passkey: %s\n", passkeyAuthUrl)
 	err := browser.OpenURL(passkeyAuthUrl)
 	if err != nil {

--- a/cli/utils/constants/constants.go
+++ b/cli/utils/constants/constants.go
@@ -3,4 +3,3 @@ package constants
 const CliDataPath = "/cli-data/"
 
 const EnteApiUrl = "https://api.ente.com"
-const EnteAccountUrl = "https://accounts.ente.com"

--- a/rust/crates/accounts/src/client.rs
+++ b/rust/crates/accounts/src/client.rs
@@ -552,6 +552,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_srp_session_rejects_passkey_response_without_accounts_url() {
+        let mut server = Server::new_async().await;
+        let verify = server
+            .mock("POST", "/users/srp/verify-session")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"id":1,"passkeySessionID":"passkey-session"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = make_client(server.url());
+        let error = client
+            .verify_srp_session(&uuid::Uuid::new_v4(), &uuid::Uuid::new_v4(), &[1u8; 32])
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("accountsUrl is required"));
+        verify.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn verify_email_does_not_retry_on_too_many_requests() {
         let mut server = Server::new_async().await;
         let verify = server

--- a/rust/crates/accounts/src/flow.rs
+++ b/rust/crates/accounts/src/flow.rs
@@ -28,7 +28,7 @@ use crate::{
         TwoFactorAuthorizationResponse, TwoFactorRecoveryResponse, TwoFactorType,
         UpdateSrpAndKeysRequest, UpdatedKeyAttr,
     },
-    types::{AccountSecrets, DEFAULT_ACCOUNTS_URL},
+    types::AccountSecrets,
 };
 
 const SRP_A_LEN: usize = 512;
@@ -790,10 +790,8 @@ where
 
         let accounts_url = auth_response
             .accounts_url
-            .as_ref()
-            .filter(|url| !url.is_empty())
-            .map(String::as_str)
-            .unwrap_or(DEFAULT_ACCOUNTS_URL);
+            .as_deref()
+            .expect("accountsUrl is required when passkeySessionID is present");
 
         let verification_url = build_passkey_verification_url(
             accounts_url,

--- a/rust/crates/accounts/src/lib.rs
+++ b/rust/crates/accounts/src/lib.rs
@@ -20,4 +20,4 @@ pub use flow::{
     SecondFactorMethod, SessionValidity, SetupTwoFactorParams, SetupTwoFactorResult, TotpPurpose,
 };
 pub use models::KeyAttributes;
-pub use types::{AccountSecrets, AccountsClientConfig, DEFAULT_ACCOUNTS_URL};
+pub use types::{AccountSecrets, AccountsClientConfig};

--- a/rust/crates/accounts/src/models.rs
+++ b/rust/crates/accounts/src/models.rs
@@ -74,6 +74,7 @@ pub struct KeyAttributes {
 
 /// Auth response emitted by login and verification endpoints.
 #[derive(Deserialize, Serialize, Clone)]
+#[serde(try_from = "AuthResponseWire")]
 #[serde(rename_all = "camelCase")]
 pub struct AuthResponse {
     /// User ID.
@@ -97,6 +98,53 @@ pub struct AuthResponse {
     pub srp_m2: Option<String>,
     /// Optional accounts broker URL.
     pub accounts_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthResponseWire {
+    id: i64,
+    key_attributes: Option<KeyAttributes>,
+    encrypted_token: Option<String>,
+    token: Option<String>,
+    #[serde(rename = "twoFactorSessionID")]
+    two_factor_session_id: Option<String>,
+    #[serde(rename = "twoFactorSessionIDV2")]
+    two_factor_session_id_v2: Option<String>,
+    #[serde(rename = "passkeySessionID")]
+    passkey_session_id: Option<String>,
+    srp_m2: Option<String>,
+    accounts_url: Option<String>,
+}
+
+impl TryFrom<AuthResponseWire> for AuthResponse {
+    type Error = String;
+
+    fn try_from(value: AuthResponseWire) -> std::result::Result<Self, Self::Error> {
+        if value
+            .passkey_session_id
+            .as_ref()
+            .is_some_and(|session_id| !session_id.is_empty())
+            && value
+                .accounts_url
+                .as_ref()
+                .map_or(true, |accounts_url| accounts_url.is_empty())
+        {
+            return Err("accountsUrl is required when passkeySessionID is present".into());
+        }
+
+        Ok(Self {
+            id: value.id,
+            key_attributes: value.key_attributes,
+            encrypted_token: value.encrypted_token,
+            token: value.token,
+            two_factor_session_id: value.two_factor_session_id,
+            two_factor_session_id_v2: value.two_factor_session_id_v2,
+            passkey_session_id: value.passkey_session_id,
+            srp_m2: value.srp_m2,
+            accounts_url: value.accounts_url,
+        })
+    }
 }
 
 impl fmt::Debug for AuthResponse {
@@ -494,4 +542,26 @@ pub struct AccountsTokenResponse {
     pub accounts_url: String,
     /// JWT for the accounts app.
     pub accounts_token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuthResponse;
+
+    #[test]
+    fn auth_response_requires_accounts_url_for_passkey() {
+        let error =
+            serde_json::from_str::<AuthResponse>(r#"{"id":1,"passkeySessionID":"session"}"#)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("accountsUrl is required"));
+    }
+
+    #[test]
+    fn auth_response_allows_missing_accounts_url_without_passkey() {
+        let response = serde_json::from_str::<AuthResponse>(r#"{"id":1}"#).unwrap();
+
+        assert_eq!(response.id, 1);
+        assert!(response.accounts_url.is_none());
+    }
 }

--- a/rust/crates/accounts/src/types.rs
+++ b/rust/crates/accounts/src/types.rs
@@ -9,9 +9,6 @@ use zeroize::Zeroize;
 /// Default base URL for Ente's public API.
 pub const DEFAULT_API_BASE_URL: &str = PRODUCTION_API_BASE_URL;
 
-/// Default base URL for Ente's accounts broker.
-pub const DEFAULT_ACCOUNTS_URL: &str = "https://accounts.ente.com";
-
 /// Boxed future returned by a configured sleep hook.
 pub type SleepFuture = Pin<Box<dyn Future<Output = ()> + 'static>>;
 

--- a/web/packages/accounts-rs/services/user.ts
+++ b/web/packages/accounts-rs/services/user.ts
@@ -559,21 +559,33 @@ export interface EmailOrSRPVerificationResponse {
  *
  * See: [Note: Duplicated Zod schema and TypeScript type]
  */
-const RemoteEmailOrSRPVerificationResponse = z
-    .object({
-        id: z.number(),
-        keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
-        encryptedToken: z.string().nullish().transform(nullToUndefined),
-        token: z.string().nullish().transform(nullToUndefined),
-        twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
-        passkeySessionID: z.string().nullish().transform(nullToUndefined),
-        accountsUrl: z.string().nullish().transform(nullToUndefined),
-        twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
-    })
-    .refine((r) => (r.passkeySessionID ? !!r.accountsUrl : true), {
-        path: ["accountsUrl"],
-        message: "accountsUrl is required when passkeySessionID is present",
-    });
+const RemoteEmailOrSRPVerificationResponseBase = z.object({
+    id: z.number(),
+    keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
+    encryptedToken: z.string().nullish().transform(nullToUndefined),
+    token: z.string().nullish().transform(nullToUndefined),
+    twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
+    passkeySessionID: z.string().nullish().transform(nullToUndefined),
+    accountsUrl: z.string().nullish().transform(nullToUndefined),
+    twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
+});
+
+const requireAccountsUrlForPasskey = <
+    T extends { passkeySessionID?: string; accountsUrl?: string },
+>(
+    response: T,
+) => (response.passkeySessionID ? !!response.accountsUrl : true);
+
+const accountsUrlForPasskeyRefinement = {
+    path: ["accountsUrl"],
+    message: "accountsUrl is required when passkeySessionID is present",
+};
+
+const RemoteEmailOrSRPVerificationResponse =
+    RemoteEmailOrSRPVerificationResponseBase.refine(
+        requireAccountsUrlForPasskey,
+        accountsUrlForPasskeyRefinement,
+    );
 
 /**
  * A specialization of {@link RemoteEmailOrSRPVerificationResponse} for SRP
@@ -583,14 +595,17 @@ const RemoteEmailOrSRPVerificationResponse = z
  * The declaration conceptually belongs to `srp.ts`, but is here to avoid cyclic
  * dependencies.
  */
-export const RemoteSRPVerificationResponse = z.object({
-    ...RemoteEmailOrSRPVerificationResponse.shape,
-    /**
-     * The SRP M2 (evidence message), the proof that the server has the
-     * verifier.
-     */
-    srpM2: z.string(),
-});
+export const RemoteSRPVerificationResponse =
+    RemoteEmailOrSRPVerificationResponseBase.extend({
+        /**
+         * The SRP M2 (evidence message), the proof that the server has the
+         * verifier.
+         */
+        srpM2: z.string(),
+    }).refine(
+        requireAccountsUrlForPasskey,
+        accountsUrlForPasskeyRefinement,
+    );
 
 /**
  * Verify user's access to the given {@link email} by comparing the OTT that

--- a/web/packages/accounts-rs/services/user.ts
+++ b/web/packages/accounts-rs/services/user.ts
@@ -570,11 +570,10 @@ const RemoteEmailOrSRPVerificationResponseBase = z.object({
     twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
 });
 
-const requireAccountsUrlForPasskey = <
-    T extends { passkeySessionID?: string; accountsUrl?: string },
->(
-    response: T,
-) => (response.passkeySessionID ? !!response.accountsUrl : true);
+const requireAccountsUrlForPasskey = (response: {
+    passkeySessionID?: string;
+    accountsUrl?: string;
+}) => (response.passkeySessionID ? !!response.accountsUrl : true);
 
 const accountsUrlForPasskeyRefinement = {
     path: ["accountsUrl"],
@@ -602,10 +601,7 @@ export const RemoteSRPVerificationResponse =
          * verifier.
          */
         srpM2: z.string(),
-    }).refine(
-        requireAccountsUrlForPasskey,
-        accountsUrlForPasskeyRefinement,
-    );
+    }).refine(requireAccountsUrlForPasskey, accountsUrlForPasskeyRefinement);
 
 /**
  * Verify user's access to the given {@link email} by comparing the OTT that

--- a/web/packages/accounts-rs/services/user.ts
+++ b/web/packages/accounts-rs/services/user.ts
@@ -559,16 +559,21 @@ export interface EmailOrSRPVerificationResponse {
  *
  * See: [Note: Duplicated Zod schema and TypeScript type]
  */
-const RemoteEmailOrSRPVerificationResponse = z.object({
-    id: z.number(),
-    keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
-    encryptedToken: z.string().nullish().transform(nullToUndefined),
-    token: z.string().nullish().transform(nullToUndefined),
-    twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
-    passkeySessionID: z.string().nullish().transform(nullToUndefined),
-    accountsUrl: z.string().nullish().transform(nullToUndefined),
-    twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
-});
+const RemoteEmailOrSRPVerificationResponse = z
+    .object({
+        id: z.number(),
+        keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
+        encryptedToken: z.string().nullish().transform(nullToUndefined),
+        token: z.string().nullish().transform(nullToUndefined),
+        twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
+        passkeySessionID: z.string().nullish().transform(nullToUndefined),
+        accountsUrl: z.string().nullish().transform(nullToUndefined),
+        twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
+    })
+    .refine((r) => (r.passkeySessionID ? !!r.accountsUrl : true), {
+        path: ["accountsUrl"],
+        message: "accountsUrl is required when passkeySessionID is present",
+    });
 
 /**
  * A specialization of {@link RemoteEmailOrSRPVerificationResponse} for SRP

--- a/web/packages/accounts/services/user.ts
+++ b/web/packages/accounts/services/user.ts
@@ -535,11 +535,10 @@ const RemoteEmailOrSRPVerificationResponseBase = z.object({
     twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
 });
 
-const requireAccountsUrlForPasskey = <
-    T extends { passkeySessionID?: string; accountsUrl?: string },
->(
-    response: T,
-) => (response.passkeySessionID ? !!response.accountsUrl : true);
+const requireAccountsUrlForPasskey = (response: {
+    passkeySessionID?: string;
+    accountsUrl?: string;
+}) => (response.passkeySessionID ? !!response.accountsUrl : true);
 
 const accountsUrlForPasskeyRefinement = {
     path: ["accountsUrl"],
@@ -567,10 +566,7 @@ export const RemoteSRPVerificationResponse =
          * verifier.
          */
         srpM2: z.string(),
-    }).refine(
-        requireAccountsUrlForPasskey,
-        accountsUrlForPasskeyRefinement,
-    );
+    }).refine(requireAccountsUrlForPasskey, accountsUrlForPasskeyRefinement);
 
 /**
  * Verify user's access to the given {@link email} by comparing the OTT that

--- a/web/packages/accounts/services/user.ts
+++ b/web/packages/accounts/services/user.ts
@@ -524,21 +524,33 @@ export interface EmailOrSRPVerificationResponse {
  *
  * See: [Note: Duplicated Zod schema and TypeScript type]
  */
-const RemoteEmailOrSRPVerificationResponse = z
-    .object({
-        id: z.number(),
-        keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
-        encryptedToken: z.string().nullish().transform(nullToUndefined),
-        token: z.string().nullish().transform(nullToUndefined),
-        twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
-        passkeySessionID: z.string().nullish().transform(nullToUndefined),
-        accountsUrl: z.string().nullish().transform(nullToUndefined),
-        twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
-    })
-    .refine((r) => (r.passkeySessionID ? !!r.accountsUrl : true), {
-        path: ["accountsUrl"],
-        message: "accountsUrl is required when passkeySessionID is present",
-    });
+const RemoteEmailOrSRPVerificationResponseBase = z.object({
+    id: z.number(),
+    keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
+    encryptedToken: z.string().nullish().transform(nullToUndefined),
+    token: z.string().nullish().transform(nullToUndefined),
+    twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
+    passkeySessionID: z.string().nullish().transform(nullToUndefined),
+    accountsUrl: z.string().nullish().transform(nullToUndefined),
+    twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
+});
+
+const requireAccountsUrlForPasskey = <
+    T extends { passkeySessionID?: string; accountsUrl?: string },
+>(
+    response: T,
+) => (response.passkeySessionID ? !!response.accountsUrl : true);
+
+const accountsUrlForPasskeyRefinement = {
+    path: ["accountsUrl"],
+    message: "accountsUrl is required when passkeySessionID is present",
+};
+
+const RemoteEmailOrSRPVerificationResponse =
+    RemoteEmailOrSRPVerificationResponseBase.refine(
+        requireAccountsUrlForPasskey,
+        accountsUrlForPasskeyRefinement,
+    );
 
 /**
  * A specialization of {@link RemoteEmailOrSRPVerificationResponse} for SRP
@@ -548,14 +560,17 @@ const RemoteEmailOrSRPVerificationResponse = z
  * The declaration conceptually belongs to `srp.ts`, but is here to avoid cyclic
  * dependencies.
  */
-export const RemoteSRPVerificationResponse = z.object({
-    ...RemoteEmailOrSRPVerificationResponse.shape,
-    /**
-     * The SRP M2 (evidence message), the proof that the server has the
-     * verifier.
-     */
-    srpM2: z.string(),
-});
+export const RemoteSRPVerificationResponse =
+    RemoteEmailOrSRPVerificationResponseBase.extend({
+        /**
+         * The SRP M2 (evidence message), the proof that the server has the
+         * verifier.
+         */
+        srpM2: z.string(),
+    }).refine(
+        requireAccountsUrlForPasskey,
+        accountsUrlForPasskeyRefinement,
+    );
 
 /**
  * Verify user's access to the given {@link email} by comparing the OTT that

--- a/web/packages/accounts/services/user.ts
+++ b/web/packages/accounts/services/user.ts
@@ -524,16 +524,21 @@ export interface EmailOrSRPVerificationResponse {
  *
  * See: [Note: Duplicated Zod schema and TypeScript type]
  */
-const RemoteEmailOrSRPVerificationResponse = z.object({
-    id: z.number(),
-    keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
-    encryptedToken: z.string().nullish().transform(nullToUndefined),
-    token: z.string().nullish().transform(nullToUndefined),
-    twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
-    passkeySessionID: z.string().nullish().transform(nullToUndefined),
-    accountsUrl: z.string().nullish().transform(nullToUndefined),
-    twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
-});
+const RemoteEmailOrSRPVerificationResponse = z
+    .object({
+        id: z.number(),
+        keyAttributes: RemoteKeyAttributes.nullish().transform(nullToUndefined),
+        encryptedToken: z.string().nullish().transform(nullToUndefined),
+        token: z.string().nullish().transform(nullToUndefined),
+        twoFactorSessionID: z.string().nullish().transform(nullToUndefined),
+        passkeySessionID: z.string().nullish().transform(nullToUndefined),
+        accountsUrl: z.string().nullish().transform(nullToUndefined),
+        twoFactorSessionIDV2: z.string().nullish().transform(nullToUndefined),
+    })
+    .refine((r) => (r.passkeySessionID ? !!r.accountsUrl : true), {
+        path: ["accountsUrl"],
+        message: "accountsUrl is required when passkeySessionID is present",
+    });
 
 /**
  * A specialization of {@link RemoteEmailOrSRPVerificationResponse} for SRP


### PR DESCRIPTION
Remove other fallback references to the hardcoded accounts URL. This should be coming from museum.

The only remaining reference is the Ensu code that anyways is due for a second look.