### PR TITLE
[mob][native_video_editor] Fix Media3 transformer export crash

### DIFF
--- a/mobile/packages/native_video_editor/android/build.gradle
+++ b/mobile/packages/native_video_editor/android/build.gradle
@@ -25,9 +25,12 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def nativeVideoEditorCompileSdkVersion = rootProject.ext.has('compileSdkVersion') ?
+        rootProject.ext.compileSdkVersion : 35
+
 android {
     namespace 'io.ente.native_video_editor'
-    compileSdkVersion 33
+    compileSdkVersion nativeVideoEditorCompileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/mobile/packages/native_video_editor/android/build.gradle
+++ b/mobile/packages/native_video_editor/android/build.gradle
@@ -3,6 +3,7 @@ version '1.0'
 
 buildscript {
     ext.kotlin_version = '1.9.25'
+    ext.media3_version = '1.9.2'
     repositories {
         google()
         mavenCentral()
@@ -51,10 +52,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
     // Media3 Transformer for efficient video operations
-    implementation "androidx.media3:media3-transformer:1.1.1"
-    implementation "androidx.media3:media3-common:1.1.1"
-    implementation "androidx.media3:media3-effect:1.1.1"
-    implementation "androidx.media3:media3-extractor:1.1.1"
+    implementation "androidx.media3:media3-transformer:$media3_version"
+    implementation "androidx.media3:media3-common:$media3_version"
+    implementation "androidx.media3:media3-effect:$media3_version"
+    implementation "androidx.media3:media3-extractor:$media3_version"
 
     // Guava for ImmutableList
     implementation "com.google.guava:guava:31.1-android"

--- a/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/Media3TransformerProcessor.kt
+++ b/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/Media3TransformerProcessor.kt
@@ -246,9 +246,8 @@ class Media3TransformerProcessor(private val context: Context) {
             }
 
             val editedMediaItem = editedMediaItemBuilder.build()
-            val sequence = EditedMediaItemSequence.withAudioAndVideoFrom(
-                listOf(editedMediaItem)
-            )
+            @Suppress("DEPRECATION")
+            val sequence = EditedMediaItemSequence.Builder(listOf(editedMediaItem)).build()
             val composition = Composition.Builder(listOf(sequence)).build()
 
             // Start export

--- a/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/Media3TransformerProcessor.kt
+++ b/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/Media3TransformerProcessor.kt
@@ -200,15 +200,11 @@ class Media3TransformerProcessor(private val context: Context) {
 
             // Configure Transformer
             val transformerBuilder = Transformer.Builder(context)
-                .setTransformationRequest(
-                    TransformationRequest.Builder()
-                        .setVideoMimeType(MimeTypes.VIDEO_H264) // Use H.264 for compatibility
-                        .build()
-                )
+                .setVideoMimeType(MimeTypes.VIDEO_H264) // Use H.264 for compatibility
                 .addListener(object : Transformer.Listener {
                     override fun onCompleted(composition: Composition, exportResult: ExportResult) {
                         logVerbose("Export completed successfully")
-                        logVerbose("Export result: duration=${exportResult.durationMs}ms, " +
+                        logVerbose("Export result: duration=${exportResult.approximateDurationMs}ms, " +
                                   "size=${exportResult.fileSizeBytes} bytes")
                         latch.countDown()
                     }
@@ -250,7 +246,9 @@ class Media3TransformerProcessor(private val context: Context) {
             }
 
             val editedMediaItem = editedMediaItemBuilder.build()
-            val sequence = EditedMediaItemSequence(listOf(editedMediaItem))
+            val sequence = EditedMediaItemSequence.withAudioAndVideoFrom(
+                listOf(editedMediaItem)
+            )
             val composition = Composition.Builder(listOf(sequence)).build()
 
             // Start export

--- a/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/NativeVideoEditorPlugin.kt
+++ b/mobile/packages/native_video_editor/android/src/main/kotlin/io/ente/native_video_editor/NativeVideoEditorPlugin.kt
@@ -76,11 +76,10 @@ class NativeVideoEditorPlugin : FlutterPlugin, MethodCallHandler, EventChannel.S
                                 )
                             )
                         }
+                    } catch (e: LinkageError) {
+                        reportProcessingError(result, "TRIM_LINKAGE_ERROR", "Trim", e)
                     } catch (e: Exception) {
-                        // Log.e(TAG, "Trim failed", e)
-                        withContext(Dispatchers.Main) {
-                            result.error("TRIM_ERROR", e.message, buildErrorDetails(e))
-                        }
+                        reportProcessingError(result, "TRIM_ERROR", "Trim", e)
                     } finally {
                         currentJob = null
                     }
@@ -116,11 +115,10 @@ class NativeVideoEditorPlugin : FlutterPlugin, MethodCallHandler, EventChannel.S
                                 )
                             )
                         }
+                    } catch (e: LinkageError) {
+                        reportProcessingError(result, "ROTATE_LINKAGE_ERROR", "Rotation", e)
                     } catch (e: Exception) {
-                        // Log.e(TAG, "Rotation failed", e)
-                        withContext(Dispatchers.Main) {
-                            result.error("ROTATE_ERROR", e.message, buildErrorDetails(e))
-                        }
+                        reportProcessingError(result, "ROTATE_ERROR", "Rotation", e)
                     } finally {
                         currentJob = null
                     }
@@ -162,11 +160,10 @@ class NativeVideoEditorPlugin : FlutterPlugin, MethodCallHandler, EventChannel.S
                                 )
                             )
                         }
+                    } catch (e: LinkageError) {
+                        reportProcessingError(result, "CROP_LINKAGE_ERROR", "Crop", e)
                     } catch (e: Exception) {
-                        // Log.e(TAG, "Crop failed", e)
-                        withContext(Dispatchers.Main) {
-                            result.error("CROP_ERROR", e.message, buildErrorDetails(e))
-                        }
+                        reportProcessingError(result, "CROP_ERROR", "Crop", e)
                     } finally {
                         currentJob = null
                     }
@@ -185,10 +182,10 @@ class NativeVideoEditorPlugin : FlutterPlugin, MethodCallHandler, EventChannel.S
                         withContext(Dispatchers.Main) {
                             result.success(info)
                         }
+                    } catch (e: LinkageError) {
+                        reportProcessingError(result, "INFO_LINKAGE_ERROR", "Get video info", e)
                     } catch (e: Exception) {
-                        withContext(Dispatchers.Main) {
-                            result.error("INFO_ERROR", e.message, buildErrorDetails(e))
-                        }
+                        reportProcessingError(result, "INFO_ERROR", "Get video info", e)
                     } finally {
                         currentJob = null
                     }
@@ -316,14 +313,29 @@ class NativeVideoEditorPlugin : FlutterPlugin, MethodCallHandler, EventChannel.S
                         )
                     )
                 }
+            } catch (e: LinkageError) {
+                reportProcessingError(result, "PROCESS_LINKAGE_ERROR", "Process video", e)
             } catch (e: Exception) {
-                // Log.e(TAG, "Process video failed", e)
-                withContext(Dispatchers.Main) {
-                    result.error("PROCESS_ERROR", e.message, buildErrorDetails(e))
-                }
+                reportProcessingError(result, "PROCESS_ERROR", "Process video", e)
             } finally {
                 currentJob = null
             }
+        }
+    }
+
+    private suspend fun reportProcessingError(
+        result: Result,
+        code: String,
+        operation: String,
+        throwable: Throwable
+    ) {
+        Log.e(TAG, "$operation failed", throwable)
+        withContext(Dispatchers.Main) {
+            result.error(
+                code,
+                throwable.message ?: throwable::class.java.simpleName,
+                buildErrorDetails(throwable)
+            )
         }
     }
 


### PR DESCRIPTION
## Description

Fix Android native video export with Media3 1.9.2 and convert native linkage failures into MethodChannel errors so Dart can fall back to FFmpeg.

## Tests

- [x] `dart format .`
- [x] `flutter analyze .`
- [x] `cd mobile/apps/photos/android && ./gradlew :native_video_editor:compileDebugKotlin`
- [x] `cd mobile/apps/photos/android && ./gradlew :native_video_editor:compileReleaseKotlin`
- [x] `cd mobile/apps/photos/android && ./gradlew :native_video_editor:checkDebugAarMetadata`
- [x] `cd mobile/apps/photos/android && ./gradlew :app:dependencyInsight --configuration independentDebugRuntimeClasspath --dependency androidx.media3:media3-transformer`