### PR TITLE
[mob][auth] Focus newly added codes after add

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1285,6 +1285,15 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  bool get _shouldFocusAddedCode {
+    if ((_showSearchBox && _searchText.isNotEmpty) ||
+        selectedTag.isNotEmpty ||
+        _isTrashOpen) {
+      return true;
+    }
+    return (_allCodes?.where((e) => !e.hasError).length ?? 0) > 2;
+  }
+
   Future<void> _importFromGalleryNative() async {
     if (_isImportingFromGallery) {
       return;
@@ -1299,7 +1308,7 @@ class _HomePageState extends State<HomePage> {
       }
       await CodeStore.instance.addCode(newCode, shouldSync: false);
       // Focus the new code by searching
-      if ((_allCodes?.where((e) => !e.hasError).length ?? 0) > 2) {
+      if (_shouldFocusAddedCode) {
         _focusNewCode(newCode);
       }
       LocalBackupService.instance.triggerDailyBackupIfNeeded().ignore();
@@ -1322,7 +1331,7 @@ class _HomePageState extends State<HomePage> {
         shouldSync: result.fromGallery ? false : true,
       );
       // Focus the new code by searching
-      if ((_allCodes?.where((e) => !e.hasError).length ?? 0) > 2) {
+      if (_shouldFocusAddedCode) {
         _focusNewCode(result.code);
       }
       LocalBackupService.instance.triggerDailyBackupIfNeeded().ignore();
@@ -1339,6 +1348,9 @@ class _HomePageState extends State<HomePage> {
     );
     if (code != null) {
       await CodeStore.instance.addCode(code);
+      if (_shouldFocusAddedCode) {
+        _focusNewCode(code);
+      }
       LocalBackupService.instance.triggerDailyBackupIfNeeded().ignore();
     }
   }
@@ -1990,6 +2002,8 @@ class _HomePageState extends State<HomePage> {
 
   void _focusNewCode(Code newCode) {
     _showSearchBox = true;
+    selectedTag = "";
+    _isTrashOpen = false;
     _textController.text = newCode.account;
     _searchText = newCode.account;
     _applyFilteringAndRefresh();

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -1,5 +1,6 @@
 - Upgraded Auth to Flutter 3.38.10 and Android target SDK 36
 - Fixed saved theme selection being reset after unlocking Auth and improved password manager autofill detection for password fields
+- Focus newly added Auth codes so stale search or tag filters do not hide successful additions
 - Added custom icons for 1984 Hosting, Art Fight, BJ-Share, CatRealm, Cove Backup, eClinicalWorks, HaloPSA, JumpCloud, Patchmon, Racket Coach, RustDesk, Sherweb, Smogon, Sony, Zabbix, and Zyxel Nebula
 - Updated the Availity custom icon and fixed several multi-color custom icons rendering as single-color masks
 - Preserved maximized window state across desktop app launches


### PR DESCRIPTION
## Summary
- focus newly added manual Auth codes through the same search path used by scanner and gallery imports
- clear active tag/trash filters when focusing a newly added code so saved codes are not hidden by stale filters
- update Auth internal changes for the add-code focus fix

Fixes #3699
Fixes #7415

## Tests
- `flutter analyze lib/ui/home_page.dart` in `mobile/apps/auth`
- `git diff --check`
