### PR TITLE
[auth] Restore Auth macOS keychain entitlement signing

### DIFF
--- a/.github/workflows/auth-beta-release.yml
+++ b/.github/workflows/auth-beta-release.yml
@@ -386,6 +386,16 @@ jobs:
               run: |
                   pip3 install codemagic-cli-tools --break-system-packages
 
+            - name: Add provisioning profiles
+              run: |
+                  PROFILES_HOME="$HOME/Library/MobileDevice/Provisioning Profiles"
+                  mkdir -p "$PROFILES_HOME"
+                  PROFILE_PATH="$(mktemp "$PROFILES_HOME"/$(uuidgen).provisionprofile)"
+                  echo ${CM_PROVISIONING_PROFILE} | base64 --decode > "$PROFILE_PATH"
+                  echo "Saved provisioning profile $PROFILE_PATH"
+              env:
+                  CM_PROVISIONING_PROFILE: ${{ secrets.MAC_OS_BUILD_PROVISION_PROFILE_BASE64 }}
+
             - name: Add certificates
               run: |
                   # create variables
@@ -397,6 +407,9 @@ jobs:
                   # add certificate to keychain
                   keychain initialize
                   keychain add-certificates --certificate $CERTIFICATE_PATH --certificate-password $P12_PASSWORD
+
+                  # Use profile in current project
+                  xcode-project use-profiles --project=macos/**/*.xcodeproj
 
                   signing_settings="$RUNNER_TEMP/auth-macos-ci-signing.xcconfig"
                   printf '%s\n' \

--- a/.github/workflows/auth-release.yml
+++ b/.github/workflows/auth-release.yml
@@ -330,6 +330,16 @@ jobs:
               run: |
                   pip3 install codemagic-cli-tools --break-system-packages
 
+            - name: Add provisioning profiles
+              run: |
+                  PROFILES_HOME="$HOME/Library/MobileDevice/Provisioning Profiles"
+                  mkdir -p "$PROFILES_HOME"
+                  PROFILE_PATH="$(mktemp "$PROFILES_HOME"/$(uuidgen).provisionprofile)"
+                  echo ${CM_PROVISIONING_PROFILE} | base64 --decode > "$PROFILE_PATH"
+                  echo "Saved provisioning profile $PROFILE_PATH"
+              env:
+                  CM_PROVISIONING_PROFILE: ${{ secrets.MAC_OS_BUILD_PROVISION_PROFILE_BASE64 }}
+
             - name: Add certificates
               run: |
                   # create variables
@@ -341,6 +351,9 @@ jobs:
                   # add certificate to keychain
                   keychain initialize
                   keychain add-certificates --certificate $CERTIFICATE_PATH --certificate-password $P12_PASSWORD
+
+                  # Use profile in current project
+                  xcode-project use-profiles --project=macos/**/*.xcodeproj
 
                   signing_settings="$RUNNER_TEMP/auth-macos-ci-signing.xcconfig"
                   printf '%s\n' \

--- a/mobile/apps/auth/macos/Runner/DebugProfile.entitlements
+++ b/mobile/apps/auth/macos/Runner/DebugProfile.entitlements
@@ -14,6 +14,8 @@
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 </dict>

--- a/mobile/apps/auth/macos/Runner/Release.entitlements
+++ b/mobile/apps/auth/macos/Runner/Release.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Restore Auth macOS `keychain-access-groups` entitlement removed by `3823d53b14`.
- Restore the Auth macOS provisioning profile install/use flow removed by `3a8d70ff0d`.
- Keep the later Developer ID CI signing override from `34ec1018f7`.

## Context

Auth beta macOS builds regressed when deleting `flutter_secure_storage` entries with:

```text
PlatformException(Unexpected security result code, Code: -34018, Message: A required entitlement isn't present., -34018, null)
```

The provisioning profile is app-specific, while the Developer ID certificate remains shared across apps. This restores the Auth-specific profile path needed for the keychain entitlement.

Related: https://github.com/juliansteenbakker/flutter_secure_storage/issues/804

## Validation

- `plutil -lint mobile/apps/auth/macos/Runner/Release.entitlements mobile/apps/auth/macos/Runner/DebugProfile.entitlements`
- YAML parse check for `.github/workflows/auth-release.yml` and `.github/workflows/auth-beta-release.yml`
- `git diff --check`
- Verified Auth macOS entitlements match `3823d53b14^` exactly
