### PR TITLE
[auth] Work around Android search autofocus keyboard

### DIFF
--- a/mobile/apps/auth/lib/ui/home/android_search_autofocus.dart
+++ b/mobile/apps/auth/lib/ui/home/android_search_autofocus.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+class AndroidSearchAutofocus extends StatefulWidget {
+  const AndroidSearchAutofocus({
+    super.key,
+    required this.enabled,
+    required this.focusNode,
+    required this.child,
+  });
+
+  final bool enabled;
+  final FocusNode focusNode;
+  final Widget child;
+
+  @override
+  State<AndroidSearchAutofocus> createState() => _AndroidSearchAutofocusState();
+}
+
+class _AndroidSearchAutofocusState extends State<AndroidSearchAutofocus> {
+  int _token = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleFocus();
+  }
+
+  @override
+  void didUpdateWidget(AndroidSearchAutofocus oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.enabled && widget.enabled) {
+      _scheduleFocus();
+    }
+  }
+
+  @override
+  void dispose() {
+    _token++;
+    super.dispose();
+  }
+
+  void _scheduleFocus() {
+    if (!Platform.isAndroid || !widget.enabled) {
+      return;
+    }
+    unawaited(_focusAndShowKeyboard(++_token));
+  }
+
+  Future<void> _focusAndShowKeyboard(int token) async {
+    bool isValid() => mounted && token == _token && widget.enabled;
+
+    await WidgetsBinding.instance.endOfFrame;
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    if (!isValid()) return;
+
+    widget.focusNode.requestFocus();
+
+    await WidgetsBinding.instance.endOfFrame;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (!isValid() || !widget.focusNode.hasFocus) return;
+
+    await SystemChannels.textInput.invokeMethod<void>('TextInput.show');
+
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    if (!isValid() || !widget.focusNode.hasFocus) return;
+
+    await SystemChannels.textInput.invokeMethod<void>('TextInput.show');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -32,6 +32,7 @@ import 'package:ente_auth/ui/components/horizontal_scroll_area.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
 import 'package:ente_auth/ui/components/note_dialog.dart';
 import 'package:ente_auth/ui/home/add_tag_sheet.dart';
+import 'package:ente_auth/ui/home/android_search_autofocus.dart';
 import 'package:ente_auth/ui/home/coach_mark_widget.dart';
 import 'package:ente_auth/ui/home/home_empty_state.dart';
 import 'package:ente_auth/ui/home/shortcuts.dart';
@@ -1530,27 +1531,31 @@ class _HomePageState extends State<HomePage> {
       ),
       title: !_showSearchBox
           ? const AuthLogoWidget(height: 18)
-          : TextField(
-              autocorrect: false,
-              enableSuggestions: false,
-              autofocus: _autoFocusSearch,
-              controller: _textController,
-              onChanged: (val) {
-                _searchText = val;
-                _applyFilteringAndRefresh();
-              },
-              onSubmitted: (_) {
-                if (_filteredCodes.isNotEmpty) {
-                  // Move focus to the first item in the grid
-                  _firstItemFocusNode.requestFocus();
-                }
-              },
-              decoration: InputDecoration(
-                hintText: l10n.searchHint,
-                border: InputBorder.none,
-                focusedBorder: InputBorder.none,
-              ),
+          : AndroidSearchAutofocus(
+              enabled: _autoFocusSearch,
               focusNode: searchBoxFocusNode,
+              child: TextField(
+                autocorrect: false,
+                enableSuggestions: false,
+                autofocus: _autoFocusSearch && !Platform.isAndroid,
+                controller: _textController,
+                onChanged: (val) {
+                  _searchText = val;
+                  _applyFilteringAndRefresh();
+                },
+                onSubmitted: (_) {
+                  if (_filteredCodes.isNotEmpty) {
+                    // Move focus to the first item in the grid
+                    _firstItemFocusNode.requestFocus();
+                  }
+                },
+                decoration: InputDecoration(
+                  hintText: l10n.searchHint,
+                  border: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                ),
+                focusNode: searchBoxFocusNode,
+              ),
             ),
       centerTitle: true,
       actions: <Widget>[

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -1,4 +1,5 @@
 - Upgraded Auth to Flutter 3.38.10 and Android target SDK 36
+- Worked around Android search autofocus not reliably opening the keyboard on app start
 - Made overflowing Auth tag strips scrollable with desktop mouse wheel and drag interactions
 - Made Auth tag chips reachable by keyboard Tab and selectable with Enter or Space
 - Fixed saved theme selection being reset after unlocking Auth and improved password manager autofill detection for password fields


### PR DESCRIPTION
## Summary

Works around the Auth app's "Focus search on app start" setting not reliably showing the keyboard on Android release builds.

Flutter's `autofocus` can focus the search field without consistently opening the keyboard on some Android devices. This adds a small Android-only wrapper around the search box that waits until the field is mounted, requests focus, and explicitly shows the keyboard with one guarded retry.

Ref #279.

Related upstream Flutter issue: flutter/flutter#122994.

## Changes

- Add `AndroidSearchAutofocus` helper for the Auth home search box.
- Use the helper only when the existing auto-focus setting is enabled.
- Keep the existing `autofocus` behavior for non-Android platforms.
- Disable Flutter `autofocus` for this field on Android to avoid the release-mode timing race.
