### PR TITLE
[mob][photos] Fix album search empty states

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -163,14 +163,19 @@ class _DeviceFolderVerticalGridViewBodyState
   @override
   Widget build(BuildContext context) {
     if (backupPreferenceService.hasSkippedOnboardingPermission) {
-      return SliverFillRemaining(
-        hasScrollBody: false,
-        child: OnDeviceEmptyState.permission(
-          onFoldersSelected: () {
-            _refreshDeviceCollections();
-          },
-        ),
-      );
+      if (widget.emptyStateSliver != null) {
+        return widget.emptyStateSliver!;
+      }
+      return widget.showEmptyState
+          ? SliverFillRemaining(
+              hasScrollBody: false,
+              child: OnDeviceEmptyState.permission(
+                onFoldersSelected: () {
+                  _refreshDeviceCollections();
+                },
+              ),
+            )
+          : const SliverToBoxAdapter(child: SizedBox.shrink());
     }
 
     return FutureBuilder<List<DeviceCollection>>(

--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -184,6 +184,7 @@ class _DeviceFolderVerticalGridViewBodyState
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           List<DeviceCollection> deviceCollections = snapshot.data!.toList();
+          final hasDeviceCollections = deviceCollections.isNotEmpty;
           if (widget.searchQuery.isNotEmpty) {
             final String query = widget.searchQuery.toLowerCase();
             deviceCollections = deviceCollections
@@ -206,7 +207,7 @@ class _DeviceFolderVerticalGridViewBodyState
             return widget.showEmptyState
                 ? SliverFillRemaining(
                     hasScrollBody: false,
-                    child: widget.searchQuery.isEmpty
+                    child: !hasDeviceCollections
                         ? OnDeviceEmptyState.noFolders(
                             onFoldersSelected: _refreshDeviceCollections,
                           )

--- a/mobile/apps/photos/lib/ui/social/feed_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/feed_screen.dart
@@ -553,6 +553,8 @@ class _FeedScreenState extends State<FeedScreen> {
         backgroundColor: isDark ? null : colorScheme.backgroundColour,
         elevation: 0,
         centerTitle: false,
+        leadingWidth: widget.showBackButton ? 48 : null,
+        titleSpacing: widget.showBackButton ? 4 : null,
         leading: widget.showBackButton
             ? IconButtonWidget(
                 iconButtonType: IconButtonType.primary,
@@ -563,7 +565,7 @@ class _FeedScreenState extends State<FeedScreen> {
         title: Text(
           AppLocalizations.of(context).feed,
           style: widget.showBackButton
-              ? TextStyles.bodyBold.copyWith(color: textTheme.bodyBold.color)
+              ? TextStyles.display3.copyWith(color: textTheme.h4Bold.color)
               : TextStyles.display1.copyWith(color: textTheme.h4Bold.color),
         ),
       ),

--- a/mobile/apps/photos/lib/ui/tabs/albums/empty_states/on_device_empty_state.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums/empty_states/on_device_empty_state.dart
@@ -102,15 +102,9 @@ class OnDeviceEmptyState extends StatelessWidget {
     final strings = AppLocalizations.of(context);
     final bottomPadding = 64 + MediaQuery.paddingOf(context).bottom + 32;
 
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(
-          16,
-          _permissionTopPadding,
-          16,
-          bottomPadding,
-        ),
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 0, 16, bottomPadding),
+      child: Center(
         child: SizedBox(
           width: _contentWidth,
           child: Column(

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -405,12 +405,12 @@ class _AlbumsTabState extends State<AlbumsTab>
   }
 
   Widget _buildSearchSectionHeader(String title) {
-    final colors = context.componentColors;
+    final textTheme = getEnteTextTheme(context);
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, top: 16),
       child: Text(
         title,
-        style: TextStyles.large.copyWith(color: colors.textBase),
+        style: TextStyles.h2.copyWith(color: textTheme.largeBold.color),
       ),
     );
   }


### PR DESCRIPTION
## Summary

- Hide per-section album empty states while global album search is active unless the whole search state is empty.
- Keep the real no-device-albums state distinct from a search query with no matching device folders.
- Center the on-device empty albums state.
- Match album search section headers to the Search tab header typography.

## Notes

- This branch also includes the existing feed title commit already present on `albumfix`.

## Validation

- `dart analyze lib/ui/collections/device/device_folders_vertical_grid_view.dart`
- `dart analyze lib/ui/tabs/albums/empty_states/on_device_empty_state.dart`
- `dart analyze lib/ui/tabs/albums_tab.dart`
