### PR TITLE
[mob][photos] Refine album and search tab styling

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/album/list_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/list_item.dart
@@ -70,7 +70,7 @@ class AlbumListItemWidget extends StatelessWidget {
     final colors = context.componentColors;
     return ThumbnailListItem(
       backgroundColor: thumbnailListItemBackgroundColor(context),
-      selectedBorderColor: colors.primaryStroke,
+      selectedBorderColor: colors.strokeDark,
       isSelected: isSelected,
       onTap: onTapCallback == null ? null : () => onTapCallback!(collection),
       onLongPress: onLongPressCallback == null
@@ -211,17 +211,17 @@ class AlbumListItemWidget extends StatelessWidget {
             ImageIcon(
               const AssetImage("assets/collection_pin.png"),
               size: 12,
-              color: colors.textLight,
+              color: colors.textBase,
             ),
           if (showArchive)
             HugeIcon(
               icon: HugeIcons.strokeRoundedArchive03,
               size: 12,
-              color: colors.textLight,
+              color: colors.textBase,
               strokeWidth: 2.0,
             ),
           if (isFavoriteAlbum)
-            Icon(EnteIcons.favoriteFilled, size: 12, color: colors.primary),
+            Icon(EnteIcons.favoriteFilled, size: 12, color: colors.textBase),
         ],
       ],
     );

--- a/mobile/apps/photos/lib/ui/collections/album/new_list_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/new_list_item.dart
@@ -37,7 +37,7 @@ class NewAlbumListItemWidget extends StatelessWidget {
         ),
       ),
       title: Text(
-        AppLocalizations.of(context).addNew,
+        AppLocalizations.of(context).createAlbum,
         style: TextStyles.body.copyWith(color: colors.textLight),
         maxLines: 1,
         softWrap: false,

--- a/mobile/apps/photos/lib/ui/collections/album/new_row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/new_row_item.dart
@@ -44,7 +44,7 @@ class NewAlbumRowItemWidget extends StatelessWidget {
           ),
           const SizedBox(height: _thumbnailToTextSpacing),
           Text(
-            AppLocalizations.of(context).addNew,
+            AppLocalizations.of(context).createAlbum,
             style: TextStyles.body.copyWith(color: colors.textLight),
             maxLines: 1,
             softWrap: false,

--- a/mobile/apps/photos/lib/ui/collections/album/row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/row_item.dart
@@ -65,7 +65,7 @@ class AlbumRowItemWidget extends StatelessWidget {
             icon: HugeIcons.strokeRoundedLink02,
             color: c.publicURLs.first.isExpired
                 ? componentColors.warning
-                : componentColors.specialWhite,
+                : componentColors.textBase,
             size: 8,
             strokeWidth: 2,
           )
@@ -121,8 +121,6 @@ class AlbumRowItemWidget extends StatelessWidget {
                                   fit: StackFit.expand,
                                   children: [
                                     thumbnailWidget,
-                                    if (shouldShowSharePill)
-                                      const _ThumbnailShareGradientOverlay(),
                                     if (isSelected)
                                       Container(
                                         decoration: BoxDecoration(
@@ -153,7 +151,10 @@ class AlbumRowItemWidget extends StatelessWidget {
                               transitionOnUserGestures: true,
                               child: Container(
                                 padding: _sharePillPadding,
-                                decoration: _sharePillDecoration(context),
+                                decoration: BoxDecoration(
+                                  color: componentColors.fillLight,
+                                  borderRadius: BorderRadius.circular(40),
+                                ),
                                 child: SizedBox(
                                   height: getAvatarSize(AvatarType.xs),
                                   child: _AlbumRowSharePillContent(
@@ -216,8 +217,7 @@ class AlbumRowItemWidget extends StatelessWidget {
                                           decoration: BoxDecoration(
                                             shape: BoxShape.circle,
                                             border: Border.all(
-                                              color:
-                                                  componentColors.specialWhite,
+                                              color: componentColors.fillLight,
                                               width: _sharedAvatarStrokeWidth,
                                             ),
                                           ),
@@ -340,33 +340,6 @@ class AlbumRowItemWidget extends StatelessWidget {
     );
   }
 
-  BoxDecoration _sharePillDecoration(BuildContext context) {
-    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    return BoxDecoration(
-      borderRadius: BorderRadius.circular(40),
-      gradient: RadialGradient(
-        center: Alignment.center,
-        radius: isDarkMode ? 1.28 : 1.18,
-        colors: isDarkMode
-            ? const [
-                Color.fromRGBO(46, 46, 46, 1),
-                Color.fromRGBO(50, 50, 50, 0),
-              ]
-            : const [
-                Color.fromRGBO(255, 255, 255, 0.51),
-                Color.fromRGBO(255, 255, 255, 0.1275),
-              ],
-      ),
-      boxShadow: [
-        BoxShadow(
-          color: Color.fromRGBO(0, 0, 0, isDarkMode ? 0.15 : 0.05),
-          offset: const Offset(0, 1),
-          blurRadius: isDarkMode ? 1.5 : 0.8,
-        ),
-      ],
-    );
-  }
-
   Widget _buildAlbumStatusChips({required bool isOwner}) {
     final bool isFavoriteAlbum = c.type == CollectionType.favorites;
     final bool showPin = isOwner ? c.isPinned : c.hasShareePinned();
@@ -388,32 +361,6 @@ class AlbumRowItemWidget extends StatelessWidget {
           chips[i],
         ],
       ],
-    );
-  }
-}
-
-class _ThumbnailShareGradientOverlay extends StatelessWidget {
-  const _ThumbnailShareGradientOverlay();
-
-  @override
-  Widget build(BuildContext context) {
-    return IgnorePointer(
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.bottomLeft,
-            end: Alignment.topRight,
-            transform: const GradientRotation(pi / 4),
-            colors: [
-              Colors.black.withValues(alpha: 0.16),
-              Colors.black.withValues(alpha: 0.06),
-              Colors.transparent,
-            ],
-            stops: const [0, 0.42, 0.78],
-          ),
-        ),
-        child: const SizedBox.expand(),
-      ),
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/components/collection_share_badge.dart
+++ b/mobile/apps/photos/lib/ui/components/collection_share_badge.dart
@@ -104,6 +104,7 @@ class CollectionShareBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
     final isOutlined = variant == CollectionShareBadgeVariant.outlined;
+    final outlinedColor = colorScheme.textBase;
     return Container(
       width: 12,
       height: 12,
@@ -111,7 +112,7 @@ class CollectionShareBadge extends StatelessWidget {
         color: isOutlined ? Colors.transparent : colorScheme.greenBase,
         shape: BoxShape.circle,
         border: Border.all(
-          color: isOutlined ? colorScheme.greenBase : colorScheme.fill,
+          color: isOutlined ? outlinedColor : colorScheme.fill,
           width: isOutlined ? 1.0 : kCollectionBadgeBorderWidth,
         ),
       ),
@@ -121,7 +122,7 @@ class CollectionShareBadge extends StatelessWidget {
               ? HugeIcons.strokeRoundedArrowUpRight01
               : HugeIcons.strokeRoundedArrowDownLeft01,
           strokeWidth: kCollectionBadgeStrokeWidth,
-          color: isOutlined ? colorScheme.greenBase : Colors.white,
+          color: isOutlined ? outlinedColor : Colors.white,
           size: 8,
         ),
       ),
@@ -145,7 +146,7 @@ class CollectionLinkBadge extends StatelessWidget {
       return HugeIcon(
         icon: HugeIcons.strokeRoundedLink02,
         strokeWidth: kCollectionBadgeStrokeWidth,
-        color: colorScheme.greenBase,
+        color: colorScheme.textBase,
         size: kCollectionBadgeIconSize,
       );
     }

--- a/mobile/apps/photos/lib/ui/components/searchable_appbar.dart
+++ b/mobile/apps/photos/lib/ui/components/searchable_appbar.dart
@@ -1,8 +1,8 @@
+import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/buttons/soft_icon_button.dart";
-import "package:photos/ui/components/text_input_widget_v2.dart";
 
 class SearchableAppBar extends StatefulWidget {
   final Widget title;
@@ -137,29 +137,30 @@ class _SearchableAppBarState extends State<SearchableAppBar> {
   }
 
   Widget _buildSearchField() {
-    final colorScheme = getEnteColorScheme(context);
+    final colors = context.componentColors;
     return Container(
       key: const ValueKey('searchBar'),
       alignment: Alignment.center,
-      child: TextInputWidgetV2(
-        textEditingController: _searchController,
+      child: TextInputComponent(
+        controller: _searchController,
         focusNode: _searchFocusNode,
-        autoFocus: true,
-        shouldSurfaceExecutionStates: false,
-        leadingWidget: HugeIcon(
+        autofocus: true,
+        shouldUnfocusOnClearOrSubmit: true,
+        prefix: HugeIcon(
           icon: HugeIcons.strokeRoundedSearch01,
           size: 18,
-          color: colorScheme.textMuted,
+          color: colors.textLight,
         ),
-        trailingWidget: GestureDetector(
+        suffix: GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: _deactivateSearch,
           child: HugeIcon(
             icon: HugeIcons.strokeRoundedCancel01,
             size: 18,
-            color: colorScheme.textMuted,
+            color: colors.textLight,
           ),
         ),
-        onChange: widget.onSearch,
+        onChanged: widget.onSearch,
       ),
     );
   }

--- a/mobile/apps/photos/lib/ui/components/thumbnail_list_item.dart
+++ b/mobile/apps/photos/lib/ui/components/thumbnail_list_item.dart
@@ -66,7 +66,7 @@ class _ThumbnailListItemState extends State<ThumbnailListItem> {
         borderRadius: BorderRadius.all(Radius.circular(widget.borderRadius)),
         border: Border.all(
           color: widget.isSelected
-              ? widget.selectedBorderColor ?? colors.primaryStroke
+              ? widget.selectedBorderColor ?? colors.strokeDark
               : widget.borderColor ?? _backgroundColor(colors),
         ),
       ),

--- a/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
-import 'dart:math' as math;
 
+import 'package:ente_components/theme/icon_sizes.dart';
+import 'package:ente_components/theme/radii.dart';
+import 'package:ente_components/theme/spacing.dart';
 import 'package:ente_components/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -8,9 +10,11 @@ import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/tab_changed_event.dart';
 import "package:photos/models/selected_albums.dart";
 import 'package:photos/models/selected_files.dart';
+import 'package:photos/ui/tabs/nav_bar.dart';
 
-const double _homeNavBarHeight = 62;
-const double _homeNavContainerHeight = 78;
+const double _homeNavContainerHeight = 70;
+const double _homeNavButtonPadding = 10;
+const double _homeNavItemSpacing = 22;
 
 class HomeBottomNavigationBar extends StatefulWidget {
   const HomeBottomNavigationBar(
@@ -121,18 +125,23 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
           height: filesAreSelected || albumsAreSelected
               ? 0
               : _homeNavContainerHeight,
-          child: ClipRect(
-            child: IgnorePointer(
-              ignoring: filesAreSelected || albumsAreSelected,
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: _FigmaHomeNavBar(
-                  selectedIndex: currentTabIndex,
-                  onTabChange: (index) {
-                    _onTabChange(index, mode: "OnPressed");
-                  },
+          child: IgnorePointer(
+            ignoring: filesAreSelected || albumsAreSelected,
+            child: ListView(
+              physics: const NeverScrollableScrollPhysics(),
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    _HomeNavBar(
+                      selectedIndex: currentTabIndex,
+                      onTabChange: (index) {
+                        _onTabChange(index, mode: "OnPressed");
+                      },
+                    ),
+                  ],
                 ),
-              ),
+              ],
             ),
           ),
         ),
@@ -141,29 +150,26 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
   }
 }
 
-class _FigmaHomeNavBar extends StatelessWidget {
-  const _FigmaHomeNavBar({
-    required this.selectedIndex,
-    required this.onTabChange,
-  });
+class _HomeNavBar extends StatelessWidget {
+  const _HomeNavBar({required this.selectedIndex, required this.onTabChange});
 
   static const _tabs = [
-    _FigmaNavTab(
+    _HomeNavTab(
       semanticLabel: 'Home',
       outlineAsset: 'assets/icons/nav_bar/home_outline.svg',
       filledAsset: 'assets/icons/nav_bar/home_filled.svg',
     ),
-    _FigmaNavTab(
+    _HomeNavTab(
       semanticLabel: 'Albums',
       outlineAsset: 'assets/icons/nav_bar/albums_outline.svg',
       filledAsset: 'assets/icons/nav_bar/albums_filled.svg',
     ),
-    _FigmaNavTab(
+    _HomeNavTab(
       semanticLabel: 'Feed',
       outlineAsset: 'assets/icons/nav_bar/feed_outline.svg',
       filledAsset: 'assets/icons/nav_bar/feed_filled.svg',
     ),
-    _FigmaNavTab(
+    _HomeNavTab(
       semanticLabel: 'Search',
       outlineAsset: 'assets/icons/nav_bar/search_outline.svg',
       filledAsset: 'assets/icons/nav_bar/search_filled.svg',
@@ -176,87 +182,58 @@ class _FigmaHomeNavBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
-    final navWidth = math.min(
-      318.0,
-      math.max(0.0, MediaQuery.sizeOf(context).width - 32.0),
-    );
-
-    return Container(
-      width: navWidth,
-      height: _homeNavBarHeight,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: colors.fillLight,
-        borderRadius: BorderRadius.circular(20),
-        boxShadow: const [
-          BoxShadow(
-            color: Color.fromRGBO(0, 0, 0, 0.25),
-            offset: Offset(0, 4),
-            blurRadius: 8.75,
-          ),
-        ],
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: List.generate(_tabs.length, (index) {
-          return _FigmaNavButton(
-            tab: _tabs[index],
-            selected: selectedIndex == index,
-            onTap: () => onTabChange(index),
-          );
-        }),
-      ),
-    );
-  }
-}
-
-class _FigmaNavButton extends StatelessWidget {
-  const _FigmaNavButton({
-    required this.tab,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final _FigmaNavTab tab;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.componentColors;
-    final iconColor = colors.iconColor;
-    return Semantics(
-      label: tab.semanticLabel,
-      selected: selected,
-      button: true,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOutExpo,
-          width: 38,
-          height: 38,
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: selected ? colors.fillDark : colors.fillLight,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: _FigmaNavIcon(tab: tab, selected: selected, color: iconColor),
+    return GNav(
+      curve: Curves.easeOutExpo,
+      backgroundColor: colors.fillLight,
+      mainAxisAlignment: MainAxisAlignment.center,
+      padding: const EdgeInsets.all(_homeNavButtonPadding),
+      duration: const Duration(milliseconds: 200),
+      gap: 0,
+      borderRadius: Radii.button,
+      boxShadow: const [
+        BoxShadow(
+          color: Color.fromRGBO(0, 0, 0, 0.25),
+          offset: Offset(0, 4),
+          blurRadius: 8.75,
         ),
-      ),
+      ],
+      tabBorderRadius: Radii.md,
+      tabBackgroundColor: colors.fillDark,
+      haptic: false,
+      selectedIndex: selectedIndex,
+      onTabChange: onTabChange,
+      tabs: List.generate(_tabs.length, (index) {
+        return GButton(
+          margin: EdgeInsets.only(
+            left: index == 0 ? Spacing.lg : _homeNavItemSpacing,
+            right: index == _tabs.length - 1 ? Spacing.lg : _homeNavItemSpacing,
+            top: Spacing.md,
+            bottom: Spacing.md,
+          ),
+          text: '',
+          semanticLabel: _tabs[index].semanticLabel,
+          leading: SizedBox.square(
+            dimension: IconSizes.small,
+            child: _HomeNavIcon(
+              tab: _tabs[index],
+              selected: selectedIndex == index,
+              color: colors.iconColor,
+            ),
+          ),
+        );
+      }),
     );
   }
 }
 
-class _FigmaNavIcon extends StatelessWidget {
-  const _FigmaNavIcon({
+class _HomeNavIcon extends StatelessWidget {
+  const _HomeNavIcon({
     required this.tab,
     required this.selected,
     required this.color,
   });
 
-  final _FigmaNavTab tab;
+  final _HomeNavTab tab;
   final bool selected;
   final Color color;
 
@@ -265,15 +242,15 @@ class _FigmaNavIcon extends StatelessWidget {
     final colorFilter = ColorFilter.mode(color, BlendMode.srcIn);
     return SvgPicture.asset(
       selected ? tab.filledAsset : tab.outlineAsset,
-      width: 18,
-      height: 18,
+      width: IconSizes.small,
+      height: IconSizes.small,
       colorFilter: colorFilter,
     );
   }
 }
 
-class _FigmaNavTab {
-  const _FigmaNavTab({
+class _HomeNavTab {
+  const _HomeNavTab({
     required this.semanticLabel,
     required this.outlineAsset,
     required this.filledAsset,

--- a/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
@@ -9,6 +9,9 @@ import 'package:photos/events/tab_changed_event.dart';
 import "package:photos/models/selected_albums.dart";
 import 'package:photos/models/selected_files.dart';
 
+const double _homeNavBarHeight = 62;
+const double _homeNavContainerHeight = 78;
+
 class HomeBottomNavigationBar extends StatefulWidget {
   const HomeBottomNavigationBar(
     this.selectedFiles,
@@ -115,24 +118,21 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeInOut,
-          height: filesAreSelected || albumsAreSelected ? 0 : 62,
-          child: IgnorePointer(
-            ignoring: filesAreSelected || albumsAreSelected,
-            child: ListView(
-              physics: const NeverScrollableScrollPhysics(),
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    _FigmaHomeNavBar(
-                      selectedIndex: currentTabIndex,
-                      onTabChange: (index) {
-                        _onTabChange(index, mode: "OnPressed");
-                      },
-                    ),
-                  ],
+          height: filesAreSelected || albumsAreSelected
+              ? 0
+              : _homeNavContainerHeight,
+          child: ClipRect(
+            child: IgnorePointer(
+              ignoring: filesAreSelected || albumsAreSelected,
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: _FigmaHomeNavBar(
+                  selectedIndex: currentTabIndex,
+                  onTabChange: (index) {
+                    _onTabChange(index, mode: "OnPressed");
+                  },
                 ),
-              ],
+              ),
             ),
           ),
         ),
@@ -183,7 +183,7 @@ class _FigmaHomeNavBar extends StatelessWidget {
 
     return Container(
       width: navWidth,
-      height: 62,
+      height: _homeNavBarHeight,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
         color: colors.fillLight,

--- a/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
+++ b/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
@@ -1,6 +1,7 @@
 import "dart:math" as math;
 
 import "package:dotted_border/dotted_border.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_icons/ente_icons.dart";
 import "package:flutter/material.dart";
 import "package:flutter_svg/flutter_svg.dart";
@@ -27,13 +28,10 @@ class StartNewRitualCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
     final textTheme = getEnteTextTheme(context);
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final componentColors = context.componentColors;
     const fillColor = Colors.transparent;
-    final dottedBorderColor = isDark
-        ? colorScheme.strokeFaint
-        : const Color(0xFFF0F0F0);
+    final dottedBorderColor = componentColors.textLightest;
     final contentRightPadding = variant == StartNewRitualCardVariant.compact
         ? 14.0
         : 0.0;

--- a/mobile/apps/photos/lib/ui/social/widgets/comment_input_widget.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/comment_input_widget.dart
@@ -1,3 +1,4 @@
+import "package:ente_components/ente_components.dart";
 import "package:ente_icons/ente_icons.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
@@ -87,7 +88,7 @@ class _CommentInputWidgetState extends State<CommentInputWidget>
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
+    final componentColors = context.componentColors;
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
     final textFieldFillColor = isDarkMode
         ? const Color(0xFF212121)
@@ -141,14 +142,14 @@ class _CommentInputWidgetState extends State<CommentInputWidget>
                 minLines: 1,
                 maxLines: widget.replyingTo != null ? 4 : 8,
                 textAlignVertical: TextAlignVertical.center,
-                style: textTheme.body.copyWith(
-                  height: 15 / 16,
-                  letterSpacing: -0.32,
-                  color: colorScheme.textBase.withValues(alpha: 0.8),
+                style: TextStyles.body.copyWith(
+                  color: componentColors.textBase,
                 ),
                 decoration: InputDecoration(
                   hintText: l10n.commentHint,
-                  hintStyle: textTheme.bodyFaint,
+                  hintStyle: TextStyles.body.copyWith(
+                    color: componentColors.textLighter,
+                  ),
                   border: InputBorder.none,
                   filled: true,
                   fillColor: Colors.transparent,

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -1127,7 +1127,9 @@ class _HomeWidgetState extends State<HomeWidget> {
   }
 
   Widget _buildTabHeroMode(int tabIndex, int selectedTabIndex, Widget child) {
-    return HeroMode(enabled: tabIndex == selectedTabIndex, child: child);
+    return ClipRect(
+      child: HeroMode(enabled: tabIndex == selectedTabIndex, child: child),
+    );
   }
 
   void _closeDrawerIfOpen(BuildContext context) {

--- a/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
@@ -28,6 +28,8 @@ class GNav extends StatefulWidget {
     this.tabShadow,
     this.haptic,
     this.tabBackgroundGradient,
+    this.borderRadius,
+    this.boxShadow,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
   });
 
@@ -54,6 +56,8 @@ class GNav extends StatefulWidget {
   final Border? tabActiveBorder;
   final List<BoxShadow>? tabShadow;
   final Gradient? tabBackgroundGradient;
+  final double? borderRadius;
+  final List<BoxShadow>? boxShadow;
   final MainAxisAlignment mainAxisAlignment;
 
   @override
@@ -78,9 +82,9 @@ class _GNavState extends State<GNav> {
 
     return Container(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(32),
+        borderRadius: BorderRadius.circular(widget.borderRadius ?? 32),
         color: widget.backgroundColor,
-        boxShadow: shadowMenuLight,
+        boxShadow: widget.boxShadow ?? shadowMenuLight,
       ),
       child: Row(
         mainAxisAlignment: widget.mainAxisAlignment,
@@ -115,6 +119,7 @@ class _GNavState extends State<GNav> {
                     t.backgroundGradient ?? widget.tabBackgroundGradient,
                 backgroundColor: t.backgroundColor ?? widget.tabBackgroundColor,
                 duration: widget.duration ?? const Duration(milliseconds: 500),
+                semanticLabel: t.semanticLabel,
                 onPressed: () {
                   widget.onTabChange!(widget.tabs!.indexOf(t));
                 },

--- a/mobile/apps/photos/lib/ui/tabs/shared/memory_link_item.dart
+++ b/mobile/apps/photos/lib/ui/tabs/shared/memory_link_item.dart
@@ -56,7 +56,7 @@ class MemoryLinkAlbumItem extends StatelessWidget {
         decoration: BoxDecoration(
           color: colorScheme.fill,
           border: Border.all(
-            color: isSelected ? colorScheme.greenStroke : colorScheme.fill,
+            color: isSelected ? colorScheme.strokeDark : colorScheme.fill,
           ),
           borderRadius: const BorderRadius.all(Radius.circular(_cardRadius)),
         ),

--- a/mobile/apps/photos/lib/ui/tabs/shared/memory_link_item.dart
+++ b/mobile/apps/photos/lib/ui/tabs/shared/memory_link_item.dart
@@ -98,11 +98,6 @@ class MemoryLinkAlbumItem extends StatelessWidget {
                             );
                           },
                         ),
-                        const Positioned(
-                          right: -4,
-                          bottom: -4,
-                          child: CollectionLinkBadge(),
-                        ),
                       ],
                     ),
                   ),
@@ -113,11 +108,22 @@ class MemoryLinkAlbumItem extends StatelessWidget {
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          title,
-                          maxLines: 1,
-                          softWrap: false,
-                          overflow: TextOverflow.ellipsis,
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Flexible(
+                              child: Text(
+                                title,
+                                maxLines: 1,
+                                softWrap: false,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            const CollectionLinkBadge(
+                              variant: CollectionShareBadgeVariant.outlined,
+                            ),
+                          ],
                         ),
                         const SizedBox(height: 4),
                         Text(

--- a/mobile/apps/photos/lib/ui/tabs/shared/quick_link_album_item.dart
+++ b/mobile/apps/photos/lib/ui/tabs/shared/quick_link_album_item.dart
@@ -38,7 +38,7 @@ class QuickLinkAlbumItem extends StatelessWidget {
       decoration: BoxDecoration(
         color: colorScheme.fill,
         border: Border.all(
-          color: isSelected ? colorScheme.greenStroke : colorScheme.fill,
+          color: isSelected ? colorScheme.strokeDark : colorScheme.fill,
         ),
         borderRadius: const BorderRadius.all(Radius.circular(_cardRadius)),
       ),

--- a/mobile/apps/photos/lib/ui/tabs/shared/quick_link_album_item.dart
+++ b/mobile/apps/photos/lib/ui/tabs/shared/quick_link_album_item.dart
@@ -81,11 +81,6 @@ class QuickLinkAlbumItem extends StatelessWidget {
                           }
                         },
                       ),
-                      const Positioned(
-                        right: -4,
-                        bottom: -4,
-                        child: CollectionLinkBadge(),
-                      ),
                     ],
                   ),
                 ),
@@ -96,11 +91,22 @@ class QuickLinkAlbumItem extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        c.displayName,
-                        maxLines: 1,
-                        softWrap: false,
-                        overflow: TextOverflow.ellipsis,
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Flexible(
+                            child: Text(
+                              c.displayName,
+                              maxLines: 1,
+                              softWrap: false,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          const CollectionLinkBadge(
+                            variant: CollectionShareBadgeVariant.outlined,
+                          ),
+                        ],
                       ),
                       const SizedBox(height: 4),
                       FutureBuilder<int>(

--- a/mobile/apps/photos/lib/ui/viewer/search/search_suffix_icon_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_suffix_icon_widget.dart
@@ -1,4 +1,6 @@
+import 'package:ente_components/ente_components.dart';
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/clear_and_unfocus_search_bar_event.dart";
 import "package:photos/theme/ente_theme.dart";
@@ -17,27 +19,25 @@ class SearchSuffixIcon extends StatefulWidget {
 }
 
 class _SearchSuffixIconState extends State<SearchSuffixIcon> {
-  static const double _suffixContainerSize = 44;
+  static const double _suffixContainerSize = 24;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
+    final componentColors = context.componentColors;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 175),
       child: widget.shouldShowSpinner
           ? SizedBox(
               width: _suffixContainerSize,
               height: _suffixContainerSize,
-              child: Align(
-                alignment: Alignment.centerRight,
+              child: Center(
                 child: SizedBox(
                   height: 20,
                   width: 20,
-                  child: Center(
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: colorScheme.strokeMuted,
-                    ),
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: colorScheme.strokeMuted,
                   ),
                 ),
               ),
@@ -55,7 +55,11 @@ class _SearchSuffixIconState extends State<SearchSuffixIcon> {
               onPressed: () {
                 Bus.instance.fire(ClearAndUnfocusSearchBar());
               },
-              icon: Icon(Icons.close, color: colorScheme.strokeMuted, size: 16),
+              icon: HugeIcon(
+                icon: HugeIcons.strokeRoundedCancel01,
+                color: componentColors.textLight,
+                size: 18,
+              ),
             )
           : const SizedBox(
               width: _suffixContainerSize,

--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:flutter/scheduler.dart";
@@ -13,7 +14,6 @@ import "package:photos/models/search/generic_search_result.dart";
 import "package:photos/models/search/index_of_indexed_stack.dart";
 import "package:photos/models/search/search_result.dart";
 import "package:photos/services/search_service.dart";
-import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/viewer/search/search_suffix_icon_widget.dart";
 
 class SearchWidget extends StatefulWidget {
@@ -143,10 +143,7 @@ class SearchWidgetState extends State<SearchWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
-    final mutedTextColor =
-        textTheme.smallMuted.color ?? colorScheme.strokeMuted;
+    final componentColors = context.componentColors;
     final shouldShowClearButton =
         focusNode.hasFocus ||
         MediaQuery.viewInsetsOf(context).bottom > 0 ||
@@ -156,63 +153,25 @@ class SearchWidgetState extends State<SearchWidget> {
       child: Padding(
         padding: EdgeInsets.only(bottom: _bottomPadding),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-          child: SizedBox(
-            height: 58,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(16),
-              child: ColoredBox(
-                color: colorScheme.fillFaint,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Row(
-                    children: [
-                      HugeIcon(
-                        icon: HugeIcons.strokeRoundedSearch01,
-                        color: mutedTextColor,
-                        size: 24,
-                        strokeWidth: 1.5,
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: TextField(
-                          controller: textController,
-                          focusNode: focusNode,
-                          style: textTheme.small,
-                          textAlignVertical: TextAlignVertical.center,
-                          // Below parameters are to disable auto-suggestion
-                          // Above parameters are to disable auto-suggestion
-                          decoration: InputDecoration(
-                            hintText: AppLocalizations.of(context).search,
-                            hintStyle: textTheme.smallMuted,
-                            border: InputBorder.none,
-                            focusedBorder: InputBorder.none,
-                            isDense: true,
-                            contentPadding: EdgeInsets.zero,
-                          ),
-                        ),
-                      ),
-
-                      /*Using valueListenableBuilder inside a stateful widget because this widget is only rebuild when
-                      setState is called when deboucncing is over and the spinner needs to be shown while debouncing */
-                      ValueListenableBuilder(
-                        valueListenable: isLoading,
-                        builder:
-                            (
-                              BuildContext context,
-                              bool isSearching,
-                              Widget? child,
-                            ) {
-                              return SearchSuffixIcon(
-                                isSearching,
-                                showClearButton: shouldShowClearButton,
-                              );
-                            },
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: TextInputComponent(
+            controller: textController,
+            focusNode: focusNode,
+            hintText: AppLocalizations.of(context).search,
+            shouldUnfocusOnClearOrSubmit: true,
+            prefix: HugeIcon(
+              icon: HugeIcons.strokeRoundedSearch01,
+              size: 18,
+              color: componentColors.textLight,
+            ),
+            suffix: ValueListenableBuilder(
+              valueListenable: isLoading,
+              builder: (BuildContext context, bool isSearching, Widget? child) {
+                return SearchSuffixIcon(
+                  isSearching,
+                  showClearButton: shouldShowClearButton,
+                );
+              },
             ),
           ),
         ),

--- a/mobile/packages/ente_components/lib/components/menu_component.dart
+++ b/mobile/packages/ente_components/lib/components/menu_component.dart
@@ -109,7 +109,7 @@ class _MenuComponentState extends State<MenuComponent> {
                 ),
                 border: Border.all(
                   color: widget.selected
-                      ? colors.primaryStroke
+                      ? colors.strokeDark
                       : Colors.transparent,
                 ),
                 borderRadius: borderRadius,


### PR DESCRIPTION
## Summary

- Refine album grid/list badge styling for shared albums, links, selected albums, and favorite/pinned/archive status chips.
- Move MemoryLink and QuickLink link badges into the album title row so text and badge alignment stay consistent.
- Align Photos search fields with the shared text input component, including icon sizing, hint styling, clear action, and keyboard dismissal behavior.
- Fix bottom nav placement/clipping so tab content stays within page bounds and the nav uses shared sizing/radius/spacing tokens.
- Improve Ritual card dotted border contrast using mode-aware component colors.
- Update comment input hint styling to match the shared text-field hint style.