### PR TITLE
[server] Fuse object access checks for file downloads

### DIFF
--- a/server/pkg/api/file_link.go
+++ b/server/pkg/api/file_link.go
@@ -61,7 +61,7 @@ func (h *FileHandler) PasswordInfo(c *gin.Context) {
 
 func (h *FileHandler) LinkThumbnail(c *gin.Context) {
 	linkCtx := auth.MustGetFileLinkAccessContext(c)
-	url, err := h.Controller.GetThumbnailURL(c, linkCtx.OwnerID, linkCtx.FileID)
+	url, err := h.Controller.GetThumbnailURLForOwner(c, linkCtx.OwnerID, linkCtx.FileID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -71,7 +71,7 @@ func (h *FileHandler) LinkThumbnail(c *gin.Context) {
 
 func (h *FileHandler) LinkFile(c *gin.Context) {
 	linkCtx := auth.MustGetFileLinkAccessContext(c)
-	url, err := h.Controller.GetFileURL(c, linkCtx.OwnerID, linkCtx.FileID)
+	url, err := h.Controller.GetFileURLForOwner(c, linkCtx.OwnerID, linkCtx.FileID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -431,6 +431,18 @@ func (c *FileController) GetThumbnailURLUsingFusedLookup(ctx *gin.Context, userI
 	return c.getSignedURLForAccessibleObject(ctx, userID, fileID, ente.THUMBNAIL)
 }
 
+// GetFileURLForOwner verifies ownership and returns a presigned URL using a
+// fused ownership-check and object lookup path.
+func (c *FileController) GetFileURLForOwner(ctx *gin.Context, ownerID int64, fileID int64) (string, error) {
+	return c.getSignedURLForOwnedObject(ctx, ownerID, fileID, ente.FILE)
+}
+
+// GetThumbnailURLForOwner verifies ownership and returns a presigned URL using
+// a fused ownership-check and object lookup path.
+func (c *FileController) GetThumbnailURLForOwner(ctx *gin.Context, ownerID int64, fileID int64) (string, error) {
+	return c.getSignedURLForOwnedObject(ctx, ownerID, fileID, ente.THUMBNAIL)
+}
+
 func (c *FileController) CleanUpStaleCollectionFiles(userID int64, fileID int64) {
 	logger := log.WithFields(log.Fields{
 		"userID": userID,
@@ -462,11 +474,7 @@ func (c *FileController) CleanUpStaleCollectionFiles(userID int64, fileID int64)
 
 // GetPublicOrCastFileURL verifies permissions and returns a presigned url to the requested file
 func (c *FileController) GetPublicOrCastFileURL(ctx *gin.Context, fileID int64, objType ente.ObjectType, collectionID int64) (string, error) {
-	// validate that the given fileID is present in the corresponding collection for public album or cast session
-	if err := c.DoesFileExistInCollection(ctx, fileID, collectionID); err != nil {
-		return "", stacktrace.Propagate(err, "")
-	}
-	return c.getSignedURLForType(ctx, fileID, objType)
+	return c.getSignedURLForCollectionObject(ctx, collectionID, fileID, objType)
 }
 
 func (c *FileController) DoesFileExistInCollection(ctx *gin.Context, fileID int64, collectionID int64) error {
@@ -518,6 +526,64 @@ func (c *FileController) getSignedURLForAccessibleObject(ctx *gin.Context, userI
 	return url, nil
 }
 
+func (c *FileController) getSignedURLForOwnedObject(ctx *gin.Context, ownerID int64, fileID int64, objType ente.ObjectType) (string, error) {
+	var url string
+	var err error
+	if isCliRequest(ctx) {
+		var s3Object ente.S3ObjectKey
+		var dcs []string
+		s3Object, dcs, err = c.ObjectRepo.GetOwnedObjectWithDCs(ctx, fileID, ownerID, objType)
+		if err == nil {
+			url, err = c.getSignedURLFromObjectAndDCs(s3Object, dcs, objType)
+		}
+	} else {
+		var s3Object ente.S3ObjectKey
+		s3Object, err = c.ObjectRepo.GetOwnedObject(ctx, fileID, ownerID, objType)
+		if err == nil {
+			url, err = c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+		}
+	}
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			go c.CleanUpStaleCollectionFiles(ownerID, fileID)
+		}
+		return "", stacktrace.Propagate(err, "")
+	}
+	return url, nil
+}
+
+func (c *FileController) getSignedURLForCollectionObject(ctx *gin.Context, collectionID int64, fileID int64, objType ente.ObjectType) (string, error) {
+	var url string
+	var err error
+	if isCliRequest(ctx) {
+		var s3Object ente.S3ObjectKey
+		var dcs []string
+		s3Object, dcs, err = c.ObjectRepo.GetCollectionObjectWithDCs(ctx, collectionID, fileID, objType)
+		if err == nil {
+			url, err = c.getSignedURLFromObjectAndDCs(s3Object, dcs, objType)
+		}
+	} else {
+		var s3Object ente.S3ObjectKey
+		s3Object, err = c.ObjectRepo.GetCollectionObject(ctx, collectionID, fileID, objType)
+		if err == nil {
+			url, err = c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+		}
+	}
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
+	return url, nil
+}
+
+func (c *FileController) getSignedURLFromObjectAndDCs(s3Object ente.S3ObjectKey, dcs []string, objType ente.ObjectType) (string, error) {
+	for _, dc := range dcs {
+		if dc == c.S3Config.GetHotWasabiDC() {
+			return c.getPreSignedURLForDC(s3Object.ObjectKey, dc, objType)
+		}
+	}
+	return c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+}
+
 // ignore lint unused inspection
 func isCliRequest(ctx *gin.Context) bool {
 	// check if user-agent contains go-resty
@@ -545,12 +611,7 @@ func (c *FileController) getWasabiSignedUrlForAccessibleObject(ctx *gin.Context,
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}
-	for _, dc := range dcs {
-		if dc == c.S3Config.GetHotWasabiDC() {
-			return c.getPreSignedURLForDC(s3Object.ObjectKey, dc, objType)
-		}
-	}
-	return c.getHotDcSignedUrl(s3Object.ObjectKey, objType)
+	return c.getSignedURLFromObjectAndDCs(s3Object, dcs, objType)
 }
 
 // Trash deletes file and move them to trash

--- a/server/pkg/repo/object.go
+++ b/server/pkg/repo/object.go
@@ -148,6 +148,116 @@ func (repo *ObjectRepository) GetAccessibleObjectWithDCs(ctx context.Context, fi
 	return s3ObjectKey, datacenters, nil
 }
 
+// GetOwnedObject verifies ownership and returns the S3 object key in a single
+// latency-sensitive DB query.
+func (repo *ObjectRepository) GetOwnedObject(ctx context.Context, fileID int64, ownerID int64, objType ente.ObjectType) (ente.S3ObjectKey, error) {
+	s3ObjectKey, _, err := repo.GetOwnedObjectWithDCs(ctx, fileID, ownerID, objType)
+	return s3ObjectKey, err
+}
+
+// GetOwnedObjectWithDCs verifies ownership and returns the S3 object key along
+// with replicated datacenters in a single latency-sensitive DB query.
+func (repo *ObjectRepository) GetOwnedObjectWithDCs(ctx context.Context, fileID int64, ownerID int64, objType ente.ObjectType) (ente.S3ObjectKey, []string, error) {
+	row := repo.objectLookupDB().QueryRowContext(ctx, `
+		SELECT
+			f.file_id,
+			f.owner_id = $2 AS is_owner,
+			ok.object_key,
+			ok.size,
+			ok.o_type::text,
+			COALESCE(ok.datacenters, '{}'::s3region[])
+		FROM files f
+		LEFT JOIN object_keys ok
+			ON ok.file_id = f.file_id
+			AND ok.o_type = $3::object_type
+			AND ok.is_deleted = FALSE
+		WHERE f.file_id = $1`,
+		fileID, ownerID, objType)
+
+	var s3ObjectKey ente.S3ObjectKey
+	var isOwner bool
+	var objectKey sql.NullString
+	var fileSize sql.NullInt64
+	var objectType sql.NullString
+	datacenters := make([]string, 0)
+	err := row.Scan(
+		&s3ObjectKey.FileID,
+		&isOwner,
+		&objectKey,
+		&fileSize,
+		&objectType,
+		pq.Array(&datacenters),
+	)
+	if err != nil {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(err, "")
+	}
+	if !isOwner {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(ente.ErrPermissionDenied, "not file owner")
+	}
+	if !objectKey.Valid || !fileSize.Valid || !objectType.Valid {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(sql.ErrNoRows, "")
+	}
+	s3ObjectKey.ObjectKey = objectKey.String
+	s3ObjectKey.FileSize = fileSize.Int64
+	s3ObjectKey.Type = ente.ObjectType(objectType.String)
+	return s3ObjectKey, datacenters, nil
+}
+
+// GetCollectionObject verifies collection membership and returns the S3 object
+// key in a single latency-sensitive DB query.
+func (repo *ObjectRepository) GetCollectionObject(ctx context.Context, collectionID int64, fileID int64, objType ente.ObjectType) (ente.S3ObjectKey, error) {
+	s3ObjectKey, _, err := repo.GetCollectionObjectWithDCs(ctx, collectionID, fileID, objType)
+	return s3ObjectKey, err
+}
+
+// GetCollectionObjectWithDCs verifies collection membership and returns the S3
+// object key along with replicated datacenters in a single latency-sensitive DB
+// query.
+func (repo *ObjectRepository) GetCollectionObjectWithDCs(ctx context.Context, collectionID int64, fileID int64, objType ente.ObjectType) (ente.S3ObjectKey, []string, error) {
+	row := repo.objectLookupDB().QueryRowContext(ctx, `
+		SELECT
+			cf.file_id,
+			ok.object_key,
+			ok.size,
+			ok.o_type::text,
+			COALESCE(ok.datacenters, '{}'::s3region[])
+		FROM collection_files cf
+		LEFT JOIN object_keys ok
+			ON ok.file_id = cf.file_id
+			AND ok.o_type = $3::object_type
+			AND ok.is_deleted = FALSE
+		WHERE cf.collection_id = $1
+			AND cf.file_id = $2
+			AND cf.is_deleted = FALSE`,
+		collectionID, fileID, objType)
+
+	var s3ObjectKey ente.S3ObjectKey
+	var objectKey sql.NullString
+	var fileSize sql.NullInt64
+	var objectType sql.NullString
+	datacenters := make([]string, 0)
+	err := row.Scan(
+		&s3ObjectKey.FileID,
+		&objectKey,
+		&fileSize,
+		&objectType,
+		pq.Array(&datacenters),
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(ente.ErrPermissionDenied, "file not in collection")
+	}
+	if err != nil {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(err, "")
+	}
+	if !objectKey.Valid || !fileSize.Valid || !objectType.Valid {
+		return s3ObjectKey, datacenters, stacktrace.Propagate(sql.ErrNoRows, "")
+	}
+	s3ObjectKey.ObjectKey = objectKey.String
+	s3ObjectKey.FileSize = fileSize.Int64
+	s3ObjectKey.Type = ente.ObjectType(objectType.String)
+	return s3ObjectKey, datacenters, nil
+}
+
 func (repo *ObjectRepository) GetAllFileObjectsByObjectKey(objectKey string) ([]ente.S3ObjectKey, error) {
 	rows, err := repo.DB.Query(`SELECT file_id, o_type, object_key, size from object_keys where file_id in 
                                                                 (select file_id from object_keys where object_key= $1) 

--- a/server/pkg/repo/object_test.go
+++ b/server/pkg/repo/object_test.go
@@ -183,6 +183,144 @@ func TestGetAccessibleObjectWithDCsReturnsDatacenters(t *testing.T) {
 	}
 }
 
+func TestGetOwnedObjectAllowsOwner(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owned-object-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "owned-file-object", 100, []string{"b2-eu-cen"})
+
+	fileObject, err := repository.GetOwnedObject(context.Background(), fileID, ownerID, ente.FILE)
+	if err != nil {
+		t.Fatalf("GetOwnedObject() error = %v", err)
+	}
+	if fileObject.ObjectKey != "owned-file-object" || fileObject.FileSize != 100 || fileObject.Type != ente.FILE {
+		t.Fatalf("unexpected owned file object: %+v", fileObject)
+	}
+}
+
+func TestGetOwnedObjectRejectsForeignOwner(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owned-object-real-owner@ente.com",
+		CreationTime: 1,
+	})
+	actorID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "owned-object-actor@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "foreign-owned-file-object", 100, []string{"b2-eu-cen"})
+
+	_, err := repository.GetOwnedObject(context.Background(), fileID, actorID, ente.FILE)
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
+func TestGetOwnedObjectReturnsNoRowsForOwnedFileWithMissingObject(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owned-object-missing-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+
+	_, err := repository.GetOwnedObject(context.Background(), fileID, ownerID, ente.FILE)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetCollectionObjectAllowsCollectionFile(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-object-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.THUMBNAIL, "collection-thumbnail-object", 10, []string{"b2-eu-cen"})
+
+	thumbnailObject, err := repository.GetCollectionObject(context.Background(), collectionID, fileID, ente.THUMBNAIL)
+	if err != nil {
+		t.Fatalf("GetCollectionObject() error = %v", err)
+	}
+	if thumbnailObject.ObjectKey != "collection-thumbnail-object" || thumbnailObject.Type != ente.THUMBNAIL {
+		t.Fatalf("unexpected collection thumbnail object: %+v", thumbnailObject)
+	}
+}
+
+func TestGetCollectionObjectRejectsFileOutsideCollection(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-object-outside-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "outside-collection-file-object", 100, []string{"b2-eu-cen"})
+
+	_, err := repository.GetCollectionObject(context.Background(), collectionID, fileID, ente.FILE)
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
+func TestGetCollectionObjectReturnsNoRowsForMissingObject(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-object-missing-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+
+	_, err := repository.GetCollectionObject(context.Background(), collectionID, fileID, ente.FILE)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestGetCollectionObjectRejectsDeletedCollectionFile(t *testing.T) {
+	repository, db := setupAccessibleObjectTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-object-deleted-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "deleted-collection-file-object", 100, []string{"b2-eu-cen"})
+	if _, err := db.Exec(`UPDATE collection_files SET is_deleted = TRUE WHERE collection_id = $1 AND file_id = $2`, collectionID, fileID); err != nil {
+		t.Fatalf("failed to mark collection file deleted: %v", err)
+	}
+
+	_, err := repository.GetCollectionObject(context.Background(), collectionID, fileID, ente.FILE)
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
 func setupAccessibleObjectTest(t *testing.T) (*ObjectRepository, *sql.DB) {
 	t.Helper()
 

--- a/server/pkg/repo/public/file_link.go
+++ b/server/pkg/repo/public/file_link.go
@@ -199,19 +199,49 @@ func (pcr *FileLinkRepository) DisableLinksForUser(ctx context.Context, userID i
 }
 
 func (pcr *FileLinkRepository) GetFileUrlRowByToken(ctx context.Context, accessToken string) (*ente.FileLinkRow, error) {
+	result, err := pcr.getActiveFileUrlRowByToken(ctx, accessToken)
+	if err == nil {
+		return result, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, stacktrace.Propagate(err, "failed to get active public file url summary by token")
+	}
+	result, err = pcr.getDisabledFileUrlRowByToken(ctx, accessToken)
+	if err == nil {
+		return result, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ente.ErrNotFound
+	}
+	return nil, stacktrace.Propagate(err, "failed to get disabled public file url summary by token")
+}
+
+func (pcr *FileLinkRepository) getActiveFileUrlRowByToken(ctx context.Context, accessToken string) (*ente.FileLinkRow, error) {
 	row := pcr.DB.QueryRowContext(ctx,
 		`SELECT id, file_id, owner_id, is_disabled, valid_till, device_limit, enable_download, pw_hash, pw_nonce, mem_limit, ops_limit,
        created_at, updated_at, encrypted_file_key, encrypted_file_key_nonce, kdf_nonce, kdf_mem_limit, kdf_ops_limit, encrypted_share_key
 		from public_file_tokens
-		where access_token = $1
+		where access_token = $1 and is_disabled = FALSE
 `, accessToken)
+	return scanFileLinkRow(row)
+}
+
+func (pcr *FileLinkRepository) getDisabledFileUrlRowByToken(ctx context.Context, accessToken string) (*ente.FileLinkRow, error) {
+	row := pcr.DB.QueryRowContext(ctx,
+		`SELECT id, file_id, owner_id, is_disabled, valid_till, device_limit, enable_download, pw_hash, pw_nonce, mem_limit, ops_limit,
+       created_at, updated_at, encrypted_file_key, encrypted_file_key_nonce, kdf_nonce, kdf_mem_limit, kdf_ops_limit, encrypted_share_key
+		from public_file_tokens
+		where access_token = $1 and is_disabled = TRUE
+		limit 1
+`, accessToken)
+	return scanFileLinkRow(row)
+}
+
+func scanFileLinkRow(row interface{ Scan(dest ...any) error }) (*ente.FileLinkRow, error) {
 	var result = ente.FileLinkRow{}
 	err := row.Scan(&result.LinkID, &result.FileID, &result.OwnerID, &result.IsDisabled, &result.ValidTill, &result.DeviceLimit, &result.EnableDownload, &result.PassHash, &result.Nonce, &result.MemLimit, &result.OpsLimit, &result.CreatedAt, &result.UpdatedAt, &result.EncryptedFileKey, &result.EncryptedFileKeyNonce, &result.KdfNonce, &result.KdfMemLimit, &result.KdfOpsLimit, &result.EncryptedShareKey)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, ente.ErrNotFound
-		}
-		return nil, stacktrace.Propagate(err, "failed to get public file url summary by token")
+		return nil, err
 	}
 	return &result, nil
 }

--- a/server/pkg/repo/public/file_link_test.go
+++ b/server/pkg/repo/public/file_link_test.go
@@ -1,0 +1,91 @@
+package public
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/ente-io/museum/ente"
+	"github.com/ente-io/museum/internal/testutil"
+)
+
+func TestGetFileUrlRowByTokenReturnsActiveRowBeforeDisabledRow(t *testing.T) {
+	repository, db := setupFileLinkRepositoryTest(t)
+
+	insertFileLinkToken(t, db, "pft_disabled", "reused-token", 1, 11, true)
+	insertFileLinkToken(t, db, "pft_active", "reused-token", 2, 22, false)
+
+	row, err := repository.GetFileUrlRowByToken(context.Background(), "reused-token")
+	if err != nil {
+		t.Fatalf("GetFileUrlRowByToken() error = %v", err)
+	}
+	if row.LinkID != "pft_active" || row.FileID != 2 || row.OwnerID != 22 || row.IsDisabled {
+		t.Fatalf("expected active row, got %+v", row)
+	}
+}
+
+func TestGetFileUrlRowByTokenReturnsDisabledRowWhenNoActiveRowExists(t *testing.T) {
+	repository, db := setupFileLinkRepositoryTest(t)
+
+	insertFileLinkToken(t, db, "pft_disabled", "disabled-token", 1, 11, true)
+
+	row, err := repository.GetFileUrlRowByToken(context.Background(), "disabled-token")
+	if err != nil {
+		t.Fatalf("GetFileUrlRowByToken() error = %v", err)
+	}
+	if row.LinkID != "pft_disabled" || !row.IsDisabled {
+		t.Fatalf("expected disabled row, got %+v", row)
+	}
+}
+
+func TestGetFileUrlRowByTokenReturnsNotFoundForUnknownToken(t *testing.T) {
+	repository, _ := setupFileLinkRepositoryTest(t)
+
+	_, err := repository.GetFileUrlRowByToken(context.Background(), "missing-token")
+	if !errors.Is(err, ente.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func setupFileLinkRepositoryTest(t *testing.T) (*FileLinkRepository, *sql.DB) {
+	t.Helper()
+
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	resetFileLinkTables(t, db)
+	t.Cleanup(func() {
+		testutil.ResetTables(t, db)
+		resetFileLinkTables(t, db)
+	})
+
+	return NewFileLinkRepo(db), db
+}
+
+func resetFileLinkTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	_, err := db.Exec(`TRUNCATE TABLE public_file_tokens_access_history, public_file_tokens RESTART IDENTITY CASCADE`)
+	if err != nil {
+		t.Fatalf("failed to reset public file token tables: %v", err)
+	}
+}
+
+func insertFileLinkToken(t *testing.T, db *sql.DB, id string, accessToken string, fileID int64, ownerID int64, isDisabled bool) {
+	t.Helper()
+
+	_, err := db.Exec(
+		`INSERT INTO public_file_tokens(id, file_id, owner_id, app, access_token, is_disabled)
+		 VALUES($1, $2, $3, $4, $5, $6)`,
+		id,
+		fileID,
+		ownerID,
+		"photos",
+		accessToken,
+		isDisabled,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert public file token %q: %v", id, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Fuse ownership / collection access checks with object key lookup for file-link, public collection, and cast download/preview paths
- Prefer active public file-link token lookup so the existing partial index is used, with disabled-token fallback preserving 410 behavior
- Add DB-backed repo tests for fused object access and file-link token lookup behavior

## Tests
- `ENV=test go test -count=1 ./pkg/repo -run 'Test(GetAccessibleObject|GetOwnedObject|GetCollectionObject)'`
- `ENV=test go test -count=1 ./pkg/repo/public`
- `go test -count=1 ./pkg/api ./pkg/controller -run '^$'`