### PR TITLE
Prune stale migration code

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -22,7 +22,6 @@ import {
 } from "electron/main";
 import serveNextAt from "next-electron-server";
 import { existsSync } from "node:fs";
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -157,15 +156,6 @@ const main = () => {
             Menu.setApplicationMenu(createApplicationMenu(mainWindow));
             setupTrayItem(mainWindow);
             setupAutoUpdater(mainWindow);
-
-            try {
-                await deleteLegacyDiskCacheDirIfExists();
-                await deleteLegacyKeysStoreIfExists();
-            } catch (e) {
-                // Log but otherwise ignore errors during non-critical startup
-                // actions.
-                log.error("Ignoring startup error", e);
-            }
         })();
     });
 
@@ -744,68 +734,6 @@ const setupTrayItem = (mainWindow: BrowserWindow) => {
                 mainWindow.show();
             }
         });
-    }
-};
-
-/**
- * Older versions of our app used to maintain a cache dir using the main
- * process. This has been removed in favor of cache on the web layer. Delete the
- * old cache dir if it exists.
- *
- * Added May 2024, v1.7.0. This migration code can be removed after some time
- * once most people have upgraded to newer versions (tag: Migration).
- */
-const deleteLegacyDiskCacheDirIfExists = async () => {
-    const removeIfExists = async (dirPath: string) => {
-        if (existsSync(dirPath)) {
-            log.info(`Removing legacy disk cache from ${dirPath}`);
-            await fs.rm(dirPath, { recursive: true });
-        }
-    };
-
-    // [Note: Getting the cache path]
-    //
-    // The existing code was passing "cache" as a parameter to getPath.
-    //
-    // However, "cache" is not a valid parameter to getPath. It works (for
-    // example, on macOS I get `~/Library/Caches`), but it is intentionally not
-    // documented as part of the public API:
-    //
-    // - docs: remove "cache" from app.getPath
-    //   https://github.com/electron/electron/pull/33509
-    //
-    // Irrespective, we replicate the original behaviour so that we get back the
-    // same path that the old code was getting.
-    //
-    // @ts-expect-error "cache" works but is not part of the public API.
-    const cacheDir = path.join(app.getPath("cache"), "ente");
-    if (process.platform == "win32") {
-        // On Windows the cache dir is the same as the app data (!). So deleting
-        // the ente subfolder of the cache dir is equivalent to deleting the
-        // user data dir.
-        //
-        // Obviously, that's not good. So instead of Windows we explicitly
-        // delete the named cache directories.
-        await removeIfExists(path.join(cacheDir, "thumbs"));
-        await removeIfExists(path.join(cacheDir, "files"));
-        await removeIfExists(path.join(cacheDir, "face-crops"));
-    } else {
-        await removeIfExists(cacheDir);
-    }
-};
-
-/**
- * Older versions of our app used to keep a keys.json. It is not needed anymore,
- * remove it if it exists.
- *
- * This code was added March 2024, and can be removed after some time once most
- * people have upgraded to newer versions.
- */
-const deleteLegacyKeysStoreIfExists = async () => {
-    const keysStore = path.join(app.getPath("userData"), "keys.json");
-    if (existsSync(keysStore)) {
-        log.info(`Removing legacy keys store at ${keysStore}`);
-        await fs.rm(keysStore);
     }
 };
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -37,7 +37,6 @@ import autoLauncher from "./main/services/auto-launcher";
 import { shouldHideDockIcon } from "./main/services/store";
 import { createWatcher } from "./main/services/watch";
 import { userPreferences } from "./main/stores/user-preferences";
-import { migrateLegacyWatchStoreIfNeeded } from "./main/stores/watch";
 import { registerStreamProtocol } from "./main/stream";
 import { wait } from "./main/utils/common";
 import { isDev } from "./main/utils/electron";
@@ -91,7 +90,6 @@ const main = () => {
     // The order of the next two calls is important
     setupRendererServer();
     registerPrivilegedSchemes();
-    migrateLegacyWatchStoreIfNeeded();
 
     /**
      * Handle an open URL request, but ensuring that we have a mainWindow.

--- a/desktop/src/main/services/upload.ts
+++ b/desktop/src/main/services/upload.ts
@@ -62,37 +62,15 @@ export const pathOrZipItemSize = async (
     }
 };
 
-export const pendingUploads = async (): Promise<PendingUploads | undefined> => {
+export const pendingUploads = (): PendingUploads | undefined => {
     const collectionName = uploadStatusStore.get("collectionName") ?? undefined;
 
     const allFilePaths = uploadStatusStore.get("filePaths") ?? [];
     const filePaths = allFilePaths.filter((f) => existsSync(f));
 
-    const allZipItems = uploadStatusStore.get("zipItems");
-    let zipItems: ZipItem[] = [];
-    let skippedFiles: SkippedFile[] = [];
-
-    // Migration code - May 2024. Remove after a bit (tag: Migration).
-    //
-    // The older store formats will not have zipItems and instead will have
-    // zipPaths. If we find such a case, read the zipPaths and enqueue all of
-    // their files as zipItems in the result.
-    //
-    // This potentially can be cause us to try reuploading an already uploaded
-    // file, but the dedup logic will kick in at that point so no harm will come
-    // of it.
-    if (allZipItems === undefined) {
-        const allZipPaths = uploadStatusStore.get("zipPaths") ?? [];
-        const zipPaths = allZipPaths.filter((f) => existsSync(f));
-        for (const zip of zipPaths) {
-            const result = await listZipItems(zip);
-            zipItems = zipItems.concat(result.items);
-            skippedFiles = skippedFiles.concat(result.skippedFiles);
-        }
-    } else {
-        zipItems = allZipItems.filter(([z]) => existsSync(z));
-        skippedFiles = uploadStatusStore.get("skippedFiles") ?? [];
-    }
+    const allZipItems = uploadStatusStore.get("zipItems") ?? [];
+    const zipItems = allZipItems.filter(([z]) => existsSync(z));
+    const skippedFiles = uploadStatusStore.get("skippedFiles") ?? [];
 
     if (filePaths.length == 0 && zipItems.length == 0) return undefined;
 

--- a/desktop/src/main/stores/watch.ts
+++ b/desktop/src/main/stores/watch.ts
@@ -1,17 +1,9 @@
 import Store, { Schema } from "electron-store";
 import { type FolderWatch } from "../../types/ipc";
-import log from "../log";
 
 interface WatchStore {
-    mappings?: FolderWatchWithLegacyFields[];
+    mappings?: FolderWatch[];
 }
-
-type FolderWatchWithLegacyFields = FolderWatch & {
-    /** @deprecated Only retained for migration, do not use in other code */
-    rootFolderName?: string;
-    /** @deprecated Only retained for migration, do not use in other code */
-    uploadStrategy?: number;
-};
 
 const watchStoreSchema: Schema<WatchStore> = {
     mappings: {
@@ -19,9 +11,7 @@ const watchStoreSchema: Schema<WatchStore> = {
         items: {
             type: "object",
             properties: {
-                rootFolderName: { type: "string" },
                 collectionMapping: { type: "string" },
-                uploadStrategy: { type: "number" },
                 folderPath: { type: "string" },
                 syncedFiles: {
                     type: "array",
@@ -44,34 +34,3 @@ export const watchStore = new Store({
     name: "watch-status",
     schema: watchStoreSchema,
 });
-
-/**
- * Previous versions of the store used to store an integer to indicate the
- * collection mapping, migrate these to the new schema if we encounter them.
- */
-export const migrateLegacyWatchStoreIfNeeded = () => {
-    let needsUpdate = false;
-    const updatedWatches = [];
-    for (const watch of watchStore.get("mappings") ?? []) {
-        let collectionMapping = watch.collectionMapping;
-        // The required type defines the latest schema, but before migration
-        // this'll be undefined, so tell ESLint to calm down.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!collectionMapping) {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            collectionMapping = watch.uploadStrategy == 1 ? "parent" : "root";
-            needsUpdate = true;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        if (watch.rootFolderName) {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            delete watch.rootFolderName;
-            needsUpdate = true;
-        }
-        updatedWatches.push({ ...watch, collectionMapping });
-    }
-    if (needsUpdate) {
-        watchStore.set("mappings", updatedWatches);
-        log.info("Migrated legacy watch store data to new schema");
-    }
-};

--- a/web/packages/accounts-rs/services/accounts-db.ts
+++ b/web/packages/accounts-rs/services/accounts-db.ts
@@ -171,18 +171,6 @@ export const savedLocalUser = (): LocalUser | undefined => {
 };
 
 /**
- * Sanity check to ensure that KV token and local storage token are the same.
- *
- * TODO: Added July 2025, can just be removed soon, there is already a sanity
- * check `isLocalStorageAndIndexedDBMismatch` on app start (tag: Migration).
- */
-export const ensureTokensMatch = async (user: PartialLocalUser | undefined) => {
-    if (user?.token !== (await savedAuthToken())) {
-        throw new Error("Token mismatch");
-    }
-};
-
-/**
  * Return true if the saved user token in local storage and the persisted auth
  * token are out of sync.
  *
@@ -377,12 +365,6 @@ export const saveIsFirstLogin = () => {
  * without clearing it by using {@link savedIsFirstLogin}.
  */
 export const getAndClearIsFirstLogin = () => {
-    // Completely unrelated, but since this code runs on each /gallery load, use
-    // this as a chance to remove the unused "showBackButton" property saved in
-    // local storage. This code was added 1.7.15-beta (July 2025) and can be
-    // removed after a while, soonish (tag: Migration).
-    localStorage.removeItem("showBackButton");
-
     const result = savedIsFirstLogin();
     localStorage.removeItem("isFirstLogin");
     return result;
@@ -428,17 +410,6 @@ export const getAndClearJustSignedUp = () => {
 };
 
 /**
- * Zod schema for the format in which the {@link stashReferralSource} used to
- * saved the referral source in local storage.
- *
- * Starting 1.7.15-beta (July 2025), we started saving the string directly, but
- * when reading we fallback to the old format if needed. This fallback can be
- * removed, and soonish, since these is a transient value that isn't expected to
- * remain in the user's local storage for long anyway. (tag: Migration).
- */
-const LocalLegacyReferralSource = z.object({ source: z.string() });
-
-/**
  * Save the referral source entered by the user on the signup screen in local
  * storage.
  *
@@ -455,17 +426,8 @@ export const stashReferralSource = (referralSource: string) => {
  * from local storage.
  */
 export const unstashReferralSource = () => {
-    const jsonString = localStorage.getItem("referralSource");
-    if (!jsonString) return undefined;
+    const referralSource = localStorage.getItem("referralSource");
+    if (!referralSource) return undefined;
     localStorage.removeItem("referralSource");
-    try {
-        // Try the old format first. The trim is also a legacy expectation and
-        // can be removed when we remove this fallfront.
-        return LocalLegacyReferralSource.parse(
-            JSON.parse(jsonString),
-        ).source.trim();
-    } catch {
-        // Otherwise try the new format.
-        return jsonString;
-    }
+    return referralSource;
 };

--- a/web/packages/accounts/services/accounts-db.ts
+++ b/web/packages/accounts/services/accounts-db.ts
@@ -121,9 +121,7 @@ const LocalUser = z.object({
 export const savedPartialLocalUser = (): PartialLocalUser | undefined => {
     const jsonString = localStorage.getItem("user");
     if (!jsonString) return undefined;
-    const result = PartialLocalUser.parse(JSON.parse(jsonString));
-    void ensureTokensMatch(result);
-    return result;
+    return PartialLocalUser.parse(JSON.parse(jsonString));
 };
 
 /**
@@ -169,20 +167,7 @@ export const savedLocalUser = (): LocalUser | undefined => {
     if (!jsonString) return undefined;
     // We might have some data, but not all of it. So do a non-throwing parse.
     const { success, data } = LocalUser.safeParse(JSON.parse(jsonString));
-    if (success) void ensureTokensMatch(data);
     return success ? data : undefined;
-};
-
-/**
- * Sanity check to ensure that KV token and local storage token are the same.
- *
- * TODO: Added July 2025, can just be removed soon, there is already a sanity
- * check `isLocalStorageAndIndexedDBMismatch` on app start (tag: Migration).
- */
-export const ensureTokensMatch = async (user: PartialLocalUser | undefined) => {
-    if (user?.token !== (await savedAuthToken())) {
-        throw new Error("Token mismatch");
-    }
 };
 
 /**
@@ -366,12 +351,6 @@ export const saveIsFirstLogin = () => {
  * without clearing it by using {@link savedIsFirstLogin}.
  */
 export const getAndClearIsFirstLogin = () => {
-    // Completely unrelated, but since this code runs on each /gallery load, use
-    // this as a chance to remove the unused "showBackButton" property saved in
-    // local storage. This code was added 1.7.15-beta (July 2025) and can be
-    // removed after a while, soonish (tag: Migration).
-    localStorage.removeItem("showBackButton");
-
     const result = savedIsFirstLogin();
     localStorage.removeItem("isFirstLogin");
     return result;
@@ -417,17 +396,6 @@ export const getAndClearJustSignedUp = () => {
 };
 
 /**
- * Zod schema for the format in which the {@link stashReferralSource} used to
- * saved the referral source in local storage.
- *
- * Starting 1.7.15-beta (July 2025), we started saving the string directly, but
- * when reading we fallback to the old format if needed. This fallback can be
- * removed, and soonish, since these is a transient value that isn't expected to
- * remain in the user's local storage for long anyway. (tag: Migration).
- */
-const LocalLegacyReferralSource = z.object({ source: z.string() });
-
-/**
  * Save the referral source entered by the user on the signup screen in local
  * storage.
  *
@@ -444,17 +412,8 @@ export const stashReferralSource = (referralSource: string) => {
  * from local storage.
  */
 export const unstashReferralSource = () => {
-    const jsonString = localStorage.getItem("referralSource");
-    if (!jsonString) return undefined;
+    const referralSource = localStorage.getItem("referralSource");
+    if (!referralSource) return undefined;
     localStorage.removeItem("referralSource");
-    try {
-        // Try the old format first. The trim is also a legacy expectation and
-        // can be removed when we remove this fallfront.
-        return LocalLegacyReferralSource.parse(
-            JSON.parse(jsonString),
-        ).source.trim();
-    } catch {
-        // Otherwise try the new format.
-        return jsonString;
-    }
+    return referralSource;
 };

--- a/web/packages/new/photos/services/migration.ts
+++ b/web/packages/new/photos/services/migration.ts
@@ -1,9 +1,5 @@
-import { isDesktop } from "ente-base/app";
-import { getKVN, removeKV, setKV } from "ente-base/kv";
+import { getKVN, setKV } from "ente-base/kv";
 import log from "ente-base/log";
-import { localForage } from "ente-gallery/services/files-db";
-import { deleteDB } from "idb";
-import { retryIndexingFailuresIfNeeded } from "./ml";
 
 /**
  * App specific migrations.
@@ -30,99 +26,16 @@ import { retryIndexingFailuresIfNeeded } from "./ml";
  */
 export const runMigrations = async () => {
     const m = (await getKVN("migrationLevel")) ?? 0;
-    const isNewInstall = m == 0;
     const latest = 5;
     if (m < latest) {
         log.info(`Running migrations ${m} => ${latest}`);
-        if (m < 1 && isDesktop) await m1();
-        if (m < 2) await m2();
-        if (m < 3) await m3();
-        if (m < 4) m4();
-        if (m < 5) m5(isNewInstall);
+        // Migration levels 1-5 (Aug 2024 - Feb 2025) were pruned.
+        // New migrations should be 6+. e.g.,
+        // if (m < 6) await m6();
         await setKV("migrationLevel", latest);
     }
 };
 
-// Some of these (indicated by "Prunable") can be no-oped in the future when
-// almost all clients would've migrated over, and there wouldn't be any critical
-// impact if the few remaining outliers never ran that specific migration.
-
-// Added: Aug 2024 (v1.7.3). Prunable.
-const m1 = () =>
-    Promise.all([
-        // Delete the legacy face DB v1.
-        deleteDB("mldata"),
-
-        // Delete the legacy CLIP (mostly) related keys from LocalForage.
-        localForage.removeItem("embeddings"),
-        localForage.removeItem("embedding_sync_time"),
-        localForage.removeItem("embeddings_v2"),
-        localForage.removeItem("file_embeddings"),
-        localForage.removeItem("onnx-clip-embedding_sync_time"),
-        localForage.removeItem("file-ml-clip-face-embedding_sync_time"),
-
-        // Delete keys for the legacy diff based sync.
-        removeKV("embeddingSyncTime:onnx-clip"),
-        removeKV("embeddingSyncTime:file-ml-clip-face"),
-
-        // Delete the legacy face DB v2.
-        deleteDB("face"),
-    ]).then(() => {
-        // Delete legacy ML keys.
-        localStorage.removeItem("faceIndexingEnabled");
-    });
-
-// Added: Sep 2024 (v1.7.5-beta). Prunable.
-const m2 = () =>
-    // Older versions of the user-entities code kept the diff related state
-    // in a different place. These entries are not needed anymore (the tags
-    // themselves will get resynced).
-    Promise.all([
-        localForage.removeItem("location_tags"),
-        localForage.removeItem("location_tags_key"),
-        localForage.removeItem("location_tags_time"),
-
-        // Remove data from an intermediate format that stored user-entities
-        // piecewise instead of as generic, verbatim, entities.
-        removeKV("locationTags"),
-        removeKV("entityKey/locationTags"),
-        removeKV("latestUpdatedAt/locationTags"),
-    ]);
-
-// Added: Sep 2024 (v1.7.5-beta). Prunable.
-const m3 = () =>
-    Promise.all([
-        // Delete the legacy face DB v1.
-        //
-        // This was already removed in m1, but that was behind an isDesktop
-        // check, but later I found out that old web versions also created this
-        // DB (although empty).
-        deleteDB("mldata"),
-
-        // Remove data from an intermediate format that stored user-entities in
-        // their parsed form instead of as generic, verbatim, entities.
-        removeKV("locationTags"),
-        removeKV("entityKey/location"),
-        removeKV("latestUpdatedAt/location"),
-    ]);
-
-// Added: Nov 2024 (v1.7.7-beta). Prunable.
-const m4 = () => {
-    // Delete old local storage keys that have been subsumed elsewhere.
-    localStorage.removeItem("mapEnabled");
-    localStorage.removeItem("userDetails");
-    localStorage.removeItem("subscription");
-    localStorage.removeItem("familyData");
-};
-
-// Added: Feb 2025 (v1.7.10). Prunable.
-const m5 = (isNewInstall: boolean) => {
-    // MUI now persists the color scheme (also in local storage). This was
-    // anyway never released, was only ever an internal user flag.
-    localStorage.removeItem("theme");
-    if (!isNewInstall) {
-        // Let the indexer have another go at the files, the new vips conversion
-        // logic added since 1.7.9 might be able to convert more outliers.
-        retryIndexingFailuresIfNeeded();
-    }
-};
+// const m6 = () => {
+//     // See git history for other examples.
+// }

--- a/web/scripts/check-deps.mjs
+++ b/web/scripts/check-deps.mjs
@@ -12,6 +12,6 @@ if (
 ) {
     console.error("Error: web dependencies are missing or stale.");
     console.error("Run:");
-    console.error("  cd web && npm ci");
+    console.error('  (cd "$(git rev-parse --show-toplevel)/web" && npm ci)');
     process.exit(1);
 }


### PR DESCRIPTION
Prunes migration / back-compat code that's outdated now that old clients
(1.6-era desktop, 2024 web) are gone:

- Desktop: 2024 cache + keys-store cleanups and the zip-paths upload shim
- Web: app-level migrations (m1–m5) + stale accounts localStorage fallbacks
- Desktop: legacy watch-store schema migration

Also makes the web check-deps hint runnable from any directory.