### PR TITLE
docs: update Photos changelog for v1.3.54

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -28,6 +28,8 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Fixed video edit delete navigation
 - Fixed upload dates for files with ISO-like metadata timestamps
 - Fixed grey screen after single-memory delete or favorite actions
+- Contacts in Search is now generally available
+- Better file-picker support for selecting photos in other Android apps
 
 ## v1.3.44 (mobile) - May 2026
 

--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -28,7 +28,6 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Fixed video edit delete navigation
 - Fixed upload dates for files with ISO-like metadata timestamps
 - Fixed grey screen after single-memory delete or favorite actions
-- Contacts in Search is now generally available
 - Better file-picker support for selecting photos in other Android apps
 
 ## v1.3.44 (mobile) - May 2026


### PR DESCRIPTION
## Summary
- add the missing user-visible Search contacts rollout to the v1.3.54 changelog
- add the missing Android file-picker compatibility improvement to the same release entry

## Why
The mobile v1.3.54 release shipped user-visible changes beyond the current public changelog entry, so the docs should mention them.

## Test plan
- docs-only changelog edit