### PR TITLE
[auth][desktop] Fix Auth tray icon in sandboxed Linux builds

### DIFF
--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -45,11 +45,11 @@ final _logger = Logger("main");
 
 Future<void> initSystemTray() async {
   if (PlatformDetector.isMobile()) return;
-  String path = Platform.isWindows
+  final String path = Platform.isWindows
       ? 'assets/icons/auth-icon-monochrome.ico'
       : Platform.isMacOS
       ? 'assets/icons/auth-icon-monochrome-padded.png'
-      : 'assets/icons/auth-icon-monochrome.png';
+      : _linuxTrayIconPath();
   await trayManager.setIcon(path, isTemplate: true);
   Menu menu = Menu(
     items: [
@@ -60,6 +60,14 @@ Future<void> initSystemTray() async {
     ],
   );
   await trayManager.setContextMenu(menu);
+}
+
+String _linuxTrayIconPath() {
+  if (Platform.environment.containsKey('FLATPAK_ID') ||
+      Platform.environment.containsKey('SNAP')) {
+    return 'io.ente.auth';
+  }
+  return 'assets/icons/auth-icon-monochrome.png';
 }
 
 void main() async {


### PR DESCRIPTION
Refs #4608.
Refs #7815.
Refs https://github.com/flathub/io.ente.auth/issues/75.
Refs #4329.

References:
- Flatpak app icons are named with the application ID and desktop files use that icon name: https://docs.flatpak.org/en/latest/conventions.html#application-icons
- Flatpak exported desktop/icon files are expected to match the application ID, or be renamed to it by the manifest: https://docs.flatpak.org/en/latest/manifests.html#file-renaming
- Snapcraft uses the desktop file `Icon=` value for desktop menu icons: https://documentation.ubuntu.com/snapcraft/latest/reference/project-file/snapcraft-yaml/
- `tray_manager` documents sandboxed Flatpak/Snap apps should pass the manifest icon name to `setIcon`: https://github.com/leanflutter/tray_manager/blob/main/packages/tray_manager/lib/src/tray_manager.dart
