### PR TITLE
[mob][photos] Add release notes for recent fixes

### DIFF
--- a/mobile/apps/photos/changes/fix-image-editor-jpeg-artifacts.md
+++ b/mobile/apps/photos/changes/fix-image-editor-jpeg-artifacts.md
@@ -1,0 +1,1 @@
+- Fixed JPEG export artifacts in the image editor.

--- a/mobile/apps/photos/changes/preserve-gallery-download-metadata.md
+++ b/mobile/apps/photos/changes/preserve-gallery-download-metadata.md
@@ -1,0 +1,1 @@
+- Preserved date and location metadata when downloading photos from the gallery.


### PR DESCRIPTION
## Description

Adds Photos release-note entries for two recently merged fixes:

- Preserving date and location metadata when downloading photos from the gallery.
- Fixing JPEG export artifacts in the image editor.

## Tests

Not run; release-note-only change.
