### PR TITLE
[mobile] Update dio HTTP/2 adapter

### DIFF
--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -551,10 +551,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio_http2_adapter
-      sha256: "79f3d69b155b92a786c8734bd11860390b986210d4e07cbb6a5c8c806a7187b2"
+      sha256: c56522c50bb3bab7e3ca77c153b0f03ae672a87d8c32e46be8f2868693ec9f0a
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.7.1"
   dio_web_adapter:
     dependency: transitive
     description:

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   defer_pointer: 0.0.2
   device_info_plus: 11.3.0
   dio: 5.9.2
-  dio_http2_adapter: 2.7.0
+  dio_http2_adapter: 2.7.1
   dots_indicator: 4.0.1
   dotted_border: 2.1.0
   dropdown_button2: 2.3.9


### PR DESCRIPTION
Updates `dio_http2_adapter` to 2.7.1 for Photos.

Refs #10501