### PR TITLE
[mobile] Harden Auth theme persistence

### DIFF
--- a/docs/docs/auth/troubleshooting/linux-system-auth.md
+++ b/docs/docs/auth/troubleshooting/linux-system-auth.md
@@ -24,7 +24,7 @@ shows **Linux setup required**, install the policy manually.
 The policy action is:
 
 ```text
-io.ente.auth.unlock
+com.ente.auth.unlock
 ```
 
 ### Manual Policy Setup
@@ -34,22 +34,22 @@ manual builds may also need manual setup. Download the policy from GitHub and
 verify its SHA-256 checksum before installing it:
 
 ```sh
-policy_url="https://raw.githubusercontent.com/ente-io/ente/main/mobile/apps/auth/assets/polkit/io.ente.auth.policy"
-policy_sha256="31e4fb0757c8a55cee49324ddc310ff660a53d7f143049de202510fa58fe1d24"
+policy_url="https://raw.githubusercontent.com/ente-io/ente/main/mobile/apps/auth/assets/polkit/com.ente.auth.policy"
+policy_sha256="efba0409db9a0a53196fa8a7c9f4d4e874234b48287eb5242cf399f466e4c695"
 policy="$(mktemp)"
 
 if curl -fsSL "$policy_url" -o "$policy" &&
   printf "%s  %s\n" "$policy_sha256" "$policy" | sha256sum -c -; then
   sudo install -D -o root -g root -m 0644 \
     "$policy" \
-    /usr/share/polkit-1/actions/io.ente.auth.policy
+    /usr/share/polkit-1/actions/com.ente.auth.policy
 
   if command -v chcon >/dev/null 2>&1; then
     sudo chcon system_u:object_r:usr_t:s0 \
-      /usr/share/polkit-1/actions/io.ente.auth.policy || true
+      /usr/share/polkit-1/actions/com.ente.auth.policy || true
   fi
 
-  pkaction --action-id io.ente.auth.unlock --verbose
+  pkaction --action-id com.ente.auth.unlock --verbose
 else
   echo "Policy download or checksum verification failed. Not installing."
 fi
@@ -63,7 +63,7 @@ If you manually installed the Polkit policy and no longer want Ente Auth to use
 Linux system authentication, remove it:
 
 ```sh
-sudo rm -f /usr/share/polkit-1/actions/io.ente.auth.policy
+sudo rm -f /usr/share/polkit-1/actions/com.ente.auth.policy
 ```
 
 ## Fingerprint Prompts

--- a/mobile/apps/auth/assets/polkit/com.ente.auth.policy
+++ b/mobile/apps/auth/assets/polkit/com.ente.auth.policy
@@ -4,9 +4,9 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
   <vendor>Ente</vendor>
-  <vendor_url>https://ente.io</vendor_url>
+  <vendor_url>https://ente.com</vendor_url>
 
-  <action id="io.ente.auth.unlock">
+  <action id="com.ente.auth.unlock">
     <description>Unlock Ente Auth</description>
     <message>Authenticate to unlock Ente Auth.</message>
     <defaults>

--- a/mobile/apps/auth/lib/app/view/app.dart
+++ b/mobile/apps/auth/lib/app/view/app.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
-import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/ente_theme_data.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/locale.dart';
 import 'package:ente_auth/onboarding/view/onboarding_page.dart';
+import 'package:ente_auth/services/auth_theme_preferences.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
 import 'package:ente_auth/services/update_service.dart';
 import 'package:ente_auth/ui/home_page.dart';
@@ -22,16 +22,26 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 class App extends StatefulWidget {
   final Locale? locale;
-  final AdaptiveThemeMode savedThemeMode;
+  final ThemeMode savedThemeMode;
   const App({
     super.key,
     this.locale = const Locale("en"),
-    this.savedThemeMode = AdaptiveThemeMode.system,
+    this.savedThemeMode = ThemeMode.system,
   });
 
   static void setLocale(BuildContext context, Locale newLocale) {
     _AppState state = context.findAncestorStateOfType<_AppState>()!;
     state.setLocale(newLocale);
+  }
+
+  static ThemeMode themeModeOf(BuildContext context) {
+    return context.findAncestorStateOfType<_AppState>()!._themeMode;
+  }
+
+  static Future<void> setThemeMode(BuildContext context, ThemeMode themeMode) {
+    return context.findAncestorStateOfType<_AppState>()!.setThemeMode(
+      themeMode,
+    );
   }
 
   @override
@@ -42,6 +52,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   static final Logger _renderErrorLogger = Logger('RenderError');
   late StreamSubscription<SignedOutEvent> _signedOutEvent;
   late StreamSubscription<SignedInEvent> _signedInEvent;
+  late ThemeMode _themeMode;
   Locale? locale;
   void setLocale(Locale newLocale) {
     setState(() {
@@ -49,9 +60,19 @@ class _AppState extends State<App> with WidgetsBindingObserver {
     });
   }
 
+  Future<void> setThemeMode(ThemeMode themeMode) async {
+    await AuthThemePreferences.setThemeMode(themeMode);
+    if (mounted) {
+      setState(() {
+        _themeMode = themeMode;
+      });
+    }
+  }
+
   @override
   void initState() {
     WidgetsBinding.instance.addObserver(this);
+    _themeMode = widget.savedThemeMode;
 
     _signedOutEvent = Bus.instance.on<SignedOutEvent>().listen((event) {
       if (mounted) {
@@ -102,38 +123,25 @@ class _AppState extends State<App> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    return AdaptiveTheme(
-      light: lightThemeData,
-      dark: darkThemeData,
-      initial: widget.savedThemeMode,
-      builder: (lightTheme, darkTheme) => Builder(
-        builder: (context) => MaterialApp(
-          title: "ente",
-          themeMode: _themeMode(AdaptiveTheme.of(context).mode),
-          theme: lightTheme,
-          darkTheme: darkTheme,
-          debugShowCheckedModeBanner: false,
-          locale: locale,
-          supportedLocales: appSupportedLocales,
-          localeListResolutionCallback: localResolutionCallBack,
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            StringsLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
-          routes: _getRoutes,
-          builder: _materialAppBuilder,
-        ),
-      ),
+    return MaterialApp(
+      title: "ente",
+      themeMode: _themeMode,
+      theme: lightThemeData,
+      darkTheme: darkThemeData,
+      debugShowCheckedModeBanner: false,
+      locale: locale,
+      supportedLocales: appSupportedLocales,
+      localeListResolutionCallback: localResolutionCallBack,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        StringsLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      routes: _getRoutes,
+      builder: _materialAppBuilder,
     );
-  }
-
-  ThemeMode _themeMode(AdaptiveThemeMode mode) {
-    if (mode.isLight) return ThemeMode.light;
-    if (mode.isDark) return ThemeMode.dark;
-    return ThemeMode.system;
   }
 
   Map<String, WidgetBuilder> get _getRoutes {

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_auth/app/view/app.dart';
 import 'package:ente_auth/core/configuration.dart';
@@ -103,8 +102,7 @@ void main() async {
 
 Future<void> _runInForeground() async {
   AppThemeConfig.initialize(EnteApp.auth);
-  final adaptiveThemeMode = await AuthThemePreferences.getThemeMode();
-  final savedThemeMode = _themeMode(adaptiveThemeMode);
+  final savedThemeMode = await AuthThemePreferences.getThemeMode();
   final configuration = Configuration.instance;
   return await _runWithLogs(() async {
     _logger.info("Starting app in foreground");
@@ -118,8 +116,7 @@ Future<void> _runInForeground() async {
     unawaited(UpdateService.instance.showUpdateNotification());
     runApp(
       AppLock(
-        builder: (args) =>
-            App(locale: locale, savedThemeMode: adaptiveThemeMode),
+        builder: (args) => App(locale: locale, savedThemeMode: savedThemeMode),
         lockScreen: LockScreen(configuration),
         enabled: await LockScreenSettings.instance.shouldShowLockScreen(),
         locale: locale,
@@ -136,13 +133,6 @@ Future<void> _runInForeground() async {
       ),
     );
   });
-}
-
-ThemeMode _themeMode(AdaptiveThemeMode? savedThemeMode) {
-  if (savedThemeMode == null) return ThemeMode.system;
-  if (savedThemeMode.isLight) return ThemeMode.light;
-  if (savedThemeMode.isDark) return ThemeMode.dark;
-  return ThemeMode.system;
 }
 
 Future _runWithLogs(Function() function, {String prefix = ""}) async {

--- a/mobile/apps/auth/lib/services/auth_theme_preferences.dart
+++ b/mobile/apps/auth/lib/services/auth_theme_preferences.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 
-import "package:adaptive_theme/adaptive_theme.dart";
 import "package:flutter/material.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
@@ -8,61 +7,53 @@ class AuthThemePreferences {
   AuthThemePreferences._();
 
   static const _authThemeModeKey = "ente_auth_theme_mode";
+  static const _adaptiveThemePrefKey = "adaptive_theme_preferences";
   static const _themeModeKey = "theme_mode";
-  static const _defaultThemeModeKey = "default_theme_mode";
 
-  static Future<AdaptiveThemeMode> getThemeMode() async {
+  static Future<ThemeMode> getThemeMode() async {
     final authThemeMode = await _getAuthThemeMode();
     if (authThemeMode != null) {
       return authThemeMode;
     }
 
-    final savedThemeMode = await AdaptiveTheme.getThemeMode();
-    if (savedThemeMode != null) {
-      return savedThemeMode;
+    final migratedThemeMode = await _getMigratedThemeMode();
+    if (migratedThemeMode != null) {
+      await _setAuthThemeMode(migratedThemeMode);
+      return migratedThemeMode;
     }
 
-    return await _getLegacyThemeMode() ?? AdaptiveThemeMode.system;
+    return ThemeMode.system;
   }
 
-  static Future<void> setThemeMode(
-    AdaptiveThemeManager<ThemeData> adaptiveTheme,
-    AdaptiveThemeMode themeMode,
-  ) async {
-    adaptiveTheme.setThemeMode(themeMode);
-    await Future.wait([
-      _setAuthThemeMode(themeMode),
-      _setAdaptiveThemeMode(themeMode),
-      _setLegacyThemeMode(themeMode),
-    ]);
-  }
+  static Future<void> setThemeMode(ThemeMode themeMode) =>
+      _setAuthThemeMode(themeMode);
 
-  static Future<AdaptiveThemeMode?> _getAuthThemeMode() async {
-    final prefs = SharedPreferencesAsync();
-    return _themeModeFromIndex(await prefs.getInt(_authThemeModeKey));
-  }
-
-  static Future<void> _setAuthThemeMode(AdaptiveThemeMode themeMode) async {
-    final prefs = SharedPreferencesAsync();
-    await prefs.setInt(_authThemeModeKey, themeMode.index);
-  }
-
-  static Future<void> _setAdaptiveThemeMode(AdaptiveThemeMode themeMode) async {
-    final prefs = SharedPreferencesAsync();
-    await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
-  }
-
-  static Future<AdaptiveThemeMode?> _getLegacyThemeMode() async {
+  static Future<ThemeMode?> _getAuthThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    final themeDataString = prefs.getString(AdaptiveTheme.prefKey);
+    return _themeModeFromIndex(prefs.getInt(_authThemeModeKey));
+  }
+
+  static Future<void> _setAuthThemeMode(ThemeMode themeMode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_authThemeModeKey, _themeModeIndex(themeMode));
+  }
+
+  static Future<ThemeMode?> _getMigratedThemeMode() async {
+    final prefs = SharedPreferencesAsync();
+    return _parseThemeMode(await prefs.getString(_adaptiveThemePrefKey)) ??
+        await _getLegacyAdaptiveThemeMode();
+  }
+
+  static Future<ThemeMode?> _getLegacyAdaptiveThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _parseThemeMode(prefs.getString(_adaptiveThemePrefKey));
+  }
+
+  static ThemeMode? _parseThemeMode(String? themeDataString) {
     if (themeDataString == null || themeDataString.isEmpty) {
       return null;
     }
 
-    return _parseThemeMode(themeDataString);
-  }
-
-  static AdaptiveThemeMode? _parseThemeMode(String themeDataString) {
     try {
       final decoded = json.decode(themeDataString);
       if (decoded is! Map<String, dynamic>) {
@@ -76,25 +67,27 @@ class AuthThemePreferences {
     }
   }
 
-  static AdaptiveThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
-    if (themeModeIndex is! int ||
-        themeModeIndex < 0 ||
-        themeModeIndex >= AdaptiveThemeMode.values.length) {
-      return null;
+  static ThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
+    switch (themeModeIndex) {
+      case 0:
+        return ThemeMode.light;
+      case 1:
+        return ThemeMode.dark;
+      case 2:
+        return ThemeMode.system;
+      default:
+        return null;
     }
-
-    return AdaptiveThemeMode.values[themeModeIndex];
   }
 
-  static Future<void> _setLegacyThemeMode(AdaptiveThemeMode themeMode) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
-  }
-
-  static String _themeModeJson(AdaptiveThemeMode themeMode) {
-    return json.encode({
-      _themeModeKey: themeMode.index,
-      _defaultThemeModeKey: AdaptiveThemeMode.system.index,
-    });
+  static int _themeModeIndex(ThemeMode themeMode) {
+    switch (themeMode) {
+      case ThemeMode.light:
+        return 0;
+      case ThemeMode.dark:
+        return 1;
+      case ThemeMode.system:
+        return 2;
+    }
   }
 }

--- a/mobile/apps/auth/lib/services/auth_theme_preferences.dart
+++ b/mobile/apps/auth/lib/services/auth_theme_preferences.dart
@@ -30,26 +30,31 @@ class AuthThemePreferences {
 
   static Future<ThemeMode?> _getAuthThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return _themeModeFromIndex(prefs.getInt(_authThemeModeKey));
+    return _authThemeModeFromIndex(prefs.getInt(_authThemeModeKey));
   }
 
   static Future<void> _setAuthThemeMode(ThemeMode themeMode) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_authThemeModeKey, _themeModeIndex(themeMode));
+    // Auth owns this key, so persist Flutter's ThemeMode.index directly.
+    await prefs.setInt(_authThemeModeKey, themeMode.index);
   }
 
   static Future<ThemeMode?> _getMigratedThemeMode() async {
+    // AdaptiveTheme can live in either the newer async backend or the legacy
+    // cached SharedPreferences backend depending on platform/plugin history.
     final prefs = SharedPreferencesAsync();
-    return _parseThemeMode(await prefs.getString(_adaptiveThemePrefKey)) ??
+    return _parseAdaptiveThemeMode(
+          await prefs.getString(_adaptiveThemePrefKey),
+        ) ??
         await _getLegacyAdaptiveThemeMode();
   }
 
   static Future<ThemeMode?> _getLegacyAdaptiveThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return _parseThemeMode(prefs.getString(_adaptiveThemePrefKey));
+    return _parseAdaptiveThemeMode(prefs.getString(_adaptiveThemePrefKey));
   }
 
-  static ThemeMode? _parseThemeMode(String? themeDataString) {
+  static ThemeMode? _parseAdaptiveThemeMode(String? themeDataString) {
     if (themeDataString == null || themeDataString.isEmpty) {
       return null;
     }
@@ -61,13 +66,24 @@ class AuthThemePreferences {
       }
 
       final themeModeIndex = decoded[_themeModeKey];
-      return _themeModeFromIndex(themeModeIndex);
+      return _adaptiveThemeModeFromIndex(themeModeIndex);
     } on FormatException {
       return null;
     }
   }
 
-  static ThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
+  static ThemeMode? _authThemeModeFromIndex(Object? themeModeIndex) {
+    if (themeModeIndex is! int ||
+        themeModeIndex < 0 ||
+        themeModeIndex >= ThemeMode.values.length) {
+      return null;
+    }
+    return ThemeMode.values[themeModeIndex];
+  }
+
+  static ThemeMode? _adaptiveThemeModeFromIndex(Object? themeModeIndex) {
+    // AdaptiveTheme persisted its own enum order: light=0, dark=1, system=2.
+    // Keep this separate from Flutter's ThemeMode.index used by Auth's key.
     switch (themeModeIndex) {
       case 0:
         return ThemeMode.light;
@@ -77,17 +93,6 @@ class AuthThemePreferences {
         return ThemeMode.system;
       default:
         return null;
-    }
-  }
-
-  static int _themeModeIndex(ThemeMode themeMode) {
-    switch (themeMode) {
-      case ThemeMode.light:
-        return 0;
-      case ThemeMode.dark:
-        return 1;
-      case ThemeMode.system:
-        return 2;
     }
   }
 }

--- a/mobile/apps/auth/lib/services/auth_theme_preferences.dart
+++ b/mobile/apps/auth/lib/services/auth_theme_preferences.dart
@@ -7,10 +7,16 @@ import "package:shared_preferences/shared_preferences.dart";
 class AuthThemePreferences {
   AuthThemePreferences._();
 
+  static const _authThemeModeKey = "ente_auth_theme_mode";
   static const _themeModeKey = "theme_mode";
   static const _defaultThemeModeKey = "default_theme_mode";
 
   static Future<AdaptiveThemeMode> getThemeMode() async {
+    final authThemeMode = await _getAuthThemeMode();
+    if (authThemeMode != null) {
+      return authThemeMode;
+    }
+
     final savedThemeMode = await AdaptiveTheme.getThemeMode();
     if (savedThemeMode != null) {
       return savedThemeMode;
@@ -24,8 +30,26 @@ class AuthThemePreferences {
     AdaptiveThemeMode themeMode,
   ) async {
     adaptiveTheme.setThemeMode(themeMode);
-    await adaptiveTheme.persist();
-    await _setLegacyThemeMode(themeMode);
+    await Future.wait([
+      _setAuthThemeMode(themeMode),
+      _setAdaptiveThemeMode(themeMode),
+      _setLegacyThemeMode(themeMode),
+    ]);
+  }
+
+  static Future<AdaptiveThemeMode?> _getAuthThemeMode() async {
+    final prefs = SharedPreferencesAsync();
+    return _themeModeFromIndex(await prefs.getInt(_authThemeModeKey));
+  }
+
+  static Future<void> _setAuthThemeMode(AdaptiveThemeMode themeMode) async {
+    final prefs = SharedPreferencesAsync();
+    await prefs.setInt(_authThemeModeKey, themeMode.index);
+  }
+
+  static Future<void> _setAdaptiveThemeMode(AdaptiveThemeMode themeMode) async {
+    final prefs = SharedPreferencesAsync();
+    await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
   }
 
   static Future<AdaptiveThemeMode?> _getLegacyThemeMode() async {
@@ -46,26 +70,31 @@ class AuthThemePreferences {
       }
 
       final themeModeIndex = decoded[_themeModeKey];
-      if (themeModeIndex is! int ||
-          themeModeIndex < 0 ||
-          themeModeIndex >= AdaptiveThemeMode.values.length) {
-        return null;
-      }
-
-      return AdaptiveThemeMode.values[themeModeIndex];
+      return _themeModeFromIndex(themeModeIndex);
     } on FormatException {
       return null;
     }
   }
 
+  static AdaptiveThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
+    if (themeModeIndex is! int ||
+        themeModeIndex < 0 ||
+        themeModeIndex >= AdaptiveThemeMode.values.length) {
+      return null;
+    }
+
+    return AdaptiveThemeMode.values[themeModeIndex];
+  }
+
   static Future<void> _setLegacyThemeMode(AdaptiveThemeMode themeMode) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-      AdaptiveTheme.prefKey,
-      json.encode({
-        _themeModeKey: themeMode.index,
-        _defaultThemeModeKey: AdaptiveThemeMode.system.index,
-      }),
-    );
+    await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
+  }
+
+  static String _themeModeJson(AdaptiveThemeMode themeMode) {
+    return json.encode({
+      _themeModeKey: themeMode.index,
+      _defaultThemeModeKey: AdaptiveThemeMode.system.index,
+    });
   }
 }

--- a/mobile/apps/auth/lib/ui/settings/theme_switch_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/theme_switch_widget.dart
@@ -1,7 +1,6 @@
-import 'package:adaptive_theme/adaptive_theme.dart';
+import 'package:ente_auth/app/view/app.dart';
 import 'package:ente_auth/ente_theme_data.dart';
 import 'package:ente_auth/l10n/l10n.dart';
-import 'package:ente_auth/services/auth_theme_preferences.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/components/captioned_text_widget.dart';
 import 'package:ente_auth/ui/components/expandable_menu_item_widget.dart';
@@ -33,29 +32,29 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
     return Column(
       children: [
         sectionOptionSpacing,
-        _menuItem(context, AdaptiveThemeMode.light),
+        _menuItem(context, ThemeMode.light),
         sectionOptionSpacing,
-        _menuItem(context, AdaptiveThemeMode.dark),
+        _menuItem(context, ThemeMode.dark),
         sectionOptionSpacing,
-        _menuItem(context, AdaptiveThemeMode.system),
+        _menuItem(context, ThemeMode.system),
         sectionOptionSpacing,
       ],
     );
   }
 
-  String _name(BuildContext ctx, AdaptiveThemeMode mode) {
+  String _name(BuildContext ctx, ThemeMode mode) {
     switch (mode) {
-      case AdaptiveThemeMode.light:
+      case ThemeMode.light:
         return ctx.l10n.lightTheme;
-      case AdaptiveThemeMode.dark:
+      case ThemeMode.dark:
         return ctx.l10n.darkTheme;
-      case AdaptiveThemeMode.system:
+      case ThemeMode.system:
         return ctx.l10n.systemTheme;
     }
   }
 
-  Widget _menuItem(BuildContext context, AdaptiveThemeMode themeMode) {
-    final currentThemeMode = AdaptiveTheme.of(context).mode;
+  Widget _menuItem(BuildContext context, ThemeMode themeMode) {
+    final currentThemeMode = App.themeModeOf(context);
     return MenuItemWidget(
       captionedTextWidget: CaptionedTextWidget(
         title: _name(context, themeMode),
@@ -66,20 +65,13 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
       trailingIcon: currentThemeMode == themeMode ? Icons.check : null,
       trailingExtraMargin: 4,
       onTap: () async {
-        final adaptiveTheme = AdaptiveTheme.of(context);
         final appLock = AppLock.of(context);
-        await AuthThemePreferences.setThemeMode(adaptiveTheme, themeMode);
-        appLock?.setThemeMode(_themeMode(themeMode));
+        await App.setThemeMode(context, themeMode);
+        appLock?.setThemeMode(themeMode);
         if (mounted) {
           setState(() {});
         }
       },
     );
-  }
-
-  ThemeMode _themeMode(AdaptiveThemeMode themeMode) {
-    if (themeMode.isLight) return ThemeMode.light;
-    if (themeMode.isDark) return ThemeMode.dark;
-    return ThemeMode.system;
   }
 }

--- a/mobile/apps/auth/linux/packaging/build_rpm.sh
+++ b/mobile/apps/auth/linux/packaging/build_rpm.sh
@@ -75,7 +75,7 @@ cp linux/packaging/enteauth.desktop "$STAGING_DIR/usr/share/applications/"
 
 # Copy Polkit policy.
 echo -e "${YELLOW}Copying Polkit policy...${NC}"
-install -D -m 0644 assets/polkit/io.ente.auth.policy "$STAGING_DIR/usr/share/polkit-1/actions/io.ente.auth.policy"
+install -D -m 0644 assets/polkit/com.ente.auth.policy "$STAGING_DIR/usr/share/polkit-1/actions/com.ente.auth.policy"
 
 # Create symlink
 echo -e "${YELLOW}Creating symlink...${NC}"

--- a/mobile/apps/auth/linux/packaging/deb/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/deb/make_config.yaml
@@ -24,11 +24,11 @@ dependencies:
   - libayatana-ido3-0.4-0
 
 postinstall_scripts:
-  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy /usr/share/polkit-1/actions/io.ente.auth.policy
-  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/io.ente.auth.policy || true; fi
+  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy /usr/share/polkit-1/actions/com.ente.auth.policy
+  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.ente.auth.policy || true; fi
 
 postuninstall_scripts:
-  - rm -f /usr/share/polkit-1/actions/io.ente.auth.policy
+  - rm -f /usr/share/polkit-1/actions/com.ente.auth.policy
 
 keywords:
   - Authentication

--- a/mobile/apps/auth/linux/packaging/pacman/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/pacman/make_config.yaml
@@ -31,8 +31,8 @@ supported_mime_type:
 postinstall_scripts:
   - gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
   - update-desktop-database -q
-  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy /usr/share/polkit-1/actions/io.ente.auth.policy
-  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/io.ente.auth.policy || true; fi
+  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy /usr/share/polkit-1/actions/com.ente.auth.policy
+  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.ente.auth.policy || true; fi
   - if [ ! -e /usr/lib/libsodium.so.23 ]; then
   - "   ln -s /usr/lib/libsodium.so /usr/lib/libsodium.so.23"
   - fi
@@ -43,7 +43,7 @@ postupgrade_scripts:
 postremove_scripts:
   - gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
   - update-desktop-database -q
-  - rm -f /usr/share/polkit-1/actions/io.ente.auth.policy
+  - rm -f /usr/share/polkit-1/actions/com.ente.auth.policy
   - if [ -e /usr/lib/libsodium.so.23 ]; then
   - rm /usr/lib/libsodium.so.23
   - fi

--- a/mobile/apps/auth/linux/packaging/rpm/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/rpm/make_config.yaml
@@ -20,11 +20,11 @@ requires:
   - polkit
 
 postinstall_scripts:
-  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy /usr/share/polkit-1/actions/io.ente.auth.policy
-  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/io.ente.auth.policy || true; fi
+  - install -D -o root -g root -m 0644 /usr/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy /usr/share/polkit-1/actions/com.ente.auth.policy
+  - if command -v chcon >/dev/null 2>&1; then chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.ente.auth.policy || true; fi
 
 postuninstall_scripts:
-  - rm -f /usr/share/polkit-1/actions/io.ente.auth.policy
+  - rm -f /usr/share/polkit-1/actions/com.ente.auth.policy
 
 keywords:
   - Authentication

--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "85.0.0"
-  adaptive_theme:
-    dependency: "direct main"
-    description:
-      name: adaptive_theme
-      sha256: "5caccff82e40ef6d3ebb28caaa091ab1865b0e35bd2ab2ddccf49cd336331012"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.2"
   analyzer:
     dependency: transitive
     description:

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
-  adaptive_theme: 3.7.2
   app_links: 6.4.1
   archive: 4.0.7
   auto_size_text: 3.0.0

--- a/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
+++ b/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
@@ -2,6 +2,7 @@ import "dart:convert";
 
 import "package:adaptive_theme/adaptive_theme.dart";
 import "package:ente_auth/services/auth_theme_preferences.dart";
+import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:shared_preferences/shared_preferences.dart";
 import "package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart";
@@ -27,6 +28,34 @@ void main() {
 
   test("falls back to legacy adaptive theme preference", () async {
     await _setLegacyThemeMode(AdaptiveThemeMode.light);
+
+    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.light);
+  });
+
+  testWidgets("keeps Auth theme preference when adaptive value resets", (
+    tester,
+  ) async {
+    late BuildContext adaptiveThemeContext;
+    await tester.pumpWidget(
+      AdaptiveTheme(
+        light: ThemeData.light(),
+        dark: ThemeData.dark(),
+        initial: AdaptiveThemeMode.system,
+        builder: (_, _) => Builder(
+          builder: (context) {
+            adaptiveThemeContext = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    await AuthThemePreferences.setThemeMode(
+      AdaptiveTheme.of(adaptiveThemeContext),
+      AdaptiveThemeMode.light,
+    );
+    await _setAsyncThemeMode(AdaptiveThemeMode.system);
+    await _setLegacyThemeMode(AdaptiveThemeMode.system);
 
     expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.light);
   });

--- a/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
+++ b/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
@@ -1,12 +1,14 @@
 import "dart:convert";
 
-import "package:adaptive_theme/adaptive_theme.dart";
 import "package:ente_auth/services/auth_theme_preferences.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:shared_preferences/shared_preferences.dart";
 import "package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart";
 import "package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart";
+
+const _authThemeModeKey = "ente_auth_theme_mode";
+const _adaptiveThemePrefKey = "adaptive_theme_preferences";
 
 void main() {
   setUp(() {
@@ -16,65 +18,88 @@ void main() {
   });
 
   test("returns system when no theme preference exists", () async {
-    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.system);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.system);
   });
 
-  test("prefers adaptive theme async preference", () async {
-    await _setAsyncThemeMode(AdaptiveThemeMode.dark);
-    await _setLegacyThemeMode(AdaptiveThemeMode.light);
+  test("prefers Auth theme preference", () async {
+    await _setAuthThemeMode(ThemeMode.dark);
+    await _setAsyncThemeMode(ThemeMode.light);
+    await _setLegacyThemeMode(ThemeMode.light);
 
-    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.dark);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
   });
 
-  test("falls back to legacy adaptive theme preference", () async {
-    await _setLegacyThemeMode(AdaptiveThemeMode.light);
+  test("migrates adaptive theme async preference", () async {
+    await _setAsyncThemeMode(ThemeMode.dark);
+    await _setLegacyThemeMode(ThemeMode.light);
 
-    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.light);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
+    expect(await _getAuthThemeMode(), ThemeMode.dark);
   });
 
-  testWidgets("keeps Auth theme preference when adaptive value resets", (
-    tester,
-  ) async {
-    late BuildContext adaptiveThemeContext;
-    await tester.pumpWidget(
-      AdaptiveTheme(
-        light: ThemeData.light(),
-        dark: ThemeData.dark(),
-        initial: AdaptiveThemeMode.system,
-        builder: (_, _) => Builder(
-          builder: (context) {
-            adaptiveThemeContext = context;
-            return const SizedBox.shrink();
-          },
-        ),
-      ),
-    );
+  test("migrates legacy adaptive theme preference", () async {
+    await _setLegacyThemeMode(ThemeMode.light);
 
-    await AuthThemePreferences.setThemeMode(
-      AdaptiveTheme.of(adaptiveThemeContext),
-      AdaptiveThemeMode.light,
-    );
-    await _setAsyncThemeMode(AdaptiveThemeMode.system);
-    await _setLegacyThemeMode(AdaptiveThemeMode.system);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
+    expect(await _getAuthThemeMode(), ThemeMode.light);
+  });
 
-    expect(await AuthThemePreferences.getThemeMode(), AdaptiveThemeMode.light);
+  test("keeps Auth theme preference when adaptive value resets", () async {
+    await AuthThemePreferences.setThemeMode(ThemeMode.light);
+    await _setAsyncThemeMode(ThemeMode.system);
+    await _setLegacyThemeMode(ThemeMode.system);
+
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
   });
 }
 
-Future<void> _setAsyncThemeMode(AdaptiveThemeMode themeMode) async {
+Future<void> _setAuthThemeMode(ThemeMode themeMode) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setInt(_authThemeModeKey, _themeModeIndex(themeMode));
+}
+
+Future<ThemeMode?> _getAuthThemeMode() async {
+  final prefs = await SharedPreferences.getInstance();
+  return _themeModeFromIndex(prefs.getInt(_authThemeModeKey));
+}
+
+Future<void> _setAsyncThemeMode(ThemeMode themeMode) async {
   final prefs = SharedPreferencesAsync();
-  await prefs.setString(AdaptiveTheme.prefKey, _themeModeJson(themeMode));
+  await prefs.setString(_adaptiveThemePrefKey, _themeModeJson(themeMode));
 }
 
-Future<void> _setLegacyThemeMode(AdaptiveThemeMode themeMode) async {
-  SharedPreferences.setMockInitialValues({
-    AdaptiveTheme.prefKey: _themeModeJson(themeMode),
-  });
+Future<void> _setLegacyThemeMode(ThemeMode themeMode) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(_adaptiveThemePrefKey, _themeModeJson(themeMode));
 }
 
-String _themeModeJson(AdaptiveThemeMode themeMode) {
+String _themeModeJson(ThemeMode themeMode) {
   return json.encode({
-    "theme_mode": themeMode.index,
-    "default_theme_mode": AdaptiveThemeMode.system.index,
+    "theme_mode": _themeModeIndex(themeMode),
+    "default_theme_mode": _themeModeIndex(ThemeMode.system),
   });
+}
+
+ThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
+  switch (themeModeIndex) {
+    case 0:
+      return ThemeMode.light;
+    case 1:
+      return ThemeMode.dark;
+    case 2:
+      return ThemeMode.system;
+    default:
+      return null;
+  }
+}
+
+int _themeModeIndex(ThemeMode themeMode) {
+  switch (themeMode) {
+    case ThemeMode.light:
+      return 0;
+    case ThemeMode.dark:
+      return 1;
+    case ThemeMode.system:
+      return 2;
+  }
 }

--- a/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
+++ b/mobile/apps/auth/test/services/auth_theme_preferences_test.dart
@@ -21,85 +21,114 @@ void main() {
     expect(await AuthThemePreferences.getThemeMode(), ThemeMode.system);
   });
 
+  test("reads Auth theme preference using Flutter ThemeMode index", () async {
+    await _setAuthThemeModeIndex(ThemeMode.system.index);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.system);
+
+    await _setAuthThemeModeIndex(ThemeMode.light.index);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
+
+    await _setAuthThemeModeIndex(ThemeMode.dark.index);
+    expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
+  });
+
+  test(
+    "persists Auth theme preference using Flutter ThemeMode index",
+    () async {
+      await AuthThemePreferences.setThemeMode(ThemeMode.system);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.system.index);
+
+      await AuthThemePreferences.setThemeMode(ThemeMode.light);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.light.index);
+
+      await AuthThemePreferences.setThemeMode(ThemeMode.dark);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.dark.index);
+    },
+  );
+
   test("prefers Auth theme preference", () async {
-    await _setAuthThemeMode(ThemeMode.dark);
-    await _setAsyncThemeMode(ThemeMode.light);
-    await _setLegacyThemeMode(ThemeMode.light);
+    await _setAuthThemeModeIndex(ThemeMode.dark.index);
+    await _setAsyncAdaptiveThemeModeIndex(0);
+    await _setLegacyAdaptiveThemeModeIndex(0);
 
     expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
   });
 
   test("migrates adaptive theme async preference", () async {
-    await _setAsyncThemeMode(ThemeMode.dark);
-    await _setLegacyThemeMode(ThemeMode.light);
+    await _setAsyncAdaptiveThemeModeIndex(1);
+    await _setLegacyAdaptiveThemeModeIndex(0);
 
     expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
-    expect(await _getAuthThemeMode(), ThemeMode.dark);
+    expect(await _getAuthThemeModeIndex(), ThemeMode.dark.index);
   });
 
   test("migrates legacy adaptive theme preference", () async {
-    await _setLegacyThemeMode(ThemeMode.light);
+    await _setLegacyAdaptiveThemeModeIndex(0);
 
     expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
-    expect(await _getAuthThemeMode(), ThemeMode.light);
+    expect(await _getAuthThemeModeIndex(), ThemeMode.light.index);
   });
+
+  test(
+    "converts adaptive theme indices to Flutter ThemeMode indices",
+    () async {
+      await _setAsyncAdaptiveThemeModeIndex(0);
+      expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.light.index);
+
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      SharedPreferences.setMockInitialValues({});
+
+      await _setAsyncAdaptiveThemeModeIndex(1);
+      expect(await AuthThemePreferences.getThemeMode(), ThemeMode.dark);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.dark.index);
+
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      SharedPreferences.setMockInitialValues({});
+
+      await _setAsyncAdaptiveThemeModeIndex(2);
+      expect(await AuthThemePreferences.getThemeMode(), ThemeMode.system);
+      expect(await _getAuthThemeModeIndex(), ThemeMode.system.index);
+    },
+  );
 
   test("keeps Auth theme preference when adaptive value resets", () async {
     await AuthThemePreferences.setThemeMode(ThemeMode.light);
-    await _setAsyncThemeMode(ThemeMode.system);
-    await _setLegacyThemeMode(ThemeMode.system);
+    await _setAsyncAdaptiveThemeModeIndex(2);
+    await _setLegacyAdaptiveThemeModeIndex(2);
 
     expect(await AuthThemePreferences.getThemeMode(), ThemeMode.light);
   });
 }
 
-Future<void> _setAuthThemeMode(ThemeMode themeMode) async {
+Future<void> _setAuthThemeModeIndex(int themeModeIndex) async {
   final prefs = await SharedPreferences.getInstance();
-  await prefs.setInt(_authThemeModeKey, _themeModeIndex(themeMode));
+  await prefs.setInt(_authThemeModeKey, themeModeIndex);
 }
 
-Future<ThemeMode?> _getAuthThemeMode() async {
+Future<int?> _getAuthThemeModeIndex() async {
   final prefs = await SharedPreferences.getInstance();
-  return _themeModeFromIndex(prefs.getInt(_authThemeModeKey));
+  return prefs.getInt(_authThemeModeKey);
 }
 
-Future<void> _setAsyncThemeMode(ThemeMode themeMode) async {
+Future<void> _setAsyncAdaptiveThemeModeIndex(int themeModeIndex) async {
   final prefs = SharedPreferencesAsync();
-  await prefs.setString(_adaptiveThemePrefKey, _themeModeJson(themeMode));
+  await prefs.setString(
+    _adaptiveThemePrefKey,
+    _adaptiveThemeJson(themeModeIndex),
+  );
 }
 
-Future<void> _setLegacyThemeMode(ThemeMode themeMode) async {
+Future<void> _setLegacyAdaptiveThemeModeIndex(int themeModeIndex) async {
   final prefs = await SharedPreferences.getInstance();
-  await prefs.setString(_adaptiveThemePrefKey, _themeModeJson(themeMode));
+  await prefs.setString(
+    _adaptiveThemePrefKey,
+    _adaptiveThemeJson(themeModeIndex),
+  );
 }
 
-String _themeModeJson(ThemeMode themeMode) {
-  return json.encode({
-    "theme_mode": _themeModeIndex(themeMode),
-    "default_theme_mode": _themeModeIndex(ThemeMode.system),
-  });
-}
-
-ThemeMode? _themeModeFromIndex(Object? themeModeIndex) {
-  switch (themeModeIndex) {
-    case 0:
-      return ThemeMode.light;
-    case 1:
-      return ThemeMode.dark;
-    case 2:
-      return ThemeMode.system;
-    default:
-      return null;
-  }
-}
-
-int _themeModeIndex(ThemeMode themeMode) {
-  switch (themeMode) {
-    case ThemeMode.light:
-      return 0;
-    case ThemeMode.dark:
-      return 1;
-    case ThemeMode.system:
-      return 2;
-  }
+String _adaptiveThemeJson(int themeModeIndex) {
+  return json.encode({"theme_mode": themeModeIndex, "default_theme_mode": 2});
 }

--- a/mobile/packages/local_auth_linux/lib/local_auth_linux.dart
+++ b/mobile/packages/local_auth_linux/lib/local_auth_linux.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
 
 const MethodChannel _defaultChannel = MethodChannel('ente.io/local_auth_linux');
-const String linuxLocalAuthPolkitActionId = 'io.ente.auth.unlock';
+const String linuxLocalAuthPolkitActionId = 'com.ente.auth.unlock';
 
 class LinuxLocalAuthSetupStatus {
   const LinuxLocalAuthSetupStatus({
@@ -42,14 +42,14 @@ class LinuxLocalAuthSetupStatus {
       return '''
 app_id="\${FLATPAK_ID:-io.ente.auth}"
 install_dir="\$(flatpak info --show-location "\$app_id")"
-policy="\$install_dir/files/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy"
-sudo install -D -o root -g root -m 0644 "\$policy" /usr/share/polkit-1/actions/io.ente.auth.policy
-if command -v chcon >/dev/null 2>&1; then sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/io.ente.auth.policy || true; fi
+policy="\$install_dir/files/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy"
+sudo install -D -o root -g root -m 0644 "\$policy" /usr/share/polkit-1/actions/com.ente.auth.policy
+if command -v chcon >/dev/null 2>&1; then sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.ente.auth.policy || true; fi
 pkaction --action-id $actionId --verbose''';
     }
     return '''
-sudo install -D -o root -g root -m 0644 "$policyAssetPath" /usr/share/polkit-1/actions/io.ente.auth.policy
-if command -v chcon >/dev/null 2>&1; then sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/io.ente.auth.policy || true; fi
+sudo install -D -o root -g root -m 0644 "$policyAssetPath" /usr/share/polkit-1/actions/com.ente.auth.policy
+if command -v chcon >/dev/null 2>&1; then sudo chcon system_u:object_r:usr_t:s0 /usr/share/polkit-1/actions/com.ente.auth.policy || true; fi
 pkaction --action-id $actionId --verbose''';
   }
 }
@@ -59,8 +59,8 @@ bool get _isFlatpak =>
     File('/.flatpak-info').existsSync();
 
 String get _policyAssetPath => _isFlatpak
-    ? '/app/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy'
-    : '/usr/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy';
+    ? '/app/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy'
+    : '/usr/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy';
 
 class LocalAuthLinux extends LocalAuthPlatform {
   LocalAuthLinux({@visibleForTesting MethodChannel? channel})

--- a/mobile/packages/local_auth_linux/linux/local_auth_linux_plugin.cc
+++ b/mobile/packages/local_auth_linux/linux/local_auth_linux_plugin.cc
@@ -14,13 +14,13 @@ static constexpr const char* kPolkitAuthorityPath =
     "/org/freedesktop/PolicyKit1/Authority";
 static constexpr const char* kPolkitAuthorityInterface =
     "org.freedesktop.PolicyKit1.Authority";
-static constexpr const char* kPolkitActionId = "io.ente.auth.unlock";
+static constexpr const char* kPolkitActionId = "com.ente.auth.unlock";
 static constexpr const char* kPolicyAssetPath =
-    "/usr/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy";
+    "/usr/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy";
 static constexpr const char* kFlatpakPolicyAssetPath =
-    "/app/share/enteauth/data/flutter_assets/assets/polkit/io.ente.auth.policy";
+    "/app/share/enteauth/data/flutter_assets/assets/polkit/com.ente.auth.policy";
 static constexpr const char* kBundledPolicyAssetRelativePath =
-    "data/flutter_assets/assets/polkit/io.ente.auth.policy";
+    "data/flutter_assets/assets/polkit/com.ente.auth.policy";
 
 struct _LocalAuthLinuxPlugin {
   GObject parent_instance;


### PR DESCRIPTION
## Summary
- persist Auth theme selection under an Auth-owned key
- migrate existing AdaptiveTheme preferences
- remove AdaptiveTheme from Auth runtime

## Tests
- flutter analyze
- flutter test
- Docker Linux shared_preferences probe