### PR TITLE
[mob][photos] Fix gallery hero animation clipping

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/album/row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/row_item.dart
@@ -116,19 +116,33 @@ class AlbumRowItemWidget extends StatelessWidget {
                               );
                               return Hero(
                                 tag: heroTag,
+                                flightShuttleBuilder:
+                                    (
+                                      flightContext,
+                                      animation,
+                                      flightDirection,
+                                      fromHeroContext,
+                                      toHeroContext,
+                                    ) => (toHeroContext.widget as Hero).child,
                                 transitionOnUserGestures: true,
-                                child: Stack(
-                                  fit: StackFit.expand,
-                                  children: [
-                                    thumbnailWidget,
-                                    if (isSelected)
-                                      Container(
-                                        decoration: BoxDecoration(
-                                          color: componentColors.specialScrim
-                                              .withValues(alpha: 0.4),
+                                child: ClipSmoothRect(
+                                  radius: SmoothBorderRadius(
+                                    cornerRadius: _cornerRadius,
+                                    cornerSmoothing: _cornerSmoothing,
+                                  ),
+                                  child: Stack(
+                                    fit: StackFit.expand,
+                                    children: [
+                                      thumbnailWidget,
+                                      if (isSelected)
+                                        Container(
+                                          decoration: BoxDecoration(
+                                            color: componentColors.specialScrim
+                                                .withValues(alpha: 0.4),
+                                          ),
                                         ),
-                                      ),
-                                  ],
+                                    ],
+                                  ),
                                 ),
                               );
                             } else {

--- a/mobile/apps/photos/lib/ui/components/buttons/icon_button_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/buttons/icon_button_widget.dart
@@ -6,7 +6,8 @@ enum IconButtonType { primary, secondary, rounded }
 
 class IconButtonWidget extends StatefulWidget {
   final IconButtonType iconButtonType;
-  final IconData icon;
+  final IconData? icon;
+  final Widget? iconWidget;
   final bool disableGestureDetector;
   final VoidCallback? onTap;
   final Color? defaultColor;
@@ -15,7 +16,8 @@ class IconButtonWidget extends StatefulWidget {
   final double size;
   final bool roundedIcon;
   const IconButtonWidget({
-    required this.icon,
+    this.icon,
+    this.iconWidget,
     required this.iconButtonType,
     this.disableGestureDetector = false,
     this.onTap,
@@ -25,7 +27,7 @@ class IconButtonWidget extends StatefulWidget {
     this.size = 24,
     this.roundedIcon = true,
     super.key,
-  });
+  }) : assert(icon != null || iconWidget != null);
 
   @override
   State<IconButtonWidget> createState() => _IconButtonWidgetState();
@@ -35,7 +37,9 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
   Color? iconStateColor;
   @override
   void didUpdateWidget(IconButtonWidget oldWidget) {
-    if (oldWidget.icon != widget.icon && mounted) {
+    if ((oldWidget.icon != widget.icon ||
+            oldWidget.iconWidget != widget.iconWidget) &&
+        mounted) {
       setState(() {
         iconStateColor = null;
       });
@@ -65,6 +69,13 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
   }
 
   Widget _iconButton(EnteColorScheme colorTheme) {
+    final iconColor =
+        widget.iconColor ??
+        (widget.iconButtonType == IconButtonType.secondary
+            ? colorTheme.strokeMuted
+            : colorTheme.strokeBase);
+    final icon = widget.iconWidget ?? Icon(widget.icon, size: widget.size);
+
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: widget.roundedIcon
@@ -75,24 +86,14 @@ class _IconButtonWidgetState extends State<IconButtonWidget> {
                 borderRadius: BorderRadius.circular(widget.size),
                 color: iconStateColor,
               ),
-              child: Icon(
-                widget.icon,
-                color:
-                    widget.iconColor ??
-                    (widget.iconButtonType == IconButtonType.secondary
-                        ? colorTheme.strokeMuted
-                        : colorTheme.strokeBase),
-                size: widget.size,
+              child: IconTheme(
+                data: IconThemeData(color: iconColor, size: widget.size),
+                child: icon,
               ),
             )
-          : Icon(
-              widget.icon,
-              color:
-                  widget.iconColor ??
-                  (widget.iconButtonType == IconButtonType.secondary
-                      ? colorTheme.strokeMuted
-                      : colorTheme.strokeBase),
-              size: widget.size,
+          : IconTheme(
+              data: IconThemeData(color: iconColor, size: widget.size),
+              child: icon,
             ),
     );
   }

--- a/mobile/apps/photos/lib/ui/components/home_header_widget.dart
+++ b/mobile/apps/photos/lib/ui/components/home_header_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import "package:hugeicons/hugeicons.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/ui/common/backup_flow_helper.dart";
 import 'package:photos/ui/components/buttons/icon_button_widget.dart';
@@ -24,7 +25,7 @@ class _HomeHeaderWidgetState extends State<HomeHeaderWidget> {
           children: [
             IconButtonWidget(
               iconButtonType: IconButtonType.primary,
-              icon: Icons.menu_outlined,
+              iconWidget: const HugeIcon(icon: HugeIcons.strokeRoundedMenu01),
               onTap: () {
                 Scaffold.of(context).openDrawer();
               },
@@ -37,7 +38,9 @@ class _HomeHeaderWidgetState extends State<HomeHeaderWidget> {
         ),
         showAddAlbumAction
             ? IconButtonWidget(
-                icon: Icons.add_photo_alternate_outlined,
+                iconWidget: const HugeIcon(
+                  icon: HugeIcons.strokeRoundedUpload01,
+                ),
                 iconButtonType: IconButtonType.primary,
                 onTap: () async => handleFullPermissionBackupFlow(context),
               )

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -151,9 +151,12 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
                           flightDirection,
                           fromHeroContext,
                           toHeroContext,
-                        ) => thumbnailWidget,
+                        ) => (toHeroContext.widget as Hero).child,
                     transitionOnUserGestures: true,
-                    child: thumbnailWidget,
+                    child: ClipRRect(
+                      borderRadius: borderRadius,
+                      child: thumbnailWidget,
+                    ),
                   ),
                 ),
                 Container(
@@ -186,9 +189,12 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
                       flightDirection,
                       fromHeroContext,
                       toHeroContext,
-                    ) => thumbnailWidget,
+                    ) => (toHeroContext.widget as Hero).child,
                 transitionOnUserGestures: true,
-                child: thumbnailWidget,
+                child: ClipRRect(
+                  borderRadius: borderRadius,
+                  child: thumbnailWidget,
+                ),
               ),
             ),
     );


### PR DESCRIPTION
## Description
- Keeps gallery and album hero transitions clipped to their rounded thumbnail bounds.
- Uses the destination Hero child for the flight shuttle so the animation preserves the target shape during navigation.

## Tests
Not run per request.