### PR TITLE
[server] Add recovery link to inactive account deletion email

### DIFF
--- a/server/mail-templates/inactive-user-deletion/confirm_13m.html
+++ b/server/mail-templates/inactive-user-deletion/confirm_13m.html
@@ -4,5 +4,6 @@
 <p>Hi,</p>
 
 <p>Your Ente account associated with <strong>{{.Email}}</strong> and associated data was deleted on {{.DeletionDate}} because there was no activity across our apps for more than 13 months.</p>
-<p>If you believe this was a mistake, you can reply to this email or send an email to <a href="mailto:support@ente.com">support@ente.com</a>.</p>
+<p>If you'd like to restore it, you can <a href="{{.AccountRecoveryLink}}">recover your account</a> within 7 days of deletion. After that, the scheduled data deletion won't be reversible.</p>
+<p>If you believe this was a mistake or need help, you can reply to this email or send an email to <a href="mailto:support@ente.com">support@ente.com</a>.</p>
 {{end}}

--- a/server/pkg/controller/user/inactive_user_orchestrator.go
+++ b/server/pkg/controller/user/inactive_user_orchestrator.go
@@ -379,6 +379,7 @@ func (c *InactiveUserOrchestrator) processCandidate(candidate repo.UserInactivit
 		return inactivityEmailStageNone, false, false, false, nil
 	}
 
+	accountRecoveryLink := ""
 	if config.IsFinal {
 		if c.UserController == nil {
 			return stage, false, false, false, fmt.Errorf("inactive user deletion requires user controller")
@@ -423,6 +424,11 @@ func (c *InactiveUserOrchestrator) processCandidate(candidate repo.UserInactivit
 			}
 		}
 
+		accountRecoveryLink, err = c.UserController.getAccountRecoveryLink(user.ID, user.Email)
+		if err != nil {
+			return stage, false, false, false, err
+		}
+
 		deleteLogger := log.WithFields(log.Fields{
 			"user_id": user.ID,
 			"req_ctx": "inactive_account_deletion",
@@ -436,6 +442,9 @@ func (c *InactiveUserOrchestrator) processCandidate(candidate repo.UserInactivit
 	templateData := map[string]interface{}{
 		"Email":        user.Email,
 		"DeletionDate": deletionDate,
+	}
+	if accountRecoveryLink != "" {
+		templateData["AccountRecoveryLink"] = accountRecoveryLink
 	}
 	if emailSemaphore != nil {
 		emailSemaphore <- struct{}{}

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -102,6 +102,8 @@ const (
 	AccountDeletedEmailTemplate                       = "account_deleted.html"
 	AccountDeletedWithActiveSubscriptionEmailTemplate = "account_deleted_active_sub.html"
 	AccountDeletedEmailSubject                        = "Your Ente account has been deleted"
+	accountRecoveryLinkHost                           = "https://api.ente.com"
+	accountRecoveryLinkValidityDays                   = 7
 )
 
 func NewUserController(
@@ -335,25 +337,34 @@ func (c *UserController) NotifyAccountDeletion(userID int64, userEmail string, i
 	if !isSubscriptionCancelled {
 		template = AccountDeletedWithActiveSubscriptionEmailTemplate
 	}
-	recoverToken, err2 := c.GetJWTTokenForClaim(&enteJWT.WebCommonJWTClaim{
-		UserID:     userID,
-		ExpiryTime: time.MicrosecondsAfterDays(7),
-		ClaimScope: enteJWT.RestoreAccount.Ptr(),
-		Email:      userEmail,
-	})
-	if err2 != nil {
-		logrus.WithError(err2).Error("failed to generate recover token")
+	accountRecoveryLink, err := c.getAccountRecoveryLink(userID, userEmail)
+	if err != nil {
+		logrus.WithError(err).Error("failed to generate recover token")
 		return
 	}
 
 	templateData := make(map[string]interface{})
-	templateData["AccountRecoveryLink"] = fmt.Sprintf("%s/users/recover-account?token=%s", "https://api.ente.com", recoverToken)
-	err := email.SendTemplatedEmail([]string{userEmail}, "ente", "team@ente.com",
+	templateData["AccountRecoveryLink"] = accountRecoveryLink
+	err = email.SendTemplatedEmail([]string{userEmail}, "ente", "team@ente.com",
 		AccountDeletedEmailSubject, template, templateData, nil)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to send the account deletion email to %s", userEmail)
 	}
 }
+
+func (c *UserController) getAccountRecoveryLink(userID int64, userEmail string) (string, error) {
+	recoverToken, err := c.GetJWTTokenForClaim(&enteJWT.WebCommonJWTClaim{
+		UserID:     userID,
+		ExpiryTime: time.MicrosecondsAfterDays(accountRecoveryLinkValidityDays),
+		ClaimScope: enteJWT.RestoreAccount.Ptr(),
+		Email:      userEmail,
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/users/recover-account?token=%s", accountRecoveryLinkHost, recoverToken), nil
+}
+
 func (c *UserController) HandleSelfAccountRecovery(ctx *gin.Context, token string) error {
 	jwtToken, err := c.ValidateJWTToken(token, enteJWT.RestoreAccount)
 	if err != nil {

--- a/server/pkg/utils/email/storage_warning_template_test.go
+++ b/server/pkg/utils/email/storage_warning_template_test.go
@@ -28,3 +28,19 @@ func TestStorageWarningTemplatesIncludeAccountEmail(t *testing.T) {
 		})
 	}
 }
+
+func TestInactiveUserDeletionFinalTemplateIncludesRecoveryLink(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	recoveryLink := "https://api.ente.com/users/recover-account?token=test-token"
+	body, err := getMailBodyWithBase("ente_base.html", "inactive-user-deletion/confirm_13m.html", map[string]interface{}{
+		"Email":               "inactive@example.com",
+		"DeletionDate":        "01 Apr 2026",
+		"AccountRecoveryLink": recoveryLink,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, body, recoveryLink)
+	assert.Contains(t, body, "recover your account")
+	assert.Contains(t, body, "within 7 days of deletion")
+}


### PR DESCRIPTION
## Summary
- Add a 7-day recovery link to the final inactive account deletion email.
- Reuse the existing deleted-account recovery token flow.

## Tests
- ./scripts/lint.sh
- ./scripts/test-in-docker.sh