### PR TITLE
[mob][auth] Include tags in code search

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1188,6 +1188,7 @@ class _HomePageState extends State<HomePage> {
       final List<Code> issuerMatch = [];
       final List<Code> accountMatch = [];
       final List<Code> noteMatch = [];
+      final List<Code> tagMatch = [];
 
       for (final Code codeState in _allCodes!) {
         if (codeState.hasError ||
@@ -1203,11 +1204,16 @@ class _HomePageState extends State<HomePage> {
           accountMatch.add(codeState);
         } else if (codeState.note.toLowerCase().contains(val)) {
           noteMatch.add(codeState);
+        } else if (codeState.display.tags.any(
+          (tag) => tag.toLowerCase().contains(val),
+        )) {
+          tagMatch.add(codeState);
         }
       }
       _filteredCodes = issuerMatch;
       _filteredCodes.addAll(accountMatch);
       _filteredCodes.addAll(noteMatch);
+      _filteredCodes.addAll(tagMatch);
     } else if (_isTrashOpen) {
       _filteredCodes = _allCodes
               ?.where(

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -1,6 +1,7 @@
 - Upgraded Auth to Flutter 3.38.10 and Android target SDK 36
 - Fixed saved theme selection being reset after unlocking Auth and improved password manager autofill detection for password fields
 - Focus newly added Auth codes so stale search or tag filters do not hide successful additions
+- Include tag names when searching Auth codes
 - Added custom icons for 1984 Hosting, Art Fight, BJ-Share, CatRealm, Cove Backup, eClinicalWorks, HaloPSA, JumpCloud, Patchmon, Racket Coach, RustDesk, Sherweb, Smogon, Sony, Zabbix, and Zyxel Nebula
 - Updated the Availity custom icon and fixed several multi-color custom icons rendering as single-color masks
 - Preserved maximized window state across desktop app launches


### PR DESCRIPTION
## Summary
- include Auth tag names as a search-result bucket after issuer/account/note matches
- preserve the existing search priority while allowing tag-only queries to return matching codes
- update Auth internal changes for tag search

Fixes #5291

## Notes
- The tag chip strip overflow mentioned in the issue appears already addressed by the current horizontal tag ListView and should be retested separately.

## Tests
- `flutter analyze lib/ui/home_page.dart` in `mobile/apps/auth`
- `git diff --check`
