### PR TITLE
 Fix quickstart.sh POSIX compatibility, auth export MIME types, video volume slider, and auto-logout keyboard handler

### DIFF
--- a/mobile/apps/auth/lib/ui/account/logout_dialog.dart
+++ b/mobile/apps/auth/lib/ui/account/logout_dialog.dart
@@ -66,4 +66,7 @@ Future<void> _logout(BuildContext context, AppLocalizations l10n) async {
   await dialog.show();
   await Configuration.instance.logout();
   await dialog.hide();
+  if (context.mounted) {
+    Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+  }
 }

--- a/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/export_widget.dart
@@ -155,6 +155,8 @@ Future<void> _exportCodes(
   if (!hasAuthenticated) {
     return;
   }
+  final mimeType = extension == "json" ? MimeType.json : MimeType.text;
+  final mimeString = extension == "json" ? 'application/json' : 'text/plain';
   Future.delayed(
     const Duration(milliseconds: 1200),
     () async => await auth_share.shareDialog(
@@ -165,7 +167,7 @@ Future<void> _exportCodes(
           exportFileName,
           extension,
           CryptoUtil.strToBin(fileContent),
-          MimeType.text,
+          mimeType,
         );
       },
       sendAction: () async {
@@ -179,7 +181,7 @@ Future<void> _exportCodes(
         final Size size = MediaQuery.of(context).size;
         await SharePlus.instance.share(
           ShareParams(
-            files: <XFile>[XFile(codeFile.path, mimeType: 'text/plain')],
+            files: <XFile>[XFile(codeFile.path, mimeType: mimeString)],
             sharePositionOrigin: Rect.fromLTWH(
               0,
               0,

--- a/server/quickstart.sh
+++ b/server/quickstart.sh
@@ -232,7 +232,7 @@ sleep 1
 printf " \033[1;32mE\033[0m   Do you want to start Ente? (y/n) [n]: "
 read -r choice
 
-if [[ "$choice" =~ ^[Yy]$ ]]; then
+if [ "$choice" = "y" ] || [ "$choice" = "Y" ]; then
     printf "\nStarting docker compose\n"
     printf "\nAfter the cluster has started, open web app at \033[1mhttp://localhost:3000\033[0m\n"
     printf "(Verification code will be in the logs here)\n\n"

--- a/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
+++ b/web/apps/albums/src/public-album/viewer/lib/photoswipe.ts
@@ -2194,6 +2194,7 @@ const hlsVideoControlsHTML = () => `
   <media-control-bar>
     <media-play-button notooltip></media-play-button>
     <media-mute-button notooltip></media-mute-button>
+    <media-volume-range></media-volume-range>
     <media-time-display showduration notoggle></media-time-display>
     <media-text-display></media-text-display>
     <media-settings-menu-button id="ente-settings-menu-btn" invoketarget="ente-settings-menu" notooltip>

--- a/web/packages/gallery/components/viewer/photoswipe.ts
+++ b/web/packages/gallery/components/viewer/photoswipe.ts
@@ -2149,6 +2149,7 @@ const hlsVideoControlsHTML = () => `
   <media-control-bar>
     <media-play-button notooltip></media-play-button>
     <media-mute-button notooltip></media-mute-button>
+    <media-volume-range></media-volume-range>
     <media-time-display showduration notoggle></media-time-display>
     <media-text-display></media-text-display>
     <media-settings-menu-button id="ente-settings-menu-btn" invoketarget="ente-settings-menu" notooltip>


### PR DESCRIPTION
Some old bugs i saw in your issues, focused on small issues that were clearly bugs and not design decisions on your part that could be easily fixed with a quick ai prompt.

[server] Fix quickstart.sh using bash syntax in #!/bin/sh script — replace [[ =~ ]] with POSIX-compatible [ ] || [ ] so the script works on Debian/Ubuntu where sh is dash.

[auth] Use correct MIME type for encrypted code exports — encrypted exports now use MimeType.json / application/json instead of MimeType.text / text/plain, fixing .txt files being generated instead of .json.

[web] Add volume slider to video player controls — add to the media-chrome control bar in both the gallery and public albums viewers, giving users granular volume control instead of only mute/unmute.

[auth] Fix stale keyboard handler after auto-logout on desktop — the auto-logout path (session expiry) did not clear the route stack, leaving the HomePage mounted with its global keyboard handler registered. Add pushNamedAndRemoveUntil after logout to properly dispose the old widget tree.

Fixes #6324, #5441, #6608, #451