### PR TITLE
[mobile] Exclude x86 libs from Photos release APKs

### DIFF
--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -115,6 +115,10 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            ndk {
+                abiFilters.clear()
+                abiFilters "arm64-v8a", "armeabi-v7a"
+            }
             minifyEnabled true
             proguardFiles getDefaultProguardFile(
                 "proguard-android-optimize.txt",


### PR DESCRIPTION
## Summary
- constrain Photos release builds to ARM ABIs at the Gradle build type level
- prevent x86/x86_64 transitive JNI libraries from being packaged in release APKs

## Test
- built Photos independent release APK with dummy signing key
- verified no `lib/x86` or `lib/x86_64` entries are present
- `flutter analyze`

Side note: local verification reduced the independent APK from 326.5 MB to 269.2 MB.