### PR TITLE
[auth][mobile] Fix icon registry asset paths

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -89,7 +89,7 @@
     },
     {
       "title": "Animal Crossing",
-      "slug:": "animal_crossing",
+      "slug": "animal_crossing",
       "altNames": [
         "AnimalCrossing",
         "Bell Tree Forums",
@@ -141,13 +141,6 @@
       "slug": "autenti"
     },
     {
-      "title": "Autenticacion Digital",
-      "slug": "autenticacion-digital",
-      "altNames": [
-        "autenticaciondigital.and.gov.co"
-      ]
-    },
-    {
       "title": "authentik",
       "altNames": [
         "goauthentik"
@@ -177,7 +170,7 @@
     },
     {
       "title": "AzurWare",
-      "slug": "azuware"
+      "slug": "azurware"
     },
     {
       "title": "Badlion",
@@ -882,7 +875,7 @@
     },
     {
       "title": "Gate.io",
-      "slug": "gateio.svg"
+      "slug": "gateio"
     },
     {
       "title": "GERID"
@@ -1041,10 +1034,6 @@
       "altNames": [
         "ImmobilienScout24"
       ]
-    },
-    {
-      "title": "Impact.com",
-      "slug": "impact"
     },
     {
       "title": "Infomaniak"
@@ -1870,9 +1859,6 @@
     {
       "title": "Reolink",
       "slug": "reolink"
-    },
-    {
-      "title": "Restorecord"
     },
     {
       "title": "Restream",

--- a/mobile/apps/auth/lib/ui/custom_icon_page.dart
+++ b/mobile/apps/auth/lib/ui/custom_icon_page.dart
@@ -212,7 +212,7 @@ class _CustomIconPageState extends State<CustomIconPage> {
                       String? slug = iconData.slug;
                       Widget iconWidget;
                       if (iconType == IconType.simpleIcon) {
-                        final simpleIconPath = normalizeSimpleIconName(title);
+                        final simpleIconPath = simpleIconAssetStem(title, slug);
                         iconWidget = IconUtils.instance.getSVGIcon(
                           "assets/simple-icons/icons/$simpleIconPath.svg",
                           title,

--- a/mobile/apps/auth/lib/ui/utils/icon_utils.dart
+++ b/mobile/apps/auth/lib/ui/utils/icon_utils.dart
@@ -15,7 +15,7 @@ class IconUtils {
   static final IconUtils instance = IconUtils._privateConstructor();
 
   // Map of icon-title to the color code in HEX
-  final Map<String, String> _simpleIcons = {};
+  final Map<String, SimpleIconData> _simpleIcons = {};
   final Map<String, CustomIconData> _customIcons = {};
   // Map of icon-color to its luminance
   final Map<Color, double> _colorLuminance = {};
@@ -44,12 +44,14 @@ class IconUtils {
 
       while (simpleEntry != null && customEntry != null) {
         if (simpleEntry.key.compareTo(customEntry.key) <= 0) {
-          simpleIconPath = "assets/simple-icons/icons/${simpleEntry.key}.svg";
+          simpleIconPath =
+              "assets/simple-icons/icons/${simpleIconAssetStem(simpleEntry.key, simpleEntry.value.slug)}.svg";
           if (!processedIconPaths.contains(simpleIconPath)) {
             allIcons[simpleEntry.key] = AllIconData(
               title: simpleEntry.key,
               type: IconType.simpleIcon,
-              color: simpleEntry.value,
+              color: simpleEntry.value.color,
+              slug: simpleEntry.value.slug,
             );
             processedIconPaths.add(simpleIconPath);
           }
@@ -76,13 +78,15 @@ class IconUtils {
       }
 
       while (simpleEntry != null) {
-        simpleIconPath = "assets/simple-icons/icons/${simpleEntry.key}.svg";
+        simpleIconPath =
+            "assets/simple-icons/icons/${simpleIconAssetStem(simpleEntry.key, simpleEntry.value.slug)}.svg";
 
         if (!processedIconPaths.contains(simpleIconPath)) {
           allIcons[simpleEntry.key] = AllIconData(
             title: simpleEntry.key,
             type: IconType.simpleIcon,
-            color: simpleEntry.value,
+            color: simpleEntry.value.color,
+            slug: simpleEntry.value.slug,
           );
           processedIconPaths.add(simpleIconPath);
         }
@@ -131,11 +135,14 @@ class IconUtils {
             context,
           );
         } else if (_simpleIcons.containsKey(title)) {
-          final simpleIconPath = normalizeSimpleIconName(title);
+          final simpleIconPath = simpleIconAssetStem(
+            title,
+            _simpleIcons[title]!.slug,
+          );
           return getSVGIcon(
             "assets/simple-icons/icons/$simpleIconPath.svg",
             title,
-            _simpleIcons[title],
+            _simpleIcons[title]!.color,
             width,
             context,
           );
@@ -241,32 +248,24 @@ class IconUtils {
       final simpleIcons = json.decode(simpleIconData);
       for (final icon in simpleIcons) {
         _simpleIcons[icon["title"]
-                .toString()
-                .replaceAll(' ', '')
-                .toLowerCase()] =
-            icon["hex"];
+            .toString()
+            .replaceAll(' ', '')
+            .toLowerCase()] = SimpleIconData(
+          icon["slug"],
+          icon["hex"],
+        );
       }
       final customIconData = await rootBundle.loadString(
         'assets/custom-icons/_data/custom-icons.json',
       );
       final customIcons = json.decode(customIconData);
       for (final icon in customIcons["icons"]) {
-        _customIcons[icon["title"]
-            .toString()
-            .replaceAll(' ', '')
-            .toLowerCase()] = CustomIconData(
-          icon["slug"],
-          icon["hex"],
-        );
+        final titleKey = _getProviderTitle(icon["title"].toString());
+        _customIcons[titleKey] = CustomIconData(icon["slug"], icon["hex"]);
         if (icon["altNames"] != null) {
           for (final name in icon["altNames"]) {
-            _customIcons[name
-                .toString()
-                .replaceAll(' ', '')
-                .toLowerCase()] = CustomIconData(
-              icon["slug"] ?? ((icon["title"] as String).toLowerCase()),
-              icon["hex"],
-            );
+            _customIcons[name.toString().replaceAll(' ', '').toLowerCase()] =
+                CustomIconData(icon["slug"] ?? titleKey, icon["hex"]);
           }
         }
       }
@@ -290,11 +289,19 @@ class CustomIconData {
   CustomIconData(this.slug, this.color);
 }
 
+class SimpleIconData {
+  final String? slug;
+  final String? color;
+
+  SimpleIconData(this.slug, this.color);
+}
+
 final charMap = {
   'á': 'a',
   'à': 'a',
   'â': 'a',
   'ä': 'a',
+  'ã': 'a',
   'é': 'e',
   'è': 'e',
   'ê': 'e',
@@ -313,6 +320,9 @@ final charMap = {
   'ü': 'u',
   'ç': 'c',
   'ñ': 'n',
+  'ř': 'r',
+  'š': 's',
+  'ż': 'z',
   '.': 'dot',
   '-': '',
   '&': 'and',
@@ -321,6 +331,8 @@ final charMap = {
   "'": '',
   '/': '',
   '!': '',
+  '_': '',
+  '°': '',
 };
 String normalizeSimpleIconName(String input) {
   final buffer = StringBuffer();
@@ -328,4 +340,8 @@ String normalizeSimpleIconName(String input) {
     buffer.write(charMap[char] ?? char);
   }
   return buffer.toString().trim();
+}
+
+String simpleIconAssetStem(String title, String? slug) {
+  return slug ?? normalizeSimpleIconName(title);
 }

--- a/mobile/apps/auth/scripts/internal_changes.txt
+++ b/mobile/apps/auth/scripts/internal_changes.txt
@@ -7,6 +7,7 @@
 - Updated the Availity and Mozilla custom icons, and fixed several multi-color custom icons rendering as single-color masks ([#10281](https://github.com/ente-io/ente/pull/10281), [#10328](https://github.com/ente-io/ente/pull/10328), [#10453](https://github.com/ente-io/ente/pull/10453), [#10710](https://github.com/ente-io/ente/pull/10710))
 - Fixed the CoinMarketCap custom icon being invisible in dark mode ([#10615](https://github.com/ente-io/ente/issues/10615))
 - Fixed several single-color custom icons rendering with the wrong color or disappearing in dark mode ([#7828](https://github.com/ente-io/ente/issues/7828))
+- Fixed some Simple Icons and custom icons not loading in the Auth icon picker because their registry filenames were not resolved correctly
 - Fixed Auth desktop custom icons flashing for Amazon and other monochrome icons ([#8264](https://github.com/ente-io/ente/issues/8264), [#8499](https://github.com/ente-io/ente/issues/8499))
 - Fixed missing Auth tray icons in sandboxed Linux builds ([#4608](https://github.com/ente-io/ente/issues/4608), [#7815](https://github.com/ente-io/ente/issues/7815), [flathub/io.ente.auth#75](https://github.com/flathub/io.ente.auth/issues/75))
 - Fixed Auth tray close, exit, and menu actions on Windows ([#8164](https://github.com/ente-io/ente/issues/8164), [#4360](https://github.com/ente-io/ente/issues/4360), [#3518](https://github.com/ente-io/ente/issues/3518))

--- a/mobile/apps/auth/test/ui/utils/icon_utils_test.dart
+++ b/mobile/apps/auth/test/ui/utils/icon_utils_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ente_auth/ui/utils/icon_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('simple icon registry entries resolve to bundled SVG assets', () {
+    final missingAssets = <String>[];
+    final registry =
+        json.decode(
+              File(
+                'assets/simple-icons/_data/simple-icons.json',
+              ).readAsStringSync(),
+            )
+            as List<dynamic>;
+
+    for (final icon in registry.cast<Map<String, dynamic>>()) {
+      final title = icon['title'].toString().replaceAll(' ', '').toLowerCase();
+      final slug = icon['slug']?.toString();
+      final assetPath =
+          'assets/simple-icons/icons/${simpleIconAssetStem(title, slug)}.svg';
+      final asset = File(assetPath);
+      if (!asset.existsSync()) {
+        missingAssets.add(assetPath);
+      } else if (asset.lengthSync() == 0) {
+        missingAssets.add('$assetPath is empty');
+      }
+    }
+
+    expect(missingAssets, isEmpty);
+  });
+
+  test('custom icon registry entries resolve to bundled SVG assets', () {
+    final missingAssets = <String>[];
+    final registry =
+        json.decode(
+              File(
+                'assets/custom-icons/_data/custom-icons.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>;
+
+    for (final icon in (registry['icons'] as List<dynamic>).cast<Map>()) {
+      final title = icon['title'].toString();
+      final titleKey = title.replaceAll(' ', '').toLowerCase();
+      final slug = icon['slug']?.toString();
+      final canonicalPath = 'assets/custom-icons/icons/${slug ?? titleKey}.svg';
+      _expectAssetExists(canonicalPath, missingAssets);
+
+      for (final altName
+          in (icon['altNames'] as List<dynamic>? ?? const <dynamic>[])) {
+        final altPath = 'assets/custom-icons/icons/${slug ?? titleKey}.svg';
+        _expectAssetExists('$altPath for alias $altName', missingAssets);
+      }
+    }
+
+    expect(missingAssets, isEmpty);
+  });
+}
+
+void _expectAssetExists(String assetPath, List<String> missingAssets) {
+  final actualPath = assetPath.split(' for alias ').first;
+  final asset = File(actualPath);
+  if (!asset.existsSync()) {
+    missingAssets.add(assetPath);
+  } else if (asset.lengthSync() == 0) {
+    missingAssets.add('$assetPath is empty');
+  }
+}


### PR DESCRIPTION
Fixes Simple Icons and custom icons whose registry entries resolve to filenames that do not exist locally.

Testing:
- ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/auth
- ruby mobile/scripts/check_source_arb_plurals.rb
- custom icon JSON, hex, filename, and size checks
- flutter gen-l10n in mobile/packages/strings and mobile/apps/auth
- flutter pub get --enforce-lockfile
- dart format --output=none --set-exit-if-changed .
- flutter analyze --no-fatal-infos
- flutter test