### PR TITLE
[mob][photos] Fix button loading layout expansion

### DIFF
--- a/mobile/apps/photos/lib/ui/components/buttons/button_widget_v2.dart
+++ b/mobile/apps/photos/lib/ui/components/buttons/button_widget_v2.dart
@@ -234,44 +234,47 @@ class _ButtonWidgetV2State extends State<ButtonWidgetV2>
     );
 
     if (widget.progressStatus != null) {
-      return Center(
+      return Row(
         key: const ValueKey('loading'),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ValueListenableBuilder<String>(
-              valueListenable: widget.progressStatus!,
-              builder: (context, value, _) {
-                if (value.isEmpty) return const SizedBox.shrink();
-                return Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: Text(
-                    value,
-                    style: textTheme.smallBold.copyWith(
-                      color: colors.textColor,
-                    ),
-                  ),
-                );
-              },
-            ),
-            spinner,
-          ],
-        ),
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          ValueListenableBuilder<String>(
+            valueListenable: widget.progressStatus!,
+            builder: (context, value, _) {
+              if (value.isEmpty) return const SizedBox.shrink();
+              return Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(
+                  value,
+                  style: textTheme.smallBold.copyWith(color: colors.textColor),
+                ),
+              );
+            },
+          ),
+          spinner,
+        ],
       );
     }
 
-    return Center(key: const ValueKey('loading'), child: spinner);
+    return Row(
+      key: const ValueKey('loading'),
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [spinner],
+    );
   }
 
   Widget _buildSuccessContent(ButtonColors colors) {
-    return Center(
+    return Row(
       key: const ValueKey('success'),
-      child: HugeIcon(
-        icon: HugeIcons.strokeRoundedTick02,
-        color: colors.checkmarkColor,
-        size: 24,
-      ),
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        HugeIcon(
+          icon: HugeIcons.strokeRoundedTick02,
+          color: colors.checkmarkColor,
+          size: 24,
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## Description

Fixes a ButtonWidgetV2 layout regression where loading and success states could expand vertically when the button was placed in loose constraints, such as auth flow floating action buttons behind a progress dialog.

The regression came from the recent button wrapping fix that changed the button from a fixed height to a minHeight so long labels can wrap. That wrapping behavior is still preserved; this PR changes only the loading and success state content from expanding Center widgets to centered Rows so state icons keep the button at its intrinsic height.

## Tests

- [x] flutter analyze .