### PR TITLE
fix(public): return the error from the JWT keyfunc instead of as the key

### DIFF
--- a/server/pkg/controller/public/link_common.go
+++ b/server/pkg/controller/public/link_common.go
@@ -13,7 +13,7 @@ import (
 func validateJWTToken(secret []byte, jwtToken string, passwordHash string) error {
 	token, err := jwt.ParseWithClaims(jwtToken, &enteJWT.LinkPasswordClaim{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return stacktrace.Propagate(fmt.Errorf("unexpected signing method: %v", token.Header["alg"]), ""), nil
+			return nil, stacktrace.Propagate(fmt.Errorf("unexpected signing method: %v", token.Header["alg"]), "")
 		}
 		return secret, nil
 	})


### PR DESCRIPTION
## Description

The keyfunc passed to `jwt.ParseWithClaims` in `validateJWTToken` returned the "unexpected signing method" error as the key (first return value) with a nil error. jwt-go only inspects the second return value, so it used the error object as the verification key instead of rejecting the token. This returns `(nil, err)` so an unexpected signing method is rejected directly by the keyfunc.

## Tests

Cross-compiled the affected package (`GOOS=linux go build ./pkg/controller/public/`).