### PR TITLE
Fix Auth theme reset and autofill hints

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -28,7 +28,12 @@ import 'package:window_manager/window_manager.dart';
 
 class App extends StatefulWidget {
   final Locale? locale;
-  const App({super.key, this.locale = const Locale("en")});
+  final AdaptiveThemeMode savedThemeMode;
+  const App({
+    super.key,
+    this.locale = const Locale("en"),
+    this.savedThemeMode = AdaptiveThemeMode.system,
+  });
 
   static void setLocale(BuildContext context, Locale newLocale) {
     _AppState state = context.findAncestorStateOfType<_AppState>()!;
@@ -124,31 +129,33 @@ class _AppState extends State<App>
       return AdaptiveTheme(
         light: lightThemeData,
         dark: darkThemeData,
-        initial: AdaptiveThemeMode.system,
-        builder: (lightTheme, dartTheme) => MaterialApp(
-          title: "ente",
-          themeMode: ThemeMode.system,
-          theme: lightTheme,
-          darkTheme: dartTheme,
-          debugShowCheckedModeBanner: false,
-          locale: locale,
-          supportedLocales: appSupportedLocales,
-          localeListResolutionCallback: localResolutionCallBack,
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            StringsLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
-          routes: _getRoutes,
-          builder: _materialAppBuilder,
+        initial: widget.savedThemeMode,
+        builder: (lightTheme, darkTheme) => Builder(
+          builder: (context) => MaterialApp(
+            title: "ente",
+            themeMode: _themeMode(AdaptiveTheme.of(context).mode),
+            theme: lightTheme,
+            darkTheme: darkTheme,
+            debugShowCheckedModeBanner: false,
+            locale: locale,
+            supportedLocales: appSupportedLocales,
+            localeListResolutionCallback: localResolutionCallBack,
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              StringsLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            routes: _getRoutes,
+            builder: _materialAppBuilder,
+          ),
         ),
       );
     } else {
       return MaterialApp(
         title: "ente",
-        themeMode: ThemeMode.system,
+        themeMode: _themeMode(widget.savedThemeMode),
         theme: lightThemeData,
         darkTheme: darkThemeData,
         debugShowCheckedModeBanner: false,
@@ -166,6 +173,12 @@ class _AppState extends State<App>
         builder: _materialAppBuilder,
       );
     }
+  }
+
+  ThemeMode _themeMode(AdaptiveThemeMode mode) {
+    if (mode.isLight) return ThemeMode.light;
+    if (mode.isDark) return ThemeMode.dark;
+    return ThemeMode.system;
   }
 
   Map<String, WidgetBuilder> get _getRoutes {

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -103,7 +103,9 @@ void main() async {
 
 Future<void> _runInForeground() async {
   AppThemeConfig.initialize(EnteApp.auth);
-  final savedThemeMode = _themeMode(await AdaptiveTheme.getThemeMode());
+  final adaptiveThemeMode =
+      await AdaptiveTheme.getThemeMode() ?? AdaptiveThemeMode.system;
+  final savedThemeMode = _themeMode(adaptiveThemeMode);
   final configuration = Configuration.instance;
   return await _runWithLogs(() async {
     _logger.info("Starting app in foreground");
@@ -117,7 +119,8 @@ Future<void> _runInForeground() async {
     unawaited(UpdateService.instance.showUpdateNotification());
     runApp(
       AppLock(
-        builder: (args) => App(locale: locale),
+        builder: (args) =>
+            App(locale: locale, savedThemeMode: adaptiveThemeMode),
         lockScreen: LockScreen(configuration),
         enabled: await LockScreenSettings.instance.shouldShowLockScreen(),
         locale: locale,

--- a/mobile/apps/auth/lib/ui/components/text_input_widget.dart
+++ b/mobile/apps/auth/lib/ui/components/text_input_widget.dart
@@ -29,6 +29,7 @@ class TextInputWidget extends StatefulWidget {
   final bool shouldSurfaceExecutionStates;
   final TextCapitalization? textCapitalization;
   final bool isPasswordInput;
+  final Iterable<String>? autofillHints;
   final bool cancellable;
   final bool shouldUnfocusOnCancelOrSubmit;
   const TextInputWidget({
@@ -49,6 +50,7 @@ class TextInputWidget extends StatefulWidget {
     this.shouldSurfaceExecutionStates = true,
     this.textCapitalization = TextCapitalization.none,
     this.isPasswordInput = false,
+    this.autofillHints,
     this.cancellable = false,
     this.shouldUnfocusOnCancelOrSubmit = false,
     super.key,
@@ -124,6 +126,11 @@ class _TextInputWidgetState extends State<TextInputWidget> {
             inputFormatters: widget.maxLength != null
                 ? [LengthLimitingTextInputFormatter(50)]
                 : null,
+            autofillHints:
+                widget.autofillHints ??
+                (widget.isPasswordInput
+                    ? const [AutofillHints.password]
+                    : null),
             obscureText: _obscureTextNotifier.value,
             decoration: InputDecoration(
               hintText: widget.hintText,

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 - Upgraded Auth to Flutter 3.38.10 and Android target SDK 36
+- Fixed saved theme selection being reset after unlocking Auth and improved password manager autofill detection for password fields
 - Added custom icons for 1984 Hosting, Art Fight, BJ-Share, CatRealm, Cove Backup, eClinicalWorks, HaloPSA, JumpCloud, Patchmon, Racket Coach, RustDesk, Sherweb, Smogon, Sony, Zabbix, and Zyxel Nebula
 - Updated the Availity custom icon and fixed several multi-color custom icons rendering as single-color masks
 - Preserved maximized window state across desktop app launches

--- a/mobile/packages/ui/lib/components/text_input_widget.dart
+++ b/mobile/packages/ui/lib/components/text_input_widget.dart
@@ -29,6 +29,7 @@ class TextInputWidget extends StatefulWidget {
   final bool shouldSurfaceExecutionStates;
   final TextCapitalization? textCapitalization;
   final bool isPasswordInput;
+  final Iterable<String>? autofillHints;
   final bool cancellable;
   final bool shouldUnfocusOnCancelOrSubmit;
   const TextInputWidget({
@@ -49,6 +50,7 @@ class TextInputWidget extends StatefulWidget {
     this.shouldSurfaceExecutionStates = true,
     this.textCapitalization = TextCapitalization.none,
     this.isPasswordInput = false,
+    this.autofillHints,
     this.cancellable = false,
     this.shouldUnfocusOnCancelOrSubmit = false,
     super.key,
@@ -124,6 +126,11 @@ class _TextInputWidgetState extends State<TextInputWidget> {
             inputFormatters: widget.maxLength != null
                 ? [LengthLimitingTextInputFormatter(50)]
                 : null,
+            autofillHints:
+                widget.autofillHints ??
+                (widget.isPasswordInput
+                    ? const [AutofillHints.password]
+                    : null),
             obscureText: _obscureTextNotifier.value,
             decoration: InputDecoration(
               hintText: widget.hintText,


### PR DESCRIPTION
## Summary
- pass the saved AdaptiveTheme mode into Auth App so the nested MaterialApp does not reset to system theme after startup
- add password autofill hints to Auth-local and shared password TextInputWidget implementations
- update Auth internal changes for the theme and autofill fixes

Fixes #10466
Fixes #1303

## Tests
- `flutter analyze lib/main.dart lib/app/view/app.dart lib/ui/components/text_input_widget.dart` in `mobile/apps/auth`
- `flutter analyze lib/components/text_input_widget.dart` in `mobile/packages/ui`
- `git diff --check`
