### PR TITLE
[rust][web] Use hyphen paste password fragment prefix

### DIFF
--- a/rust/apps/cli/src/cli/paste.rs
+++ b/rust/apps/cli/src/cli/paste.rs
@@ -39,7 +39,7 @@ pub enum PasteSubcommands {
         link_or_token: String,
 
         /// Fragment key when passing only an access token.
-        /// Password-protected keys include the `p:` prefix.
+        /// Password-protected keys include the `p-` prefix.
         #[arg(long)]
         key: Option<String>,
 

--- a/rust/apps/cli/src/commands/paste.rs
+++ b/rust/apps/cli/src/commands/paste.rs
@@ -19,7 +19,7 @@ const FRAGMENT_SECRET_ALPHABET: &[u8] =
     b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const PASTE_GUARD_COOKIE: &str = "paste_guard";
 const PASTE_PASSWORD_ENV: &str = "ENTE_PASTE_PASSWORD";
-const PASSWORD_FRAGMENT_PREFIX: &str = "p:";
+const PASSWORD_FRAGMENT_PREFIX: &str = "p-";
 const PASSWORD_KDF_CONTEXT: &str = "ente-paste-password-v1";
 
 pub async fn handle_paste_command(cmd: PasteCommand) -> Result<()> {
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn parse_password_protected_paste_link() {
         let (token, paste_key) =
-            parse_paste_reference("https://paste.ente.com/ABC123#p:AbCd1234EfGh", None).unwrap();
+            parse_paste_reference("https://paste.ente.com/ABC123#p-AbCd1234EfGh", None).unwrap();
 
         assert_eq!(token, "ABC123");
         assert_eq!(
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn parse_token_with_password_key() {
         let (token, paste_key) =
-            parse_paste_reference("ABC123", Some("p:AbCd1234EfGh".to_string())).unwrap();
+            parse_paste_reference("ABC123", Some("p-AbCd1234EfGh".to_string())).unwrap();
 
         assert_eq!(token, "ABC123");
         assert_eq!(

--- a/rust/apps/cli/tests/paste.rs
+++ b/rust/apps/cli/tests/paste.rs
@@ -180,7 +180,7 @@ impl PasteLink {
             .fragment()
             .expect("paste link should include a decryption key fragment")
             .to_string();
-        let (password_required, fragment_secret) = match key.strip_prefix("p:") {
+        let (password_required, fragment_secret) = match key.strip_prefix("p-") {
             Some(fragment_secret) => (true, fragment_secret),
             None => (false, key.as_str()),
         };

--- a/web/apps/paste/src/features/paste/constants.ts
+++ b/web/apps/paste/src/features/paste/constants.ts
@@ -4,6 +4,6 @@ export const FRAGMENT_SECRET_LENGTH = 12;
 
 export const FRAGMENT_SECRET_PATTERN = /^[0-9A-Za-z]{12}$/;
 
-export const PASSWORD_FRAGMENT_PREFIX = "p:";
+export const PASSWORD_FRAGMENT_PREFIX = "p-";
 
 export const PASSWORD_KDF_CONTEXT = "ente-paste-password-v1";


### PR DESCRIPTION
Switches password-protected paste fragments from p: to p- before first deployment.