### PR TITLE
fix(passkey): do not overwrite friendly_name when deleting a passkey

### DIFF
--- a/server/pkg/repo/passkey/passkey.go
+++ b/server/pkg/repo/passkey/passkey.go
@@ -532,10 +532,9 @@ func (r *Repository) FinishAuthentication(user *ente.User, req *http.Request, se
 func (r *Repository) DeletePasskey(user *ente.User, passkeyID uuid.UUID) (err error) {
 	_, err = r.DB.Exec(`
 		UPDATE passkeys
-		SET friendly_name = $1,
-			deleted_at = $2
-		WHERE id = $3 AND user_id = $4 AND deleted_at IS NULL
-	`, passkeyID, ente_time.Microseconds(), passkeyID, user.ID)
+		SET deleted_at = $1
+		WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL
+	`, ente_time.Microseconds(), passkeyID, user.ID)
 	if err != nil {
 		err = stacktrace.Propagate(err, "")
 		return


### PR DESCRIPTION
## Description

`DeletePasskey`'s UPDATE set `friendly_name = $1` with `$1` bound to the passkey UUID — a copy-paste leftover from `RenamePasskey` — so deleting a passkey overwrote its `friendly_name` with the UUID string. Only `deleted_at` should be updated.

This drops the stray assignment and the duplicate argument.

## Tests

Cross-compiled the affected package (`GOOS=linux go build ./pkg/repo/passkey/`).