### PR TITLE
[mobile] Focus Android text input on launch

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -32,7 +32,6 @@ import 'package:ente_auth/ui/components/horizontal_scroll_area.dart';
 import 'package:ente_auth/ui/components/models/button_type.dart';
 import 'package:ente_auth/ui/components/note_dialog.dart';
 import 'package:ente_auth/ui/home/add_tag_sheet.dart';
-import 'package:ente_auth/ui/home/android_search_autofocus.dart';
 import 'package:ente_auth/ui/home/coach_mark_widget.dart';
 import 'package:ente_auth/ui/home/home_empty_state.dart';
 import 'package:ente_auth/ui/home/shortcuts.dart';
@@ -54,6 +53,7 @@ import 'package:ente_lock_screen/local_authentication_service.dart';
 import 'package:ente_lock_screen/lock_screen_settings.dart';
 import 'package:ente_lock_screen/ui/app_lock.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
+import 'package:ente_ui/components/android_text_input_autofocus.dart';
 import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -1531,7 +1531,7 @@ class _HomePageState extends State<HomePage> {
       ),
       title: !_showSearchBox
           ? const AuthLogoWidget(height: 18)
-          : AndroidSearchAutofocus(
+          : AndroidTextInputAutofocus(
               enabled: _autoFocusSearch,
               focusNode: searchBoxFocusNode,
               child: TextField(

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_password.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_password.dart
@@ -1,5 +1,6 @@
 import "package:ente_lock_screen/lock_screen_settings.dart";
 import "package:ente_strings/ente_strings.dart";
+import "package:ente_ui/components/android_text_input_autofocus.dart";
 import "package:ente_ui/components/buttons/dynamic_fab.dart";
 import "package:ente_ui/components/text_input_widget.dart";
 import "package:ente_ui/theme/ente_theme.dart";
@@ -22,13 +23,6 @@ class _LockScreenConfirmPasswordState extends State<LockScreenConfirmPassword> {
   final _focusNode = FocusNode();
   final _isFormValid = ValueNotifier<bool>(false);
   final _submitNotifier = ValueNotifier(false);
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      _focusNode.requestFocus();
-    });
-  }
 
   @override
   void dispose() {
@@ -122,21 +116,25 @@ class _LockScreenConfirmPasswordState extends State<LockScreenConfirmPassword> {
                 const Padding(padding: EdgeInsets.all(12)),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: TextInputWidget(
-                    hintText: context.strings.password,
-                    autoFocus: true,
-                    textCapitalization: TextCapitalization.none,
-                    isPasswordInput: true,
-                    shouldSurfaceExecutionStates: false,
-                    onChange: (p0) {
-                      _confirmPasswordController.text = p0;
-                      _isFormValid.value =
-                          _confirmPasswordController.text.isNotEmpty;
-                    },
-                    onSubmit: (p0) {
-                      return _confirmPasswordMatch();
-                    },
-                    submitNotifier: _submitNotifier,
+                  child: AndroidTextInputAutofocus(
+                    focusNode: _focusNode,
+                    child: TextInputWidget(
+                      hintText: context.strings.password,
+                      autoFocus: true,
+                      focusNode: _focusNode,
+                      textCapitalization: TextCapitalization.none,
+                      isPasswordInput: true,
+                      shouldSurfaceExecutionStates: false,
+                      onChange: (p0) {
+                        _confirmPasswordController.text = p0;
+                        _isFormValid.value =
+                            _confirmPasswordController.text.isNotEmpty;
+                      },
+                      onSubmit: (p0) {
+                        return _confirmPasswordMatch();
+                      },
+                      submitNotifier: _submitNotifier,
+                    ),
                   ),
                 ),
                 const Padding(padding: EdgeInsets.all(12)),

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_password.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_password.dart
@@ -5,6 +5,7 @@ import "package:ente_lock_screen/lock_screen_settings.dart";
 import "package:ente_lock_screen/ui/lock_screen_confirm_password.dart";
 import "package:ente_lock_screen/ui/lock_screen_options.dart";
 import "package:ente_strings/ente_strings.dart";
+import "package:ente_ui/components/android_text_input_autofocus.dart";
 import "package:ente_ui/components/buttons/dynamic_fab.dart";
 import "package:ente_ui/components/text_input_widget.dart";
 import "package:ente_ui/theme/ente_theme.dart";
@@ -51,9 +52,6 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
   void initState() {
     super.initState();
     invalidAttemptsCount = _lockscreenSetting.getInvalidAttemptCount();
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      _focusNode.requestFocus();
-    });
   }
 
   @override
@@ -138,20 +136,25 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
                 const Padding(padding: EdgeInsets.all(12)),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: TextInputWidget(
-                    hintText: context.strings.password,
-                    autoFocus: true,
-                    textCapitalization: TextCapitalization.none,
-                    isPasswordInput: true,
-                    shouldSurfaceExecutionStates: false,
-                    onChange: (p0) {
-                      _passwordController.text = p0;
-                      _isFormValid.value = _passwordController.text.isNotEmpty;
-                    },
-                    onSubmit: (p0) {
-                      return _confirmPassword();
-                    },
-                    submitNotifier: _submitNotifier,
+                  child: AndroidTextInputAutofocus(
+                    focusNode: _focusNode,
+                    child: TextInputWidget(
+                      hintText: context.strings.password,
+                      autoFocus: true,
+                      focusNode: _focusNode,
+                      textCapitalization: TextCapitalization.none,
+                      isPasswordInput: true,
+                      shouldSurfaceExecutionStates: false,
+                      onChange: (p0) {
+                        _passwordController.text = p0;
+                        _isFormValid.value =
+                            _passwordController.text.isNotEmpty;
+                      },
+                      onSubmit: (p0) {
+                        return _confirmPassword();
+                      },
+                      submitNotifier: _submitNotifier,
+                    ),
                   ),
                 ),
                 const Padding(padding: EdgeInsets.all(12)),

--- a/mobile/packages/ui/lib/components/android_text_input_autofocus.dart
+++ b/mobile/packages/ui/lib/components/android_text_input_autofocus.dart
@@ -4,23 +4,36 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-class AndroidSearchAutofocus extends StatefulWidget {
-  const AndroidSearchAutofocus({
+/// Requests focus and explicitly shows Android's soft keyboard for text input.
+///
+/// Flutter can mark a text field as focused during a route/app-launch
+/// transition without Android showing the IME. This is visible on launch-time
+/// app lock screens: the password field is focused, but the keyboard stays
+/// hidden. This wrapper waits until the field is attached, focuses the provided
+/// [focusNode], then asks the platform text input channel to show the keyboard.
+/// See https://github.com/flutter/flutter/issues/122994 for the upstream
+/// Flutter issue tracking this behavior.
+///
+/// Use this only for text inputs that intentionally need keyboard focus as soon
+/// as they appear. The same [focusNode] must be passed to the wrapped text field.
+class AndroidTextInputAutofocus extends StatefulWidget {
+  const AndroidTextInputAutofocus({
     super.key,
-    required this.enabled,
     required this.focusNode,
     required this.child,
+    this.enabled = true,
   });
 
-  final bool enabled;
   final FocusNode focusNode;
   final Widget child;
+  final bool enabled;
 
   @override
-  State<AndroidSearchAutofocus> createState() => _AndroidSearchAutofocusState();
+  State<AndroidTextInputAutofocus> createState() =>
+      _AndroidTextInputAutofocusState();
 }
 
-class _AndroidSearchAutofocusState extends State<AndroidSearchAutofocus> {
+class _AndroidTextInputAutofocusState extends State<AndroidTextInputAutofocus> {
   int _token = 0;
 
   @override
@@ -30,7 +43,7 @@ class _AndroidSearchAutofocusState extends State<AndroidSearchAutofocus> {
   }
 
   @override
-  void didUpdateWidget(AndroidSearchAutofocus oldWidget) {
+  void didUpdateWidget(AndroidTextInputAutofocus oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!oldWidget.enabled && widget.enabled) {
       _scheduleFocus();

--- a/mobile/packages/ui/lib/components/text_input_widget.dart
+++ b/mobile/packages/ui/lib/components/text_input_widget.dart
@@ -30,6 +30,7 @@ class TextInputWidget extends StatefulWidget {
   final TextCapitalization? textCapitalization;
   final bool isPasswordInput;
   final Iterable<String>? autofillHints;
+  final FocusNode? focusNode;
   final bool cancellable;
   final bool shouldUnfocusOnCancelOrSubmit;
   const TextInputWidget({
@@ -51,6 +52,7 @@ class TextInputWidget extends StatefulWidget {
     this.textCapitalization = TextCapitalization.none,
     this.isPasswordInput = false,
     this.autofillHints,
+    this.focusNode,
     this.cancellable = false,
     this.shouldUnfocusOnCancelOrSubmit = false,
     super.key,
@@ -124,6 +126,7 @@ class _TextInputWidgetState extends State<TextInputWidget> {
           child: TextFormField(
             textCapitalization: widget.textCapitalization!,
             autofocus: widget.autoFocus ?? false,
+            focusNode: widget.focusNode,
             controller: _textController,
             inputFormatters: widget.maxLength != null
                 ? [LengthLimitingTextInputFormatter(50)]


### PR DESCRIPTION
Fixes #10614

Validation:
- `flutter analyze --no-fatal-infos` and `flutter test` for Auth and Locker
- affected mobile package analyzes for `accounts`, `legacy`, `lock_screen`, `sharing`, `ui`, `utils`
- mobile Rust `cargo codegen frb` and clippy