### PR TITLE
fix(filedata): return an error when persisting file/video data fails

### DIFF
--- a/server/pkg/controller/filedata/controller.go
+++ b/server/pkg/controller/filedata/controller.go
@@ -129,7 +129,7 @@ func (c *Controller) InsertOrUpdateMetadata(ctx *gin.Context, req *fileData.PutF
 	dbInsertErr := c.Repo.InsertOrUpdate(context.Background(), row)
 	if dbInsertErr != nil {
 		logger.WithError(dbInsertErr).Error("insert or update failed")
-		return uploadErr
+		return stacktrace.Propagate(dbInsertErr, "failed to insert or update file data row")
 	}
 	//}()
 	return nil

--- a/server/pkg/controller/filedata/video.go
+++ b/server/pkg/controller/filedata/video.go
@@ -45,7 +45,7 @@ func (c *Controller) InsertVideoPreview(ctx *gin.Context, req *filedata.VidPrevi
 	size, uploadErr := c.uploadObject(obj, objectKey, bucketID)
 	if uploadErr != nil {
 		logger.WithError(uploadErr).Error("upload failed")
-		return nil
+		return stacktrace.Propagate(uploadErr, "failed to upload video preview metadata")
 	}
 	row := filedata.Row{
 		FileID:       req.FileID,


### PR DESCRIPTION
## Description

`InsertOrUpdateMetadata` returned `uploadErr` (already nil at that point) when the database `InsertOrUpdate` failed, and `InsertVideoPreview` returned `nil` when the S3 upload of the preview playlist failed. In both cases the handler responded `200 OK` while the data had not been persisted, so the client treated a failed write as success and did not retry.

This propagates the real error in both paths so the request fails and the client retries.

## Tests

Cross-compiled the affected package (`GOOS=linux go build ./pkg/controller/filedata/`). The change only swaps the returned error value; the success path is unchanged.