### PR TITLE
[mob][photos] Add contacts section to Search tab

### DIFF
--- a/mobile/apps/photos/lib/states/all_sections_examples_state.dart
+++ b/mobile/apps/photos/lib/states/all_sections_examples_state.dart
@@ -125,8 +125,8 @@ class _AllSectionsExamplesProviderState
         final hasAnySearchableFilesFuture = SearchService.instance
             .hasAnyFilesForSearch();
         for (SectionType sectionType in SectionType.values) {
-          // Contacts moved to shared, albums moved to the Albums tab, and file
-          // types render as a lazy placeholder in Search.
+          // Albums moved to the Albums tab. Contacts and file types render as
+          // lazy sections in Search so they do not block the section preload.
           if (sectionType == SectionType.contacts ||
               sectionType == SectionType.album ||
               sectionType == SectionType.fileTypesAndExtension) {

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
@@ -11,11 +11,63 @@ import "package:photos/models/search/generic_search_result.dart";
 import "package:photos/models/search/recent_searches.dart";
 import "package:photos/models/search/search_constants.dart";
 import "package:photos/models/search/search_types.dart";
+import "package:photos/service_locator.dart"
+    show flagService, isLocalGalleryMode;
+import "package:photos/services/search_service.dart";
 import "package:photos/theme/ente_theme.dart";
+import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/viewer/search/contact_avatar_widget.dart";
 import "package:photos/ui/viewer/search/result/contact_result_page.dart";
 import "package:photos/ui/viewer/search/search_section_cta.dart";
 import "package:photos/ui/viewer/search_tab/section_header.dart";
+
+class ContactsSectionLoader extends StatefulWidget {
+  const ContactsSectionLoader({super.key});
+
+  @override
+  State<ContactsSectionLoader> createState() => _ContactsSectionLoaderState();
+}
+
+class _ContactsSectionLoaderState extends State<ContactsSectionLoader> {
+  Future<List<GenericSearchResult>>? _contactsFuture;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLocalGalleryMode || !flagService.enableContact) {
+      return const SizedBox.shrink();
+    }
+    _contactsFuture ??= SearchService.instance.getAllContactsSearchResults(
+      kSearchSectionLimit,
+    );
+    return FutureBuilder<List<GenericSearchResult>>(
+      future: _contactsFuture!,
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          return ContactsSection(snapshot.data!);
+        }
+        return const ContactsLoadingSection();
+      },
+    );
+  }
+}
+
+class ContactsLoadingSection extends StatelessWidget {
+  const ContactsLoadingSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SectionHeader(SectionType.contacts, hasMore: false),
+          SizedBox(height: 80, child: EnteLoadingWidget()),
+        ],
+      ),
+    );
+  }
+}
 
 class ContactsSection extends StatefulWidget {
   final List<GenericSearchResult> contactSearchResults;

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab.dart
@@ -18,6 +18,7 @@ import "package:photos/ui/viewer/search/result/no_result_widget.dart";
 import "package:photos/ui/viewer/search/search_suggestions.dart";
 import "package:photos/ui/viewer/search/search_widget.dart";
 import "package:photos/ui/viewer/search/tab_empty_state.dart";
+import "package:photos/ui/viewer/search_tab/contacts_section.dart";
 import "package:photos/ui/viewer/search_tab/file_type_section.dart";
 import "package:photos/ui/viewer/search_tab/locations_section.dart";
 import "package:photos/ui/viewer/search_tab/magic_section.dart";
@@ -116,8 +117,11 @@ class _AllSearchSectionsState extends State<AllSearchSections> {
                 final sectionResultsByType = snapshot.data!.sectionResults;
                 final hasAnySearchableFiles =
                     snapshot.data!.hasAnySearchableFiles;
+                final shouldRenderContacts =
+                    !isLocalGalleryMode && flagService.enableContact;
                 if (!hasAnySearchableFiles &&
-                    sectionResultsByType.every((element) => element.isEmpty)) {
+                    sectionResultsByType.every((element) => element.isEmpty) &&
+                    !shouldRenderContacts) {
                   return const Padding(
                     padding: EdgeInsets.only(bottom: 72),
                     child: SearchTabEmptyState(),
@@ -197,7 +201,7 @@ class _AllSearchSectionsState extends State<AllSearchSections> {
                                   as List<GenericSearchResult>,
                             );
                           case SectionType.contacts:
-                            return const SizedBox.shrink();
+                            return const ContactsSectionLoader();
                           case SectionType.fileTypesAndExtension:
                             return FileTypeSection(
                               hasAnySearchableFiles: hasAnySearchableFiles,


### PR DESCRIPTION
## Summary
- Render Contacts as a lazy Search section without adding it to the all-sections preload
- Show a Contacts loading placeholder while contact search results load
- Keep Contacts hidden for local gallery mode or when contacts are disabled

## Tests
- `flutter analyze mobile/apps/photos/lib/states/all_sections_examples_state.dart mobile/apps/photos/lib/ui/viewer/search_tab/search_tab.dart mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart`