### PR TITLE
[auth][desktop] Improve Auth AppImage library loading

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -265,7 +265,9 @@ jobs:
                   mv dist/*/*.rpm "artifacts/${ARTIFACT_STEM}-x86_64.rpm"
                   dart pub global activate --source git https://github.com/ente-io/fastforgefork --git-ref develop --git-path packages/fastforge
                   fastforge package --platform=linux --targets=appimage --skip-clean
-                  mv dist/**/*-*-linux.AppImage "artifacts/${ARTIFACT_STEM}-x86_64.AppImage"
+                  appimage_path="$(find dist -name '*-*-linux.AppImage' -print -quit)"
+                  ./linux/packaging/post_process_appimage.sh "$appimage_path"
+                  mv "$appimage_path" "artifacts/${ARTIFACT_STEM}-x86_64.AppImage"
                   fastforge package --platform=linux --targets=deb --skip-clean
                   mv dist/**/*-*-linux.deb "artifacts/${ARTIFACT_STEM}-x86_64.deb"
 

--- a/mobile/apps/auth/changes/01-current.md
+++ b/mobile/apps/auth/changes/01-current.md
@@ -16,6 +16,7 @@
 - Fixed some Simple Icons and custom icons not loading in the Auth icon picker because their registry filenames were not resolved correctly
 - Fixed Auth desktop custom icons flashing for Amazon and other monochrome icons ([#8264](https://github.com/ente-io/ente/issues/8264), [#8499](https://github.com/ente-io/ente/issues/8499))
 - Fixed missing Auth tray icons in sandboxed Linux builds ([#4608](https://github.com/ente-io/ente/issues/4608), [#7815](https://github.com/ente-io/ente/issues/7815), [flathub/io.ente.auth#75](https://github.com/flathub/io.ente.auth/issues/75))
+- Fixed Auth AppImage startup failures on some Linux systems by preferring host runtime libraries before bundled AppImage fallbacks ([#6705](https://github.com/ente-io/ente/issues/6705), [#7646](https://github.com/ente-io/ente/issues/7646), [#9738](https://github.com/ente-io/ente/issues/9738), [#6976](https://github.com/ente-io/ente/issues/6976), [#6600](https://github.com/ente-io/ente/issues/6600))
 - Fixed Auth tray close, exit, and menu actions on Windows ([#8164](https://github.com/ente-io/ente/issues/8164), [#4360](https://github.com/ente-io/ente/issues/4360), [#3518](https://github.com/ente-io/ente/issues/3518))
 - Fixed stale or duplicate Auth tray icons on Windows ([#8165](https://github.com/ente-io/ente/issues/8165))
 - Improved Auth tray icon contrast in the Windows tray overflow ([#9491](https://github.com/ente-io/ente/issues/9491))

--- a/mobile/apps/auth/linux/packaging/post_process_appimage.sh
+++ b/mobile/apps/auth/linux/packaging/post_process_appimage.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path-to-appimage>" >&2
+    exit 2
+fi
+
+appimage="$1"
+if [[ ! -f "$appimage" ]]; then
+    echo "AppImage not found: $appimage" >&2
+    exit 1
+fi
+
+if ! command -v appimagetool >/dev/null 2>&1; then
+    echo "appimagetool is required to rebuild the AppImage" >&2
+    exit 1
+fi
+
+appimage_dir="$(cd "$(dirname "$appimage")" && pwd)"
+appimage_name="$(basename "$appimage")"
+appimage_path="$appimage_dir/$appimage_name"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+cp "$appimage_path" "$workdir/input.AppImage"
+chmod +x "$workdir/input.AppImage"
+
+(
+    cd "$workdir"
+    ./input.AppImage --appimage-extract >/dev/null
+)
+
+appdir="$workdir/squashfs-root"
+
+if [[ -d "$appdir/usr/lib" ]]; then
+    blocked_libs="$(
+        find "$appdir/usr/lib" \( -type f -o -type l \) \( \
+            -name 'libGL.so*' -o \
+            -name 'libEGL.so*' -o \
+            -name 'libGLES*.so*' -o \
+            -name 'libGLX.so*' -o \
+            -name 'libOpenGL.so*' -o \
+            -name 'libdrm.so*' -o \
+            -name 'libgbm.so*' -o \
+            -name 'libglapi.so*' -o \
+            -name 'libwayland-client.so*' -o \
+            -name 'libwayland-egl.so*' \
+        \) -print
+    )"
+    if [[ -n "$blocked_libs" ]]; then
+        echo "Refusing to ship graphics stack libraries in the AppImage:" >&2
+        echo "$blocked_libs" >&2
+        exit 1
+    fi
+fi
+
+cat >"$appdir/AppRun" <<'APPRUN'
+#!/usr/bin/env bash
+set -e
+
+APPDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$APPDIR"
+
+HOST_LIBRARY_PATH="/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/lib64:/usr/lib64:/lib:/usr/lib"
+BUNDLED_LIBRARY_PATH="$APPDIR/usr/lib"
+
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOST_LIBRARY_PATH:$BUNDLED_LIBRARY_PATH"
+else
+    export LD_LIBRARY_PATH="$HOST_LIBRARY_PATH:$BUNDLED_LIBRARY_PATH"
+fi
+
+exec "$APPDIR/enteauth" "$@"
+APPRUN
+chmod +x "$appdir/AppRun"
+
+output="$workdir/${appimage_name%.AppImage}.processed.AppImage"
+ARCH=x86_64 appimagetool "$appdir" "$output" >/dev/null
+mv "$output" "$appimage_path"
+chmod +x "$appimage_path"
+
+echo "Post-processed AppImage: $appimage_path"


### PR DESCRIPTION
## Summary

- Post-process Auth AppImage builds so host library paths are preferred before bundled `usr/lib` fallbacks.
- Fail the AppImage build if GL/Mesa driver libraries are bundled.

Refs:
- #6705
- #7646
- #9738
- #6976
- #6600

## Test plan

- `bash -n mobile/apps/auth/linux/packaging/post_process_appimage.sh`
- Script smoke tests for AppRun rewrite and GL library rejection with fake AppImage/appimagetool fixtures
- `ruby mobile/scripts/check_frozen_pubspecs.rb mobile/apps/auth`
- `ruby mobile/scripts/check_source_arb_plurals.rb`
- Auth lint flow: `flutter gen-l10n`, `flutter pub get --enforce-lockfile`, `dart format --output=none --set-exit-if-changed .`, `flutter analyze --no-fatal-infos`, `flutter test`