### PR TITLE
[mob][locker] Prevent repeated open file invocations

### DIFF
--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -28,6 +28,7 @@ import "package:path/path.dart" as p;
 
 class FileUtil {
   static final Logger _logger = Logger("FileUtil");
+  static final Set<int> _recentlyTappedFiles = {};
 
   static Future<void> openFile(BuildContext context, EnteFile file) async {
     if (InfoFileService.instance.isInfoFile(file)) {
@@ -41,6 +42,14 @@ class FileUtil {
       );
       return;
     }
+
+    if (!_recentlyTappedFiles.add(file.uploadedFileID!)) {
+      return;
+    }
+
+    Future.delayed(const Duration(seconds: 1), () {
+      _recentlyTappedFiles.remove(file.uploadedFileID!);
+    });
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));
     if (await cachedDecryptedFile.exists()) {
@@ -109,6 +118,8 @@ class FileUtil {
     } catch (e) {
       await dialog.hide();
       await showGenericErrorBottomSheet(context: context, error: e);
+    } finally {
+      _recentlyTappedFiles.remove(file.uploadedFileID!);
     }
   }
 

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -31,6 +31,14 @@ class FileUtil {
   static final Map<int, DateTime> _lastTapTimes = {};
 
   static Future<void> openFile(BuildContext context, EnteFile file) async {
+    if (file.uploadedFileID == null) {
+      await showGenericErrorBottomSheet(
+        context: context,
+        error: Exception(context.l10n.errorOpeningFile),
+      );
+      return;
+    }
+
     final fileId = file.uploadedFileID!;
     final now = DateTime.now();
     final lastTap = _lastTapTimes[fileId];
@@ -43,14 +51,6 @@ class FileUtil {
 
     if (InfoFileService.instance.isInfoFile(file)) {
       return _openInfoFile(context, file);
-    }
-
-    if (file.uploadedFileID == null) {
-      await showGenericErrorBottomSheet(
-        context: context,
-        error: Exception(context.l10n.errorOpeningFile),
-      );
-      return;
     }
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -28,9 +28,19 @@ import "package:path/path.dart" as p;
 
 class FileUtil {
   static final Logger _logger = Logger("FileUtil");
-  static final Set<int> _recentlyTappedFiles = {};
+  static final Map<int, DateTime> _lastTapTimes = {};
 
   static Future<void> openFile(BuildContext context, EnteFile file) async {
+    final fileId = file.uploadedFileID!;
+    final now = DateTime.now();
+    final lastTap = _lastTapTimes[fileId];
+
+    if (lastTap != null && now.difference(lastTap) < const Duration(seconds: 1)) {
+      return;
+    }
+
+    _lastTapTimes[fileId] = now;
+
     if (InfoFileService.instance.isInfoFile(file)) {
       return _openInfoFile(context, file);
     }
@@ -42,14 +52,6 @@ class FileUtil {
       );
       return;
     }
-
-    if (!_recentlyTappedFiles.add(file.uploadedFileID!)) {
-      return;
-    }
-
-    Future.delayed(const Duration(seconds: 1), () {
-      _recentlyTappedFiles.remove(file.uploadedFileID!);
-    });
 
     final cachedDecryptedFile = File(getCachedDecryptedFilePath(file));
     if (await cachedDecryptedFile.exists()) {
@@ -118,9 +120,7 @@ class FileUtil {
     } catch (e) {
       await dialog.hide();
       await showGenericErrorBottomSheet(context: context, error: e);
-    } finally {
-      _recentlyTappedFiles.remove(file.uploadedFileID!);
-    }
+    } 
   }
 
   static Future<bool> downloadFile(BuildContext context, EnteFile file) {


### PR DESCRIPTION
## Description

Product: Ente Locker Mobile App

### Issue

Rapid repeated taps on the same file could trigger multiple open requests, resulting in multiple invocations of the Open with menu.

https://github.com/user-attachments/assets/7ea6f923-526a-42e5-ae43-18a7b9b965aa

### Fix

Added a per-file cooldown to prevent duplicate open requests caused by rapid repeated taps.

https://github.com/user-attachments/assets/97eedb69-5d20-4c96-a168-d78d1fa9f6df

### Note

This PR only prevents duplicate open requests caused by rapid repeated taps on the same file. Open requests for different files are unaffected and continue to be handled like the same way before.

## Tests

### Tested On

- Realme C67 5G (Android)
- Realme Pad 2 (Android)

The issue was reproducible on both devices before the change and is resolved after applying the fix. 
