### PR TITLE
[mob] Simplify mobile theme startup

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -122,57 +122,32 @@ class _AppState extends State<App>
 
   @override
   Widget build(BuildContext context) {
-    if (Platform.isAndroid ||
-        Platform.isWindows ||
-        Platform.isLinux ||
-        kDebugMode) {
-      return AdaptiveTheme(
-        light: lightThemeData,
-        dark: darkThemeData,
-        initial: widget.savedThemeMode,
-        builder: (lightTheme, darkTheme) => Builder(
-          builder: (context) => MaterialApp(
-            title: "ente",
-            themeMode: _themeMode(AdaptiveTheme.of(context).mode),
-            theme: lightTheme,
-            darkTheme: darkTheme,
-            debugShowCheckedModeBanner: false,
-            locale: locale,
-            supportedLocales: appSupportedLocales,
-            localeListResolutionCallback: localResolutionCallBack,
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              StringsLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-            ],
-            routes: _getRoutes,
-            builder: _materialAppBuilder,
-          ),
+    return AdaptiveTheme(
+      light: lightThemeData,
+      dark: darkThemeData,
+      initial: widget.savedThemeMode,
+      builder: (lightTheme, darkTheme) => Builder(
+        builder: (context) => MaterialApp(
+          title: "ente",
+          themeMode: _themeMode(AdaptiveTheme.of(context).mode),
+          theme: lightTheme,
+          darkTheme: darkTheme,
+          debugShowCheckedModeBanner: false,
+          locale: locale,
+          supportedLocales: appSupportedLocales,
+          localeListResolutionCallback: localResolutionCallBack,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            StringsLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          routes: _getRoutes,
+          builder: _materialAppBuilder,
         ),
-      );
-    } else {
-      return MaterialApp(
-        title: "ente",
-        themeMode: _themeMode(widget.savedThemeMode),
-        theme: lightThemeData,
-        darkTheme: darkThemeData,
-        debugShowCheckedModeBanner: false,
-        locale: locale,
-        supportedLocales: appSupportedLocales,
-        localeListResolutionCallback: localResolutionCallBack,
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          StringsLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        routes: _getRoutes,
-        builder: _materialAppBuilder,
-      );
-    }
+      ),
+    );
   }
 
   ThemeMode _themeMode(AdaptiveThemeMode mode) {
@@ -183,7 +158,8 @@ class _AppState extends State<App>
 
   Map<String, WidgetBuilder> get _getRoutes {
     return {
-      "/": (context) => Configuration.instance.hasConfiguredAccount() ||
+      "/": (context) =>
+          Configuration.instance.hasConfiguredAccount() ||
               Configuration.instance.hasOptedForOfflineMode()
           ? const HomePage()
           : const OnboardingPage(),
@@ -254,8 +230,8 @@ class _AppState extends State<App>
 
   @override
   void onWindowClose() {
-    final shouldMinimizeToTray =
-        PreferenceService.instance.shouldMinimizeToTrayOnClose();
+    final shouldMinimizeToTray = PreferenceService.instance
+        .shouldMinimizeToTrayOnClose();
     if (shouldMinimizeToTray) {
       windowManager.hide();
       windowManager.setSkipTaskbar(true);

--- a/mobile/apps/locker/lib/app.dart
+++ b/mobile/apps/locker/lib/app.dart
@@ -9,7 +9,6 @@ import 'package:ente_events/models/signed_out_event.dart';
 import 'package:ente_strings/l10n/strings_localizations.dart';
 import "package:ente_ui/theme/ente_theme_data.dart";
 import 'package:ente_ui/utils/window_listener_service.dart';
-import 'package:flutter/foundation.dart';
 import "package:flutter/material.dart";
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:locker/core/locale.dart';
@@ -29,11 +28,7 @@ class App extends StatefulWidget {
   final Locale? locale;
   final AdaptiveThemeMode? savedThemeMode;
 
-  const App({
-    super.key,
-    this.locale = const Locale("en"),
-    this.savedThemeMode,
-  });
+  const App({super.key, this.locale = const Locale("en"), this.savedThemeMode});
 
   static void setLocale(BuildContext context, Locale newLocale) {
     final _AppState state = context.findAncestorStateOfType<_AppState>()!;
@@ -105,8 +100,8 @@ class _AppState extends State<App>
   }
 
   Future<bool> _checkForAppUpdates() async {
-    final shouldShow =
-        await UpdateService.instance.shouldShowUpdateNotification();
+    final shouldShow = await UpdateService.instance
+        .shouldShowUpdateNotification();
     if (!shouldShow || !mounted) {
       return false;
     }
@@ -116,10 +111,7 @@ class _AppState extends State<App>
       return false;
     }
 
-    await showAppUpdateBottomSheet(
-      context,
-      latestVersionInfo: latestVersion,
-    );
+    await showAppUpdateBottomSheet(context, latestVersionInfo: latestVersion);
     await UpdateService.instance.markUpdateNotificationShown();
     return true;
   }
@@ -159,39 +151,15 @@ class _AppState extends State<App>
   @override
   Widget build(BuildContext context) {
     Widget buildApp() {
-      if (Platform.isAndroid ||
-          Platform.isWindows ||
-          Platform.isLinux ||
-          kDebugMode) {
-        return AdaptiveTheme(
-          light: lightThemeData,
-          dark: darkThemeData,
-          initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
-          builder: (lightTheme, dartTheme) => MaterialApp(
-            title: "ente",
-            themeMode: ThemeMode.system,
-            theme: lightTheme,
-            darkTheme: dartTheme,
-            debugShowCheckedModeBanner: false,
-            locale: locale,
-            supportedLocales: appSupportedLocales,
-            localeListResolutionCallback: localResolutionCallBack,
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              StringsLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-            ],
-            routes: _getRoutes,
-          ),
-        );
-      } else {
-        return MaterialApp(
+      return AdaptiveTheme(
+        light: lightThemeData,
+        dark: darkThemeData,
+        initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
+        builder: (lightTheme, dartTheme) => MaterialApp(
           title: "ente",
           themeMode: ThemeMode.system,
-          theme: lightThemeData,
-          darkTheme: darkThemeData,
+          theme: lightTheme,
+          darkTheme: dartTheme,
           debugShowCheckedModeBanner: false,
           locale: locale,
           supportedLocales: appSupportedLocales,
@@ -204,8 +172,8 @@ class _AppState extends State<App>
             GlobalWidgetsLocalizations.delegate,
           ],
           routes: _getRoutes,
-        );
-      }
+        ),
+      );
     }
 
     // Wrap the app with MediaQuery to control text scaling and ensure

--- a/mobile/apps/photos/lib/app.dart
+++ b/mobile/apps/photos/lib/app.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:adaptive_theme/adaptive_theme.dart';
 import "package:ente_pure_utils/ente_pure_utils.dart";
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:home_widget/home_widget.dart' as hw;
@@ -87,12 +86,13 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
   }
 
   void setupSubscription() {
-    _memoriesChangedSubscription =
-        Bus.instance.on<MemoriesChangedEvent>().listen(
-      (event) async {
-        await MemoryHomeWidgetService.instance.memoryChanged();
-      },
-    );
+    _memoriesChangedSubscription = Bus.instance
+        .on<MemoriesChangedEvent>()
+        .listen(
+          (event) async {
+            await MemoryHomeWidgetService.instance.memoryChanged();
+          },
+        );
     _changeCallbackDebouncer = Debouncer(const Duration(milliseconds: 1500));
     _peopleChangedSubscription = Bus.instance.on<PeopleChangedEvent>().listen(
       (event) async {
@@ -136,7 +136,8 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
   }
 
   Future<Widget> _resolveInitialAndroidHome() async {
-    final mediaExtentionAction = widget.initialMediaExtensionAction ??
+    final mediaExtentionAction =
+        widget.initialMediaExtensionAction ??
         (Platform.isAndroid
             ? await initIntentAction()
             : MediaExtentionAction(action: IntentAction.main));
@@ -215,45 +216,21 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    if (Platform.isAndroid || kDebugMode) {
-      return Listener(
-        onPointerDown: (event) {
-          computeController.onUserInteraction();
-        },
-        child: AdaptiveTheme(
-          light: lightThemeData,
-          dark: darkThemeData,
-          initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
-          builder: (lightTheme, dartTheme) => MaterialApp(
-            navigatorKey: AppNavigationService.instance.navigatorKey,
-            title: "ente",
-            themeMode: ThemeMode.system,
-            theme: lightTheme,
-            darkTheme: dartTheme,
-            home: _buildHome(),
-            debugShowCheckedModeBanner: false,
-            builder: EasyLoading.init(),
-            locale: locale,
-            supportedLocales: appSupportedLocales,
-            localeListResolutionCallback: localResolutionCallBack,
-            localizationsDelegates: const [
-              ...AppLocalizations.localizationsDelegates,
-            ],
-          ),
-        ),
-      );
-    } else {
-      return Listener(
-        onPointerDown: (event) {
-          computeController.onUserInteraction();
-        },
-        child: MaterialApp(
+    return Listener(
+      onPointerDown: (event) {
+        computeController.onUserInteraction();
+      },
+      child: AdaptiveTheme(
+        light: lightThemeData,
+        dark: darkThemeData,
+        initial: widget.savedThemeMode ?? AdaptiveThemeMode.system,
+        builder: (lightTheme, dartTheme) => MaterialApp(
           navigatorKey: AppNavigationService.instance.navigatorKey,
           title: "ente",
           themeMode: ThemeMode.system,
-          theme: lightThemeData,
-          darkTheme: darkThemeData,
-          home: const HomeWidget(),
+          theme: lightTheme,
+          darkTheme: dartTheme,
+          home: _buildHome(),
           debugShowCheckedModeBanner: false,
           builder: EasyLoading.init(),
           locale: locale,
@@ -263,8 +240,8 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
             ...AppLocalizations.localizationsDelegates,
           ],
         ),
-      );
-    }
+      ),
+    );
   }
 
   @override
@@ -283,8 +260,9 @@ class _EnteAppState extends State<EnteApp> with WidgetsBindingObserver {
     final String stateChangeReason = 'app -> $state';
     if (state == AppLifecycleState.resumed) {
       final lastAppOpenTime = AppLifecycleService.instance.getLastAppOpenTime();
-      AppLifecycleService.instance
-          .onAppInForeground(stateChangeReason + ': sync now');
+      AppLifecycleService.instance.onAppInForeground(
+        stateChangeReason + ': sync now',
+      );
       if (_isPickerLaunch) {
         return;
       }

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
@@ -28,6 +28,7 @@ class SettingsSearchRegistry {
     final l10n = AppLocalizations.of(context);
     final hasLoggedIn = Configuration.instance.isLoggedIn();
     final isLocalGallery = isLocalGalleryMode;
+    final showThemeControls = Platform.isAndroid || kDebugMode;
     final items = <SettingsSearchItem>[];
 
     // Account settings
@@ -281,11 +282,13 @@ class SettingsSearchRegistry {
         sectionPath: l10n.appearance,
         icon: HugeIcons.strokeRoundedPaintBoard,
         routeBuilder: (_) => const AppearanceSettingsPage(),
-        keywords: ["theme", "dark mode", "light mode", "app icon"],
+        keywords: showThemeControls
+            ? ["theme", "dark mode", "light mode", "app icon"]
+            : ["app icon"],
       ),
     );
 
-    if (Platform.isAndroid || kDebugMode) {
+    if (showThemeControls) {
       items.add(
         SettingsSearchItem(
           title: l10n.theme,


### PR DESCRIPTION
## Summary
- Simplify Photos, Auth, and Locker startup so each app shell uses one AdaptiveTheme path.
- Keep iOS release theme controls hidden while preserving saved theme preferences.
- Remove theme/dark/light Photos settings-search keywords when theme controls are hidden.

