### PR TITLE
[mob][photos] Add F-Droid source overlay

### DIFF
--- a/mobile/apps/photos/android/app/src/fdroid/AndroidManifest.xml
+++ b/mobile/apps/photos/android/app/src/fdroid/AndroidManifest.xml
@@ -6,6 +6,12 @@
     main/AndroidManifest.xml once
     https://github.com/flutter/flutter/issues/38965 is fixed. -->
     <application>
+        <meta-data android:name="io.sentry.dsn" tools:node="remove"/>
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false"
+            tools:replace="android:value"/>
+
         <activity android:name=".MainActivity"
             android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"

--- a/mobile/apps/photos/docs/release.md
+++ b/mobile/apps/photos/docs/release.md
@@ -30,3 +30,12 @@ Set "Previous tag" to the last release of auth and press "Generate release
 notes". The generated release note will contain all PRs and new contributors
 from all the releases in the monorepo, so you'll need to filter them to keep
 only the things that relate to the Photos mobile app.
+
+## F-Droid
+
+For F-Droid, create an `fdroid-v` tag with the same pubspec version.
+
+```sh
+./scripts/create_tag.sh fdroid-v1.2.3
+git push origin fdroid-v1.2.3
+```

--- a/mobile/apps/photos/fdroid/overlay/lib/services/account/purchase_update_listener.dart
+++ b/mobile/apps/photos/fdroid/overlay/lib/services/account/purchase_update_listener.dart
@@ -1,0 +1,5 @@
+void listenForPurchaseUpdates({
+  required bool Function() isOnSubscriptionPage,
+  required Future<void> Function(String productID, String verificationData)
+  verifySubscription,
+}) {}

--- a/mobile/apps/photos/fdroid/overlay/lib/services/push_service.dart
+++ b/mobile/apps/photos/fdroid/overlay/lib/services/push_service.dart
@@ -1,0 +1,11 @@
+typedef BackgroundPushHandler = Future<void> Function(Object message);
+
+class PushService {
+  static final PushService instance = PushService._privateConstructor();
+
+  PushService._privateConstructor();
+
+  Future<void> init({BackgroundPushHandler? onBackgroundPush}) async {}
+
+  static bool shouldSync(Object message) => false;
+}

--- a/mobile/apps/photos/fdroid/overlay/lib/ui/payment/store_subscription_page.dart
+++ b/mobile/apps/photos/fdroid/overlay/lib/ui/payment/store_subscription_page.dart
@@ -1,0 +1,18 @@
+import "package:flutter/widgets.dart";
+
+class StoreSubscriptionPage extends StatefulWidget {
+  final bool isOnboarding;
+
+  const StoreSubscriptionPage({
+    this.isOnboarding = false,
+    super.key,
+  });
+
+  @override
+  State<StoreSubscriptionPage> createState() => _StoreSubscriptionPageState();
+}
+
+class _StoreSubscriptionPageState extends State<StoreSubscriptionPage> {
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/mobile/apps/photos/fdroid/overlay/lib/ui/payment/subscription.dart
+++ b/mobile/apps/photos/fdroid/overlay/lib/ui/payment/subscription.dart
@@ -1,0 +1,6 @@
+import "package:flutter/widgets.dart";
+import "package:photos/ui/payment/stripe_subscription_page.dart";
+
+StatefulWidget getSubscriptionPage({bool isOnBoarding = false}) {
+  return StripeSubscriptionPage(isOnboarding: isOnBoarding);
+}

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:ente_crypto/ente_crypto.dart';
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_rust/ente_rust.dart";
 import "package:ffmpeg_kit_flutter/ffmpeg_kit_config.dart";
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import "package:flutter/gestures.dart";
 import 'package:flutter/material.dart';
@@ -149,7 +148,8 @@ Future<void> _runInForeground(
           initialMediaExtensionAction: initialMediaExtensionAction,
         ),
         lockScreen: const LockScreen(),
-        enabled: await Configuration.instance.shouldShowLockScreen() ||
+        enabled:
+            await Configuration.instance.shouldShowLockScreen() ||
             localSettings.isOnGuestView(),
         locale: locale,
         lightTheme: lightThemeData,
@@ -310,8 +310,9 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
         hasGrantedMLConsent &&
         localSettings.isMLLocalIndexingEnabled) {
       PersonService.init(entityService, MLDataDB.instance, prefs);
-      _logger
-          .info("[BG TASK] person service initialized for memories recompute");
+      _logger.info(
+        "[BG TASK] person service initialized for memories recompute",
+      );
     }
     await _homeWidgetSync(true);
 
@@ -468,11 +469,9 @@ Future<void> _init(
     }
 
     if (Platform.isIOS) {
-      PushService.instance.init().then((_) {
-        FirebaseMessaging.onBackgroundMessage(
-          _firebaseMessagingBackgroundHandler,
-        );
-      }).ignore();
+      PushService.instance
+          .init(onBackgroundPush: _handleBackgroundPush)
+          .ignore();
     }
     _logger.info("PushService/HomeWidget done $tlog");
     unawaited(MLService.instance.init());
@@ -533,8 +532,9 @@ void logLocalSettings() {
         VideoPreviewService.instance.isVideoStreamingEnabled,
   };
 
-  final formattedSettings =
-      settings.entries.map((e) => '${e.key}: ${e.value}').join(', ');
+  final formattedSettings = settings.entries
+      .map((e) => '${e.key}: ${e.value}')
+      .join(', ');
   _logger.info('Local settings - $formattedSettings');
 }
 
@@ -625,7 +625,7 @@ Future<bool> _isRunningInForeground() async {
       (currentTime - kFGTaskDeathTimeoutInMicroseconds);
 }
 
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+Future<void> _handleBackgroundPush(Object message) async {
   final bool isRunningInFG = await _isRunningInForeground(); // hb
   final bool isInForeground = AppLifecycleService.instance.isForeground;
   if (isRunningInFG) {

--- a/mobile/apps/photos/lib/services/account/billing_service.dart
+++ b/mobile/apps/photos/lib/services/account/billing_service.dart
@@ -4,13 +4,13 @@ import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 // import 'package:flutter/foundation.dart';
 // import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
-import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:logging/logging.dart';
 import "package:photos/gateways/billing/billing_gateway.dart";
 import 'package:photos/gateways/billing/models/billing_plan.dart';
 import 'package:photos/gateways/billing/models/subscription.dart';
 import 'package:photos/models/user_details.dart';
 import "package:photos/service_locator.dart";
+import "package:photos/services/account/purchase_update_listener.dart";
 import 'package:photos/ui/family/family_plan_page.dart';
 import 'package:photos/utils/dialog_util.dart';
 
@@ -43,23 +43,10 @@ class BillingService {
     //   await FlutterInappPurchase.instance.initConnection;
     //   FlutterInappPurchase.instance.clearTransactionIOS();
     // }
-    InAppPurchase.instance.purchaseStream.listen((purchases) {
-      if (_isOnSubscriptionPage) {
-        return;
-      }
-      for (final purchase in purchases) {
-        if (purchase.status == PurchaseStatus.purchased) {
-          verifySubscription(
-            purchase.productID,
-            purchase.verificationData.serverVerificationData,
-          ).then((response) {
-            InAppPurchase.instance.completePurchase(purchase);
-          });
-        } else if (Platform.isIOS && purchase.pendingCompletePurchase) {
-          InAppPurchase.instance.completePurchase(purchase);
-        }
-      }
-    });
+    listenForPurchaseUpdates(
+      isOnSubscriptionPage: () => _isOnSubscriptionPage,
+      verifySubscription: verifySubscription,
+    );
   }
 
   void clearCache() {

--- a/mobile/apps/photos/lib/services/account/purchase_update_listener.dart
+++ b/mobile/apps/photos/lib/services/account/purchase_update_listener.dart
@@ -1,0 +1,27 @@
+import "dart:io";
+
+import "package:in_app_purchase/in_app_purchase.dart";
+
+void listenForPurchaseUpdates({
+  required bool Function() isOnSubscriptionPage,
+  required Future<void> Function(String productID, String verificationData)
+  verifySubscription,
+}) {
+  InAppPurchase.instance.purchaseStream.listen((purchases) {
+    if (isOnSubscriptionPage()) {
+      return;
+    }
+    for (final purchase in purchases) {
+      if (purchase.status == PurchaseStatus.purchased) {
+        verifySubscription(
+          purchase.productID,
+          purchase.verificationData.serverVerificationData,
+        ).then((response) {
+          InAppPurchase.instance.completePurchase(purchase);
+        });
+      } else if (Platform.isIOS && purchase.pendingCompletePurchase) {
+        InAppPurchase.instance.completePurchase(purchase);
+      }
+    }
+  });
+}

--- a/mobile/apps/photos/lib/services/push_service.dart
+++ b/mobile/apps/photos/lib/services/push_service.dart
@@ -11,6 +11,8 @@ import 'package:photos/service_locator.dart';
 import 'package:photos/services/sync/sync_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+typedef BackgroundPushHandler = Future<void> Function(Object message);
+
 class PushService {
   static const kFCMPushToken = "fcm_push_token";
   static const kLastFCMTokenUpdationTime = "fcm_push_token_updation_time";
@@ -27,14 +29,20 @@ class PushService {
 
   PushService._privateConstructor();
 
-  Future<void> init() async {
+  Future<void> init({BackgroundPushHandler? onBackgroundPush}) async {
     _prefs = await SharedPreferences.getInstance();
     await Firebase.initializeApp();
+    if (onBackgroundPush != null) {
+      FirebaseMessaging.onBackgroundMessage(
+        onBackgroundPush,
+      );
+    }
     if (_foregroundMessageSubscription != null) {
       await _foregroundMessageSubscription!.cancel();
     }
-    _foregroundMessageSubscription =
-        FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+    _foregroundMessageSubscription = FirebaseMessaging.onMessage.listen((
+      RemoteMessage message,
+    ) {
       _logger.info("Got a message whilst in the foreground!");
       _handleForegroundPushMessage(message);
     });
@@ -45,8 +53,9 @@ class PushService {
       if (Configuration.instance.hasConfiguredAccount()) {
         await _configurePushToken();
       } else {
-        _signedInSubscription =
-            Bus.instance.on<SignedInEvent>().listen((_) async {
+        _signedInSubscription = Bus.instance.on<SignedInEvent>().listen((
+          _,
+        ) async {
           // ignore: unawaited_futures
           _configurePushToken();
         });
@@ -60,8 +69,8 @@ class PushService {
     final String? fcmToken = await FirebaseMessaging.instance.getToken();
     final shouldForceRefreshServerToken =
         DateTime.now().microsecondsSinceEpoch -
-                (_prefs.getInt(kLastFCMTokenUpdationTime) ?? 0) >
-            kFCMTokenUpdationIntervalInMicroSeconds;
+            (_prefs.getInt(kLastFCMTokenUpdationTime) ?? 0) >
+        kFCMTokenUpdationIntervalInMicroSeconds;
     if (fcmToken != null &&
         (_prefs.getString(kFCMPushToken) != fcmToken ||
             shouldForceRefreshServerToken)) {
@@ -105,7 +114,10 @@ class PushService {
     }
   }
 
-  static bool shouldSync(RemoteMessage message) {
+  static bool shouldSync(Object message) {
+    if (message is! RemoteMessage) {
+      return false;
+    }
     return message.data.containsKey(kPushAction) &&
         message.data[kPushAction] == kSync;
   }

--- a/mobile/apps/photos/scripts/check_fdroid_overlay.sh
+++ b/mobile/apps/photos/scripts/check_fdroid_overlay.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+app_root=$(pwd)
+
+fail() {
+    echo "check_fdroid_overlay: $*" >&2
+    exit 1
+}
+
+repo_root=$(git rev-parse --show-toplevel)
+app_rel=${app_root#"$repo_root"/}
+tmp_root=$(mktemp -d "${TMPDIR:-/tmp}/ente-photos-fdroid.XXXXXX")
+worktree="$tmp_root/worktree"
+
+cleanup() {
+    local status=$?
+    git -C "$repo_root" worktree remove --force "$worktree" >/dev/null 2>&1 || true
+    rm -rf "$tmp_root"
+    exit "$status"
+}
+trap cleanup EXIT
+
+git -C "$repo_root" worktree add --detach "$worktree" HEAD >/dev/null
+
+git -C "$repo_root" diff --binary HEAD -- "$app_rel" .github/workflows/mobile-release.yml > "$tmp_root/current.patch"
+if [[ -s "$tmp_root/current.patch" ]]; then
+    git -C "$worktree" apply "$tmp_root/current.patch"
+fi
+
+while IFS= read -r -d "" file; do
+    mkdir -p "$worktree/$(dirname "$file")"
+    cp -p "$repo_root/$file" "$worktree/$file"
+done < <(
+    git -C "$repo_root" ls-files \
+        --others \
+        --exclude-standard \
+        -z \
+        -- "$app_rel"
+)
+
+cd "$worktree/mobile/apps/photos"
+
+./scripts/prepare_fdroid_source.sh
+flutter pub get
+
+if rg -n "firebase_core|firebase_messaging|in_app_purchase" pubspec.yaml pubspec.lock; then
+    fail "restricted dependencies remain after flutter pub get"
+fi
+
+command -v flutter_rust_bridge_codegen >/dev/null \
+    || fail "flutter_rust_bridge_codegen is required; install it with cargo install flutter_rust_bridge_codegen"
+
+pushd ../../packages/rust >/dev/null
+flutter_rust_bridge_codegen generate
+popd >/dev/null
+flutter_rust_bridge_codegen generate
+
+flutter analyze --no-pub
+flutter build apk \
+    --config-only \
+    --flavor fdroid \
+    -t lib/main.dart \
+    --dart-define=cronetHttpNoPlay=true \
+    --no-pub

--- a/mobile/apps/photos/scripts/create_tag.sh
+++ b/mobile/apps/photos/scripts/create_tag.sh
@@ -1,66 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-#!/bin/bash
+cd "$(dirname "$0")/.."
 
-# Function to display usage
-usage() {
-    echo "Usage: $0 tag"
+[[ $# -eq 1 ]] || {
+    echo "Usage: $0 fdroid-vX.Y.Z" >&2
     exit 1
 }
 
-# Ensure a tag was provided
-[[ $# -eq 0 ]] && usage
+tag="$1"
+version=$(awk '/^version:/ { print $2 }' pubspec.yaml | cut -d "+" -f 1)
 
-# Exit immediately if a command exits with a non-zero status
-set -e
-
-# Go to the project root directory
-cd "$(dirname "$0")/.."
-
-# Get the tag from the command line argument
-TAG=$1
-
-# Get the current branch
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-# Get the version from the pubspec.yaml file and cut everything after the +
-VERSION=$(grep "^version:" pubspec.yaml | awk '{ print $2 }' | cut -d '+' -f 1)
-
-
-# Check the current branch and set the tag prefix
-if [[ $BRANCH == "independent" ]]; then
-    PREFIX="v"
-elif [[ $BRANCH == "f-droid" ]]; then
-    PREFIX="fdroid-"
-    # Additional checks for f-droid branch
-    # Verify that the pubspec.yaml doesn't contain certain words
-    WORDS=("in_app_purchase" "firebase")
-    for word in ${WORDS[@]}; do
-        if grep -q $word pubspec.yaml; then
-            echo "The pubspec.yaml file dependency on '$word', which is not allowed on the f-droid branch."
-            exit 1
-        fi
-    done
-else
-    echo "Tags can only be created on the independent or f-droid branches."
+[[ "$tag" == fdroid-v* ]] || {
+    echo "create_tag: expected fdroid-v tag" >&2
     exit 1
-fi
+}
 
-# Ensure the tag has the correct prefix
-if [[ $TAG != $PREFIX* ]]; then
-    echo "Invalid tag. On the $BRANCH branch, tags must start with '$PREFIX'."
+[[ "${tag#fdroid-v}" == "$version" ]] || {
+    echo "create_tag: pubspec version $version does not match $tag" >&2
     exit 1
-fi
+}
 
-# Ensure the tag version is in the pubspec.yaml file
-if [[ $TAG != *$VERSION ]]; then
-    echo "Invalid tag."
-    echo "The version $VERSION in pubspec doesn't match the version in tag $TAG."
-    exit 1
-fi
-
-## If all checks pass, create the tag
-git tag $TAG
-echo "Tag $TAG created."
-
-exit 0
+./scripts/check_fdroid_overlay.sh
+git tag "$tag"
+echo "Tag $tag created."

--- a/mobile/apps/photos/scripts/prepare_fdroid_source.sh
+++ b/mobile/apps/photos/scripts/prepare_fdroid_source.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+    echo "prepare_fdroid_source: $*" >&2
+    exit 1
+}
+
+remove_direct_dependencies() {
+    local count
+    count=$(rg -c "^  (firebase_core|firebase_messaging|in_app_purchase):" pubspec.yaml || true)
+    [[ "$count" == "3" ]] || fail "expected three restricted dependencies in pubspec.yaml"
+    perl -0pi -e 's/^  (firebase_core|firebase_messaging|in_app_purchase):[^\n]*\n//mg' pubspec.yaml
+}
+
+copy_fdroid_overlay() {
+    cp -R fdroid/overlay/lib/. lib/
+}
+
+assert_fdroid_source() {
+    if rg -n "package:(firebase_core|firebase_messaging|in_app_purchase)" lib pubspec.yaml; then
+        fail "restricted package imports or direct dependencies remain"
+    fi
+
+    if rg -n "FirebaseMessaging|Firebase\\.initializeApp|RemoteMessage|InAppPurchase|PurchaseStatus" lib; then
+        fail "restricted Firebase or in-app purchase references remain"
+    fi
+}
+
+remove_direct_dependencies
+copy_fdroid_overlay
+assert_fdroid_source


### PR DESCRIPTION
## Summary
- Isolate Photos push and store purchase integrations behind small replaceable files.
- Add an F-Droid source overlay and smoke-check script for validating the transformed source without tagging.
- Remove the Sentry DSN from the F-Droid manifest and document F-Droid tagging from main.

## Test plan
- `bash -n mobile/apps/photos/scripts/create_tag.sh mobile/apps/photos/scripts/prepare_fdroid_source.sh mobile/apps/photos/scripts/check_fdroid_overlay.sh`
- `git diff --check`
- `cd mobile/apps/photos && flutter analyze`
- `cd mobile/apps/photos && flutter build apk --config-only --flavor independent -t lib/main.dart --dart-define=cronetHttpNoPlay=true --no-pub`
- `cd mobile/apps/photos && ./scripts/check_fdroid_overlay.sh`
