### PR TITLE
[auth][desktop] Fix Windows tray lifecycle and icon visibility

### DIFF
--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:ente_accounts/services/user_service.dart';
@@ -9,9 +8,7 @@ import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/locale.dart';
 import 'package:ente_auth/onboarding/view/onboarding_page.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
-import 'package:ente_auth/services/preference_service.dart';
 import 'package:ente_auth/services/update_service.dart';
-import 'package:ente_auth/services/window_listener_service.dart';
 import 'package:ente_auth/ui/home_page.dart';
 import 'package:ente_auth/ui/settings/app_update_dialog.dart';
 import 'package:ente_events/event_bus.dart';
@@ -22,9 +19,6 @@ import 'package:ente_strings/l10n/strings_localizations.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:tray_manager/tray_manager.dart';
-import 'package:win32/win32.dart';
-import 'package:window_manager/window_manager.dart';
 
 class App extends StatefulWidget {
   final Locale? locale;
@@ -44,8 +38,7 @@ class App extends StatefulWidget {
   State<App> createState() => _AppState();
 }
 
-class _AppState extends State<App>
-    with WindowListener, TrayListener, WidgetsBindingObserver {
+class _AppState extends State<App> with WidgetsBindingObserver {
   static final Logger _renderErrorLogger = Logger('RenderError');
   late StreamSubscription<SignedOutEvent> _signedOutEvent;
   late StreamSubscription<SignedInEvent> _signedInEvent;
@@ -56,18 +49,8 @@ class _AppState extends State<App>
     });
   }
 
-  Future<void> initWindowManager() async {
-    windowManager.addListener(this);
-  }
-
-  Future<void> initTrayManager() async {
-    trayManager.addListener(this);
-  }
-
   @override
   void initState() {
-    initWindowManager();
-    initTrayManager();
     WidgetsBinding.instance.addObserver(this);
 
     _signedOutEvent = Bus.instance.on<SignedOutEvent>().listen((event) {
@@ -103,9 +86,6 @@ class _AppState extends State<App>
   @override
   void dispose() {
     super.dispose();
-
-    windowManager.removeListener(this);
-    trayManager.removeListener(this);
 
     _signedOutEvent.cancel();
     _signedInEvent.cancel();
@@ -164,97 +144,6 @@ class _AppState extends State<App>
           ? const HomePage()
           : const OnboardingPage(),
     };
-  }
-
-  @override
-  void onWindowResize() {
-    WindowListenerService.instance.onWindowResize().ignore();
-  }
-
-  @override
-  void onWindowMaximize() {
-    WindowListenerService.instance.onWindowMaximize().ignore();
-  }
-
-  @override
-  void onWindowUnmaximize() {
-    WindowListenerService.instance.onWindowUnmaximize().ignore();
-  }
-
-  @override
-  void onTrayIconMouseDown() {
-    if (Platform.isWindows) {
-      windowManager.show();
-    } else {
-      trayManager.popUpContextMenu();
-    }
-  }
-
-  @override
-  void onTrayIconRightMouseDown() {
-    if (Platform.isWindows) {
-      trayManager.popUpContextMenu();
-    } else {
-      windowManager.show();
-    }
-  }
-
-  @override
-  void onWindowFocus() {
-    // When window receives focus (e.g., reopened from app launcher while
-    // hidden to tray), ensure the taskbar icon is visible
-    if (Platform.isWindows || Platform.isLinux) {
-      windowManager.setSkipTaskbar(false);
-    }
-  }
-
-  @override
-  void onTrayIconRightMouseUp() {}
-
-  @override
-  void onTrayMenuItemClick(MenuItem menuItem) {
-    switch (menuItem.key) {
-      case 'hide_window':
-        windowManager.hide();
-        windowManager.setSkipTaskbar(true);
-        break;
-      case 'show_window':
-        windowManager.show();
-        windowManager.setSkipTaskbar(false);
-        break;
-      case 'exit_app':
-        _quitApp().ignore();
-        break;
-    }
-  }
-
-  @override
-  void onWindowClose() {
-    final shouldMinimizeToTray = PreferenceService.instance
-        .shouldMinimizeToTrayOnClose();
-    if (shouldMinimizeToTray) {
-      windowManager.hide();
-      windowManager.setSkipTaskbar(true);
-    } else {
-      _quitApp().ignore();
-    }
-  }
-
-  Future<void> _quitApp() async {
-    if (Platform.isWindows) {
-      final int hProcess = GetCurrentProcess();
-      TerminateProcess(hProcess, 0);
-      return;
-    }
-
-    await windowManager.setPreventClose(false);
-    await windowManager.destroy();
-
-    // On Linux, closing via window_manager.destroy() can still segfault during
-    // native window teardown. Explicitly exiting here avoids that crash.
-    if (Platform.isLinux) {
-      exit(0);
-    }
   }
 
   Widget _materialAppBuilder(BuildContext context, Widget? widget) {

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -46,7 +46,7 @@ final _logger = Logger("main");
 Future<void> initSystemTray() async {
   if (PlatformDetector.isMobile()) return;
   final String path = Platform.isWindows
-      ? 'assets/icons/auth-icon-monochrome.ico'
+      ? 'assets/icons/auth-icon.ico'
       : Platform.isMacOS
       ? 'assets/icons/auth-icon-monochrome-padded.png'
       : _linuxTrayIconPath();

--- a/mobile/apps/auth/lib/services/window_listener_service.dart
+++ b/mobile/apps/auth/lib/services/window_listener_service.dart
@@ -1,17 +1,22 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter/widgets.dart';
+import 'package:ente_auth/services/preference_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tray_manager/tray_manager.dart';
+import 'package:win32/win32.dart';
 import 'package:window_manager/window_manager.dart';
 
-class WindowListenerService {
+class WindowListenerService with WindowListener, TrayListener {
   static const double initialWindowHeight = 1200.0;
   static const double initialWindowWidth = 800.0;
   static const bool initialIsMaximized = false;
   static const double maxWindowHeight = 8192.0;
   static const double maxWindowWidth = 8192.0;
   late SharedPreferences _preferences;
+  bool _isListening = false;
+  bool _isQuitting = false;
 
   WindowListenerService._privateConstructor();
 
@@ -20,6 +25,10 @@ class WindowListenerService {
 
   Future<void> init() async {
     _preferences = await SharedPreferences.getInstance();
+    if (_isListening) return;
+    windowManager.addListener(this);
+    trayManager.addListener(this);
+    _isListening = true;
   }
 
   Size getWindowSize() {
@@ -36,19 +45,118 @@ class WindowListenerService {
     return _preferences.getBool('is_maximized') ?? initialIsMaximized;
   }
 
-  Future<void> onWindowResize() async {
+  @override
+  void onWindowResize() {
+    unawaited(_saveWindowSize());
+  }
+
+  Future<void> _saveWindowSize() async {
     final width = (await windowManager.getSize()).width;
     final height = (await windowManager.getSize()).height;
-    // Save the window size to shared preferences
     await _preferences.setDouble('windowWidth', width);
     await _preferences.setDouble('windowHeight', height);
   }
 
-  Future<void> onWindowMaximize() async {
-    await _preferences.setBool('is_maximized', true);
+  @override
+  void onWindowMaximize() {
+    unawaited(_preferences.setBool('is_maximized', true));
   }
 
-  Future<void> onWindowUnmaximize() async {
-    await _preferences.setBool('is_maximized', false);
+  @override
+  void onWindowUnmaximize() {
+    unawaited(_preferences.setBool('is_maximized', false));
+  }
+
+  @override
+  void onTrayIconMouseDown() {
+    if (Platform.isWindows) {
+      unawaited(_showWindow());
+    } else {
+      unawaited(trayManager.popUpContextMenu());
+    }
+  }
+
+  @override
+  void onTrayIconRightMouseDown() {
+    if (Platform.isWindows) {
+      unawaited(trayManager.popUpContextMenu());
+    } else {
+      unawaited(_showWindow());
+    }
+  }
+
+  @override
+  void onWindowFocus() {
+    if (Platform.isWindows || Platform.isLinux) {
+      unawaited(windowManager.setSkipTaskbar(false));
+    }
+  }
+
+  @override
+  void onTrayIconRightMouseUp() {}
+
+  @override
+  void onTrayMenuItemClick(MenuItem menuItem) {
+    switch (menuItem.key) {
+      case 'hide_window':
+        unawaited(_hideWindow());
+        break;
+      case 'show_window':
+        unawaited(_showWindow());
+        break;
+      case 'exit_app':
+        unawaited(_quitApp());
+        break;
+    }
+  }
+
+  @override
+  void onWindowClose() {
+    if (_shouldMinimizeToTrayOnClose()) {
+      unawaited(_hideWindow());
+    } else {
+      unawaited(_quitApp());
+    }
+  }
+
+  bool _shouldMinimizeToTrayOnClose() {
+    return _preferences.getBool(
+          PreferenceService.kShouldMinimizeToTrayOnClose,
+        ) ??
+        false;
+  }
+
+  Future<void> _hideWindow() async {
+    await windowManager.hide();
+    await windowManager.setSkipTaskbar(true);
+  }
+
+  Future<void> _showWindow() async {
+    await windowManager.show();
+    await windowManager.setSkipTaskbar(false);
+  }
+
+  Future<void> _quitApp() async {
+    if (_isQuitting) return;
+    _isQuitting = true;
+
+    if (Platform.isWindows) {
+      final int hProcess = GetCurrentProcess();
+      try {
+        await trayManager.destroy();
+      } finally {
+        TerminateProcess(hProcess, 0);
+      }
+      return;
+    }
+
+    await windowManager.setPreventClose(false);
+    await windowManager.destroy();
+
+    // On Linux, closing via window_manager.destroy() can still segfault during
+    // native window teardown. Explicitly exiting here avoids that crash.
+    if (Platform.isLinux) {
+      exit(0);
+    }
   }
 }


### PR DESCRIPTION
Refs #8165.
Refs #8164.
Refs #4360.
Refs #3518.
Refs #9491.
Refs https://github.com/flathub/io.ente.auth/issues/87.
Refs #9286.

## Test plan
- `ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/auth`
- `ruby mobile/scripts/check_source_arb_plurals.rb`
- `flutter gen-l10n` in `mobile/packages/strings`
- `flutter gen-l10n` in `mobile/apps/auth`
- `dart format --output=none --set-exit-if-changed .` in `mobile/apps/auth`
- `flutter analyze --no-fatal-infos` in `mobile/apps/auth`
- `flutter test` in `mobile/apps/auth`

Manual Windows validation needed:
- Launch while Auth is locked and verify window close and tray Exit work before entering PIN.
- Exit repeatedly and verify stale tray icons do not remain before hover.
- Verify minimize-to-tray still hides on close when enabled.
- Verify tray Hide/Show restores the taskbar icon.
- Verify the tray icon is visible in the Windows 11 tray overflow panel in both light and dark system themes.
