### PR TITLE
[mob][photos] Preserve recoverable EXIF dates

### DIFF
--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -28,7 +28,7 @@ const kEmptyExifDateTime = "0000:00:00 00:00:00";
 
 final _logger = Logger("ExifUtil");
 final _standardExifDateTimePattern = RegExp(
-  r'^\d{4}:(0[1-9]|1[0-2]):(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):([0-5]\d):([0-5]\d)$',
+  r'^(\d{4}:(0[1-9]|1[0-2]):(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):([0-5]\d):([0-5]\d))([\.:]\d+)?$',
 );
 final _isoExifDateTimePattern = RegExp(
   r'^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])[T ]([01]\d|2[0-3]):([0-5]\d):([0-5]\d)([\.:]\d+)?([Zz]|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$',
@@ -169,11 +169,14 @@ ParsedExifDateTime _getStandardExifDateTimeInDeviceTimezone(
   String exifTime,
   String? offsetString,
 ) {
-  final offsetTime = _normalizeOffset(offsetString, throwOnInvalid: true);
+  final offsetTime = _normalizeOffset(offsetString);
   final hasOffset = offsetTime != null;
-  final DateTime result = DateFormat(
-    kExifDateTimePattern,
-  ).parseStrict(exifTime, hasOffset);
+  final match = _standardExifDateTimePattern.firstMatch(exifTime)!;
+  final DateTime result = DateFormat(kExifDateTimePattern)
+      .parseStrict(match.group(1)!, hasOffset)
+      .add(
+        Duration(microseconds: _parseFractionalMicroseconds(match.group(7))),
+      );
   if (hasOffset && offsetTime != "Z") {
     final List<String> splitHHMM = offsetTime.split(":");
     final int offsetHours = int.parse(splitHHMM[0]);
@@ -210,8 +213,7 @@ ParsedExifDateTime _getIsoExifDateTimeInDeviceTimezone(
   final metadataDateTime = _parseIsoDateTimeComponents(match);
   final localDateTimeString = formatPubMagicDateTime(metadataDateTime);
   final offsetTime =
-      _normalizeOffset(match.group(8)) ??
-      _normalizeOffset(offsetString, throwOnInvalid: true);
+      _normalizeOffset(match.group(8)) ?? _normalizeOffset(offsetString);
 
   if (offsetTime != null) {
     final deviceLocalTime = DateTime.parse(
@@ -240,15 +242,12 @@ ParsedExifDateTime _getIsoExifDateTimeInDeviceTimezone(
   );
 }
 
-String? _normalizeOffset(String? offsetString, {bool throwOnInvalid = false}) {
+String? _normalizeOffset(String? offsetString) {
   final offset = offsetString?.trim();
   if (offset == null || offset.isEmpty) {
     return null;
   }
   if (!_offsetPattern.hasMatch(offset)) {
-    if (throwOnInvalid) {
-      throw FormatException("Invalid EXIF offset", offsetString);
-    }
     return null;
   }
   final normalizedOffset = offset.toUpperCase();

--- a/mobile/apps/photos/test/utils/exif_util_test.dart
+++ b/mobile/apps/photos/test/utils/exif_util_test.dart
@@ -16,6 +16,17 @@ void main() {
       expect(parsed.time!.second, 50);
     });
 
+    test("parses standard EXIF date time with fractional seconds", () {
+      final parsed = getDateTimeInDeviceTimezone(
+        "2026:04:01 15:25:27.945",
+        null,
+      );
+
+      expect(parsed.dateTime, "2026-04-01T15:25:27.945");
+      expect(parsed.offsetTime, isNull);
+      expect(parsed.time, DateTime(2026, 4, 1, 15, 25, 27, 945));
+    });
+
     test("parses standard EXIF date time with separate offset", () {
       final parsed = getDateTimeInDeviceTimezone(
         "2025:01:30 08:59:50",
@@ -36,6 +47,28 @@ void main() {
       expect(parsed.dateTime, "2025-01-30T08:59:50.000");
       expect(parsed.offsetTime, "+05:30");
       expect(parsed.time!.toUtc(), DateTime.utc(2025, 1, 30, 3, 29, 50));
+    });
+
+    test("drops invalid separate offset for standard EXIF date time", () {
+      final parsed = getDateTimeInDeviceTimezone(
+        "2025:01:30 08:59:50",
+        "    :  ",
+      );
+
+      expect(parsed.dateTime, "2025-01-30T08:59:50.000");
+      expect(parsed.offsetTime, isNull);
+      expect(parsed.time, DateTime(2025, 1, 30, 8, 59, 50));
+    });
+
+    test("drops invalid separate offset for fractional EXIF date time", () {
+      final parsed = getDateTimeInDeviceTimezone(
+        "2026:04:01 15:25:27.945",
+        "CDT",
+      );
+
+      expect(parsed.dateTime, "2026-04-01T15:25:27.945");
+      expect(parsed.offsetTime, isNull);
+      expect(parsed.time, DateTime(2026, 4, 1, 15, 25, 27, 945));
     });
 
     test("parses ISO date time with numeric offset", () {
@@ -91,6 +124,14 @@ void main() {
       expect(parsed.dateTime, "2025-01-30T08:59:50.000");
       expect(parsed.offsetTime, "+05:30");
       expect(parsed.time!.toUtc(), DateTime.utc(2025, 1, 30, 3, 29, 50));
+    });
+
+    test("drops invalid separate offset for ISO date time", () {
+      final parsed = getDateTimeInDeviceTimezone("2025-01-30T08:59:50", "CDT");
+
+      expect(parsed.dateTime, "2025-01-30T08:59:50.000");
+      expect(parsed.offsetTime, isNull);
+      expect(parsed.time, DateTime(2025, 1, 30, 8, 59, 50));
     });
 
     test("parses ISO date time with Z offset", () {
@@ -150,6 +191,13 @@ void main() {
       );
     });
 
+    test("rejects invalid standard EXIF date time components", () {
+      expect(
+        () => getDateTimeInDeviceTimezone("2025:02:30 08:00:00.945", null),
+        throwsFormatException,
+      );
+    });
+
     test("rejects invalid ISO date time components", () {
       expect(
         () => getDateTimeInDeviceTimezone("2025-02-30T08:00:00Z", null),
@@ -161,13 +209,6 @@ void main() {
       );
       expect(
         () => getDateTimeInDeviceTimezone("2025-01-30T08:00:00+99:99", null),
-        throwsFormatException,
-      );
-    });
-
-    test("rejects invalid separate offset", () {
-      expect(
-        () => getDateTimeInDeviceTimezone("2025-01-30T08:59:50", "CDT"),
         throwsFormatException,
       );
     });


### PR DESCRIPTION
Parse standard EXIF timestamps with fractional seconds and ignore malformed separate offset tags when the date itself is valid.