### PR TITLE
[mob][photos] Introduced 'archiveCollectionName' translation string

### DIFF
--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -3212,5 +3212,4 @@
   "@archiveCollectionName": {
     "description": "Name of the 'Archive' collection"
   }
-
 }

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -427,6 +427,9 @@
   "sharing": "Sharing...",
   "youCannotShareWithYourself": "You cannot share with yourself",
   "archive": "Archive",
+  "@archive": {
+    "description": "Action of 'Archiving' an element"
+  },
   "createAlbumActionHint": "Long press to select photos and click + to create an album",
   "importing": "Importing....",
   "failedToLoadAlbums": "Failed to load albums",
@@ -1168,6 +1171,9 @@
   "moveToAlbum": "Move to album",
   "unhide": "Unhide",
   "unarchive": "Unarchive",
+  "@unarchive": {
+    "description": "Action of 'Unarchiving' an element"
+  },
   "favorite": "Favorite",
   "removeFromFavorite": "Remove from favorites",
   "shareMemories": "Share memories",
@@ -3201,5 +3207,10 @@
   "offlineNameFaceBannerSubtitle": "Sign up to tag them and easily find their photos later.",
   "signUp": "Sign up",
   "dog": "Dog",
-  "cat": "Cat"
+  "cat": "Cat",
+  "archiveCollectionName": "Archive",
+  "@archiveCollectionName": {
+    "description": "Name of the 'Archive' collection"
+  }
+
 }

--- a/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
@@ -54,7 +54,7 @@ class ArchivedCollectionsButton extends StatelessWidget {
                             style: textStyle,
                             children: [
                               TextSpan(
-                                text: AppLocalizations.of(context).archive,
+                                text: AppLocalizations.of(context).archiveCollectionName,
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                               const TextSpan(text: "  \u2022  "),
@@ -69,7 +69,7 @@ class ArchivedCollectionsButton extends StatelessWidget {
                             style: textStyle,
                             children: [
                               TextSpan(
-                                text: AppLocalizations.of(context).archive,
+                                text: AppLocalizations.of(context).archiveCollectionName,
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                               //need to query in db and bring this value

--- a/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
+++ b/mobile/apps/photos/lib/ui/collections/button/archived_button.dart
@@ -54,7 +54,9 @@ class ArchivedCollectionsButton extends StatelessWidget {
                             style: textStyle,
                             children: [
                               TextSpan(
-                                text: AppLocalizations.of(context).archiveCollectionName,
+                                text: AppLocalizations.of(
+                                  context,
+                                ).archiveCollectionName,
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                               const TextSpan(text: "  \u2022  "),
@@ -69,7 +71,9 @@ class ArchivedCollectionsButton extends StatelessWidget {
                             style: textStyle,
                             children: [
                               TextSpan(
-                                text: AppLocalizations.of(context).archiveCollectionName,
+                                text: AppLocalizations.of(
+                                  context,
+                                ).archiveCollectionName,
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                               //need to query in db and bring this value

--- a/mobile/apps/photos/lib/ui/tabs/albums/albums_manage_sheet.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums/albums_manage_sheet.dart
@@ -72,7 +72,7 @@ Future<void> showAlbumsManageSheet(BuildContext context) {
             ),
             const SizedBox(height: 8),
             _manageItem(
-              label: strings.archive,
+              label: strings.archiveCollectionName,
               icon: HugeIcons.strokeRoundedArchive03,
               iconColor: colors.primary,
               onTap: () async {

--- a/mobile/apps/photos/lib/ui/viewer/gallery/archive_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/archive_page.dart
@@ -89,7 +89,7 @@ class ArchivePage extends StatelessWidget {
               CollectionListPage(
                 collections,
                 sectionType: UISectionType.archivedCollections,
-                appTitle: Text(AppLocalizations.of(context).archive),
+                appTitle: Text(AppLocalizations.of(context).archiveCollectionName),
                 tag: "archived",
               ),
             );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/archive_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/archive_page.dart
@@ -89,7 +89,9 @@ class ArchivePage extends StatelessWidget {
               CollectionListPage(
                 collections,
                 sectionType: UISectionType.archivedCollections,
-                appTitle: Text(AppLocalizations.of(context).archiveCollectionName),
+                appTitle: Text(
+                  AppLocalizations.of(context).archiveCollectionName,
+                ),
                 tag: "archived",
               ),
             );


### PR DESCRIPTION
## Description

For specific languages (like French), there is a need to make a distinction between "Archive" (the collection name) and "Archive" (the action of archiving). 

In French, the collection name would be "Archive**s**" and the action of archiving would be "Archive**r**".

With the new UI design, we see the "Archive" collection name in the "more" section of the new album management sheet. Currently it is using the translation string "archive" and it therefore shows an action in some languages (which feels off).

## Proposed changes

I have introduced a new translation string named 'archiveCollectionName' in `intl_en.arb`. It is replacing the "archive" translation string in the `albums_manage_sheet.dart`.

I have also added more context to the "archive" and "unarchive" translation strings in `intl_en.arb` to emphasize this is an action and not the archive collection name

I followed instructions in [translations.md](https://github.com/ente-io/ente/blob/main/mobile/apps/photos/docs/translations.md) document.

## Tests
Ran `flutter gen-l10n` succesfully.