### PR TITLE
[mob][photos] Improve help and support log viewing

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
@@ -39,17 +39,6 @@ class HelpSupportPage extends StatelessWidget {
       children: [
         _sectionTitle(context, l10n.getInTouch),
         SettingsItem(
-          title: l10n.reportAnIssue,
-          icon: HugeIcons.strokeRoundedBug01,
-          showOnlyLoadingState: true,
-          onTap: () async {
-            await Navigator.of(context).push(
-              MaterialPageRoute(builder: (context) => const ReportIssuePage()),
-            );
-          },
-        ),
-        const SizedBox(height: 8),
-        SettingsItem(
           title: l10n.askAQuestion,
           icon: HugeIcons.strokeRoundedHelpCircle,
           showOnlyLoadingState: true,
@@ -69,10 +58,21 @@ class HelpSupportPage extends StatelessWidget {
             );
           },
         ),
+        const SizedBox(height: 8),
+        SettingsItem(
+          title: l10n.reportAnIssue,
+          icon: HugeIcons.strokeRoundedBug01,
+          showOnlyLoadingState: true,
+          onTap: () async {
+            await Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => const ReportIssuePage()),
+            );
+          },
+        ),
         if (flagService.internalUser || kDebugMode) ...[
           const SizedBox(height: 8),
           SettingsItem(
-            title: l10n.viewLogs,
+            title: "(i) ${l10n.viewLogs}",
             icon: HugeIcons.strokeRoundedNote01,
             showOnlyLoadingState: true,
             onTap: () async {

--- a/mobile/apps/photos/lib/ui/tools/debug/log_file_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/log_file_viewer.dart
@@ -1,8 +1,8 @@
-import 'dart:io';
+import "dart:io";
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 import "package:photos/generated/l10n.dart";
-import 'package:photos/ui/common/loading_widget.dart';
+import "package:photos/ui/common/loading_widget.dart";
 
 class LogFileViewer extends StatefulWidget {
   final File file;
@@ -13,15 +13,22 @@ class LogFileViewer extends StatefulWidget {
 }
 
 class _LogFileViewerState extends State<LogFileViewer> {
-  String? _logs;
+  static const _maxLinesToShow = 2000;
+
+  late final Future<List<String>> _logsFuture;
+
   @override
   void initState() {
-    widget.file.readAsString().then((logs) {
-      setState(() {
-        _logs = logs;
-      });
-    });
     super.initState();
+    _logsFuture = _readLogs();
+  }
+
+  Future<List<String>> _readLogs() async {
+    final logs = await widget.file.readAsLines();
+    if (logs.length <= _maxLinesToShow) {
+      return logs;
+    }
+    return logs.sublist(logs.length - _maxLinesToShow);
   }
 
   @override
@@ -31,29 +38,35 @@ class _LogFileViewerState extends State<LogFileViewer> {
         elevation: 0,
         title: Text(AppLocalizations.of(context).todaysLogs),
       ),
-      body: _getBody(),
-    );
-  }
-
-  Widget _getBody() {
-    if (_logs == null) {
-      return const EnteLoadingWidget();
-    }
-    return Container(
-      padding: const EdgeInsets.only(left: 12, top: 8, right: 12),
-      child: Scrollbar(
-        interactive: true,
-        thickness: 4,
-        radius: const Radius.circular(2),
-        child: SingleChildScrollView(
-          child: Text(
-            _logs!,
-            style: const TextStyle(
-              fontFeatures: [FontFeature.tabularFigures()],
-              height: 1.2,
+      body: FutureBuilder<List<String>>(
+        future: _logsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text(snapshot.error.toString()));
+          }
+          if (!snapshot.hasData) {
+            return const EnteLoadingWidget();
+          }
+          final logs = snapshot.data!;
+          return Scrollbar(
+            interactive: true,
+            thickness: 4,
+            radius: const Radius.circular(2),
+            child: ListView.builder(
+              padding: const EdgeInsets.only(left: 12, top: 8, right: 12),
+              itemCount: logs.length,
+              itemBuilder: (context, index) {
+                return Text(
+                  logs[index],
+                  style: const TextStyle(
+                    fontFeatures: [FontFeature.tabularFigures()],
+                    height: 1.2,
+                  ),
+                );
+              },
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Reorder Help and Support contact actions to show Ask a question, Request a feature, then Report an issue.
- Mark the internal View logs entry with an (i) prefix.
- Render only the latest 2000 log lines with a ListView to avoid jank from laying out one huge log string.

## Test plan
- flutter analyze lib/ui/settings/support/help_support_page.dart lib/ui/tools/debug/log_file_viewer.dart