### PR TITLE
[server] decouple compliance hold removal from object deletion

### DIFF
--- a/docs/docs/self-hosting/troubleshooting/misc.md
+++ b/docs/docs/self-hosting/troubleshooting/misc.md
@@ -26,7 +26,7 @@ This is not guaranteed, each browsers handles CSP errors differently, and some m
 Deleted files don't immediately free up S3/MinIO storage:
 
 1. **Trash retention**: 30 days
-2. **Deletion queue**: Additional 45 days after permanent deletion
+2. **Deletion queue**: Defaults to an additional 45 days after permanent deletion
 3. **Total**: Up to 75 days before storage is freed
 
 To speed this up:

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -182,7 +182,7 @@ func main() {
 	legacyKitRepository := &legacykitrepo.Repository{DB: db}
 
 	notificationHistoryRepo := &repo.NotificationHistoryRepository{DB: db}
-	queueRepo := &repo.QueueRepository{DB: db}
+	queueRepo := &repo.QueueRepository{DB: db, S3Config: s3Config}
 	objectRepo := &repo.ObjectRepository{DB: db, LatencySensitiveDB: latencySensitiveDB, QueueRepo: queueRepo, S3Config: s3Config}
 	objectCleanupRepo := &repo.ObjectCleanupRepository{DB: db}
 	contactRepository := &contactRepo.Repository{

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -183,7 +183,7 @@ func main() {
 
 	notificationHistoryRepo := &repo.NotificationHistoryRepository{DB: db}
 	queueRepo := &repo.QueueRepository{DB: db}
-	objectRepo := &repo.ObjectRepository{DB: db, LatencySensitiveDB: latencySensitiveDB, QueueRepo: queueRepo}
+	objectRepo := &repo.ObjectRepository{DB: db, LatencySensitiveDB: latencySensitiveDB, QueueRepo: queueRepo, S3Config: s3Config}
 	objectCleanupRepo := &repo.ObjectCleanupRepository{DB: db}
 	contactRepository := &contactRepo.Repository{
 		DB:                  db,

--- a/server/pkg/controller/object.go
+++ b/server/pkg/controller/object.go
@@ -42,10 +42,6 @@ const (
 // we subsequently attempt to delete the objects from Wasabi after
 // DeleteObjectQueue delay (x days currently).
 func (c *ObjectController) RemoveComplianceHolds() {
-	if c.S3Config.WasabiComplianceDC() == "" {
-		// Wasabi compliance is currently disabled in config, nothing to do.
-		return
-	}
 	if c.complianceCronRunning {
 		log.Info("Skipping RemoveComplianceHolds cron run as another instance is still running")
 		return

--- a/server/pkg/repo/object.go
+++ b/server/pkg/repo/object.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/ente-io/museum/ente"
+	"github.com/ente-io/museum/pkg/utils/s3config"
 	"github.com/ente-io/stacktrace"
 	"github.com/lib/pq"
 )
@@ -16,6 +17,7 @@ type ObjectRepository struct {
 	DB                 *sql.DB
 	LatencySensitiveDB *sql.DB
 	QueueRepo          *QueueRepository
+	S3Config           *s3config.S3Config
 }
 
 func (repo *ObjectRepository) objectLookupDB() *sql.DB {
@@ -318,9 +320,11 @@ func (repo *ObjectRepository) MarkObjectsAsDeletedForFileIDs(ctx context.Context
 		keysToBeDeleted = append(keysToBeDeleted, s3ObjectKey.ObjectKey)
 	}
 
-	err = repo.QueueRepo.AddItems(ctx, tx, RemoveComplianceHoldQueue, keysToBeDeleted)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "")
+	if repo.S3Config.WasabiComplianceDC() != "" {
+		err = repo.QueueRepo.AddItems(ctx, tx, RemoveComplianceHoldQueue, keysToBeDeleted)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "")
+		}
 	}
 
 	err = repo.QueueRepo.AddItems(ctx, tx, DeleteObjectQueue, keysToBeDeleted)

--- a/server/pkg/repo/object_test.go
+++ b/server/pkg/repo/object_test.go
@@ -544,3 +544,124 @@ func linkObjectTestFileToCollection(t *testing.T, db *sql.DB, collectionID int64
 		t.Fatalf("failed to link file %d to collection %d: %v", fileID, collectionID, err)
 	}
 }
+
+func TestGetDelayInMinReturnsDefaultDelayForDeleteObjectQueue(t *testing.T) {
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatalf("failed to configure viper: %v", err)
+	}
+
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	t.Cleanup(viper.Reset)
+
+	s3Config := s3config.NewS3Config()
+	repo := &QueueRepository{
+		DB:       nil,
+		S3Config: s3Config,
+	}
+
+	delay, err := repo.getDelayInMin(DeleteObjectQueue)
+	if err != nil {
+		t.Fatalf("getDelayInMin error = %v", err)
+	}
+
+	expectedDelay := int64(45 * 24 * 60) // 45 days in minutes
+	if delay != expectedDelay {
+		t.Fatalf("expected delay %d, got %d", expectedDelay, delay)
+	}
+}
+
+func TestGetDelayInMinReturnsAtLeastWasabiObjectConditionalHoldDaysForDeleteObjectQueue(t *testing.T) {
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatalf("failed to configure viper: %v", err)
+	}
+
+	viper.Set("s3.wasabi-eu-central-2-v3.compliance", true)
+	configuredDays := 1
+	viper.Set("s3.object_deletion_interval_days", configuredDays)
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	t.Cleanup(viper.Reset)
+
+	s3Config := s3config.NewS3Config()
+	repo := &QueueRepository{
+		DB:       nil,
+		S3Config: s3Config,
+	}
+
+	delay, err := repo.getDelayInMin(DeleteObjectQueue)
+	if err != nil {
+		t.Fatalf("getDelayInMin error = %v", err)
+	}
+
+	expectedDelay := int64(s3config.WasabiObjectConditionalHoldDays * 24 * 60)
+	if delay != expectedDelay {
+		t.Fatalf("expected delay %d, got %d", expectedDelay, delay)
+	}
+}
+
+func TestGetDelayInMinReturnsConfiguredDelayIfLessThanWasabiObjectConditionalHoldDaysForDeleteObjectQueue(t *testing.T) {
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatalf("failed to configure viper: %v", err)
+	}
+
+	configuredDays := 1
+	viper.Set("s3.wasabi-eu-central-2-v3.compliance", false)
+	viper.Set("s3.object_deletion_interval_days", configuredDays)
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	t.Cleanup(viper.Reset)
+
+	s3Config := s3config.NewS3Config()
+	repo := &QueueRepository{
+		DB:       nil,
+		S3Config: s3Config,
+	}
+
+	delay, err := repo.getDelayInMin(DeleteObjectQueue)
+	if err != nil {
+		t.Fatalf("getDelayInMin error = %v", err)
+	}
+
+	expectedDelay := int64(configuredDays * 24 * 60)
+	if delay != expectedDelay {
+		t.Fatalf("expected delay %d, got %d", expectedDelay, delay)
+	}
+}
+
+func TestGetDelayInMinReturnsConfiguredDelayForDeleteObjectQueue(t *testing.T) {
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatalf("failed to configure viper: %v", err)
+	}
+
+	// Configure a test deletion interval
+	configuredDays := 30
+	viper.Set("s3.object_deletion_interval_days", configuredDays)
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	t.Cleanup(viper.Reset)
+
+	s3Config := s3config.NewS3Config()
+	repo := &QueueRepository{
+		DB:       nil,
+		S3Config: s3Config,
+	}
+
+	delay, err := repo.getDelayInMin(DeleteObjectQueue)
+	if err != nil {
+		t.Fatalf("getDelayInMin error = %v", err)
+	}
+
+	expectedDelay := int64(configuredDays * 24 * 60) // 30 days in minutes
+	if delay != expectedDelay {
+		t.Fatalf("expected delay %d, got %d", expectedDelay, delay)
+	}
+}

--- a/server/pkg/repo/object_test.go
+++ b/server/pkg/repo/object_test.go
@@ -1,13 +1,17 @@
 package repo
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"testing"
 
 	"github.com/ente-io/museum/ente"
 	"github.com/ente-io/museum/internal/testutil"
+	"github.com/ente-io/museum/pkg/utils/config"
+	"github.com/ente-io/museum/pkg/utils/s3config"
 	"github.com/lib/pq"
+	"github.com/spf13/viper"
 )
 
 func TestObjectLookupDBUsesLatencySensitiveDBWhenPresent(t *testing.T) {
@@ -320,6 +324,73 @@ func TestGetCollectionObjectRejectsDeletedCollectionFile(t *testing.T) {
 	}
 }
 
+func TestMarkObjectsAsDeletedWithoutComplianceHoldDoesNotQueueRemoveComplianceHold(t *testing.T) {
+	repository, db := setupComplianceHoldTest(t, false)
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "no-compliance-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "no-compliance-object", 100, []string{"b2-eu-cen"})
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("failed to begin transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	_, err = repository.MarkObjectsAsDeletedForFileIDs(context.Background(), tx, []int64{fileID})
+	if err != nil {
+		t.Fatalf("MarkObjectsAsDeletedForFileIDs error = %v", err)
+	}
+
+	// Verify that RemoveComplianceHoldQueue does not have any items
+	var count int
+	err = tx.QueryRow(`SELECT COUNT(*) FROM queue WHERE queue_name = $1`, RemoveComplianceHoldQueue).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to query queue: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 items in RemoveComplianceHoldQueue, got %d", count)
+	}
+}
+
+func TestMarkObjectsAsDeletedWithComplianceHoldQueuesRemoveComplianceHold(t *testing.T) {
+	repository, db := setupComplianceHoldTest(t, true)
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "with-compliance-owner@ente.com",
+		CreationTime: 1,
+	})
+	fileID := insertObjectTestFile(t, db, ownerID)
+	insertObjectTestKey(t, db, fileID, ente.FILE, "with-compliance-object", 100, []string{"b2-eu-cen"})
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("failed to begin transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	_, err = repository.MarkObjectsAsDeletedForFileIDs(context.Background(), tx, []int64{fileID})
+	if err != nil {
+		t.Fatalf("MarkObjectsAsDeletedForFileIDs error = %v", err)
+	}
+
+	// Verify that RemoveComplianceHoldQueue has the object key
+	var item string
+	err = tx.QueryRow(`SELECT item FROM queue WHERE queue_name = $1 LIMIT 1`, RemoveComplianceHoldQueue).Scan(&item)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected item in RemoveComplianceHoldQueue, but queue is empty")
+		}
+		t.Fatalf("failed to query queue: %v", err)
+	}
+	if item != "with-compliance-object" {
+		t.Fatalf("expected queue item 'with-compliance-object', got '%s'", item)
+	}
+}
+
 func setupAccessibleObjectTest(t *testing.T) (*ObjectRepository, *sql.DB) {
 	t.Helper()
 
@@ -331,6 +402,47 @@ func setupAccessibleObjectTest(t *testing.T) (*ObjectRepository, *sql.DB) {
 	})
 
 	return &ObjectRepository{DB: db, LatencySensitiveDB: db}, db
+}
+
+func setupComplianceHoldTest(t *testing.T, enableCompliance bool) (*ObjectRepository, *sql.DB) {
+	t.Helper()
+
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatalf("failed to configure viper: %v", err)
+	}
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	viper.Set("s3.b2-eu-cen.endpoint", "http://localhost:9000")
+	viper.Set("s3.b2-eu-cen.region", "us-east-1")
+	viper.Set("s3.b2-eu-cen.bucket", "test-bucket")
+	viper.Set("s3.b2-eu-cen.disable_ssl", true)
+	viper.Set("s3.use_path_style_urls", true)
+
+	if enableCompliance {
+		viper.Set("s3.wasabi-eu-central-2-v3.compliance", true)
+		viper.Set("s3.wasabi-eu-central-2-v3.key", "test-key")
+		viper.Set("s3.wasabi-eu-central-2-v3.secret", "test-secret")
+		viper.Set("s3.wasabi-eu-central-2-v3.endpoint", "http://localhost:9000")
+		viper.Set("s3.wasabi-eu-central-2-v3.region", "us-east-1")
+		viper.Set("s3.wasabi-eu-central-2-v3.bucket", "test-bucket")
+		viper.Set("s3.wasabi-eu-central-2-v3.disable_ssl", true)
+	} else {
+		viper.Set("s3.wasabi-eu-central-2-v3.compliance", false)
+	}
+	t.Cleanup(viper.Reset)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		testutil.ResetTables(t, db)
+	})
+
+	s3Config := s3config.NewS3Config()
+	queueRepo := &QueueRepository{DB: db}
+	repository := &ObjectRepository{DB: db, LatencySensitiveDB: db, S3Config: s3Config, QueueRepo: queueRepo}
+	return repository, db
 }
 
 func insertObjectTestFile(t *testing.T, db *sql.DB, ownerID int64) int64 {

--- a/server/pkg/repo/queue.go
+++ b/server/pkg/repo/queue.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ente-io/museum/pkg/utils/s3config"
 	"github.com/ente-io/museum/pkg/utils/time"
 	"github.com/ente-io/stacktrace"
 )
@@ -15,13 +16,13 @@ import (
 // QueueRepository defines methods to insert, delete items from queue
 type QueueRepository struct {
 	DB *sql.DB
+    S3Config *s3config.S3Config
 }
 
 // itemDeletionDelayInMinMap tracks the delay (in min) after which an item is ready to be processed.
 // -ve entry indicates that the item should be processed immediately, without any delay.
 var itemDeletionDelayInMinMap = map[string]int64{
 	DropFileEncMedataQueue:    -1 * 24 * 60, // -ve value to ensure attributes are immediately removed
-	DeleteObjectQueue:         45 * 24 * 60, // 45 days in minutes
 	DeleteEmbeddingsQueue:     -1 * 24 * 60, // -ve value to ensure embeddings are immediately removed
 	TrashCollectionQueueV3:    -1 * 24 * 60, // -ve value to ensure collections are immediately marked as trashed
 	TrashEmptyQueue:           -1 * 24 * 60, // -ve value to ensure empty trash request are processed in next cron run
@@ -46,6 +47,19 @@ const (
 type QueueItem struct {
 	Id   int64
 	Item string
+}
+
+func (repo *QueueRepository) getDelayInMin(queueName string) (int64, error) {
+	// DeleteObjectQueue has a configurable delay, so checking it before the map lookup. For other queues, the delay is fixed and stored in the map.
+	if queueName == DeleteObjectQueue && repo.S3Config != nil {
+		return int64(repo.S3Config.GetObjectDeletionIntervalDays()) * 24 * 60, nil
+	}
+	
+	delay, ok := itemDeletionDelayInMinMap[queueName]
+	if !ok {
+		return 0, fmt.Errorf("missing delay for %s", queueName)
+	}
+	return delay, nil
 }
 
 // InsertItem adds entry in the queue with given queueName and item. If entry already exists, it's no-op
@@ -125,9 +139,9 @@ func (repo *QueueRepository) DeleteItem(queueName string, item string) error {
 
 // GetItemsReadyForDeletion method, for a given queue name, returns a list of QueueItem  which are ready for deletion
 func (repo *QueueRepository) GetItemsReadyForDeletion(queueName string, count int) ([]QueueItem, error) {
-	delayInMin, ok := itemDeletionDelayInMinMap[queueName]
-	if !ok {
-		return nil, stacktrace.Propagate(fmt.Errorf("missing delay for %s", queueName), "")
+	delayInMin, err := repo.getDelayInMin(queueName)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
 	}
 	rows, err := repo.DB.Query(`SELECT queue_id, item FROM queue WHERE
                                        queue_name=$1 and created_at <= $2 and is_deleted = false order by created_at ASC LIMIT $3`,

--- a/server/pkg/utils/s3config/s3config.go
+++ b/server/pkg/utils/s3config/s3config.go
@@ -41,7 +41,11 @@ type S3Config struct {
 	// Indicates if local minio buckets are being used. Enables various
 	// debugging workarounds; not tested/intended for production.
 	areLocalBuckets bool
-
+	// Indicates the interval in days at which permanently deleted objects should be 
+	// cleaned up from the data centers. 
+	// Ensure that this is at least as large as the WasabiObjectConditionalHoldDays if 
+	// Wasabi compliance is enabled.
+	objectDeletionIntervalDays int
 	// FileDataConfig is the configuration for various file data.
 	// If for particular object type, the bucket is not specified, it will
 	// default to hotDC as the bucket with no replicas. Initially, this config won't support
@@ -130,6 +134,7 @@ func (config *S3Config) initialize() {
 	usePathStyleURLs := viper.GetBool("s3.use_path_style_urls")
 	areLocalBuckets := viper.GetBool("s3.are_local_buckets")
 	config.areLocalBuckets = areLocalBuckets
+	config.objectDeletionIntervalDays = viper.GetInt("s3.object_deletion_interval_days")
 
 	for _, dc := range dcs {
 		config.buckets[dc] = viper.GetString("s3." + dc + ".bucket")
@@ -166,6 +171,22 @@ func (config *S3Config) initialize() {
 		return
 	}
 
+}
+
+func (config *S3Config) GetObjectDeletionIntervalDays() int {
+	if config.objectDeletionIntervalDays > 0 {
+		if config.isWasabiComplianceEnabled && 
+			config.objectDeletionIntervalDays < WasabiObjectConditionalHoldDays {
+			log.Warnf("Wasabi compliance is enabled, but object deletion interval (%d days) is less than the Wasabi conditional hold period (%d days). This may lead to issues with deleting objects from Wasabi. Consider increasing the object deletion interval to at least %d days.", 
+			config.objectDeletionIntervalDays, 
+			WasabiObjectConditionalHoldDays, 
+			WasabiObjectConditionalHoldDays)
+
+			return WasabiObjectConditionalHoldDays
+		}
+		return config.objectDeletionIntervalDays
+	}
+	return 45 // default
 }
 
 func (config *S3Config) GetBucket(dcOrBucketID string) *string {


### PR DESCRIPTION
`MarkObjectsAsDeletedForFileIDs` unconditionally inserted into `RemoveComplianceHoldQueue` on every file deletion, regardless of whether Wasabi compliance is configured.

Fix by guarding the `RemoveComplianceHoldQueue` insertion behind `WasabiComplianceDC() != ""`, so items are only enqueued when Wasabi compliance is actually enabled. With the queue guaranteed empty for non-Wasabi instances, the early-return guard in `RemoveComplianceHolds` is no longer needed and is removed.

Also introduces a configurable object deletion period, replacing any previously hardcoded value.

Added two tests including one to cover a regression to existing ente server instances that rely on existing Wasabi compliance behaviour.

**Affected:** all deployments without Wasabi compliance enabled, which includes every self-hosted single-bucket instance.