### PR TITLE
[auth] Fix: in-app actions require authentication even when app lock is disabled

### DIFF
--- a/mobile/packages/lock_screen/lib/local_authentication_service.dart
+++ b/mobile/packages/lock_screen/lib/local_authentication_service.dart
@@ -36,7 +36,7 @@ class LocalAuthenticationService {
         return true;
       }
     }
-    if (await isLocalAuthSupportedOnDevice() ||
+    if (await isLocalAuthSupportedOnDevice() &&
         LockScreenSettings.instance.getIsAppLockSet()) {
       AppLock.of(context)!.setEnabled(false);
       final result = await requestAuthentication(


### PR DESCRIPTION
To me, without intimate knowledge of the application, this appears to be an unintentional bug.

When app lock is disabled, the app should not require authentication for in-app actions like edit, delete, or viewing QR codes. This is a bug, the user has explicitly chosen not to require authentication.

Linux app broken under these circumstances:
* Fingerprint reader exists
* No fingerprints enrolled

On Linux/Gnu, when a fingerprint reader is present, but no fingerprints are enrolled, the app is unusable for most operations even when app lock is disabled (edits, deletes, qr codes, backups, etc)

The solution appears to be changing "||" to "&&" in requestLocalAuthentication():
isLocalAuthSupportedOnDevice() && 
LockScreenSettings.instance.getIsAppLockSet()

