### PR TITLE
[infra] Remove advisory ghcr branches

### DIFF
--- a/.github/workflows/server-publish-ghcr.yml
+++ b/.github/workflows/server-publish-ghcr.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write  # for pushing the `ghcr/server` branch
+    contents: read
     packages: write
 
 jobs:
@@ -41,7 +41,3 @@ jobs:
                       --tag ghcr.io/ente-io/server:${museum_commit} \
                       --tag ghcr.io/ente-io/server:latest \
                       server
-
-            - name: Update branch ghcr/server to point to source commit
-              run: |
-                  git push -f origin HEAD:refs/heads/ghcr/server

--- a/.github/workflows/web-publish-ghcr.yml
+++ b/.github/workflows/web-publish-ghcr.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write  # for pushing the `ghcr/web` branch
+    contents: read
     packages: write
 
 jobs:
@@ -32,7 +32,3 @@ jobs:
                       --tag ghcr.io/ente-io/web:${GITHUB_SHA} \
                       --tag ghcr.io/ente-io/web:latest \
                       .
-
-            - name: Update branch ghcr/web to point to source commit
-              run: |
-                  git push -f origin HEAD:refs/heads/ghcr/web

--- a/server/docs/publish.md
+++ b/server/docs/publish.md
@@ -25,5 +25,3 @@ gh workflow run server-publish.yml
 > It uses the commit that is deployed on production museum instances. We can publish from any arbitrary commit really, but by using the commit that's already seen production, we avoid externally publishing images with issues.
 
 Once the workflow completes, the resultant image will be available at `ghcr.io/ente-io/server`. The image will be tagged by the commit SHA. The latest image will also be tagged, well, "latest".
-
-The workflow will also update the branch `ghcr/server` to point to the commit it used to build the image. This branch will be overwritten on each publish; thus `ghcr/server` will always points to the code from which the most recent ghcr docker image for museum has been built.


### PR DESCRIPTION
Earlier we used tags, but tags don't get updated locally and are a footgun (`git diff ghcr/server` would be misleading).

Now we used a branch, but the problem is that pushing to a branch requires a PAT with escalated permissions, otw we get

```text
git push -f origin HEAD:refs/heads/ghcr/web
remote rejected: refusing to allow a GitHub App to create or update workflow `.github/workflows/auth-build.yml` without `workflows` permission
```

It is possible to add a PAT, but instead of escalating perms I'm just removing these pointers. It is always possible to recover the full commit from the commit-SHA image tag on the Docker image.