### PR TITLE
[mob][photos] Preserve date and location on gallery downloads

### DIFF
--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -188,7 +188,7 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
-  - photo_manager (3.7.1):
+  - photo_manager (3.9.0):
     - Flutter
     - FlutterMacOS
   - privacy_screen (0.0.1):
@@ -311,7 +311,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - photo_manager (from `.symlinks/plugins/photo_manager/ios`)
+  - photo_manager (from `.symlinks/plugins/photo_manager/darwin`)
   - privacy_screen (from `.symlinks/plugins/privacy_screen/ios`)
   - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - rive_native (from `.symlinks/plugins/rive_native/ios`)
@@ -449,7 +449,7 @@ EXTERNAL SOURCES:
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   photo_manager:
-    :path: ".symlinks/plugins/photo_manager/ios"
+    :path: ".symlinks/plugins/photo_manager/darwin"
   privacy_screen:
     :path: ".symlinks/plugins/privacy_screen/ios"
   receive_sharing_intent:
@@ -547,7 +547,7 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  photo_manager: 1d80ae07a89a67dfbcae95953a1e5a24af7c3e62
+  photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
   privacy_screen: 3159a541f5d3a31bea916cfd4e58f9dc722b3fd4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00

--- a/mobile/apps/photos/lib/extensions/lat_lng_extension.dart
+++ b/mobile/apps/photos/lib/extensions/lat_lng_extension.dart
@@ -1,0 +1,20 @@
+import "package:photo_manager/photo_manager.dart";
+import "package:photos/models/location/location.dart";
+
+extension LatLngExtension on LatLng? {
+  Location? toEnteLocation() {
+    final latLng = this;
+    if (latLng == null) {
+      return null;
+    }
+    if (latLng.latitude == 0.0 ||
+        latLng.latitude.isNaN ||
+        latLng.latitude.isInfinite ||
+        latLng.longitude == 0.0 ||
+        latLng.longitude.isNaN ||
+        latLng.longitude.isInfinite) {
+      return null;
+    }
+    return Location(latitude: latLng.latitude, longitude: latLng.longitude);
+  }
+}

--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -13,6 +13,7 @@ import "package:photos/events/gallery_downloads_events.dart";
 import "package:photos/events/user_logged_out_event.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
+import "package:photos/models/location/location.dart";
 import "package:photos/module/download/manager.dart";
 import "package:photos/module/download/task.dart";
 import "package:photos/service_locator.dart";
@@ -601,6 +602,9 @@ class GalleryDownloadQueueService {
       "ownerID": file.ownerID,
       "collectionID": file.collectionID,
       "title": file.title,
+      "creationTime": file.creationTime,
+      "latitude": file.location?.latitude,
+      "longitude": file.location?.longitude,
       "fileType": file.fileType.index,
       "encryptedKey": file.encryptedKey,
       "keyDecryptionNonce": file.keyDecryptionNonce,
@@ -644,6 +648,7 @@ class GalleryDownloadQueueService {
         ..ownerID = map["ownerID"] as int?
         ..collectionID = map["collectionID"] as int?
         ..title = map["title"] as String?
+        ..creationTime = map["creationTime"] as int?
         ..fileType = getFileType(fileTypeIndex)
         ..encryptedKey = map["encryptedKey"] as String?
         ..keyDecryptionNonce = map["keyDecryptionNonce"] as String?
@@ -654,6 +659,12 @@ class GalleryDownloadQueueService {
         ..fileSize = map["fileSize"] as int?
         ..pubMmdEncodedJson = map["pubMmdEncodedJson"] as String?
         ..pubMmdVersion = map["pubMmdVersion"] as int? ?? 0;
+      final latitude = (map["latitude"] as num?)?.toDouble();
+      final longitude = (map["longitude"] as num?)?.toDouble();
+      final location = Location(latitude: latitude, longitude: longitude);
+      if (Location.isValidLocation(location)) {
+        file.location = location;
+      }
       if (file.uploadedFileID == null ||
           file.collectionID == null ||
           file.fileSize == null ||

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -7,6 +7,7 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/events/files_updated_event.dart";
 import "package:photos/events/local_photos_updated_event.dart";
+import "package:photos/extensions/lat_lng_extension.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/location/location.dart";
@@ -157,12 +158,9 @@ class OfflineImportMetadataService {
     if (shouldFetchAssetLocation) {
       final asset = await file.getAsset;
       if (asset != null) {
-        final latLong = await asset.latlngAsync();
-        if (latLong != null) {
-          file.location = Location(
-            latitude: latLong.latitude,
-            longitude: latLong.longitude,
-          );
+        final location = (await asset.latlngAsync()).toEnteLocation();
+        if (location != null) {
+          file.location = location;
         }
       }
     }

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -158,10 +158,12 @@ class OfflineImportMetadataService {
       final asset = await file.getAsset;
       if (asset != null) {
         final latLong = await asset.latlngAsync();
-        file.location = Location(
-          latitude: latLong.latitude,
-          longitude: latLong.longitude,
-        );
+        if (latLong != null) {
+          file.location = Location(
+            latitude: latLong.latitude,
+            longitude: latLong.longitude,
+          );
+        }
       }
     }
 

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -15,9 +15,9 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/ente_theme_data.dart";
 import "package:photos/events/local_photos_updated_event.dart";
+import "package:photos/extensions/lat_lng_extension.dart";
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/file/file.dart' as ente;
-import "package:photos/models/location/location.dart";
 import "package:photos/services/sync/sync_service.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/action_sheet_widget.dart";
@@ -103,12 +103,9 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       if (!newFile.hasLocation && widget.originalFile.localID != null) {
         final assetEntity = await widget.originalFile.getAsset;
         if (assetEntity != null) {
-          final latLong = await assetEntity.latlngAsync();
-          if (latLong != null) {
-            newFile.location = Location(
-              latitude: latLong.latitude,
-              longitude: latLong.longitude,
-            );
+          final location = (await assetEntity.latlngAsync()).toEnteLocation();
+          if (location != null) {
+            newFile.location = location;
           }
         }
       }

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -104,10 +104,12 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         final assetEntity = await widget.originalFile.getAsset;
         if (assetEntity != null) {
           final latLong = await assetEntity.latlngAsync();
-          newFile.location = Location(
-            latitude: latLong.latitude,
-            longitude: latLong.longitude,
-          );
+          if (latLong != null) {
+            newFile.location = Location(
+              latitude: latLong.latitude,
+              longitude: latLong.longitude,
+            );
+          }
         }
       }
       newFile.generatedID = await FilesDB.instance.insertAndGetId(newFile);

--- a/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
@@ -575,10 +575,12 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
           final assetEntity = await widget.file.getAsset;
           if (assetEntity != null) {
             final latLong = await assetEntity.latlngAsync();
-            newFile.location = Location(
-              latitude: latLong.latitude,
-              longitude: latLong.longitude,
-            );
+            if (latLong != null) {
+              newFile.location = Location(
+                latitude: latLong.latitude,
+                longitude: latLong.longitude,
+              );
+            }
           }
         }
 

--- a/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/video_editor_page.dart
@@ -12,9 +12,9 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/ente_theme_data.dart";
 import "package:photos/events/local_photos_updated_event.dart";
+import "package:photos/extensions/lat_lng_extension.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/file.dart";
-import "package:photos/models/location/location.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/sync/sync_service.dart";
 import "package:photos/theme/ente_theme.dart";
@@ -574,12 +574,9 @@ class _VideoEditorPageState extends State<VideoEditorPage> {
         if (!newFile.hasLocation && widget.file.localID != null) {
           final assetEntity = await widget.file.getAsset;
           if (assetEntity != null) {
-            final latLong = await assetEntity.latlngAsync();
-            if (latLong != null) {
-              newFile.location = Location(
-                latitude: latLong.latitude,
-                longitude: latLong.longitude,
-              );
+            final location = (await assetEntity.latlngAsync()).toEnteLocation();
+            if (location != null) {
+              newFile.location = location;
             }
           }
         }

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -18,6 +18,7 @@ import "package:photos/events/local_photos_updated_event.dart";
 import 'package:photos/models/file/file.dart';
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/ignored_file.dart";
+import "package:photos/models/location/location.dart";
 import "package:photos/module/download/file_url.dart";
 import "package:photos/module/download/manager.dart";
 import "package:photos/module/download/task.dart";
@@ -71,6 +72,49 @@ String _getGallerySaveTitle(EnteFile file, String fallbackPath) {
     return title;
   }
   return file_path.basename(fallbackPath);
+}
+
+({DateTime? creationDate, double? latitude, double? longitude})
+_getGallerySaveMetadataForDownload(EnteFile file) {
+  final creationTime = file.pubMagicMetadata?.editedTime ?? file.creationTime;
+  final creationDate = creationTime != null && creationTime > 0
+      ? DateTime.fromMicrosecondsSinceEpoch(creationTime)
+      : null;
+
+  ({DateTime? creationDate, double? latitude, double? longitude})
+  saveMetadataWithLocation(Location location) {
+    return (
+      creationDate: creationDate,
+      latitude: location.latitude!,
+      longitude: location.longitude!,
+    );
+  }
+
+  final magicMetadata = file.pubMagicMetadata;
+  final magicLocation = Location(
+    latitude: magicMetadata?.lat,
+    longitude: magicMetadata?.long,
+  );
+  if (_isValidGallerySaveLocation(magicLocation)) {
+    return saveMetadataWithLocation(magicLocation);
+  }
+
+  final location = file.location;
+  if (_isValidGallerySaveLocation(location)) {
+    return saveMetadataWithLocation(location!);
+  }
+
+  return (creationDate: creationDate, latitude: null, longitude: null);
+}
+
+bool _isValidGallerySaveLocation(Location? location) {
+  if (!Location.isValidLocation(location)) {
+    return false;
+  }
+  return Location.isValidRange(
+    latitude: location!.latitude!,
+    longitude: location.longitude!,
+  );
 }
 
 Future<String?> getExistingLocalFolderNameForDownloadSkipToast(
@@ -362,6 +406,7 @@ Future<void> downloadToGallery(
       throw DownloadFailedError("Unable to fetch file for gallery download");
     }
     final galleryTitle = _getGallerySaveTitle(file, fileToSave.path);
+    final saveMetadata = _getGallerySaveMetadataForDownload(file);
     // We use a lock to prevent synchronisation to occur while it is downloading
     // as this introduces wrong entry in FilesDB due to race condition
     // This is a fix for https://github.com/ente-io/ente/issues/4296
@@ -373,11 +418,17 @@ Future<void> downloadToGallery(
         savedAsset = await PhotoManager.editor.saveImageWithPath(
           fileToSave.path,
           title: galleryTitle,
+          creationDate: saveMetadata.creationDate,
+          latitude: saveMetadata.latitude,
+          longitude: saveMetadata.longitude,
         );
       } else if (type == FileType.video) {
         savedAsset = await PhotoManager.editor.saveVideo(
           fileToSave,
           title: galleryTitle,
+          creationDate: saveMetadata.creationDate,
+          latitude: saveMetadata.latitude,
+          longitude: saveMetadata.longitude,
         );
       } else if (type == FileType.livePhoto) {
         final File? liveVideoFile = await getFileFromServer(
@@ -454,10 +505,14 @@ Future<void> _saveLivePhotoOnDroid(
 ) async {
   debugPrint("Downloading LivePhoto on Droid");
   final imageTitle = _getGallerySaveTitle(enteFile, image.path);
+  final saveMetadata = _getGallerySaveMetadataForDownload(enteFile);
   AssetEntity? savedAsset =
       await (PhotoManager.editor.saveImageWithPath(
         image.path,
         title: imageTitle,
+        creationDate: saveMetadata.creationDate,
+        latitude: saveMetadata.latitude,
+        longitude: saveMetadata.longitude,
       )).catchError((err) {
         throw Exception("Failed to save image of live photo: $err");
       });
@@ -471,8 +526,14 @@ Future<void> _saveLivePhotoOnDroid(
   final videoTitle =
       file_path.basenameWithoutExtension(imageTitle) +
       file_path.extension(video.path);
-  savedAsset = (await (PhotoManager.editor.saveVideo(video, title: videoTitle))
-      .catchError((err) {
+  savedAsset =
+      (await (PhotoManager.editor.saveVideo(
+        video,
+        title: videoTitle,
+        creationDate: saveMetadata.creationDate,
+        latitude: saveMetadata.latitude,
+        longitude: saveMetadata.longitude,
+      )).catchError((err) {
         _logger.warning('Failed to save video $videoTitle of live photo');
         throw Exception("Failed to save video of live photo: $err");
       }));

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -342,10 +342,12 @@ Future<void> _decorateEnteFileData(
   if (file.location == null ||
       (file.location!.latitude == 0 && file.location!.longitude == 0)) {
     final latLong = await asset.latlngAsync();
-    file.location = Location(
-      latitude: latLong.latitude,
-      longitude: latLong.longitude,
-    );
+    if (latLong != null) {
+      file.location = Location(
+        latitude: latLong.latitude,
+        longitude: latLong.longitude,
+      );
+    }
   }
   if (!file.hasLocation && file.isVideo && Platform.isAndroid) {
     final FFProbeProps? props = await getVideoPropsAsync(sourceFile);

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -16,6 +16,7 @@ import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/core/errors.dart';
+import "package:photos/extensions/lat_lng_extension.dart";
 import "package:photos/gateways/collections/models/metadata.dart";
 import "package:photos/models/ffmpeg/ffprobe_props.dart";
 import "package:photos/models/file/extensions/file_props.dart";
@@ -341,12 +342,9 @@ Future<void> _decorateEnteFileData(
   // h4ck to fetch location data if missing (thank you Android Q+) lazily only during uploads
   if (file.location == null ||
       (file.location!.latitude == 0 && file.location!.longitude == 0)) {
-    final latLong = await asset.latlngAsync();
-    if (latLong != null) {
-      file.location = Location(
-        latitude: latLong.latitude,
-        longitude: latLong.longitude,
-      );
+    final location = (await asset.latlngAsync()).toEnteLocation();
+    if (location != null) {
+      file.location = location;
     }
   }
   if (!file.hasLocation && file.isVideo && Platform.isAndroid) {

--- a/mobile/apps/photos/pubspec.lock
+++ b/mobile/apps/photos/pubspec.lock
@@ -2179,10 +2179,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: a0d9a7a9bc35eda02d33766412bde6d883a8b0acb86bbe37dac5f691a0894e8a
+      sha256: fb3bc8ea653370f88742b3baa304700107c83d12748aa58b2b9f2ed3ef15e6c2
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.1"
+    version: "3.9.0"
   photo_manager_image_provider:
     dependency: "direct main"
     description:

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -212,7 +212,7 @@ dependencies:
   path_provider: 2.1.5
   path_provider_foundation: 2.4.1
   permission_handler: 12.0.1
-  photo_manager: 3.7.1
+  photo_manager: 3.9.0
   photo_manager_image_provider: 2.2.0
   photo_view: 0.15.0
   pinput: 5.0.2


### PR DESCRIPTION
## Summary

- Upgrade `photo_manager` to `3.9.0`
- Pass Ente metadata date/location into gallery saves for image and video downloads
- Persist queued download creation time and location so resumed gallery downloads retain metadata
- Handle nullable `latlngAsync()` responses after the `photo_manager` upgrade

## Tests

- [x] `flutter analyze .`
- [x] Manual Android/iOS simulator download validation for date/location metadata