### PR TITLE
[mobile] Add title tooltips and align Photos typography

### DIFF
--- a/mobile/apps/photos/changes/album-tooltips-and-typography.md
+++ b/mobile/apps/photos/changes/album-tooltips-and-typography.md
@@ -1,0 +1,1 @@
+- Add album title tooltips, fix album sorting labels, and consistent typography.

--- a/mobile/apps/photos/lib/ui/collections/album/row_item.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/row_item.dart
@@ -35,7 +35,7 @@ class AlbumRowItemWidget extends StatelessWidget {
   static const _overlayPadding = 8.0;
   static const _thumbnailToTextSpacing = 8.0;
   static const _titleToSubtitleSpacing = 2.0;
-  static const _sharePillPadding = EdgeInsets.all(2);
+  static const _sharePillPadding = EdgeInsets.all(1);
   static const _sharedAvatarStrokeWidth = 1.0;
 
   const AlbumRowItemWidget(

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
@@ -193,7 +193,7 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
           const SizedBox(height: 8),
           Text(
             AppLocalizations.of(context).suggestions,
-            style: TextStyles.bodyBold.copyWith(
+            style: TextStyles.large.copyWith(
               color: context.componentColors.textBase,
             ),
           ),
@@ -263,8 +263,8 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
             padding: const EdgeInsets.only(top: 12, bottom: 8),
             child: Text(
               entry.sectionKey,
-              style: TextStyles.mini.copyWith(
-                color: context.componentColors.textLight,
+              style: TextStyles.large.copyWith(
+                color: context.componentColors.textBase,
               ),
             ),
           ),

--- a/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/support/help_support_page.dart
@@ -143,8 +143,8 @@ class HelpSupportPage extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: Spacing.sm, top: 6, bottom: 6),
       child: Text(
-        title.toUpperCase(),
-        style: TextStyles.mini.copyWith(color: colors.textLight),
+        title,
+        style: TextStyles.large.copyWith(color: colors.textBase),
       ),
     );
   }

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -36,7 +36,7 @@ import "package:photos/utils/local_settings.dart";
 
 enum _AlbumsFilter { ente, onDevice, shared }
 
-enum _AlbumsMenuAction { toggleView, name, newest, updated }
+enum _AlbumsMenuAction { toggleView, name, lastUpdated }
 
 class AlbumsTab extends StatefulWidget {
   const AlbumsTab({
@@ -667,17 +667,10 @@ class _AlbumsTabState extends State<AlbumsTab>
               ? strings.sortAToZ
               : strings.sortZToA,
           isActive: currentSortKey == AlbumSortKey.albumName,
-          activeTrailingWidget: activeTrailingWidget,
         ),
         EntePopupMenuOption(
-          value: _AlbumsMenuAction.newest,
-          label: strings.newest,
-          isActive: currentSortKey == AlbumSortKey.newestPhoto,
-          activeTrailingWidget: activeTrailingWidget,
-        ),
-        EntePopupMenuOption(
-          value: _AlbumsMenuAction.updated,
-          label: strings.updated,
+          value: _AlbumsMenuAction.lastUpdated,
+          label: strings.lastUpdated,
           isActive: currentSortKey == AlbumSortKey.lastUpdated,
           activeTrailingWidget: activeTrailingWidget,
           showDivider: false,
@@ -694,10 +687,7 @@ class _AlbumsTabState extends State<AlbumsTab>
       case _AlbumsMenuAction.name:
         await _setSortMode(AlbumSortKey.albumName);
         break;
-      case _AlbumsMenuAction.newest:
-        await _setSortMode(AlbumSortKey.newestPhoto);
-        break;
-      case _AlbumsMenuAction.updated:
+      case _AlbumsMenuAction.lastUpdated:
         await _setSortMode(AlbumSortKey.lastUpdated);
         break;
     }

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -240,11 +240,17 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
               const _GalleryAppBarBackButton(),
               const SizedBox(width: Spacing.sm),
               Expanded(
-                child: Text(
-                  _appBarTitle!,
-                  style: TextStyles.h2.copyWith(color: colors.textBase),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: TooltipComponent(
+                    message: _appBarTitle!,
+                    child: Text(
+                      _appBarTitle!,
+                      style: TextStyles.h2.copyWith(color: colors.textBase),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
                 ),
               ),
               if (actions.isNotEmpty) ...[

--- a/mobile/apps/photos/lib/ui/viewer/search/result/search_result_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/search_result_widget.dart
@@ -1,3 +1,4 @@
+import "package:ente_components/ente_components.dart";
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import "package:intl/intl.dart";
@@ -31,7 +32,7 @@ class SearchResultWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final heroTagPrefix = searchResult.heroTag();
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final colorScheme = getEnteColorScheme(context);
 
     return SizedBox(
@@ -68,7 +69,7 @@ class SearchResultWidget extends StatelessWidget {
               ),
         title: Text(
           searchResult.name(),
-          style: textTheme.body,
+          style: TextStyles.body.copyWith(color: colors.textBase),
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: FutureBuilder<int>(
@@ -85,14 +86,14 @@ class SearchResultWidget extends StatelessWidget {
                   : count.toString();
               return Text(
                 label != null ? "$label \u2022 $countText" : countText,
-                style: textTheme.smallMuted,
+                style: TextStyles.mini.copyWith(color: colors.textLight),
                 overflow: TextOverflow.ellipsis,
               );
             }
             if (label != null) {
               return Text(
                 label,
-                style: textTheme.smallMuted,
+                style: TextStyles.mini.copyWith(color: colors.textLight),
                 overflow: TextOverflow.ellipsis,
               );
             }

--- a/mobile/apps/photos/lib/ui/viewer/search/result/search_section_all_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/search_section_all_page.dart
@@ -323,11 +323,17 @@ class _SearchSectionAllPageState extends State<SearchSectionAllPage> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Expanded(
-            child: Text(
-              state.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: state.textStyle,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TooltipComponent(
+                message: state.title,
+                child: Text(
+                  state.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: state.textStyle,
+                ),
+              ),
             ),
           ),
           const SizedBox(width: Spacing.md),

--- a/mobile/apps/photos/lib/ui/viewer/search/result/searchable_item.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/searchable_item.dart
@@ -1,3 +1,4 @@
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:intl/intl.dart";
@@ -32,7 +33,7 @@ class SearchableItemWidget extends StatelessWidget {
     //SearchResultPage
     const additionalPrefix = "searchable_item";
     final heroTagPrefix = additionalPrefix + searchResult.heroTag();
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final colorScheme = getEnteColorScheme(context);
     final result = searchResult;
     final bool isCluster =
@@ -78,7 +79,7 @@ class SearchableItemWidget extends StatelessWidget {
           ? const SizedBox.shrink()
           : Text(
               searchResult.name(),
-              style: textTheme.body,
+              style: TextStyles.body.copyWith(color: colors.textBase),
               overflow: TextOverflow.ellipsis,
             ),
       subtitle: FutureBuilder<int>(
@@ -91,7 +92,7 @@ class SearchableItemWidget extends StatelessWidget {
                 count: noOfMemories,
                 formattedCount: NumberFormat().format(noOfMemories),
               ),
-              style: textTheme.smallMuted,
+              style: TextStyles.mini.copyWith(color: colors.textLight),
               overflow: TextOverflow.ellipsis,
             );
           } else {
@@ -121,7 +122,7 @@ class SearchableItemPlaceholder extends StatelessWidget {
     }
 
     final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     return ThumbnailListItem(
       backgroundColor: thumbnailListItemBackgroundColor(context),
       onTap: sectionType.ctaOnTap(context),
@@ -134,7 +135,10 @@ class SearchableItemPlaceholder extends StatelessWidget {
           child: Icon(sectionType.getCTAIcon(), color: colorScheme.strokeMuted),
         ),
       ),
-      title: Text(sectionType.getCTAText(context), style: textTheme.body),
+      title: Text(
+        sectionType.getCTAText(context),
+        style: TextStyles.body.copyWith(color: colors.textBase),
+      ),
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import 'package:flutter/material.dart';
 import "package:flutter_animate/flutter_animate.dart";
@@ -361,7 +362,7 @@ class _SearchResultsSectionWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final showTypeLabel = results.length > 1;
     final children = <Widget>[];
     for (int i = 0; i < results.length; i++) {
@@ -408,7 +409,10 @@ class _SearchResultsSectionWidget extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 10),
-              Text(title, style: textTheme.bodyBold),
+              Text(
+                title,
+                style: TextStyles.large.copyWith(color: colors.textBase),
+              ),
             ],
           ),
         ),

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 
 import "package:dotted_border/dotted_border.dart";
-import "package:ente_components/theme/text_styles.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:photos/core/constants.dart";
@@ -122,7 +122,7 @@ class _ContactsSectionState extends State<ContactsSection> {
   @override
   Widget build(BuildContext context) {
     if (_contactSearchResults.isEmpty) {
-      final textTheme = getEnteTextTheme(context);
+      final colors = context.componentColors;
       return Padding(
         padding: const EdgeInsets.only(left: 12, right: 8, bottom: 24),
         child: Row(
@@ -133,16 +133,14 @@ class _ContactsSectionState extends State<ContactsSection> {
                 children: [
                   Text(
                     SectionType.contacts.sectionTitle(context),
-                    style: TextStyles.h2.copyWith(
-                      color: textTheme.largeBold.color,
-                    ),
+                    style: TextStyles.h2.copyWith(color: colors.textBase),
                   ),
                   const SizedBox(height: 24),
                   Padding(
                     padding: const EdgeInsets.only(left: 4),
                     child: Text(
                       SectionType.contacts.getEmptyStateText(context),
-                      style: textTheme.smallMuted,
+                      style: TextStyles.body.copyWith(color: colors.textLight),
                     ),
                   ),
                 ],
@@ -203,7 +201,7 @@ class ContactRecommendation extends StatefulWidget {
 class _ContactRecommendationState extends State<ContactRecommendation> {
   @override
   Widget build(BuildContext context) {
-    final enteTextTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final personId =
         widget.contactSearchResult.params[kPersonParamID] as String?;
     final contactUserId =
@@ -257,7 +255,7 @@ class _ContactRecommendationState extends State<ContactRecommendation> {
                     children: [
                       Text(
                         widget.contactSearchResult.name(),
-                        style: enteTextTheme.small,
+                        style: TextStyles.body.copyWith(color: colors.textBase),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         textAlign: TextAlign.center,
@@ -279,6 +277,7 @@ class ContactCTA extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.componentColors;
     final enteColorScheme = getEnteColorScheme(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 2.5),
@@ -319,7 +318,7 @@ class ContactCTA extends StatelessWidget {
                 const SizedBox(height: 10.5),
                 Text(
                   AppLocalizations.of(context).invite,
-                  style: getEnteTextTheme(context).smallFaint,
+                  style: TextStyles.body.copyWith(color: colors.textLighter),
                 ),
               ],
             ),

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
@@ -3,7 +3,7 @@ import "dart:math";
 import "dart:ui";
 
 import "package:dotted_border/dotted_border.dart";
-import "package:ente_components/theme/text_styles.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:figma_squircle/figma_squircle.dart";
 import "package:flutter/material.dart";
@@ -76,7 +76,7 @@ class _LocationsSectionState extends State<LocationsSection> {
   @override
   Widget build(BuildContext context) {
     if (_locationsSearchResults.isEmpty) {
-      final textTheme = getEnteTextTheme(context);
+      final colors = context.componentColors;
       return Padding(
         padding: const EdgeInsets.only(left: 12, right: 8, bottom: 24),
         child: Row(
@@ -87,16 +87,14 @@ class _LocationsSectionState extends State<LocationsSection> {
                 children: [
                   Text(
                     SectionType.location.sectionTitle(context),
-                    style: TextStyles.h2.copyWith(
-                      color: textTheme.largeBold.color,
-                    ),
+                    style: TextStyles.h2.copyWith(color: colors.textBase),
                   ),
                   const SizedBox(height: 24),
                   Padding(
                     padding: const EdgeInsets.only(left: 4),
                     child: Text(
                       SectionType.location.getEmptyStateText(context),
-                      style: textTheme.smallMuted,
+                      style: TextStyles.body.copyWith(color: colors.textLight),
                     ),
                   ),
                 ],
@@ -166,7 +164,7 @@ class LocationRecommendation extends StatelessWidget {
     final heroTag =
         locationSearchResult.heroTag() +
         (locationSearchResult.previewThumbnail()?.tag ?? "");
-    final enteTextTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: max(0, 2.5 - outerStrokeWidth)),
       child: GestureDetector(
@@ -314,7 +312,9 @@ class LocationRecommendation extends StatelessWidget {
                                     children: [
                                       Text(
                                         locationSearchResult.name(),
-                                        style: enteTextTheme.small,
+                                        style: TextStyles.body.copyWith(
+                                          color: colors.textBase,
+                                        ),
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
                                         textAlign: TextAlign.center,
@@ -378,7 +378,7 @@ class GoToMapWithBG extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enteTextTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     return Padding(
       padding: EdgeInsets.symmetric(
         horizontal: max(0, 2.5 - LocationRecommendation.outerStrokeWidth),
@@ -479,8 +479,8 @@ class GoToMapWithBG extends StatelessWidget {
                                   children: [
                                     Text(
                                       AppLocalizations.of(context).yourMap,
-                                      style: enteTextTheme.mini.copyWith(
-                                        color: Colors.white,
+                                      style: TextStyles.mini.copyWith(
+                                        color: colors.specialWhite,
                                       ),
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
@@ -510,7 +510,7 @@ class LocationCTA extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enteTextTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final enteColorScheme = getEnteColorScheme(context);
     return Padding(
       padding: EdgeInsets.symmetric(
@@ -602,7 +602,9 @@ class LocationCTA extends StatelessWidget {
                               children: [
                                 Text(
                                   AppLocalizations.of(context).addNew,
-                                  style: enteTextTheme.miniFaint,
+                                  style: TextStyles.mini.copyWith(
+                                    color: colors.textLighter,
+                                  ),
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   textAlign: TextAlign.center,

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/magic_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/magic_section.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 import "dart:math";
 
+import "package:ente_components/ente_components.dart";
 import "package:figma_squircle/figma_squircle.dart";
 import "package:flutter/material.dart";
 import "package:photos/core/constants.dart";
@@ -144,7 +145,7 @@ class MagicRecommendation extends StatelessWidget {
     final heroTag =
         magicSearchResult.heroTag() +
         (magicSearchResult.previewThumbnail()?.tag ?? "");
-    final enteTextTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: max(2.5 - _borderWidth, 0)),
       child: GestureDetector(
@@ -226,8 +227,8 @@ class MagicRecommendation extends StatelessWidget {
                           padding: const EdgeInsets.only(bottom: 8),
                           child: Text(
                             magicSearchResult.name(),
-                            style: enteTextTheme.small.copyWith(
-                              color: Colors.white,
+                            style: TextStyles.body.copyWith(
+                              color: colors.specialWhite,
                             ),
                             maxLines: 3,
                             overflow: TextOverflow.fade,

--- a/mobile/packages/ente_components/example/lib/main.dart
+++ b/mobile/packages/ente_components/example/lib/main.dart
@@ -271,6 +271,12 @@ class _CatalogHomeState extends State<CatalogHome> {
         routeBuilder: _buildHeaderAppBarDemo,
       ),
       CatalogSection(
+        title: 'Tooltip',
+        icon: HugeIcons.strokeRoundedHelpCircle,
+        components: const ['Top pointer', 'Tap trigger'],
+        previewBuilder: (_) => const _TooltipPreview(),
+      ),
+      CatalogSection(
         title: 'Avatar',
         icon: HugeIcons.strokeRoundedUser,
         components: const ['Sizes', 'Seed palette', 'Add contact'],
@@ -2150,6 +2156,104 @@ class _HeaderAppBarEntryPreview extends StatelessWidget {
   }
 }
 
+class _TooltipPreview extends StatelessWidget {
+  const _TooltipPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+
+    return _CatalogPreviewList(
+      children: [
+        _CatalogPreviewGroup(
+          title: 'Top pointer',
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: colors.fillDarker,
+              borderRadius: BorderRadius.circular(Radii.lg),
+            ),
+            child: const Padding(
+              padding: EdgeInsets.all(Spacing.xl),
+              child: TooltipBubbleComponent(message: 'Tooltip text'),
+            ),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Tap triggers',
+          child: Column(
+            children: [
+              _TooltipTriggerRow(
+                title: 'Short',
+                subtitle: 'Compact bubble',
+                message: 'Tooltip',
+                colors: colors,
+              ),
+              const SizedBox(height: Spacing.sm),
+              _TooltipTriggerRow(
+                title: 'Medium title',
+                subtitle: 'Normal app title length',
+                message: 'Whatsapp video long long long name',
+                colors: colors,
+              ),
+              const SizedBox(height: Spacing.sm),
+              _TooltipTriggerRow(
+                title: 'Long email',
+                subtitle: 'Tests email wrapping points',
+                message:
+                    'alexandra.rivera.photo.archive.longtitle.test@examplemail.com',
+                colors: colors,
+              ),
+              const SizedBox(height: Spacing.sm),
+              _TooltipTriggerRow(
+                title: 'Overflow',
+                subtitle: 'Caps at max width and ellipsizes',
+                message:
+                    'This is an intentionally very long tooltip message that should wrap up to three lines and then ellipsize cleanly without covering the full screen.',
+                maxWidth: 240,
+                colors: colors,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TooltipTriggerRow extends StatelessWidget {
+  const _TooltipTriggerRow({
+    required this.title,
+    required this.subtitle,
+    required this.message,
+    required this.colors,
+    this.maxWidth = 320,
+  });
+
+  final String title;
+  final String subtitle;
+  final String message;
+  final ColorTokens colors;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return TooltipComponent(
+      message: message,
+      maxWidth: maxWidth,
+      child: MenuComponent(
+        title: title,
+        subtitle: subtitle,
+        leading: const _CatalogHugeIcon(HugeIcons.strokeRoundedHelpCircle),
+        trailing: _CatalogHugeIcon(
+          HugeIcons.strokeRoundedArrowRight02,
+          color: colors.textLight,
+          size: IconSizes.small,
+        ),
+      ),
+    );
+  }
+}
+
 class HeaderAppBarDemoPage extends StatefulWidget {
   const HeaderAppBarDemoPage({
     super.key,
@@ -2164,14 +2268,24 @@ class HeaderAppBarDemoPage extends StatefulWidget {
   State<HeaderAppBarDemoPage> createState() => _HeaderAppBarDemoPageState();
 }
 
+enum _HeaderTitleRevealVariant { tooltip, disabled }
+
 class _HeaderAppBarDemoPageState extends State<HeaderAppBarDemoPage> {
   static const _itemCount = 48;
+  static const _longTitle =
+      'alexandra.rivera.photo.archive.longtitle.test@examplemail.com';
 
   late ThemeMode _themeMode = widget.themeMode;
+  _HeaderTitleRevealVariant _titleRevealVariant =
+      _HeaderTitleRevealVariant.tooltip;
 
   void _setThemeMode(ThemeMode mode) {
     setState(() => _themeMode = mode);
     widget.onThemeModeChanged(mode);
+  }
+
+  void _setTitleRevealVariant(_HeaderTitleRevealVariant variant) {
+    setState(() => _titleRevealVariant = variant);
   }
 
   void _showAction(String label) {
@@ -2181,30 +2295,47 @@ class _HeaderAppBarDemoPageState extends State<HeaderAppBarDemoPage> {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
+    final titleRevealVariant = _titleRevealVariant;
+    final disableTitleTapReveal =
+        titleRevealVariant != _HeaderTitleRevealVariant.tooltip;
+    final actions = <Widget>[
+      IconButtonComponent(
+        tooltip: 'Add item',
+        variant: IconButtonComponentVariant.primary,
+        icon: const _CatalogHugeIcon(HugeIcons.strokeRoundedAdd01),
+        onTap: () => _showAction('Add tapped'),
+      ),
+      _CatalogThemeCycleButton(themeMode: _themeMode, onChanged: _setThemeMode),
+    ];
+
     return Scaffold(
       backgroundColor: colors.backgroundBase,
       body: AppBarComponent(
-        title: 'Menu items',
-        subtitle: 'Scroll to collapse into a single app bar row',
+        title: _longTitle,
+        disableTitleTapReveal: disableTitleTapReveal,
+        subtitle: titleRevealVariant.description,
         onBack: () => Navigator.of(context).pop(),
         leading: const _HeaderAppBarDemoLeading(),
-        actions: [
-          IconButtonComponent(
-            tooltip: 'Add item',
-            variant: IconButtonComponentVariant.primary,
-            icon: const _CatalogHugeIcon(HugeIcons.strokeRoundedAdd01),
-            onTap: () => _showAction('Add tapped'),
-          ),
-          _CatalogThemeCycleButton(
-            themeMode: _themeMode,
-            onChanged: _setThemeMode,
-          ),
-        ],
+        actions: actions,
         slivers: [
           SliverPadding(
             padding: const EdgeInsets.fromLTRB(
               Spacing.lg,
               Spacing.xs,
+              Spacing.lg,
+              Spacing.xxl,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: _HeaderAppBarTitleRevealControls(
+                variant: titleRevealVariant,
+                onVariantChanged: _setTitleRevealVariant,
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              Spacing.lg,
+              0,
               Spacing.lg,
               Spacing.xxl,
             ),
@@ -2217,6 +2348,63 @@ class _HeaderAppBarDemoPageState extends State<HeaderAppBarDemoPage> {
                 return _HeaderAppBarDemoListItem(index: index ~/ 2);
               },
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+extension on _HeaderTitleRevealVariant {
+  String get label => switch (this) {
+    _HeaderTitleRevealVariant.tooltip => 'Tap popup',
+    _HeaderTitleRevealVariant.disabled => 'Disabled',
+  };
+
+  String get description => switch (this) {
+    _HeaderTitleRevealVariant.tooltip =>
+      'Default: tap title to show the full value in a popup',
+    _HeaderTitleRevealVariant.disabled =>
+      'Title tap reveal disabled for this screen',
+  };
+}
+
+class _HeaderAppBarTitleRevealControls extends StatelessWidget {
+  const _HeaderAppBarTitleRevealControls({
+    required this.variant,
+    required this.onVariantChanged,
+  });
+
+  final _HeaderTitleRevealVariant variant;
+  final ValueChanged<_HeaderTitleRevealVariant> onVariantChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+
+    return _CatalogPreviewGroup(
+      title: 'Title tap behavior',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: Spacing.sm,
+            runSpacing: Spacing.sm,
+            children: [
+              for (final option in _HeaderTitleRevealVariant.values)
+                FilterChipComponent(
+                  label: option.label,
+                  state: option == variant
+                      ? FilterChipComponentState.selected
+                      : FilterChipComponentState.unselected,
+                  onChanged: (_) => onVariantChanged(option),
+                ),
+            ],
+          ),
+          const SizedBox(height: Spacing.md),
+          Text(
+            variant.description,
+            style: TextStyles.mini.copyWith(color: colors.textLight),
           ),
         ],
       ),

--- a/mobile/packages/ente_components/lib/components/app_bar_component.dart
+++ b/mobile/packages/ente_components/lib/components/app_bar_component.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:ente_components/components/tooltip_component.dart';
 import 'package:ente_components/theme/colors.dart';
 import 'package:ente_components/theme/icon_sizes.dart';
 import 'package:ente_components/theme/spacing.dart';
@@ -40,6 +41,7 @@ class AppBarComponent extends StatefulWidget {
     this.onTitleTap,
     this.onTitleDoubleTap,
     this.onTitleLongPress,
+    this.disableTitleTapReveal = false,
     this.subtitle,
     this.leading,
     this.backButton,
@@ -61,6 +63,7 @@ class AppBarComponent extends StatefulWidget {
   final VoidCallback? onTitleTap;
   final VoidCallback? onTitleDoubleTap;
   final VoidCallback? onTitleLongPress;
+  final bool disableTitleTapReveal;
   final String? subtitle;
   final Widget? leading;
   final Widget? backButton;
@@ -231,6 +234,7 @@ class _AppBarComponentState extends State<AppBarComponent> {
             onTitleTap: widget.onTitleTap,
             onTitleDoubleTap: widget.onTitleDoubleTap,
             onTitleLongPress: widget.onTitleLongPress,
+            disableTitleTapReveal: widget.disableTitleTapReveal,
             subtitle: widget.subtitle,
             leading: widget.leading,
             backButton: widget.backButton,
@@ -285,6 +289,7 @@ class SliverAppBarComponent extends StatelessWidget {
     this.onTitleTap,
     this.onTitleDoubleTap,
     this.onTitleLongPress,
+    this.disableTitleTapReveal = false,
     this.subtitle,
     this.leading,
     this.backButton,
@@ -303,6 +308,7 @@ class SliverAppBarComponent extends StatelessWidget {
   final VoidCallback? onTitleTap;
   final VoidCallback? onTitleDoubleTap;
   final VoidCallback? onTitleLongPress;
+  final bool disableTitleTapReveal;
   final String? subtitle;
   final Widget? leading;
   final Widget? backButton;
@@ -334,6 +340,7 @@ class SliverAppBarComponent extends StatelessWidget {
         onTitleTap: onTitleTap,
         onTitleDoubleTap: onTitleDoubleTap,
         onTitleLongPress: onTitleLongPress,
+        disableTitleTapReveal: disableTitleTapReveal,
         subtitle: subtitle,
         leading: leading,
         backButton: backButton,
@@ -362,6 +369,7 @@ class _HeaderAppBarDelegate extends SliverPersistentHeaderDelegate {
     required this.onTitleTap,
     required this.onTitleDoubleTap,
     required this.onTitleLongPress,
+    required this.disableTitleTapReveal,
     required this.subtitle,
     required this.leading,
     required this.backButton,
@@ -385,6 +393,7 @@ class _HeaderAppBarDelegate extends SliverPersistentHeaderDelegate {
   final VoidCallback? onTitleTap;
   final VoidCallback? onTitleDoubleTap;
   final VoidCallback? onTitleLongPress;
+  final bool disableTitleTapReveal;
   final String? subtitle;
   final Widget? leading;
   final Widget? backButton;
@@ -497,6 +506,7 @@ class _HeaderAppBarDelegate extends SliverPersistentHeaderDelegate {
               onTap: onTitleTap,
               onDoubleTap: onTitleDoubleTap,
               onLongPress: onTitleLongPress,
+              disableTapReveal: disableTitleTapReveal,
               top: titleTop,
               left: titleLeft,
               right: titleRight,
@@ -553,6 +563,7 @@ class _HeaderAppBarDelegate extends SliverPersistentHeaderDelegate {
         oldDelegate.onTitleTap != onTitleTap ||
         oldDelegate.onTitleDoubleTap != onTitleDoubleTap ||
         oldDelegate.onTitleLongPress != onTitleLongPress ||
+        oldDelegate.disableTitleTapReveal != disableTitleTapReveal ||
         oldDelegate.subtitle != subtitle ||
         oldDelegate.leading != leading ||
         oldDelegate.backButton != backButton ||
@@ -695,6 +706,7 @@ const _expandedContentBottomGap = Spacing.lg;
 const _subtitleGap = 2.0;
 const _headerSnapTolerance = 1.0;
 const _headerSnapDuration = Duration(milliseconds: 160);
+const _titleTooltipShowDuration = Duration(seconds: 3);
 
 class _HeaderAppBarMetrics {
   const _HeaderAppBarMetrics({
@@ -796,6 +808,7 @@ class _MovingHeaderTitle extends StatelessWidget {
     required this.onTap,
     required this.onDoubleTap,
     required this.onLongPress,
+    required this.disableTapReveal,
     required this.top,
     required this.left,
     required this.right,
@@ -808,6 +821,7 @@ class _MovingHeaderTitle extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
   final VoidCallback? onLongPress;
+  final bool disableTapReveal;
   final double top;
   final double left;
   final double right;
@@ -840,26 +854,76 @@ class _MovingHeaderTitle extends StatelessWidget {
       );
     }
 
-    final titleText = Text(
-      title,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: textStyle,
-    );
+    final canShowTitleTooltip = !disableTapReveal && onTap == null;
 
     return Positioned(
       left: left,
       right: right,
       top: top,
-      child: onTap == null && onDoubleTap == null && onLongPress == null
-          ? IgnorePointer(child: titleText)
+      child: canShowTitleTooltip
+          ? LayoutBuilder(
+              builder: (context, constraints) {
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: TooltipComponent(
+                    message: title,
+                    showDuration: _titleTooltipShowDuration,
+                    onDoubleTap: onDoubleTap,
+                    onLongPress: onLongPress,
+                    child: SizedBox(
+                      width: _singleLineTextWidth(
+                        context,
+                        title: title,
+                        style: textStyle,
+                        maxWidth: constraints.maxWidth,
+                      ),
+                      child: Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textStyle,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            )
+          : onTap == null && onDoubleTap == null && onLongPress == null
+          ? IgnorePointer(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: textStyle,
+              ),
+            )
           : GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: onTap,
               onDoubleTap: onDoubleTap,
               onLongPress: onLongPress,
-              child: titleText,
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: textStyle,
+              ),
             ),
     );
   }
+}
+
+double _singleLineTextWidth(
+  BuildContext context, {
+  required String title,
+  required TextStyle style,
+  required double maxWidth,
+}) {
+  final textPainter = TextPainter(
+    text: TextSpan(text: title, style: style),
+    maxLines: 1,
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+  )..layout(maxWidth: maxWidth);
+  return math.min(textPainter.width, maxWidth);
 }

--- a/mobile/packages/ente_components/lib/components/tooltip_component.dart
+++ b/mobile/packages/ente_components/lib/components/tooltip_component.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:ente_components/theme/radii.dart';
+import 'package:ente_components/theme/spacing.dart';
+import 'package:ente_components/theme/text_styles.dart';
+import 'package:ente_components/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=11025-18810&m=dev
+/// Section: Tooltip
+/// Specs: fill/light rounded tooltip bubble with a top pointer.
+class TooltipBubbleComponent extends StatelessWidget {
+  const TooltipBubbleComponent({
+    super.key,
+    required this.message,
+    this.maxWidth = 320,
+    this.backgroundColor,
+    this.textColor,
+    this.textStyle,
+  });
+
+  final String message;
+  final double maxWidth;
+  final Color? backgroundColor;
+  final Color? textColor;
+  final TextStyle? textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    final effectiveTextStyle = (textStyle ?? TextStyles.mini).copyWith(
+      color: textColor ?? colors.textBase,
+      decoration: TextDecoration.none,
+      decorationColor: Colors.transparent,
+    );
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: CustomPaint(
+        painter: _TooltipBubblePainter(
+          color: backgroundColor ?? colors.fillLight,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            Spacing.lg,
+            _tooltipVerticalPadding + _pointerDepth,
+            Spacing.lg,
+            _tooltipVerticalPadding,
+          ),
+          child: Material(
+            type: MaterialType.transparency,
+            child: Text(
+              _breakableMessage(message),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              softWrap: true,
+              textAlign: TextAlign.center,
+              style: effectiveTextStyle,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class TooltipComponent extends StatefulWidget {
+  const TooltipComponent({
+    super.key,
+    required this.message,
+    required this.child,
+    this.showDuration = const Duration(seconds: 3),
+    this.maxWidth = 320,
+    this.textStyle,
+    this.onDoubleTap,
+    this.onLongPress,
+  });
+
+  final String message;
+  final Widget child;
+  final Duration showDuration;
+  final double maxWidth;
+  final TextStyle? textStyle;
+  final VoidCallback? onDoubleTap;
+  final VoidCallback? onLongPress;
+
+  @override
+  State<TooltipComponent> createState() => _TooltipComponentState();
+}
+
+class _TooltipComponentState extends State<TooltipComponent> {
+  OverlayEntry? _overlayEntry;
+  Timer? _hideTimer;
+
+  @override
+  void dispose() {
+    _hideTooltip();
+    super.dispose();
+  }
+
+  void _showTooltip() {
+    _hideTooltip();
+
+    final overlay = Overlay.of(context);
+    final overlayBox = overlay.context.findRenderObject() as RenderBox?;
+    final targetBox = context.findRenderObject() as RenderBox?;
+    if (overlayBox == null || targetBox == null || !targetBox.hasSize) {
+      return;
+    }
+
+    final targetOffset = targetBox.localToGlobal(
+      Offset.zero,
+      ancestor: overlayBox,
+    );
+    final targetRect = targetOffset & targetBox.size;
+
+    _overlayEntry = OverlayEntry(
+      builder: (context) {
+        return _TooltipOverlay(
+          targetRect: targetRect,
+          maxWidth: widget.maxWidth,
+          message: widget.message,
+          textStyle: widget.textStyle,
+          onDismiss: _hideTooltip,
+        );
+      },
+    );
+    overlay.insert(_overlayEntry!);
+    _hideTimer = Timer(widget.showDuration, _hideTooltip);
+  }
+
+  void _hideTooltip() {
+    _hideTimer?.cancel();
+    _hideTimer = null;
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _showTooltip,
+      onDoubleTap: widget.onDoubleTap,
+      onLongPress: widget.onLongPress,
+      child: widget.child,
+    );
+  }
+}
+
+class _TooltipOverlay extends StatelessWidget {
+  const _TooltipOverlay({
+    required this.targetRect,
+    required this.maxWidth,
+    required this.message,
+    required this.textStyle,
+    required this.onDismiss,
+  });
+
+  final Rect targetRect;
+  final double maxWidth;
+  final String message;
+  final TextStyle? textStyle;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final textStyle = this.textStyle ?? TextStyles.mini;
+    final maxBubbleWidth = math.min(
+      maxWidth,
+      screenWidth - (_screenPadding * 2),
+    );
+    final maxTextWidth = math.max(0.0, maxBubbleWidth - (Spacing.lg * 2));
+    final textPainter = TextPainter(
+      text: TextSpan(text: _breakableMessage(message), style: textStyle),
+      maxLines: 3,
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: maxTextWidth);
+    final bubbleWidth = math.min(
+      maxBubbleWidth,
+      textPainter.width + (Spacing.lg * 2),
+    );
+    final left = (targetRect.center.dx - (bubbleWidth / 2)).clamp(
+      _screenPadding,
+      math.max(_screenPadding, screenWidth - bubbleWidth - _screenPadding),
+    );
+
+    return Positioned.fill(
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: onDismiss,
+        child: Stack(
+          children: [
+            Positioned(
+              left: left.toDouble(),
+              top: targetRect.bottom + _targetGap,
+              width: bubbleWidth,
+              child: TooltipBubbleComponent(
+                message: message,
+                maxWidth: bubbleWidth,
+                textStyle: this.textStyle,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TooltipBubblePainter extends CustomPainter {
+  const _TooltipBubblePainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bodyRect = Rect.fromLTWH(
+      0,
+      _pointerDepth,
+      size.width,
+      size.height - _pointerDepth,
+    );
+    final pointerCenter = size.width / 2;
+    final path = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(bodyRect, const Radius.circular(Radii.md)),
+      )
+      ..moveTo(pointerCenter - _pointerHalfWidth, bodyRect.top)
+      ..lineTo(pointerCenter, bodyRect.top - _pointerDepth)
+      ..lineTo(pointerCenter + _pointerHalfWidth, bodyRect.top)
+      ..close();
+
+    canvas.drawShadow(path, const Color(0x33000000), 18, true);
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(covariant _TooltipBubblePainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+String _breakableMessage(String message) {
+  return message.replaceAllMapped(
+    RegExp(r'([@._-])'),
+    (match) => '${match.group(0)}\u200B',
+  );
+}
+
+const _tooltipVerticalPadding = 10.0;
+const _pointerDepth = 7.0;
+const _pointerHalfWidth = 6.0;
+const _targetGap = 4.0;
+const _screenPadding = 8.0;

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -16,6 +16,7 @@ export 'components/slider_component.dart';
 export 'components/stepper_component.dart';
 export 'components/tag_chip_component.dart';
 export 'components/text_input_component.dart';
+export 'components/tooltip_component.dart';
 export 'models/component_execution_state.dart';
 export 'theme/colors.dart';
 export 'theme/icon_sizes.dart';

--- a/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
+++ b/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:ente_components/components/app_bar_component.dart';
 import 'package:ente_components/components/menu_component.dart';
 import 'package:ente_components/components/menu_group_component.dart';
+import 'package:ente_components/components/tooltip_component.dart';
 import 'package:ente_components/theme/colors.dart';
 import 'package:ente_components/theme/icon_sizes.dart';
 import 'package:ente_components/theme/text_styles.dart';
@@ -569,6 +570,173 @@ void main() {
       closeTo(tester.getCenter(find.byIcon(Icons.arrow_back)).dy, 1),
     );
     expect(find.text('Menu items'), findsWidgets);
+  });
+
+  testWidgets('SliverAppBarComponent supports tap tooltip title reveal', (
+    tester,
+  ) async {
+    const title = 'Aman';
+
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          const SliverAppBarComponent(
+            title: title,
+            actions: [Icon(Icons.search), Icon(Icons.more_vert)],
+          ),
+          SliverList.builder(
+            itemCount: 8,
+            itemBuilder: (context, index) {
+              return SizedBox(height: 60, child: Text('Item $index'));
+            },
+          ),
+        ],
+      ),
+      width: 320,
+      height: 360,
+    );
+
+    expect(find.byType(TooltipComponent), findsOneWidget);
+    expect(tester.getSize(find.byType(TooltipComponent)).width, lessThan(160));
+    expect(find.byType(TooltipBubbleComponent), findsNothing);
+
+    await tester.tap(find.byType(TooltipComponent));
+    await tester.pump();
+
+    expect(find.byType(TooltipBubbleComponent), findsOneWidget);
+    expect(
+      tester.getSize(find.byType(TooltipBubbleComponent)).width,
+      lessThan(160),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('SliverAppBarComponent keeps tap tooltip with title gestures', (
+    tester,
+  ) async {
+    var longPressed = false;
+
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          SliverAppBarComponent(
+            title: 'aman@example.com',
+            onTitleLongPress: () => longPressed = true,
+            actions: const [Icon(Icons.search), Icon(Icons.more_vert)],
+          ),
+          SliverList.builder(
+            itemCount: 8,
+            itemBuilder: (context, index) {
+              return SizedBox(height: 60, child: Text('Item $index'));
+            },
+          ),
+        ],
+      ),
+      width: 320,
+      height: 360,
+    );
+
+    expect(find.byType(TooltipComponent), findsOneWidget);
+    expect(find.byType(TooltipBubbleComponent), findsNothing);
+
+    await tester.tap(find.byType(TooltipComponent));
+    await tester.pump();
+
+    expect(find.byType(TooltipBubbleComponent), findsOneWidget);
+    expect(longPressed, isFalse);
+
+    await tester.tapAt(Offset.zero);
+    await tester.pump();
+
+    await tester.longPress(find.byType(TooltipComponent));
+    await tester.pump();
+
+    expect(longPressed, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('SliverAppBarComponent can disable tap tooltip title reveal', (
+    tester,
+  ) async {
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          const SliverAppBarComponent(
+            title: 'Aman',
+            disableTitleTapReveal: true,
+            actions: [Icon(Icons.search)],
+          ),
+          SliverList.builder(
+            itemCount: 8,
+            itemBuilder: (context, index) {
+              return SizedBox(height: 60, child: Text('Item $index'));
+            },
+          ),
+        ],
+      ),
+      width: 320,
+      height: 360,
+    );
+
+    expect(find.byType(TooltipComponent), findsNothing);
+    expect(find.byType(TooltipBubbleComponent), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('SliverAppBarComponent preserves tap-only title callbacks', (
+    tester,
+  ) async {
+    var tapped = false;
+
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          SliverAppBarComponent(
+            title: 'Tap me',
+            onTitleTap: () => tapped = true,
+            actions: const [Icon(Icons.search)],
+          ),
+          SliverList.builder(
+            itemCount: 8,
+            itemBuilder: (context, index) {
+              return SizedBox(height: 60, child: Text('Item $index'));
+            },
+          ),
+        ],
+      ),
+      width: 320,
+      height: 360,
+    );
+
+    expect(find.byType(TooltipComponent), findsNothing);
+
+    await tester.tap(find.text('Tap me'));
+    await tester.pump();
+
+    expect(tapped, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TooltipBubbleComponent renders top pointer bubble', (
+    tester,
+  ) async {
+    await pumpComponent(
+      tester,
+      const TooltipBubbleComponent(message: 'Tooltip text'),
+      width: 390,
+      height: 200,
+    );
+
+    expect(find.byType(TooltipBubbleComponent), findsOneWidget);
+    final tooltipText = tester.widget<Text>(find.text('Tooltip text'));
+    expect(tooltipText.style?.fontSize, 12);
+    expect(tooltipText.style?.fontWeight, FontWeight.w500);
+    expect(tooltipText.style?.height, 16 / 12);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(


### PR DESCRIPTION
## Description

Adds shared title tooltip support and applies it to album/gallery title surfaces, including custom search section app bars. Also aligns Photos search/support typography with component package text styles, fixes album sort labels by merging newest/updated into last updated, and matches the album share pill border with the shared tab treatment.

## Tests

- [x] `flutter analyze lib/ui/settings/search/settings_search_page.dart lib/ui/settings/support/help_support_page.dart lib/ui/viewer/search/search_suggestions.dart lib/ui/viewer/search/result/search_section_all_page.dart lib/ui/viewer/search/result/search_result_widget.dart lib/ui/viewer/search/result/searchable_item.dart lib/ui/viewer/search_tab/contacts_section.dart lib/ui/viewer/search_tab/locations_section.dart lib/ui/viewer/search_tab/magic_section.dart`
