### PR TITLE
[mobile] Ignore PhotoKit network resource failures

### DIFF
--- a/mobile/apps/photos/changes/ignore-photokit-network-errors.md
+++ b/mobile/apps/photos/changes/ignore-photokit-network-errors.md
@@ -1,0 +1,1 @@
+- Stopped repeatedly retrying Apple Photos items that cannot be downloaded from iCloud during backup.

--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -9,6 +9,7 @@ enum InvalidReason {
   livePhotoVideoMissing,
   thumbnailMissing,
   tooLargeFile,
+  photosResourceUnavailable,
   unknown,
 }
 

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -289,11 +289,14 @@ class LocalSyncService {
       // but the file might be available later
       return;
     }
+    final reason = error.reason == InvalidReason.photosResourceUnavailable
+        ? (error.message?.toString() ?? error.reason.name)
+        : error.reason.name;
     final ignored = IgnoredFile(
       file.localID,
       file.title,
       file.deviceFolder,
-      error.reason.name,
+      reason,
     );
     await IgnoredFilesService.instance.cacheAndInsert([ignored]);
   }

--- a/mobile/apps/photos/lib/utils/apple_photos_errors.dart
+++ b/mobile/apps/photos/lib/utils/apple_photos_errors.dart
@@ -1,0 +1,24 @@
+import "package:flutter/services.dart" show PlatformException;
+
+const phPhotosResourceUnavailableReason =
+    "iCloud Photos download failed (PHPhotosErrorDomain 3169)";
+
+const _phPhotosErrorDomain = "PHPhotosErrorDomain";
+const _phPhotosNetworkErrorCode = "3169";
+const _phPhotosUnsupportedResourceErrorCode = "3302";
+
+bool isPHPhotosNetworkError(Object error) {
+  return _isPHPhotosError(error, _phPhotosNetworkErrorCode);
+}
+
+bool isPHPhotosUnsupportedResourceError(Object error) {
+  return _isPHPhotosError(error, _phPhotosUnsupportedResourceErrorCode);
+}
+
+bool _isPHPhotosError(Object error, String code) {
+  if (error is! PlatformException) return false;
+  return error.code == "$_phPhotosErrorDomain ($code)" ||
+      (error.code.contains(_phPhotosErrorDomain) &&
+          error.code.contains(code)) ||
+      (error.message?.contains("$_phPhotosErrorDomain error $code") ?? false);
+}

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -5,7 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:ente_crypto/ente_crypto.dart';
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
-import "package:flutter/services.dart";
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as file_path;
 import "package:photo_manager/photo_manager.dart";
@@ -26,6 +25,7 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
 import "package:photos/services/ignored_files_service.dart";
 import "package:photos/services/sync/local_sync_service.dart";
+import "package:photos/utils/apple_photos_errors.dart";
 import "package:photos/utils/file_key.dart";
 import "package:photos/utils/file_util.dart";
 
@@ -470,7 +470,7 @@ Future<void> downloadToGallery(
       _logger.severe("Failed to save file due to storage limit", e, s);
       throw DownloadNotEnoughStorageError();
     }
-    if (_isApplePhotosUnsupportedResourceError(e)) {
+    if (isPHPhotosUnsupportedResourceError(e)) {
       _logger.warning(
         "Failed to save file because Apple Photos rejected the resource",
         e,
@@ -486,16 +486,6 @@ Future<void> downloadToGallery(
     await PhotoManager.startChangeNotify();
     LocalSyncService.instance.checkAndSync().ignore();
   }
-}
-
-bool _isApplePhotosUnsupportedResourceError(Object error) {
-  if (error is! PlatformException) {
-    return false;
-  }
-  return error.code == "PHPhotosErrorDomain (3302)" ||
-      (error.code.contains("PHPhotosErrorDomain") &&
-          error.code.contains("3302")) ||
-      (error.message?.contains("PHPhotosErrorDomain error 3302") ?? false);
 }
 
 Future<void> _saveLivePhotoOnDroid(

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -26,6 +26,7 @@ import "package:photos/models/location/location.dart";
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/services/sync/local_sync_service.dart";
 import "package:photos/src/rust/api/motion_photo_api.dart";
+import "package:photos/utils/apple_photos_errors.dart";
 import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
 import "package:uuid/uuid.dart";
@@ -132,16 +133,26 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   if (Platform.isIOS) {
     trackOriginFetchForUploadOrML.put(file.localID!, true);
   }
-  sourceFile = await asset.originFile
-      .timeout(const Duration(seconds: 15))
-      .catchError((e) async {
-        if (e is TimeoutException) {
-          _logger.info("Origin file fetch timed out for " + file.tag);
-          return await asset.originFile;
-        } else {
-          throw e;
-        }
-      });
+  try {
+    sourceFile = await asset.originFile
+        .timeout(const Duration(seconds: 15))
+        .catchError((e) async {
+          if (e is TimeoutException) {
+            _logger.info("Origin file fetch timed out for " + file.tag);
+            return await asset.originFile;
+          } else {
+            throw e;
+          }
+        });
+  } catch (e) {
+    if (isPHPhotosNetworkError(e)) {
+      throw InvalidFileError(
+        phPhotosResourceUnavailableReason,
+        InvalidReason.photosResourceUnavailable,
+      );
+    }
+    rethrow;
+  }
   if (sourceFile == null || !sourceFile.existsSync()) {
     throw InvalidFileError(
       "id: ${file.localID}",


### PR DESCRIPTION
## Summary
- classify PhotoKit 3169 failures while fetching local source files for upload
- ignore those uploads with a readable reason until the user retries

## Tests
- cd mobile/apps/photos && flutter pub get --enforce-lockfile && dart format --output=none --set-exit-if-changed . && flutter analyze
- cd mobile/apps/photos/ios && pod install --deployment
- cd mobile/apps/photos && flutter test