### PR TITLE
[mob][photos] Fix offline to online gallery transition

### DIFF
--- a/mobile/apps/photos/lib/services/sync/sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/sync_service.dart
@@ -9,6 +9,7 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/errors.dart';
 import 'package:photos/core/event_bus.dart';
+import 'package:photos/events/account_configured_event.dart';
 import 'package:photos/events/subscription_purchased_event.dart';
 import 'package:photos/events/sync_status_update_event.dart';
 import 'package:photos/events/trigger_logout_event.dart';
@@ -40,6 +41,33 @@ class SyncService {
     Bus.instance.on<SubscriptionPurchasedEvent>().listen((event) {
       _uploader.clearQueue(SilentlyCancelUploadsError());
       sync();
+    });
+
+    Bus.instance.on<AccountConfiguredEvent>().listen((event) {
+      // This listener is only a transition hook for local-gallery -> online
+      // login. First import must have materialized local rows before remote
+      // sync can merge server files into them.
+      if (!Configuration.instance.hasConfiguredAccount() ||
+          isLocalGalleryMode) {
+        _logger.info(
+          "Account configured event ignored; account is not ready for online sync",
+        );
+        return;
+      }
+      if (!_localSyncService.hasCompletedFirstImport()) {
+        _logger.info(
+          "Account configured event ignored; first gallery import is not completed",
+        );
+        return;
+      }
+      if (isSyncInProgress()) {
+        _logger.info(
+          "Account configured while sync is already in progress, skipping extra trigger",
+        );
+        return;
+      }
+      _logger.info("Account configured, triggering sync");
+      unawaited(sync());
     });
 
     Connectivity().onConnectivityChanged.listen((

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -109,6 +109,7 @@ class _HomeWidgetState extends State<HomeWidget> {
 
   final PageController _pageController = PageController();
   int _selectedTabIndex = 0;
+  final ValueNotifier<int> _selectedTabIndexNotifier = ValueNotifier<int>(0);
   final ValueNotifier<double> _christmasPullOffsetNotifier =
       ValueNotifier<double>(0);
   final ValueNotifier<bool> _christmasPullReleasedNotifier =
@@ -163,6 +164,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     ) {
       final previousTabIndex = _selectedTabIndex;
       _selectedTabIndex = event.selectedIndex;
+      _selectedTabIndexNotifier.value = event.selectedIndex;
 
       if (event.selectedIndex == 3) {
         isOnSearchTabNotifier.value = true;
@@ -210,6 +212,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     _loggedOutEvent = Bus.instance.on<UserLoggedOutEvent>().listen((event) {
       _logger.info('logged out, selectTab index to 0');
       _selectedTabIndex = 0;
+      _selectedTabIndexNotifier.value = 0;
       if (mounted) {
         setState(() {});
       }
@@ -546,6 +549,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     _homepageSwipeToSelectInProgressEventSubscription.cancel();
     _christmasBannerEventSubscription.cancel();
     _swipeToSelectInProgressNotifier.dispose();
+    _selectedTabIndexNotifier.dispose();
     _christmasPullOffsetNotifier.dispose();
     _christmasPullReleasedNotifier.dispose();
     super.dispose();
@@ -1007,23 +1011,44 @@ class _HomeWidgetState extends State<HomeWidget> {
             return ValueListenableBuilder(
               valueListenable: _swipeToSelectInProgressNotifier,
               builder: (context, inProgress, child) {
-                return ExtentsPageView(
-                  onPageChanged: (page) {
-                    Bus.instance.fire(
-                      TabChangedEvent(page, TabChangedEventSource.pageView),
+                return ValueListenableBuilder<int>(
+                  valueListenable: _selectedTabIndexNotifier,
+                  builder: (context, selectedTabIndex, _) {
+                    return ExtentsPageView(
+                      onPageChanged: (page) {
+                        Bus.instance.fire(
+                          TabChangedEvent(page, TabChangedEventSource.pageView),
+                        );
+                      },
+                      controller: _pageController,
+                      openDrawer: Scaffold.of(context).openDrawer,
+                      physics: inProgress
+                          ? const NeverScrollableScrollPhysics()
+                          : const BouncingScrollPhysics(),
+                      children: [
+                        _buildTabHeroMode(
+                          0,
+                          selectedTabIndex,
+                          child!,
+                        ),
+                        _buildTabHeroMode(
+                          1,
+                          selectedTabIndex,
+                          AlbumsTab(selectedAlbums: _selectedAlbums),
+                        ),
+                        _buildTabHeroMode(
+                          2,
+                          selectedTabIndex,
+                          _feedTab,
+                        ),
+                        _buildTabHeroMode(
+                          3,
+                          selectedTabIndex,
+                          _searchTab,
+                        ),
+                      ],
                     );
                   },
-                  controller: _pageController,
-                  openDrawer: Scaffold.of(context).openDrawer,
-                  physics: inProgress
-                      ? const NeverScrollableScrollPhysics()
-                      : const BouncingScrollPhysics(),
-                  children: [
-                    child!,
-                    AlbumsTab(selectedAlbums: _selectedAlbums),
-                    _feedTab,
-                    _searchTab,
-                  ],
                 );
               },
               child: NotificationListener<ScrollNotification>(
@@ -1091,6 +1116,13 @@ class _HomeWidgetState extends State<HomeWidget> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildTabHeroMode(int tabIndex, int selectedTabIndex, Widget child) {
+    return HeroMode(
+      enabled: tabIndex == selectedTabIndex,
+      child: child,
     );
   }
 

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,5 +1,6 @@
 Latest changes:
 - Neeraj: Ignore missing files during stale upload cleanup [Sentry]
+- Neeraj: Fix blank gallery after switching from offline mode to online account
 - Neeraj: Fix smart memories and ML lookup failures for large offline galleries [Sentry]
 - Neeraj: Stop reporting inline OCR pre-check timeouts as errors [Sentry]
 - Neeraj: Avoid repeated iOS reupload checks when copied temp files are already cleaned up [Sentry]


### PR DESCRIPTION
## Summary
- Fix blank gallery after switching from local-gallery/offline mode to an online account.
- Trigger account-configured sync only after first local import has completed so remote sync can merge into local rows correctly.
- Disable Hero participation for inactive home tabs to avoid duplicate device-folder Hero tags.

## Root cause
Offline-to-online login switched the app into online mode without a follow-up remote sync, so the online gallery could show no files. The account-configured sync must wait for first local import because remote `_storeDiff` depends on existing local rows to preserve local identity while merging server files.

## Test plan
- `flutter analyze lib/services/sync/sync_service.dart lib/ui/tabs/home_widget.dart`