### PR TITLE
[auth][desktop] Improve local authentication handling

### DIFF
--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -1037,26 +1037,26 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: "63ad7ca6396290626dc0cb34725a939e4cfe965d80d36112f08d49cf13a8136e"
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.49"
+    version: "2.0.8"
   local_auth_darwin:
     dependency: "direct main"
     description:
       name: local_auth_darwin
-      sha256: "25163ce60a5a6c468cf7a0e3dc8a165f824cabc2aa9e39a5e9fc5c2311b7686f"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -1069,10 +1069,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -101,9 +101,9 @@ dependencies:
   io: 1.0.5
   json_annotation: 4.9.0
   launcher_icon_switcher: 0.0.2
-  local_auth: 2.3.0
-  local_auth_android: 1.0.49
-  local_auth_darwin: 1.5.0
+  local_auth: 3.0.1
+  local_auth_android: 2.0.8
+  local_auth_darwin: 2.0.3
   logging: 1.3.0
   modal_bottom_sheet: 3.0.0
   move_to_background: # no updates in git, replace package

--- a/mobile/apps/locker/pubspec.lock
+++ b/mobile/apps/locker/pubspec.lock
@@ -824,26 +824,26 @@ packages:
     dependency: transitive
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.56"
+    version: "2.0.8"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -856,10 +856,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:

--- a/mobile/packages/accounts/pubspec.lock
+++ b/mobile/packages/accounts/pubspec.lock
@@ -583,26 +583,26 @@ packages:
     dependency: transitive
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.56"
+    version: "2.0.8"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -615,10 +615,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:

--- a/mobile/packages/legacy/pubspec.lock
+++ b/mobile/packages/legacy/pubspec.lock
@@ -667,26 +667,26 @@ packages:
     dependency: transitive
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.56"
+    version: "2.0.8"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -699,10 +699,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:

--- a/mobile/packages/lock_screen/lib/auth_util.dart
+++ b/mobile/packages/lock_screen/lib/auth_util.dart
@@ -4,11 +4,252 @@ import 'package:ente_lock_screen/local_authentication_service.dart';
 import 'package:ente_lock_screen/lock_screen_settings.dart';
 import 'package:ente_strings/ente_strings.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_authentication/flutter_local_authentication.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth_android/local_auth_android.dart';
 import 'package:local_auth_darwin/types/auth_messages_ios.dart';
+import 'package:local_auth_darwin/types/auth_messages_macos.dart';
 import 'package:logging/logging.dart';
+
+final _logger = Logger("AuthUtil");
+
+enum WindowsLocalAuthIssue {
+  notConfigured,
+  noHardware,
+  unavailable,
+  busy,
+  disabledByPolicy,
+}
+
+enum LocalAuthUnavailableIssue { notConfigured, noHardware, unavailable }
+
+class LocalAuthenticationUnavailableException implements Exception {
+  const LocalAuthenticationUnavailableException({
+    required this.issue,
+    required this.code,
+    this.description,
+    this.originalError,
+  });
+
+  final LocalAuthUnavailableIssue issue;
+  final String code;
+  final String? description;
+  final Object? originalError;
+
+  String get userMessage {
+    return switch (issue) {
+      LocalAuthUnavailableIssue.notConfigured => pendingTranslation(
+        "System authentication is not set up. Set it up in your device settings, or switch Ente App lock to PIN/password.",
+      ),
+      LocalAuthUnavailableIssue.noHardware => pendingTranslation(
+        "System authentication is not available on this device. Switch Ente App lock to PIN/password.",
+      ),
+      LocalAuthUnavailableIssue.unavailable => pendingTranslation(
+        "System authentication is not available right now. Try again, or switch Ente App lock to PIN/password.",
+      ),
+    };
+  }
+
+  @override
+  String toString() {
+    return "LocalAuthenticationUnavailableException($code, $description)";
+  }
+}
+
+class WindowsLocalAuthenticationException implements Exception {
+  const WindowsLocalAuthenticationException({
+    required this.issue,
+    required this.code,
+    this.description,
+    this.originalError,
+  });
+
+  final WindowsLocalAuthIssue issue;
+  final String code;
+  final String? description;
+  final Object? originalError;
+
+  String get userMessage {
+    return switch (issue) {
+      WindowsLocalAuthIssue.notConfigured => pendingTranslation(
+        "Windows Hello or a Windows PIN is not set up. Set it up in Windows Settings, or switch Ente App lock to PIN/password.",
+      ),
+      WindowsLocalAuthIssue.noHardware => pendingTranslation(
+        "Windows authentication is not available on this device. Switch Ente App lock to PIN/password to use this action.",
+      ),
+      WindowsLocalAuthIssue.busy => pendingTranslation(
+        "Windows authentication is busy. Try again, or switch Ente App lock to PIN/password.",
+      ),
+      WindowsLocalAuthIssue.disabledByPolicy => pendingTranslation(
+        "Windows authentication is disabled by system policy. Switch Ente App lock to PIN/password to use this action.",
+      ),
+      WindowsLocalAuthIssue.unavailable => pendingTranslation(
+        "Windows authentication is not available right now. Set up Windows Hello/PIN or switch Ente App lock to PIN/password.",
+      ),
+    };
+  }
+
+  @override
+  String toString() {
+    return "WindowsLocalAuthenticationException($code, $description)";
+  }
+}
+
+WindowsLocalAuthenticationException?
+windowsLocalAuthenticationExceptionForError(Object error) {
+  if (error is PlatformException) {
+    return _windowsLocalAuthenticationExceptionForCode(
+      error.code,
+      error.message,
+      error,
+    );
+  }
+  if (error is LocalAuthException) {
+    return _windowsLocalAuthenticationExceptionForLocalAuthException(error);
+  }
+  return null;
+}
+
+bool isExpectedLocalAuthFailure(LocalAuthException error) {
+  return switch (error.code) {
+    LocalAuthExceptionCode.authInProgress ||
+    LocalAuthExceptionCode.userCanceled ||
+    LocalAuthExceptionCode.timeout ||
+    LocalAuthExceptionCode.systemCanceled ||
+    LocalAuthExceptionCode.temporaryLockout ||
+    LocalAuthExceptionCode.biometricLockout ||
+    LocalAuthExceptionCode.userRequestedFallback => true,
+    _ => false,
+  };
+}
+
+LocalAuthenticationUnavailableException?
+localAuthenticationUnavailableExceptionForError(LocalAuthException error) {
+  final code = error.code;
+  final issue = switch (code) {
+    LocalAuthExceptionCode.noCredentialsSet ||
+    LocalAuthExceptionCode.noBiometricsEnrolled =>
+      LocalAuthUnavailableIssue.notConfigured,
+    LocalAuthExceptionCode.noBiometricHardware =>
+      LocalAuthUnavailableIssue.noHardware,
+    LocalAuthExceptionCode.biometricHardwareTemporarilyUnavailable ||
+    LocalAuthExceptionCode.uiUnavailable ||
+    LocalAuthExceptionCode.deviceError ||
+    LocalAuthExceptionCode.unknownError =>
+      LocalAuthUnavailableIssue.unavailable,
+    _ => null,
+  };
+  if (issue == null) {
+    return null;
+  }
+  return LocalAuthenticationUnavailableException(
+    issue: issue,
+    code: code.name,
+    description: error.description,
+    originalError: error,
+  );
+}
+
+WindowsLocalAuthenticationException?
+_windowsLocalAuthenticationExceptionForCode(
+  String code,
+  String? description,
+  Object originalError,
+) {
+  final normalizedCode = code.toLowerCase();
+  final normalizedDescription = description?.toLowerCase() ?? "";
+  final issue = switch (normalizedCode) {
+    final c when c.contains("notenrolled") =>
+      WindowsLocalAuthIssue.notConfigured,
+    final c when c.contains("nocredentialsset") =>
+      WindowsLocalAuthIssue.notConfigured,
+    final c when c.contains("nobiometricsenrolled") =>
+      WindowsLocalAuthIssue.notConfigured,
+    final c when c.contains("nohardware") => WindowsLocalAuthIssue.noHardware,
+    final c when c.contains("nobiometrichardware") =>
+      WindowsLocalAuthIssue.noHardware,
+    final c when c.contains("devicebusy") => WindowsLocalAuthIssue.busy,
+    final c when c.contains("authinprogress") => WindowsLocalAuthIssue.busy,
+    final c when c.contains("temporarilyunavailable") =>
+      WindowsLocalAuthIssue.busy,
+    final c when c.contains("disabledbypolicy") =>
+      WindowsLocalAuthIssue.disabledByPolicy,
+    _ when normalizedDescription.contains("group policy") =>
+      WindowsLocalAuthIssue.disabledByPolicy,
+    final c when c.contains("notavailable") =>
+      WindowsLocalAuthIssue.unavailable,
+    final c when c.contains("unavailable") => WindowsLocalAuthIssue.unavailable,
+    final c when c.contains("deviceerror") => WindowsLocalAuthIssue.unavailable,
+    final c when c.contains("uiunavailable") =>
+      WindowsLocalAuthIssue.unavailable,
+    final c when c.contains("unknownerror") =>
+      WindowsLocalAuthIssue.unavailable,
+    _ => null,
+  };
+  if (issue == null) {
+    return null;
+  }
+  return WindowsLocalAuthenticationException(
+    issue: issue,
+    code: code,
+    description: description,
+    originalError: originalError,
+  );
+}
+
+WindowsLocalAuthenticationException?
+_windowsLocalAuthenticationExceptionForLocalAuthException(
+  LocalAuthException error,
+) {
+  final code = error.code;
+  if (code == LocalAuthExceptionCode.noCredentialsSet ||
+      code == LocalAuthExceptionCode.noBiometricsEnrolled) {
+    return WindowsLocalAuthenticationException(
+      issue: WindowsLocalAuthIssue.notConfigured,
+      code: code.name,
+      description: error.description,
+      originalError: error,
+    );
+  }
+  if (code == LocalAuthExceptionCode.noBiometricHardware) {
+    return WindowsLocalAuthenticationException(
+      issue: WindowsLocalAuthIssue.noHardware,
+      code: code.name,
+      description: error.description,
+      originalError: error,
+    );
+  }
+  if (code == LocalAuthExceptionCode.authInProgress ||
+      code == LocalAuthExceptionCode.biometricHardwareTemporarilyUnavailable) {
+    return WindowsLocalAuthenticationException(
+      issue: WindowsLocalAuthIssue.busy,
+      code: code.name,
+      description: error.description,
+      originalError: error,
+    );
+  }
+  if (code == LocalAuthExceptionCode.unknownError &&
+      (error.description?.toLowerCase().contains("group policy") ?? false)) {
+    return WindowsLocalAuthenticationException(
+      issue: WindowsLocalAuthIssue.disabledByPolicy,
+      code: code.name,
+      description: error.description,
+      originalError: error,
+    );
+  }
+  if (code == LocalAuthExceptionCode.uiUnavailable ||
+      code == LocalAuthExceptionCode.deviceError ||
+      code == LocalAuthExceptionCode.unknownError) {
+    return WindowsLocalAuthenticationException(
+      issue: WindowsLocalAuthIssue.unavailable,
+      code: code.name,
+      description: error.description,
+      originalError: error,
+    );
+  }
+  return null;
+}
 
 Future<bool> requestAuthentication(
   BuildContext context,
@@ -17,8 +258,6 @@ Future<bool> requestAuthentication(
   bool isOpeningApp = false,
   bool isAuthenticatingForInAppChange = false,
 }) async {
-  Logger("AuthUtil").info("Requesting authentication");
-
   final String? savedPin = await LockScreenSettings.instance.getPin();
   final String? savedPassword = await LockScreenSettings.instance.getPassword();
   if (savedPassword != null || savedPin != null) {
@@ -33,35 +272,100 @@ Future<bool> requestAuthentication(
   }
   if (Platform.isLinux) {
     // Linux uses flutter_local_authentication
-    return await FlutterLocalAuthentication().authenticate();
+    _logger.info("Starting Linux local authentication");
+    final result = await FlutterLocalAuthentication().authenticate();
+    _logger.info("Linux local authentication result: $result");
+    return result;
   } else {
-    await LocalAuthentication().stopAuthentication();
-    final l10n = context.strings;
-    return await LocalAuthentication().authenticate(
-      localizedReason: Platform.isMacOS ? macOSReason : defaultReason,
-      authMessages: [
-        AndroidAuthMessages(
-          biometricHint: l10n.androidBiometricHint,
-          biometricNotRecognized: l10n.androidBiometricNotRecognized,
-          biometricRequiredTitle: l10n.androidBiometricRequiredTitle,
-          biometricSuccess: l10n.androidBiometricSuccess,
-          cancelButton: l10n.androidCancelButton,
-          deviceCredentialsRequiredTitle:
-              l10n.androidDeviceCredentialsRequiredTitle,
-          deviceCredentialsSetupDescription:
-              l10n.androidDeviceCredentialsSetupDescription,
-          goToSettingsButton: l10n.goToSettings,
-          goToSettingsDescription: l10n.androidGoToSettingsDescription,
-          signInTitle: l10n.androidSignInTitle,
-        ),
-        IOSAuthMessages(
-          goToSettingsButton: l10n.goToSettings,
-          goToSettingsDescription: l10n.goToSettings,
-          lockOut: l10n.iOSLockOut,
-          // cancelButton default value is "Ok"
-          cancelButton: l10n.iOSOkButton,
-        ),
-      ],
+    final localAuth = LocalAuthentication();
+    try {
+      await localAuth.stopAuthentication();
+      await _logLocalAuthState(localAuth);
+      final l10n = context.strings;
+      final result = await localAuth.authenticate(
+        localizedReason: Platform.isMacOS ? macOSReason : defaultReason,
+        authMessages: [
+          AndroidAuthMessages(
+            cancelButton: l10n.androidCancelButton,
+            signInHint: l10n.androidBiometricHint,
+            signInTitle: l10n.androidSignInTitle,
+          ),
+          IOSAuthMessages(
+            cancelButton: l10n.iOSOkButton,
+            localizedFallbackTitle: l10n.enterPassword,
+          ),
+          MacOSAuthMessages(
+            cancelButton: l10n.iOSOkButton,
+            localizedFallbackTitle: l10n.enterPassword,
+          ),
+        ],
+      );
+      if (Platform.isWindows) {
+        _logger.info("Windows local authentication result: $result");
+      }
+      return result;
+    } on LocalAuthException catch (e, s) {
+      final windowsException = Platform.isWindows
+          ? windowsLocalAuthenticationExceptionForError(e)
+          : null;
+      if (windowsException != null) {
+        _logger.warning("Windows local authentication failed", e, s);
+        throw windowsException;
+      }
+      final unavailableException =
+          localAuthenticationUnavailableExceptionForError(e);
+      if (unavailableException != null) {
+        _logger.warning("System local authentication unavailable", e, s);
+        throw unavailableException;
+      }
+      if (isExpectedLocalAuthFailure(e)) {
+        _logger.fine(
+          "Local authentication did not complete: "
+          "${e.code.name}, ${e.description}",
+        );
+        return false;
+      }
+      _logger.warning("System local authentication failed", e, s);
+      rethrow;
+    } on PlatformException catch (e, s) {
+      final windowsException = Platform.isWindows
+          ? windowsLocalAuthenticationExceptionForError(e)
+          : null;
+      if (windowsException == null) {
+        _logger.warning("System local authentication platform error", e, s);
+        rethrow;
+      }
+      _logger.warning("Windows local authentication failed", e, s);
+      throw windowsException;
+    } catch (e, s) {
+      final windowsException = Platform.isWindows
+          ? windowsLocalAuthenticationExceptionForError(e)
+          : null;
+      if (windowsException == null) {
+        _logger.warning("Unexpected system local authentication error", e, s);
+        rethrow;
+      }
+      _logger.warning("Windows local authentication failed", e, s);
+      throw windowsException;
+    }
+  }
+}
+
+Future<void> _logLocalAuthState(LocalAuthentication localAuth) async {
+  if (!Platform.isWindows) {
+    return;
+  }
+  try {
+    final isDeviceSupported = await localAuth.isDeviceSupported();
+    final canCheckBiometrics = await localAuth.canCheckBiometrics;
+    final availableBiometrics = await localAuth.getAvailableBiometrics();
+    _logger.info(
+      "Windows local authentication state: "
+      "isDeviceSupported=$isDeviceSupported, "
+      "canCheckBiometrics=$canCheckBiometrics, "
+      "availableBiometrics=$availableBiometrics",
     );
+  } catch (e, s) {
+    _logger.warning("Failed to read local authentication state", e, s);
   }
 }

--- a/mobile/packages/lock_screen/lib/local_authentication_service.dart
+++ b/mobile/packages/lock_screen/lib/local_authentication_service.dart
@@ -39,17 +39,41 @@ class LocalAuthenticationService {
     if (await isLocalAuthSupportedOnDevice() ||
         LockScreenSettings.instance.getIsAppLockSet()) {
       AppLock.of(context)!.setEnabled(false);
-      final result = await requestAuthentication(
-        context,
-        infoMessage,
-        macOSReason: context.strings.unlock,
-        isAuthenticatingForInAppChange: true,
-      );
-      AppLock.of(
-        context,
-      )!.setEnabled(await LockScreenSettings.instance.shouldShowLockScreen());
-      if (refocusWindows) {
-        await PlatformUtil.refocusWindows();
+      bool result = false;
+      WindowsLocalAuthenticationException? windowsLocalAuthException;
+      LocalAuthenticationUnavailableException? localAuthUnavailableException;
+      try {
+        result = await requestAuthentication(
+          context,
+          infoMessage,
+          macOSReason: context.strings.unlock,
+          isAuthenticatingForInAppChange: true,
+        );
+      } on WindowsLocalAuthenticationException catch (e, s) {
+        windowsLocalAuthException = e;
+        logger.warning("Windows local authentication failed", e, s);
+      } on LocalAuthenticationUnavailableException catch (e, s) {
+        localAuthUnavailableException = e;
+        logger.warning("System local authentication unavailable", e, s);
+      } finally {
+        AppLock.of(
+          context,
+        )!.setEnabled(await LockScreenSettings.instance.shouldShowLockScreen());
+        if (refocusWindows) {
+          await PlatformUtil.refocusWindows();
+        }
+      }
+      if (windowsLocalAuthException != null) {
+        if (context.mounted) {
+          showToast(context, windowsLocalAuthException.userMessage);
+        }
+        return false;
+      }
+      if (localAuthUnavailableException != null) {
+        if (context.mounted) {
+          showToast(context, localAuthUnavailableException.userMessage);
+        }
+        return false;
       }
       if (!result) {
         showToast(context, infoMessage);
@@ -116,22 +140,38 @@ class LocalAuthenticationService {
     String errorDialogTitle = "",
   ]) async {
     if (await isLocalAuthSupportedOnDevice()) {
+      bool didEnableLockScreen = false;
       AppLock.of(context)!.disable();
-      final result = await requestAuthentication(
-        context,
-        infoMessage,
-        macOSReason: context.strings.unlock,
-      );
-      if (result) {
-        AppLock.of(context)!.setEnabled(shouldEnableLockScreen);
-        await LockScreenSettings.instance.setSystemLockScreen(
-          shouldEnableLockScreen,
-        );
-        return true;
-      } else {
-        AppLock.of(
+      try {
+        final result = await requestAuthentication(
           context,
-        )!.setEnabled(await LockScreenSettings.instance.shouldShowLockScreen());
+          infoMessage,
+          macOSReason: context.strings.unlock,
+        );
+        if (result) {
+          AppLock.of(context)!.setEnabled(shouldEnableLockScreen);
+          await LockScreenSettings.instance.setSystemLockScreen(
+            shouldEnableLockScreen,
+          );
+          didEnableLockScreen = true;
+          return true;
+        }
+      } on WindowsLocalAuthenticationException catch (e, s) {
+        logger.warning("Windows local authentication failed", e, s);
+        if (context.mounted) {
+          showToast(context, e.userMessage);
+        }
+      } on LocalAuthenticationUnavailableException catch (e, s) {
+        logger.warning("System local authentication unavailable", e, s);
+        if (context.mounted) {
+          showToast(context, e.userMessage);
+        }
+      } finally {
+        if (!didEnableLockScreen) {
+          AppLock.of(context)!.setEnabled(
+            await LockScreenSettings.instance.shouldShowLockScreen(),
+          );
+        }
       }
     } else {
       // ignore: unawaited_futures
@@ -142,10 +182,34 @@ class LocalAuthenticationService {
 
   Future<bool> isLocalAuthSupportedOnDevice() async {
     try {
-      return Platform.isLinux
-          ? await FlutterLocalAuthentication().canAuthenticate()
-          : await LocalAuthentication().isDeviceSupported();
+      if (Platform.isWindows) {
+        final localAuth = LocalAuthentication();
+        final isSupported = await localAuth.isDeviceSupported();
+        logger.info(
+          "Windows local authentication support: "
+          "isDeviceSupported=$isSupported",
+        );
+        return isSupported;
+      }
+      if (Platform.isLinux) {
+        logger.fine("Checking Linux local authentication support");
+        final canAuthenticate = await FlutterLocalAuthentication()
+            .canAuthenticate();
+        logger.fine(
+          "Linux local authentication support: "
+          "canAuthenticate=$canAuthenticate",
+        );
+        return canAuthenticate;
+      }
+      return await LocalAuthentication().isDeviceSupported();
     } on MissingPluginException {
+      logger.warning("Local authentication plugin is not available");
+      return false;
+    } on PlatformException catch (e, s) {
+      if (!Platform.isWindows) {
+        rethrow;
+      }
+      logger.warning("Failed to check Windows local authentication", e, s);
       return false;
     }
   }

--- a/mobile/packages/lock_screen/lib/ui/lock_screen.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen.dart
@@ -9,6 +9,7 @@ import 'package:ente_lock_screen/ui/app_lock.dart';
 import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
+import 'package:ente_ui/utils/toast_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:logging/logging.dart';
@@ -350,6 +351,18 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
           _hasAuthenticationFailed = true;
           _logger.info("Authentication failed");
         }
+      }
+    } on WindowsLocalAuthenticationException catch (e, s) {
+      _isShowingLockScreen = false;
+      _logger.warning("Windows local authentication failed", e, s);
+      if (mounted) {
+        showToast(context, e.userMessage);
+      }
+    } on LocalAuthenticationUnavailableException catch (e, s) {
+      _isShowingLockScreen = false;
+      _logger.warning("System local authentication unavailable", e, s);
+      if (mounted) {
+        showToast(context, e.userMessage);
       }
     } catch (e, s) {
       _isShowingLockScreen = false;

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_pin.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_pin.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 import "dart:io";
-import "dart:typed_data";
 
 import "package:ente_crypto_api/ente_crypto_api.dart";
 import "package:ente_lock_screen/lock_screen_settings.dart";

--- a/mobile/packages/lock_screen/pubspec.lock
+++ b/mobile/packages/lock_screen/pubspec.lock
@@ -583,26 +583,26 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.56"
+    version: "2.0.8"
   local_auth_darwin:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: local_auth_darwin
-      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -615,10 +615,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:

--- a/mobile/packages/lock_screen/pubspec.yaml
+++ b/mobile/packages/lock_screen/pubspec.yaml
@@ -39,7 +39,9 @@ dependencies:
   # If not resolved and we need to upgrade, write a migration script.
   flutter_secure_storage: 9.0.0
   flutter_svg: 2.2.3
-  local_auth: 2.3.0
+  local_auth: 3.0.1
+  local_auth_android: 2.0.8
+  local_auth_darwin: 2.0.3
   logging: 1.3.0
   pinput: 5.0.2
   privacy_screen: 0.0.8

--- a/mobile/packages/lock_screen/test/auth_util_test.dart
+++ b/mobile/packages/lock_screen/test/auth_util_test.dart
@@ -1,0 +1,134 @@
+import 'package:ente_lock_screen/auth_util.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
+
+void main() {
+  group("windowsLocalAuthenticationExceptionForError", () {
+    test("maps Windows not-enrolled errors to setup guidance", () {
+      final exception = windowsLocalAuthenticationExceptionForError(
+        PlatformException(
+          code: "NotEnrolled",
+          message: "No biometrics enrolled on this device.",
+        ),
+      );
+
+      expect(exception, isNotNull);
+      expect(exception!.issue, WindowsLocalAuthIssue.notConfigured);
+      expect(exception.userMessage, contains("Windows Hello"));
+      expect(exception.userMessage, contains("PIN"));
+    });
+
+    test("maps Windows hardware errors to app lock fallback guidance", () {
+      final exception = windowsLocalAuthenticationExceptionForError(
+        PlatformException(
+          code: "NoHardware",
+          message: "No biometric hardware found",
+        ),
+      );
+
+      expect(exception, isNotNull);
+      expect(exception!.issue, WindowsLocalAuthIssue.noHardware);
+      expect(exception.userMessage, contains("App lock"));
+    });
+
+    test("maps LocalAuthException codes", () {
+      final exception = windowsLocalAuthenticationExceptionForError(
+        const LocalAuthException(
+          code: LocalAuthExceptionCode.noBiometricsEnrolled,
+        ),
+      );
+
+      expect(exception, isNotNull);
+      expect(exception!.issue, WindowsLocalAuthIssue.notConfigured);
+    });
+
+    test("ignores unrelated platform exceptions", () {
+      final exception = windowsLocalAuthenticationExceptionForError(
+        PlatformException(code: "UserCanceled"),
+      );
+
+      expect(exception, isNull);
+    });
+  });
+
+  group("isExpectedLocalAuthFailure", () {
+    test("treats user-driven cancellations as expected failures", () {
+      expect(
+        isExpectedLocalAuthFailure(
+          const LocalAuthException(code: LocalAuthExceptionCode.userCanceled),
+        ),
+        isTrue,
+      );
+      expect(
+        isExpectedLocalAuthFailure(
+          const LocalAuthException(code: LocalAuthExceptionCode.systemCanceled),
+        ),
+        isTrue,
+      );
+      expect(
+        isExpectedLocalAuthFailure(
+          const LocalAuthException(
+            code: LocalAuthExceptionCode.userRequestedFallback,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test("does not hide setup or device errors", () {
+      expect(
+        isExpectedLocalAuthFailure(
+          const LocalAuthException(
+            code: LocalAuthExceptionCode.noCredentialsSet,
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        isExpectedLocalAuthFailure(
+          const LocalAuthException(code: LocalAuthExceptionCode.deviceError),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group("localAuthenticationUnavailableExceptionForError", () {
+    test("maps missing credentials to setup guidance", () {
+      final exception = localAuthenticationUnavailableExceptionForError(
+        const LocalAuthException(code: LocalAuthExceptionCode.noCredentialsSet),
+      );
+
+      expect(exception, isNotNull);
+      expect(exception!.issue, LocalAuthUnavailableIssue.notConfigured);
+      expect(exception.userMessage, contains("System authentication"));
+      expect(exception.userMessage, contains("PIN/password"));
+    });
+
+    test("maps hardware and device errors", () {
+      expect(
+        localAuthenticationUnavailableExceptionForError(
+          const LocalAuthException(
+            code: LocalAuthExceptionCode.noBiometricHardware,
+          ),
+        )!.issue,
+        LocalAuthUnavailableIssue.noHardware,
+      );
+      expect(
+        localAuthenticationUnavailableExceptionForError(
+          const LocalAuthException(code: LocalAuthExceptionCode.deviceError),
+        )!.issue,
+        LocalAuthUnavailableIssue.unavailable,
+      );
+    });
+
+    test("ignores expected user failures", () {
+      final exception = localAuthenticationUnavailableExceptionForError(
+        const LocalAuthException(code: LocalAuthExceptionCode.userCanceled),
+      );
+
+      expect(exception, isNull);
+    });
+  });
+}

--- a/mobile/packages/sharing/pubspec.lock
+++ b/mobile/packages/sharing/pubspec.lock
@@ -636,26 +636,26 @@ packages:
     dependency: transitive
     description:
       name: local_auth
-      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      sha256: ae6f382f638108c6becd134318d7c3f0a93875383a54010f61d7c97ac05d5137
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.1"
   local_auth_android:
     dependency: transitive
     description:
       name: local_auth_android
-      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      sha256: b201c006fa769c23386f89aa6837ec0eb8179fcfb212eadcf87b422b3f9a6a78
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.56"
+    version: "2.0.8"
   local_auth_darwin:
     dependency: transitive
     description:
       name: local_auth_darwin
-      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      sha256: a8c3d4e17454111f7fd31ff72a31222359f6059f7fe956c2dcfe0f88f49826d4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "2.0.3"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -668,10 +668,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      sha256: be12c5b8ba5e64896983123655c5f67d2484ecfcc95e367952ad6e3bff94cb16
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.1"
   logging:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Summary
- Upgrade Auth/Locker local_auth usage to 3.x
- Show actionable auth setup/unavailable messages instead of falling through to generic failures
- Add mapper tests for local_auth error handling

Refs #9918

## Test Plan
- cd mobile/packages/lock_screen && flutter analyze
- cd mobile/packages/lock_screen && flutter test test/auth_util_test.dart