### PR TITLE
[mobile] Fix Auth Linux theme and polkit packaging

### DIFF
--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -3,12 +3,13 @@ import 'dart:io';
 
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:ente_accounts/services/user_service.dart';
-import "package:ente_auth/app/view/app.dart";
+import 'package:ente_auth/app/view/app.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/core/constants.dart';
 import 'package:ente_auth/ente_theme_data.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/locale.dart';
+import 'package:ente_auth/services/auth_theme_preferences.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
 import 'package:ente_auth/services/billing_service.dart';
 import 'package:ente_auth/services/local_backup_service.dart';
@@ -35,7 +36,7 @@ import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:ente_strings/l10n/strings_localizations.dart';
 import 'package:ente_ui/theme/theme_config.dart';
 import 'package:flutter/foundation.dart';
-import "package:flutter/material.dart";
+import 'package:flutter/material.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:tray_manager/tray_manager.dart';
@@ -102,8 +103,7 @@ void main() async {
 
 Future<void> _runInForeground() async {
   AppThemeConfig.initialize(EnteApp.auth);
-  final adaptiveThemeMode =
-      await AdaptiveTheme.getThemeMode() ?? AdaptiveThemeMode.system;
+  final adaptiveThemeMode = await AuthThemePreferences.getThemeMode();
   final savedThemeMode = _themeMode(adaptiveThemeMode);
   final configuration = Configuration.instance;
   return await _runWithLogs(() async {

--- a/mobile/apps/auth/lib/services/auth_theme_preferences.dart
+++ b/mobile/apps/auth/lib/services/auth_theme_preferences.dart
@@ -1,0 +1,71 @@
+import "dart:convert";
+
+import "package:adaptive_theme/adaptive_theme.dart";
+import "package:flutter/material.dart";
+import "package:shared_preferences/shared_preferences.dart";
+
+class AuthThemePreferences {
+  AuthThemePreferences._();
+
+  static const _themeModeKey = "theme_mode";
+  static const _defaultThemeModeKey = "default_theme_mode";
+
+  static Future<AdaptiveThemeMode> getThemeMode() async {
+    final savedThemeMode = await AdaptiveTheme.getThemeMode();
+    if (savedThemeMode != null) {
+      return savedThemeMode;
+    }
+
+    return await _getLegacyThemeMode() ?? AdaptiveThemeMode.system;
+  }
+
+  static Future<void> setThemeMode(
+    AdaptiveThemeManager<ThemeData> adaptiveTheme,
+    AdaptiveThemeMode themeMode,
+  ) async {
+    adaptiveTheme.setThemeMode(themeMode);
+    await adaptiveTheme.persist();
+    await _setLegacyThemeMode(themeMode);
+  }
+
+  static Future<AdaptiveThemeMode?> _getLegacyThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final themeDataString = prefs.getString(AdaptiveTheme.prefKey);
+    if (themeDataString == null || themeDataString.isEmpty) {
+      return null;
+    }
+
+    return _parseThemeMode(themeDataString);
+  }
+
+  static AdaptiveThemeMode? _parseThemeMode(String themeDataString) {
+    try {
+      final decoded = json.decode(themeDataString);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+
+      final themeModeIndex = decoded[_themeModeKey];
+      if (themeModeIndex is! int ||
+          themeModeIndex < 0 ||
+          themeModeIndex >= AdaptiveThemeMode.values.length) {
+        return null;
+      }
+
+      return AdaptiveThemeMode.values[themeModeIndex];
+    } on FormatException {
+      return null;
+    }
+  }
+
+  static Future<void> _setLegacyThemeMode(AdaptiveThemeMode themeMode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      AdaptiveTheme.prefKey,
+      json.encode({
+        _themeModeKey: themeMode.index,
+        _defaultThemeModeKey: AdaptiveThemeMode.system.index,
+      }),
+    );
+  }
+}

--- a/mobile/apps/auth/lib/ui/settings/theme_switch_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/theme_switch_widget.dart
@@ -1,6 +1,7 @@
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:ente_auth/ente_theme_data.dart';
 import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/services/auth_theme_preferences.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/components/captioned_text_widget.dart';
 import 'package:ente_auth/ui/components/expandable_menu_item_widget.dart';
@@ -17,25 +18,6 @@ class ThemeSwitchWidget extends StatefulWidget {
 }
 
 class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
-  AdaptiveThemeMode? currentThemeMode;
-
-  @override
-  void initState() {
-    super.initState();
-    AdaptiveTheme.getThemeMode().then((value) {
-      currentThemeMode = value ?? AdaptiveThemeMode.system;
-      debugPrint('theme value $value');
-      if (mounted) {
-        setState(() => {});
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     return ExpandableMenuItemWidget(
@@ -73,6 +55,7 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
   }
 
   Widget _menuItem(BuildContext context, AdaptiveThemeMode themeMode) {
+    final currentThemeMode = AdaptiveTheme.of(context).mode;
     return MenuItemWidget(
       captionedTextWidget: CaptionedTextWidget(
         title: _name(context, themeMode),
@@ -84,10 +67,9 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
       trailingExtraMargin: 4,
       onTap: () async {
         final adaptiveTheme = AdaptiveTheme.of(context);
-        adaptiveTheme.setThemeMode(themeMode);
-        AppLock.of(context)?.setThemeMode(_themeMode(themeMode));
-        await adaptiveTheme.persist();
-        currentThemeMode = themeMode;
+        final appLock = AppLock.of(context);
+        await AuthThemePreferences.setThemeMode(adaptiveTheme, themeMode);
+        appLock?.setThemeMode(_themeMode(themeMode));
         if (mounted) {
           setState(() {});
         }

--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -1529,7 +1529,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -164,6 +164,7 @@ flutter:
     - assets/
     - assets/icons/
     - assets/launcher_icon/
+    - assets/polkit/
     - assets/simple-icons/icons/
     - assets/simple-icons/_data/
     - assets/custom-icons/icons/

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -152,6 +152,7 @@ dev_dependencies:
   json_serializable: 6.9.5
   lints: 5.1.1
   mocktail: 1.0.4
+  shared_preferences_platform_interface: 2.4.2
 
 # The following section is specific to Flutter.
 flutter:

--- a/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
+++ b/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
@@ -1,0 +1,51 @@
+import "dart:convert";
+
+import "package:adaptive_theme/adaptive_theme.dart";
+import "package:ente_auth/services/auth_theme_preferences.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:shared_preferences/shared_preferences.dart";
+import "package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart";
+import "package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart";
+
+void main() {
+  setUp(() {
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test("returns system when no theme preference exists", () async {
+    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.system);
+  });
+
+  test("prefers adaptive theme async preference", () async {
+    await _setAsyncThemeMode(AdaptiveThemeMode.dark);
+    await _setLegacyThemeMode(AdaptiveThemeMode.light);
+
+    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.dark);
+  });
+
+  test("falls back to legacy adaptive theme preference", () async {
+    await _setLegacyThemeMode(AdaptiveThemeMode.light);
+
+    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.light);
+  });
+}
+
+Future<void> _setAsyncThemeMode(AdaptiveThemeMode themeMode) async {
+  final prefs = SharedPreferencesAsync();
+  await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
+}
+
+Future<void> _setLegacyThemeMode(AdaptiveThemeMode themeMode) async {
+  SharedPreferences.setMockInitialValues({
+    AdaptiveTheme.prefKey: _themeModeJson(themeMode),
+  });
+}
+
+String _themeModeJson(AdaptiveThemeMode themeMode) {
+  return json.encode({
+    "theme_mode": themeMode.index,
+    "default_theme_mode": AdaptiveThemeMode.system.index,
+  });
+}


### PR DESCRIPTION
## Summary
- keep Auth theme selection persisted on Linux by falling back to the legacy shared_preferences key
- bundle the Auth polkit policy as a Flutter asset so the existing deb postinstall can install it

## Tests
- flutter pub get --enforce-lockfile
- flutter gen-l10n (strings, Auth)
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test
- pod install --deployment
- flutter build bundle
- verified build/flutter_assets/assets/polkit/io.ente.auth.policy exists