### PR TITLE
docs(photos): sync changelog for v1.3.54

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -15,6 +15,20 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Favorite files in shared albums
 - Indicator for shared files in map view
 
+## v1.3.54 (mobile) - Jun 2026
+
+- New design system
+- Improved albums navigation
+- Feed gets its own tab
+- Bulk ignore faces from photo info
+- Better OCR animations
+- Faster file downloads
+- Faster face thumbnail generation
+- Fixed ML lookup failures for large offline galleries
+- Fixed video edit delete navigation
+- Fixed upload dates for files with ISO-like metadata timestamps
+- Fixed grey screen after single-memory delete or favorite actions
+
 ## v1.3.44 (mobile) - May 2026
 
 - Added support for selecting photos in 3rd party apps

--- a/docs/docs/photos/features/sharing-and-collaboration/comments-and-likes.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/comments-and-likes.md
@@ -176,8 +176,7 @@ The Feed feature provides a centralized view of all social activity across your 
 
 **On mobile:**
 
-- Go to the "Sharing" tab
-- Tap "Feed" at the top
+- Open the **Feed** tab
 - Scroll through recent social activity
 
 Feed is available on public albums.


### PR DESCRIPTION
## Summary
- add Photos mobile changelog entry for v1.3.54
- update Feed docs to reflect Feed as its own tab on mobile

## Why
Release notes for photos-v1.3.54 mention "Feed gets its own tab" and the public docs still told users to open Sharing and tap Feed. This syncs the changelog and fixes the stale navigation instruction.

## Verification
- checked release tag `photos-v1.3.54`
- compared release notes with docs under `docs/docs/photos/`
- verified the stale wording in `comments-and-likes.md`
