### PR TITLE
[rust] Update ad-hoc crates to edition 2024

### DIFF
--- a/rust/apps/ensu/src-tauri/Cargo.toml
+++ b/rust/apps/ensu/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ensu-desktop"
 version = "0.1.17-beta"
-edition = "2021"
+edition = "2024"
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }

--- a/rust/apps/ensu/src-tauri/src/commands.rs
+++ b/rust/apps/ensu/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -1565,10 +1565,10 @@ impl llm::EventSink for LlmEventSink {
                 text,
                 token_id,
             } => {
-                if let Some(current) = self.buffered_job_id {
-                    if current != job_id {
-                        self.flush_text();
-                    }
+                if let Some(current) = self.buffered_job_id
+                    && current != job_id
+                {
+                    self.flush_text();
                 }
 
                 if self.buffered_text.is_empty() {

--- a/rust/apps/ensu/src-tauri/src/main.rs
+++ b/rust/apps/ensu/src-tauri/src/main.rs
@@ -24,11 +24,11 @@ fn main() {
             logging::log("App", "setup started");
 
             // Show the main window after setup is complete
-            if let Some(window) = app.get_webview_window("main") {
-                if let Err(err) = window.show() {
-                    logging::log("App", format!("failed to show main window error={err}"));
-                    return Err(Box::new(err));
-                }
+            if let Some(window) = app.get_webview_window("main")
+                && let Err(err) = window.show()
+            {
+                logging::log("App", format!("failed to show main window error={err}"));
+                return Err(Box::new(err));
             }
             logging::log("App", "setup complete");
             Ok(())

--- a/rust/bindings/uniffi/core/Cargo.toml
+++ b/rust/bindings/uniffi/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/rust/bindings/uniffi/core/src/lib.rs
+++ b/rust/bindings/uniffi/core/src/lib.rs
@@ -1,6 +1,6 @@
 use base64::{
-    engine::general_purpose::{STANDARD as BASE64_STANDARD, URL_SAFE as BASE64_URL_SAFE},
     Engine,
+    engine::general_purpose::{STANDARD as BASE64_STANDARD, URL_SAFE as BASE64_URL_SAFE},
 };
 use once_cell::sync::Lazy;
 use std::sync::{Mutex, MutexGuard};


### PR DESCRIPTION
Tests:
- cargo fmt --check
- RUSTFLAGS='-D warnings' cargo clippy --all-targets --locked
- RUSTFLAGS='-D warnings' cargo test --locked --workspace