### PR TITLE
[Ensu] Don't load model into memory on very low RAM devices (below 4 GB)

### DIFF
--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/AppViewModel.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/AppViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import io.ente.ensu.data.AdvancedSettingsDataStore
 import io.ente.ensu.data.AdvancedSettingsSnapshot
+import io.ente.ensu.data.AndroidDeviceCapabilityProvider
 import io.ente.ensu.data.EndpointPreferencesDataStore
 import io.ente.ensu.data.SessionPreferencesDataStore
 import io.ente.ensu.data.auth.EnsuAuthService
@@ -31,12 +32,14 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val advancedSettingsDataStore = AdvancedSettingsDataStore(application)
     private val credentialStore = CredentialStore(application)
     val appVersion = runCatching { getAppVersion(application) }.getOrDefault("unknown")
+    private val deviceCapabilityProvider = AndroidDeviceCapabilityProvider(application)
 
     val logRepository = FileLogRepository(application)
     private val llmProvider = InferenceRsProvider(
         context = application,
         modelDir = resolveModelDir(application),
-        legacyModelDir = File(application.filesDir, "llm")
+        legacyModelDir = File(application.filesDir, "llm"),
+        deviceCapabilityProvider = deviceCapabilityProvider
     )
     private val chatRepository = RustChatRepository(application, credentialStore)
     private val chatSyncRepository = RustChatSyncRepository(
@@ -61,6 +64,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         chatRepository = chatRepository,
         chatSyncRepository = chatSyncRepository,
         llmProvider = llmProvider,
+        deviceCapabilityProvider = deviceCapabilityProvider,
         ensuDefaults = ensuDefaults,
         logRepository = logRepository
     )

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/HomeNavigation.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/HomeNavigation.kt
@@ -141,6 +141,7 @@ internal fun HomeNavigation(
                         onStartDownload = { userInitiated ->
                             store.startModelDownload(userInitiated = userInitiated)
                         },
+                        onDismissUnsupportedDeviceDialog = store::dismissUnsupportedDeviceDialog,
                         onOverflowTrim = store::confirmOverflowTrim,
                         onOverflowCancel = store::cancelOverflowDialog
                     )

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatMessages.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatMessages.kt
@@ -92,6 +92,7 @@ internal fun MessageList(
     streamingParentId: String?,
     isGenerating: Boolean,
     isModelDownloaded: Boolean,
+    isChatUnsupported: Boolean,
     isDownloading: Boolean,
     downloadPercent: Int?,
     downloadStatus: String?,
@@ -104,7 +105,7 @@ internal fun MessageList(
     onStartDownload: (Boolean) -> Unit
 ) {
     if (messages.isEmpty() && !isGenerating) {
-        if (!isModelDownloaded) {
+        if (!isModelDownloaded && !isChatUnsupported) {
             DownloadOnboarding(
                 modifier = modifier,
                 isDownloading = isDownloading,

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatOverlays.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatOverlays.kt
@@ -29,7 +29,6 @@ import io.ente.ensu.designsystem.EnsuCornerRadius
 import io.ente.ensu.designsystem.EnsuSpacing
 import io.ente.ensu.designsystem.EnsuTypography
 import io.ente.ensu.designsystem.HugeIcons
-import io.ente.ensu.domain.device.ChatDeviceCapability
 import io.ente.ensu.domain.state.OverflowDialogState
 import io.ente.ensu.domain.util.formatBytes
 import io.ente.ensu.utils.rememberEnsuHaptics
@@ -67,9 +66,12 @@ internal fun OverflowDialog(
     )
 }
 
+private const val UNSUPPORTED_DEVICE_MESSAGE =
+    "This device doesn't have enough memory to run Ensu's AI model. " +
+        "You can view existing chats, but can't send new messages."
+
 @Composable
 internal fun UnsupportedDeviceDialog(
-    capability: ChatDeviceCapability.UnsupportedLowMemory,
     onDismiss: () -> Unit
 ) {
     AlertDialog(
@@ -77,7 +79,7 @@ internal fun UnsupportedDeviceDialog(
         title = { Text(text = "Chat unavailable on this device", style = EnsuTypography.h3) },
         text = {
             Text(
-                text = unsupportedDeviceMessage(capability),
+                text = UNSUPPORTED_DEVICE_MESSAGE,
                 style = EnsuTypography.body,
                 color = EnsuColor.textPrimary()
             )
@@ -93,7 +95,6 @@ internal fun UnsupportedDeviceDialog(
 
 @Composable
 internal fun UnsupportedChatInputNotice(
-    capability: ChatDeviceCapability.UnsupportedLowMemory,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -108,19 +109,13 @@ internal fun UnsupportedChatInputNotice(
             color = EnsuColor.textPrimary()
         )
         Text(
-            text = unsupportedDeviceMessage(capability),
+            text = UNSUPPORTED_DEVICE_MESSAGE,
             style = EnsuTypography.body,
             color = EnsuColor.textMuted(),
             modifier = Modifier.padding(top = EnsuSpacing.xs.dp)
         )
     }
 }
-
-private fun unsupportedDeviceMessage(capability: ChatDeviceCapability.UnsupportedLowMemory): String =
-    "Ensu runs the AI model locally and needs at least 4 GB of RAM. " +
-        "This device does not have enough memory for chat. " +
-        "You can still view existing chats, but sending new messages is disabled. " +
-        "Reported memory: ${formatBytes(capability.totalMemoryBytes)}."
 
 @Composable
 internal fun DownloadToastOverlay(

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatOverlays.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatOverlays.kt
@@ -29,6 +29,7 @@ import io.ente.ensu.designsystem.EnsuCornerRadius
 import io.ente.ensu.designsystem.EnsuSpacing
 import io.ente.ensu.designsystem.EnsuTypography
 import io.ente.ensu.designsystem.HugeIcons
+import io.ente.ensu.domain.device.ChatDeviceCapability
 import io.ente.ensu.domain.state.OverflowDialogState
 import io.ente.ensu.domain.util.formatBytes
 import io.ente.ensu.utils.rememberEnsuHaptics
@@ -65,6 +66,61 @@ internal fun OverflowDialog(
         containerColor = EnsuColor.backgroundBase()
     )
 }
+
+@Composable
+internal fun UnsupportedDeviceDialog(
+    capability: ChatDeviceCapability.UnsupportedLowMemory,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = "Chat unavailable on this device", style = EnsuTypography.h3) },
+        text = {
+            Text(
+                text = unsupportedDeviceMessage(capability),
+                style = EnsuTypography.body,
+                color = EnsuColor.textPrimary()
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = "Got it", color = EnsuColor.textPrimary())
+            }
+        },
+        containerColor = EnsuColor.backgroundBase()
+    )
+}
+
+@Composable
+internal fun UnsupportedChatInputNotice(
+    capability: ChatDeviceCapability.UnsupportedLowMemory,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = EnsuSpacing.lg.dp, vertical = EnsuSpacing.md.dp)
+            .background(EnsuColor.fillFaint(), RoundedCornerShape(EnsuCornerRadius.card.dp))
+            .padding(EnsuSpacing.md.dp)
+    ) {
+        Text(
+            text = "Chat unavailable on this device",
+            style = EnsuTypography.large,
+            color = EnsuColor.textPrimary()
+        )
+        Text(
+            text = unsupportedDeviceMessage(capability),
+            style = EnsuTypography.body,
+            color = EnsuColor.textMuted(),
+            modifier = Modifier.padding(top = EnsuSpacing.xs.dp)
+        )
+    }
+}
+
+private fun unsupportedDeviceMessage(capability: ChatDeviceCapability.UnsupportedLowMemory): String =
+    "Ensu runs the AI model locally and needs at least 4 GB of RAM. " +
+        "This device does not have enough memory for chat. " +
+        "You can still view existing chats, but sending new messages is disabled. " +
+        "Reported memory: ${formatBytes(capability.totalMemoryBytes)}."
 
 @Composable
 internal fun DownloadToastOverlay(

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatView.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatView.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import io.ente.ensu.designsystem.EnsuColor
 import io.ente.ensu.designsystem.EnsuSpacing
+import io.ente.ensu.domain.device.ChatDeviceCapability
 import io.ente.ensu.domain.model.Attachment
 import io.ente.ensu.domain.model.AttachmentType
 import io.ente.ensu.domain.model.ChatMessage
@@ -69,6 +70,7 @@ fun ChatView(
     onBranchChange: (String, Int) -> Unit,
     onOpenAttachment: (Attachment) -> Unit,
     onStartDownload: (Boolean) -> Unit,
+    onDismissUnsupportedDeviceDialog: () -> Unit,
     onOverflowTrim: () -> Unit,
     onOverflowCancel: () -> Unit
 ) {
@@ -79,6 +81,8 @@ fun ChatView(
     val latestOnMessageChange by rememberUpdatedState(onMessageChange)
     val sessionKey = chatState.currentSessionId ?: "new-session"
     val latestSessionKey by rememberUpdatedState(sessionKey)
+    val unsupportedCapability = chatState.deviceCapability as? ChatDeviceCapability.UnsupportedLowMemory
+    val isChatUnsupported = unsupportedCapability != null
     var pendingVoiceSessionKey by remember { mutableStateOf<String?>(null) }
     val voiceController = rememberVoiceTranscriptionController(
         onTranscript = { transcript ->
@@ -96,6 +100,7 @@ fun ChatView(
     val canStartVoiceInput = !chatState.isGenerating &&
         !chatState.isDownloading &&
         !chatState.isAttachmentDownloadBlocked &&
+        !isChatUnsupported &&
         editingMessage == null
     val latestCanStartVoiceInput by rememberUpdatedState(canStartVoiceInput)
 
@@ -118,12 +123,14 @@ fun ChatView(
     val showDownloadOnboarding by remember(
         chatState.isModelDownloaded,
         chatState.messages,
-        chatState.isGenerating
+        chatState.isGenerating,
+        isChatUnsupported
     ) {
         derivedStateOf {
             !chatState.isModelDownloaded &&
                 chatState.messages.isEmpty() &&
-                !chatState.isGenerating
+                !chatState.isGenerating &&
+                !isChatUnsupported
         }
     }
 
@@ -134,6 +141,7 @@ fun ChatView(
 
     val shouldAutoFocusInput = chatState.isModelDownloaded &&
         !showDownloadOnboarding &&
+        !isChatUnsupported &&
         !chatState.isDownloading &&
         !chatState.isGenerating &&
         !didAutoFocusInput &&
@@ -156,6 +164,7 @@ fun ChatView(
         if (wasDrawerOpen) {
             val shouldRestoreFocus = chatState.isModelDownloaded &&
                 !showDownloadOnboarding &&
+                !isChatUnsupported &&
                 !chatState.isDownloading &&
                 !chatState.isGenerating
             if (shouldRestoreFocus) {
@@ -206,6 +215,7 @@ fun ChatView(
                         streamingParentId = chatState.streamingParentId,
                         isGenerating = chatState.isGenerating,
                         isModelDownloaded = chatState.isModelDownloaded,
+                        isChatUnsupported = isChatUnsupported,
                         isDownloading = chatState.isDownloading,
                         downloadPercent = chatState.downloadPercent,
                         downloadStatus = chatState.downloadStatus,
@@ -228,7 +238,18 @@ fun ChatView(
                 )
             }
 
-            if (!showDownloadOnboarding) {
+            if (unsupportedCapability != null) {
+                UnsupportedChatInputNotice(
+                    capability = unsupportedCapability,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .background(EnsuColor.backgroundBase())
+                        .onGloballyPositioned { coords ->
+                            inputBarHeightDp = with(density) { coords.size.height.toDp() }
+                        }
+                )
+            } else if (!showDownloadOnboarding) {
                 MessageInput(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -278,6 +299,13 @@ fun ChatView(
                     focusRequestId = focusRequestId
                 )
             }
+        }
+
+        if (chatState.showUnsupportedDeviceDialog && unsupportedCapability != null) {
+            UnsupportedDeviceDialog(
+                capability = unsupportedCapability,
+                onDismiss = onDismissUnsupportedDeviceDialog
+            )
         }
 
         val imeVisible = WindowInsets.ime.getBottom(density) > 0

--- a/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatView.kt
+++ b/mobile/native/android/apps/ensu/app-ui/src/main/java/io/ente/ensu/chat/ChatView.kt
@@ -240,7 +240,6 @@ fun ChatView(
 
             if (unsupportedCapability != null) {
                 UnsupportedChatInputNotice(
-                    capability = unsupportedCapability,
                     modifier = Modifier
                         .fillMaxWidth()
                         .navigationBarsPadding()
@@ -303,7 +302,6 @@ fun ChatView(
 
         if (chatState.showUnsupportedDeviceDialog && unsupportedCapability != null) {
             UnsupportedDeviceDialog(
-                capability = unsupportedCapability,
                 onDismiss = onDismissUnsupportedDeviceDialog
             )
         }

--- a/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/AndroidDeviceCapabilityProvider.kt
+++ b/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/AndroidDeviceCapabilityProvider.kt
@@ -1,0 +1,24 @@
+package io.ente.ensu.data
+
+import android.app.ActivityManager
+import android.content.Context
+import io.ente.ensu.domain.device.CHAT_MIN_RAM_BYTES
+import io.ente.ensu.domain.device.ChatDeviceCapability
+import io.ente.ensu.domain.device.DeviceCapabilityProvider
+
+class AndroidDeviceCapabilityProvider(context: Context) : DeviceCapabilityProvider {
+    private val appContext = context.applicationContext
+
+    override fun chatCapability(): ChatDeviceCapability {
+        val activityManager = appContext.getSystemService(ActivityManager::class.java)
+            ?: return ChatDeviceCapability.Unknown
+        val memoryInfo = ActivityManager.MemoryInfo()
+        activityManager.getMemoryInfo(memoryInfo)
+        val totalMemoryBytes = memoryInfo.totalMem
+        return if (totalMemoryBytes < CHAT_MIN_RAM_BYTES) {
+            ChatDeviceCapability.UnsupportedLowMemory(totalMemoryBytes)
+        } else {
+            ChatDeviceCapability.Supported(totalMemoryBytes)
+        }
+    }
+}

--- a/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
+++ b/mobile/native/android/apps/ensu/data/src/main/java/io/ente/ensu/data/llm/InferenceRsProvider.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.net.Uri
 import android.os.Environment
 import android.util.Log
+import io.ente.ensu.domain.device.DeviceCapabilityProvider
+import io.ente.ensu.domain.device.UnknownDeviceCapabilityProvider
+import io.ente.ensu.domain.device.requireChatSupported
 import io.ente.ensu.domain.llm.DownloadProgress
 import io.ente.ensu.domain.llm.GenerationSummary
 import io.ente.ensu.domain.llm.LlmMessage
@@ -53,6 +56,7 @@ class InferenceRsProvider(
     context: Context,
     private val modelDir: File,
     private val legacyModelDir: File? = null,
+    private val deviceCapabilityProvider: DeviceCapabilityProvider = UnknownDeviceCapabilityProvider,
     private val ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.IO
 ) : LlmProvider {
     private data class LoadedModelKey(
@@ -121,6 +125,7 @@ class InferenceRsProvider(
         maxTokens: Int?,
         onToken: (String) -> Unit
     ): GenerationSummary = withContext(ioDispatcher) {
+        deviceCapabilityProvider.chatCapability().requireChatSupported()
         val context = contextHandle ?: throw IllegalStateException("Model context not loaded")
         currentJobId = null
         val mmprojPath = if (imageFiles.isEmpty()) {
@@ -362,6 +367,7 @@ class InferenceRsProvider(
         target: LlmModelTarget,
         onProgress: (DownloadProgress) -> Unit
     ) {
+        deviceCapabilityProvider.chatCapability().requireChatSupported()
         val modelKey = LoadedModelKey(target.id, target.contextLength)
         if (!backendInitialized) {
             initBackend()

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/device/ChatDeviceCapability.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/device/ChatDeviceCapability.kt
@@ -1,6 +1,9 @@
 package io.ente.ensu.domain.device
 
-const val CHAT_MIN_RAM_BYTES: Long = 4_000_000_000L
+// Compared against the memory the OS reports (ActivityManager.totalMem), which runs
+// well below marketed RAM. 3.2 GB sits in the gap between 3 GB devices (~2.7-3.0 GB
+// reported) and 4 GB devices (~3.4-3.8 GB reported), so 4 GB devices pass and 3 GB don't.
+const val CHAT_MIN_RAM_BYTES: Long = 3_200_000_000L
 
 sealed interface ChatDeviceCapability {
     val totalMemoryBytes: Long?

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/device/ChatDeviceCapability.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/device/ChatDeviceCapability.kt
@@ -1,0 +1,41 @@
+package io.ente.ensu.domain.device
+
+const val CHAT_MIN_RAM_BYTES: Long = 4_000_000_000L
+
+sealed interface ChatDeviceCapability {
+    val totalMemoryBytes: Long?
+
+    data class Supported(
+        override val totalMemoryBytes: Long?
+    ) : ChatDeviceCapability
+
+    data class UnsupportedLowMemory(
+        override val totalMemoryBytes: Long,
+        val requiredMemoryBytes: Long = CHAT_MIN_RAM_BYTES
+    ) : ChatDeviceCapability
+
+    object Unknown : ChatDeviceCapability {
+        override val totalMemoryBytes: Long? = null
+    }
+}
+
+interface DeviceCapabilityProvider {
+    fun chatCapability(): ChatDeviceCapability
+}
+
+object UnknownDeviceCapabilityProvider : DeviceCapabilityProvider {
+    override fun chatCapability(): ChatDeviceCapability = ChatDeviceCapability.Unknown
+}
+
+class UnsupportedDeviceMemoryException(
+    val capability: ChatDeviceCapability.UnsupportedLowMemory
+) : IllegalStateException("Device does not have enough RAM for local chat")
+
+fun ChatDeviceCapability.isChatSupported(): Boolean =
+    this !is ChatDeviceCapability.UnsupportedLowMemory
+
+fun ChatDeviceCapability.requireChatSupported() {
+    if (this is ChatDeviceCapability.UnsupportedLowMemory) {
+        throw UnsupportedDeviceMemoryException(this)
+    }
+}

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/state/ChatState.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/state/ChatState.kt
@@ -1,5 +1,6 @@
 package io.ente.ensu.domain.state
 
+import io.ente.ensu.domain.device.ChatDeviceCapability
 import io.ente.ensu.domain.model.Attachment
 import io.ente.ensu.domain.model.ChatMessage
 import io.ente.ensu.domain.model.ChatSession
@@ -28,6 +29,8 @@ data class ChatState(
     val isModelDownloaded: Boolean = false,
     val modelDownloadSizeBytes: Long? = null,
     val hasRequestedModelDownload: Boolean = false,
+    val deviceCapability: ChatDeviceCapability = ChatDeviceCapability.Unknown,
+    val showUnsupportedDeviceDialog: Boolean = false,
     val overflowDialog: OverflowDialogState? = null
 )
 

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/AppStore.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/AppStore.kt
@@ -2,12 +2,16 @@ package io.ente.ensu.domain.store
 
 import io.ente.ensu.domain.chat.ChatRepository
 import io.ente.ensu.domain.chat.ChatSyncRepository
+import io.ente.ensu.domain.device.ChatDeviceCapability
+import io.ente.ensu.domain.device.DeviceCapabilityProvider
+import io.ente.ensu.domain.device.UnknownDeviceCapabilityProvider
 import io.ente.ensu.domain.llm.LlmProvider
 import io.ente.ensu.domain.logging.LogRepository
 import io.ente.ensu.domain.logging.NoOpLogRepository
 import io.ente.ensu.domain.model.Attachment
 import io.ente.ensu.domain.model.ChatMessage
 import io.ente.ensu.domain.model.EnsuDefaults
+import io.ente.ensu.domain.model.LogLevel
 import io.ente.ensu.domain.preferences.SessionPreferences
 import io.ente.ensu.domain.state.AppState
 import io.ente.ensu.domain.state.DeveloperSettingsState
@@ -16,12 +20,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class AppStore(
     private val sessionPreferences: SessionPreferences,
     private val chatRepository: ChatRepository,
     private val chatSyncRepository: ChatSyncRepository? = null,
     private val llmProvider: LlmProvider,
+    private val deviceCapabilityProvider: DeviceCapabilityProvider = UnknownDeviceCapabilityProvider,
     val ensuDefaults: EnsuDefaults,
     private val clock: () -> Long = { System.currentTimeMillis() },
     private val logRepository: LogRepository = NoOpLogRepository
@@ -60,8 +66,43 @@ class AppStore(
         attachmentActions.setScope(scope)
         syncActions.setScope(scope)
         modelSettingsActions.setScope(scope)
+        refreshDeviceCapability(scope)
         chatActions.bootstrap(scope)
         modelSettingsActions.refreshModelDownloadInfo()
+    }
+
+    fun refreshDeviceCapability(scope: CoroutineScope? = null) {
+        val capability = deviceCapabilityProvider.chatCapability()
+        val unsupported = capability is ChatDeviceCapability.UnsupportedLowMemory
+        _state.value = _state.value.copy(
+            chat = _state.value.chat.copy(
+                deviceCapability = capability,
+                showUnsupportedDeviceDialog = unsupported || _state.value.chat.showUnsupportedDeviceDialog,
+                isDownloading = if (unsupported) false else _state.value.chat.isDownloading,
+                downloadPercent = if (unsupported) null else _state.value.chat.downloadPercent,
+                downloadStatus = if (unsupported) null else _state.value.chat.downloadStatus,
+                hasRequestedModelDownload = if (unsupported) false else _state.value.chat.hasRequestedModelDownload
+            )
+        )
+        if (unsupported) {
+            scope?.let { coroutineScope ->
+                coroutineScope.launch {
+                    sessionPreferences.setModelDownloadRequested(false)
+                }
+            }
+        }
+        logRepository.log(
+            LogLevel.Info,
+            "Chat device capability evaluated",
+            details = "capability=$capability",
+            tag = "App"
+        )
+    }
+
+    fun dismissUnsupportedDeviceDialog() {
+        _state.value = _state.value.copy(
+            chat = _state.value.chat.copy(showUnsupportedDeviceDialog = false)
+        )
     }
 
     fun hydrateModelDownloadRequested(requested: Boolean) {

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/AppStore.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/AppStore.kt
@@ -81,7 +81,10 @@ class AppStore(
                 isDownloading = if (unsupported) false else _state.value.chat.isDownloading,
                 downloadPercent = if (unsupported) null else _state.value.chat.downloadPercent,
                 downloadStatus = if (unsupported) null else _state.value.chat.downloadStatus,
-                hasRequestedModelDownload = if (unsupported) false else _state.value.chat.hasRequestedModelDownload
+                hasRequestedModelDownload = if (unsupported) false else _state.value.chat.hasRequestedModelDownload,
+                editingMessageId = if (unsupported) null else _state.value.chat.editingMessageId,
+                messageText = if (unsupported) "" else _state.value.chat.messageText,
+                attachments = if (unsupported) emptyList() else _state.value.chat.attachments
             )
         )
         if (unsupported) {

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ChatStoreActions.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ChatStoreActions.kt
@@ -1,6 +1,7 @@
 package io.ente.ensu.domain.store
 
 import io.ente.ensu.domain.chat.ChatRepository
+import io.ente.ensu.domain.device.isChatSupported
 import io.ente.ensu.domain.logging.LogRepository
 import io.ente.ensu.domain.llm.LlmMessage
 import io.ente.ensu.domain.llm.LlmMessageRole
@@ -286,6 +287,7 @@ internal class ChatStoreActions(
         if (state.value.chat.isGenerating) {
             stopGeneration()
         }
+        if (!state.value.chat.deviceCapability.isChatSupported()) return
         val sessionId = state.value.chat.currentSessionId ?: return
 
         // For synthetic interrupted placeholders, find the parent user message directly
@@ -311,6 +313,7 @@ internal class ChatStoreActions(
     fun sendMessage() {
         val currentState = state.value
         if (currentState.chat.isGenerating || currentState.chat.isDownloading) return
+        if (!currentState.chat.deviceCapability.isChatSupported()) return
         val text = currentState.chat.messageText.trim()
         val attachments = currentState.chat.attachments
         if (text.isEmpty() && attachments.isEmpty()) return
@@ -455,6 +458,7 @@ internal class ChatStoreActions(
 
     private fun startGeneration(sessionId: String, userMessage: ChatMessage) {
         val scope = scope ?: return
+        if (!state.value.chat.deviceCapability.isChatSupported()) return
         generationJob?.cancel()
         sessionSummaryJob?.cancel()
         stopRequested = false
@@ -795,6 +799,9 @@ internal class ChatStoreActions(
         fallback: String,
         target: LlmModelTarget
     ): String? {
+        if (!state.value.chat.deviceCapability.isChatSupported()) {
+            return sessionTitleFromText(fallback, fallback = fallback)
+        }
         if (!llmProvider.isModelDownloaded(target)) {
             return sessionTitleFromText(fallback, fallback = fallback)
         }

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ChatStoreActions.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ChatStoreActions.kt
@@ -250,7 +250,9 @@ internal class ChatStoreActions(
     }
 
     fun beginEditing(messageId: String) {
-        val sessionId = state.value.chat.currentSessionId ?: return
+        val currentState = state.value
+        if (!currentState.chat.deviceCapability.isChatSupported()) return
+        val sessionId = currentState.chat.currentSessionId ?: return
         val message = messageStore[sessionId]?.firstOrNull { it.id == messageId } ?: return
         if (message.author != MessageAuthor.User) return
 

--- a/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ModelSettingsActions.kt
+++ b/mobile/native/android/apps/ensu/domain/src/main/kotlin/io/ente/ensu/domain/store/ModelSettingsActions.kt
@@ -1,5 +1,6 @@
 package io.ente.ensu.domain.store
 
+import io.ente.ensu.domain.device.isChatSupported
 import io.ente.ensu.domain.llm.LlmModelTarget
 import io.ente.ensu.domain.llm.LlmProvider
 import io.ente.ensu.domain.logging.LogRepository
@@ -62,6 +63,24 @@ internal class ModelSettingsActions(
     }
 
     fun refreshModelDownloadInfo() {
+        if (!state.value.chat.deviceCapability.isChatSupported()) {
+            downloadProgressMonitorJob?.cancel()
+            modelDownloadJob?.cancel()
+            llmProvider.cancelDownload()
+            persistModelDownloadRequested(false)
+            state.update { appState ->
+                appState.copy(
+                    chat = appState.chat.copy(
+                        isDownloading = false,
+                        downloadPercent = null,
+                        downloadStatus = null,
+                        modelDownloadSizeBytes = null,
+                        hasRequestedModelDownload = false
+                    )
+                )
+            }
+            return
+        }
         val target = resolveTarget(state.value.modelSettings)
         val isDownloaded = llmProvider.isModelDownloaded(target)
         if (isDownloaded) {
@@ -130,6 +149,7 @@ internal class ModelSettingsActions(
     fun startModelDownload(userInitiated: Boolean = true) {
         val scope = scope ?: return
         val currentState = state.value
+        if (!currentState.chat.deviceCapability.isChatSupported()) return
         if (modelDownloadJob?.isActive == true) return
         if (currentState.chat.isDownloading || currentState.chat.isGenerating) return
         if (!userInitiated && !currentState.chat.hasRequestedModelDownload) return
@@ -256,6 +276,7 @@ internal class ModelSettingsActions(
         val scope = scope ?: return
         val currentState = state.value
         if (currentState.chat.isGenerating || currentState.chat.isDownloading) return
+        if (!currentState.chat.deviceCapability.isChatSupported()) return
 
         val target = resolveTarget(currentState.modelSettings)
         if (!llmProvider.isModelDownloaded(target)) return

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatView.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatView.swift
@@ -28,6 +28,7 @@ struct ChatView: View {
 
     private var shouldAutoFocusInput: Bool {
         viewModel.isModelDownloaded
+            && !viewModel.isChatUnsupported
             && !viewModel.isDownloading
             && !viewModel.isGenerating
             && !viewState.didAutoFocusInput
@@ -125,6 +126,7 @@ struct ChatView: View {
                     viewState.wasDrawerOpen = true
                 } else if viewState.wasDrawerOpen {
                     let shouldRestoreFocus = viewModel.isModelDownloaded
+                        && !viewModel.isChatUnsupported
                         && !viewModel.isDownloading
                         && !viewModel.isGenerating
                         && !viewState.didDismissKeyboard
@@ -200,6 +202,13 @@ struct ChatView: View {
                 },
                 secondaryButton: .cancel()
             )
+        }
+        .alert("Chat unavailable on this device", isPresented: $viewModel.showUnsupportedDeviceDialog) {
+            Button("Got it") {
+                viewModel.dismissUnsupportedDeviceDialog()
+            }
+        } message: {
+            Text(viewModel.unsupportedDeviceMessage)
         }
         .confirmationDialog("Conversation too long", isPresented: overflowDialogPresented, titleVisibility: .visible) {
             Button("Continue") {
@@ -277,7 +286,7 @@ struct ChatView: View {
             .animation(.easeInOut(duration: 0.32))
 
             ZStack(alignment: .bottom) {
-                let shouldShowDownloadOnboarding = !viewModel.isModelDownloaded
+                let shouldShowDownloadOnboarding = !viewModel.isModelDownloaded && !viewModel.isChatUnsupported
 
                 MessageListView(
                     messages: viewModel.messages,
@@ -286,7 +295,7 @@ struct ChatView: View {
                     isGenerating: viewModel.isGenerating,
                     sessionId: viewModel.currentSessionId,
                     keyboardHeight: keyboard.height,
-                    inputBarHeight: viewModel.isModelDownloaded ? viewState.inputBarHeight : 0,
+                    inputBarHeight: (viewModel.isModelDownloaded || viewModel.isChatUnsupported) ? viewState.inputBarHeight : 0,
                     emptyStateTitle: "Welcome",
                     emptyStateSubtitle: "Start typing to begin a conversation",
                     onEdit: { message in
@@ -318,7 +327,15 @@ struct ChatView: View {
                 }
                 .zIndex(0)
 
-                if viewModel.isModelDownloaded {
+                if viewModel.isChatUnsupported {
+                    UnsupportedChatInputNotice(message: viewModel.unsupportedDeviceMessage)
+                        .frame(maxWidth: .infinity, alignment: .bottom)
+                        .onPreferenceChange(InputBarHeightKey.self) { newValue in
+                            viewState.inputBarHeight = newValue
+                        }
+                        .padding(.bottom, keyboard.isVisible ? keyboard.height : 0)
+                        .zIndex(1)
+                } else if viewModel.isModelDownloaded {
                     let shouldAutoFocus = shouldAutoFocusInput
 
                     MessageInputView(

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
@@ -631,6 +631,9 @@ final class ChatViewModel: ObservableObject {
         downloadProgressMonitorTask?.cancel()
         sharedModelReadyTask?.cancel()
         clearSharedModelReadyTask()
+        editingMessageId = nil
+        draftText = ""
+        draftAttachments = []
         provider.cancelDownload()
     }
 
@@ -1053,6 +1056,10 @@ final class ChatViewModel: ObservableObject {
     }
 
     func beginEditing(message: RenderedChatMessage) {
+        guard !isChatUnsupported else {
+            showUnsupportedDeviceDialog = true
+            return
+        }
         guard message.role == .user else { return }
         editingMessageId = message.id
         draftText = message.text

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
@@ -614,7 +614,7 @@ final class ChatViewModel: ObservableObject {
     }
 
     var unsupportedDeviceMessage: String {
-        Self.unsupportedDeviceMessage(for: deviceCapability)
+        Self.unsupportedDeviceMessage
     }
 
     func refreshDeviceCapability() {
@@ -641,13 +641,9 @@ final class ChatViewModel: ObservableObject {
         showUnsupportedDeviceDialog = false
     }
 
-    static func unsupportedDeviceMessage(for capability: ChatDeviceCapability) -> String {
-        var message = "Ensu runs the AI model locally and needs at least 4 GB of RAM. This device does not have enough memory for chat. You can still view existing chats, but sending new messages is disabled."
-        if let totalMemoryBytes = capability.totalMemoryBytes {
-            message += " Reported memory: \(Int64(totalMemoryBytes).formattedFileSize)."
-        }
-        return message
-    }
+    static let unsupportedDeviceMessage =
+        "This device doesn't have enough memory to run Ensu's AI model. " +
+        "You can view existing chats, but can't send new messages."
 
     private func reopenSyncStoresIfNeeded(force: Bool = false) {
         let hasSyncDb = FileManager.default.fileExists(atPath: syncDbPath)
@@ -2749,8 +2745,8 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func userFacingModelReadyError(_ error: Error, wasDownloaded: Bool) -> String {
-        if let error = error as? UnsupportedDeviceMemoryError {
-            return Self.unsupportedDeviceMessage(for: error.capability)
+        if error is UnsupportedDeviceMemoryError {
+            return Self.unsupportedDeviceMessage
         }
         if isOutOfStorageError(error) {
             return "Not enough storage space to download the model. Please free up space and try again."

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Chat/ChatViewModel.swift
@@ -458,6 +458,8 @@ final class ChatViewModel: ObservableObject {
     @Published var isModelDownloaded: Bool = false
     @Published var modelDownloadSizeBytes: Int64?
     @Published var hasRequestedModelDownload: Bool = false
+    @Published var deviceCapability: ChatDeviceCapability = .unknown
+    @Published var showUnsupportedDeviceDialog: Bool = false
     @Published var attachmentDownloads: [AttachmentDownloadItem] = []
     @Published var currentSessionMissingAttachments: [AttachmentDownloadItem] = []
     @Published var syncState: SyncState = .idle
@@ -468,6 +470,7 @@ final class ChatViewModel: ObservableObject {
     @Published var draftCursorMoveToken = UUID()
 
     private let provider: InferenceRsProvider
+    private let deviceCapabilityProvider = ProcessInfoChatDeviceCapabilityProvider()
     private let voiceTranscriber: VoiceTranscriptionService
     private var chatDb: EnsuDb
     private var syncEngine: EnsuSync
@@ -602,7 +605,45 @@ final class ChatViewModel: ObservableObject {
             refreshAttachmentDownloadState()
         }
 
+        refreshDeviceCapability()
         refreshModelDownloadInfo()
+    }
+
+    var isChatUnsupported: Bool {
+        !deviceCapability.isChatSupported
+    }
+
+    var unsupportedDeviceMessage: String {
+        Self.unsupportedDeviceMessage(for: deviceCapability)
+    }
+
+    func refreshDeviceCapability() {
+        let capability = deviceCapabilityProvider.chatCapability()
+        deviceCapability = capability
+        logger.info("Chat device capability evaluated", details: "\(capability)")
+        guard !capability.isChatSupported else { return }
+        showUnsupportedDeviceDialog = true
+        isDownloading = false
+        downloadToast = nil
+        modelDownloadSizeBytes = nil
+        hasRequestedModelDownload = false
+        modelDownloadTask?.cancel()
+        downloadProgressMonitorTask?.cancel()
+        sharedModelReadyTask?.cancel()
+        clearSharedModelReadyTask()
+        provider.cancelDownload()
+    }
+
+    func dismissUnsupportedDeviceDialog() {
+        showUnsupportedDeviceDialog = false
+    }
+
+    static func unsupportedDeviceMessage(for capability: ChatDeviceCapability) -> String {
+        var message = "Ensu runs the AI model locally and needs at least 4 GB of RAM. This device does not have enough memory for chat. You can still view existing chats, but sending new messages is disabled."
+        if let totalMemoryBytes = capability.totalMemoryBytes {
+            message += " Reported memory: \(Int64(totalMemoryBytes).formattedFileSize)."
+        }
+        return message
     }
 
     private func reopenSyncStoresIfNeeded(force: Bool = false) {
@@ -1140,6 +1181,7 @@ final class ChatViewModel: ObservableObject {
 
     private func prewarmImageInferenceIfDownloaded() {
         guard !isGenerating && !isDownloading else { return }
+        guard !isChatUnsupported else { return }
         let target = modelSettings.currentTarget()
         guard provider.isModelDownloaded(target: target) else { return }
 
@@ -1196,6 +1238,10 @@ final class ChatViewModel: ObservableObject {
 
     func sendDraft() {
         guard !isGenerating && !isDownloading && !isAttachmentDownloadBlocked else { return }
+        guard !isChatUnsupported else {
+            showUnsupportedDeviceDialog = true
+            return
+        }
 
         let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = draftAttachments
@@ -1321,6 +1367,13 @@ final class ChatViewModel: ObservableObject {
     }
 
     func refreshModelDownloadInfo() {
+        guard !isChatUnsupported else {
+            isDownloading = false
+            downloadToast = nil
+            modelDownloadSizeBytes = nil
+            hasRequestedModelDownload = false
+            return
+        }
         let target = modelSettings.currentTarget()
         provider.cancelStaleDownloads(target: target)
         isModelDownloaded = provider.isModelDownloaded(target: target)
@@ -1365,6 +1418,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func ensureModelReadyShared(target: InferenceModelTarget) async throws {
+        if isChatUnsupported {
+            throw UnsupportedDeviceMemoryError(capability: deviceCapability)
+        }
         let modelKey = modelReadyKey(for: target)
         if let existingTask = sharedModelReadyTask, sharedModelReadyKey == modelKey {
             try await existingTask.value
@@ -1421,6 +1477,10 @@ final class ChatViewModel: ObservableObject {
 
     func startModelDownload(userInitiated: Bool = true) {
         guard !isDownloading && !isGenerating else { return }
+        guard !isChatUnsupported else {
+            showUnsupportedDeviceDialog = true
+            return
+        }
         if userInitiated {
             hasRequestedModelDownload = true
         }
@@ -1470,6 +1530,11 @@ final class ChatViewModel: ObservableObject {
 
     func autoStartModelDownloadIfNeeded() {
         guard !isDownloading && !isGenerating else { return }
+        guard !isChatUnsupported else {
+            isDownloading = false
+            downloadToast = nil
+            return
+        }
         let target = modelSettings.currentTarget()
         let isDownloaded = provider.isModelDownloaded(target: target)
         isModelDownloaded = isDownloaded
@@ -1526,6 +1591,10 @@ final class ChatViewModel: ObservableObject {
         guard message.role == .assistant else { return }
         if isGenerating {
             stopGenerating()
+        }
+        guard !isChatUnsupported else {
+            showUnsupportedDeviceDialog = true
+            return
         }
         guard let sessionId = currentSessionId else { return }
 
@@ -1588,6 +1657,10 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func startGeneration(for userNode: MessageNode) {
+        guard !isChatUnsupported else {
+            showUnsupportedDeviceDialog = true
+            return
+        }
         generationTask?.cancel()
         sessionSummaryTask?.cancel()
         stopRequested = false
@@ -2486,6 +2559,7 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func scheduleSessionSummary(for sessionId: UUID) {
+        guard !isChatUnsupported else { return }
         sessionSummaryTask?.cancel()
         let summaryKey = sessionSummaryKey(sessionId)
         guard sessionSummaries[summaryKey] == nil else { return }
@@ -2668,6 +2742,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func userFacingModelReadyError(_ error: Error, wasDownloaded: Bool) -> String {
+        if let error = error as? UnsupportedDeviceMemoryError {
+            return Self.unsupportedDeviceMessage(for: error.capability)
+        }
         if isOutOfStorageError(error) {
             return "Not enough storage space to download the model. Please free up space and try again."
         }

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Chat/Components/ChatViewComponents.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Chat/Components/ChatViewComponents.swift
@@ -78,6 +78,34 @@ struct DownloadOnboardingView: View {
 
 }
 
+struct UnsupportedChatInputNotice: View {
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: EnsuSpacing.xs) {
+            Text("Chat unavailable on this device")
+                .font(EnsuTypography.large)
+                .foregroundStyle(EnsuColor.textPrimary)
+
+            Text(message)
+                .font(EnsuTypography.body)
+                .foregroundStyle(EnsuColor.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(EnsuSpacing.md)
+        .background(EnsuColor.fillFaint)
+        .clipShape(RoundedRectangle(cornerRadius: EnsuCornerRadius.card))
+        .padding(.horizontal, EnsuSpacing.pageHorizontal)
+        .padding(.vertical, EnsuSpacing.md)
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: InputBarHeightKey.self, value: proxy.size.height)
+            }
+        )
+        .background(EnsuColor.backgroundBase)
+    }
+}
+
 struct SignInComingSoonDialog: View {
     let title: String
     let message: String

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/InferenceRsProvider.swift
@@ -89,6 +89,7 @@ final class InferenceRsProvider {
     }
 
     private let modelDir: URL
+    private let deviceCapabilityProvider: ChatDeviceCapabilityProviding
     private let downloadManager = ModelDownloadManager.shared
     private var modelHandle: ModelHandle?
     private var contextHandle: ContextHandle?
@@ -101,8 +102,12 @@ final class InferenceRsProvider {
     private var rustDownloadCancelled = false
     private let logger = EnsuLogging.shared.logger("InferenceRsProvider")
 
-    init(modelDir: URL) {
+    init(
+        modelDir: URL,
+        deviceCapabilityProvider: ChatDeviceCapabilityProviding = ProcessInfoChatDeviceCapabilityProvider()
+    ) {
         self.modelDir = modelDir
+        self.deviceCapabilityProvider = deviceCapabilityProvider
         try? FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true, attributes: nil)
     }
 
@@ -120,6 +125,10 @@ final class InferenceRsProvider {
         onProgress: @escaping (InferenceDownloadProgress) -> Void,
         allowRecovery: Bool
     ) async throws {
+        let capability = deviceCapabilityProvider.chatCapability()
+        if !capability.isChatSupported {
+            throw UnsupportedDeviceMemoryError(capability: capability)
+        }
         let modelKey = LoadedModelKey(id: target.id, requestedContextLength: target.contextLength)
         if currentModelKey == modelKey, modelHandle != nil, contextHandle != nil {
             return
@@ -197,6 +206,10 @@ final class InferenceRsProvider {
         maxTokens: Int?,
         onToken: @escaping (String) -> Void
     ) async throws -> InferenceGenerationSummary {
+        let capability = deviceCapabilityProvider.chatCapability()
+        if !capability.isChatSupported {
+            throw UnsupportedDeviceMemoryError(capability: capability)
+        }
         guard let context = contextHandle else {
             throw NSError(domain: "InferenceRsProvider", code: -1, userInfo: [NSLocalizedDescriptionKey: "Model not loaded"])
         }

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelSettingsStore.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelSettingsStore.swift
@@ -1,5 +1,56 @@
 import Foundation
 
+let chatMinimumRAMBytes: UInt64 = 4_000_000_000
+
+enum ChatDeviceCapability: Equatable {
+    case supported(totalMemoryBytes: UInt64?)
+    case unsupportedLowMemory(totalMemoryBytes: UInt64, requiredMemoryBytes: UInt64)
+    case unknown
+
+    var isChatSupported: Bool {
+        if case .unsupportedLowMemory = self {
+            return false
+        }
+        return true
+    }
+
+    var totalMemoryBytes: UInt64? {
+        switch self {
+        case .supported(let totalMemoryBytes):
+            return totalMemoryBytes
+        case .unsupportedLowMemory(let totalMemoryBytes, _):
+            return totalMemoryBytes
+        case .unknown:
+            return nil
+        }
+    }
+}
+
+protocol ChatDeviceCapabilityProviding {
+    func chatCapability() -> ChatDeviceCapability
+}
+
+struct ProcessInfoChatDeviceCapabilityProvider: ChatDeviceCapabilityProviding {
+    func chatCapability() -> ChatDeviceCapability {
+        let totalMemoryBytes = ProcessInfo.processInfo.physicalMemory
+        if totalMemoryBytes < chatMinimumRAMBytes {
+            return .unsupportedLowMemory(
+                totalMemoryBytes: totalMemoryBytes,
+                requiredMemoryBytes: chatMinimumRAMBytes
+            )
+        }
+        return .supported(totalMemoryBytes: totalMemoryBytes)
+    }
+}
+
+struct UnsupportedDeviceMemoryError: LocalizedError {
+    let capability: ChatDeviceCapability
+
+    var errorDescription: String? {
+        "Device does not have enough RAM for local chat"
+    }
+}
+
 @MainActor
 final class ModelSettingsStore: ObservableObject {
     static let shared = ModelSettingsStore()

--- a/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelSettingsStore.swift
+++ b/mobile/native/darwin/Apps/Ensu/Ensu/Services/ModelSettingsStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-let chatMinimumRAMBytes: UInt64 = 4_000_000_000
+// Compared against the memory the OS reports (ProcessInfo.physicalMemory), which runs
+// well below marketed RAM. 3.2 GB sits in the gap between 3 GB devices (~2.7-3.0 GB
+// reported) and 4 GB devices (~3.4-3.8 GB reported), so 4 GB devices pass and 3 GB don't.
+let chatMinimumRAMBytes: UInt64 = 3_200_000_000
 
 enum ChatDeviceCapability: Equatable {
     case supported(totalMemoryBytes: UInt64?)

--- a/rust/apps/ensu/changes/06-mobile-memory-guard.md
+++ b/rust/apps/ensu/changes/06-mobile-memory-guard.md
@@ -1,0 +1,1 @@
+- Added a mobile device memory check to disable local chat on devices with less than 4 GB of RAM


### PR DESCRIPTION
## Description

Don't load model into memory on very low RAM devices (below 4 GB). Instead it will show a banner explaining that sending messages is disabled.
