### PR TITLE
[mobile] Fix album widget photo rotation

### DIFF
--- a/docs/docs/photos/features/utilities/home-widgets.md
+++ b/docs/docs/photos/features/utilities/home-widgets.md
@@ -92,10 +92,11 @@ Widgets sync photos from your Ente library to your device's widget storage:
 2. Thumbnails are rendered and cached locally (512px resolution)
 3. Up to 50 photos are cached per widget type
 4. Widgets read from this local cache to display photos
+5. The album widget cache is periodically rebuilt to rotate in more photos from your selected albums
 
 ### Automatic Refresh
 
-Widgets automatically refresh approximately every **15 minutes** to display new photos. The refresh happens in the background, so you'll see different photos throughout the day without any manual intervention.
+Widgets automatically refresh approximately every **15 minutes** from their local cache. For album widgets, the app periodically refreshes that cache so a broader set of selected album photos can appear over time.
 
 ### Tapping Widgets
 

--- a/mobile/apps/photos/changes/album-widget-cache-rotation.md
+++ b/mobile/apps/photos/changes/album-widget-cache-rotation.md
@@ -1,0 +1,1 @@
+- Fixed album widgets repeatedly showing the same cached photos from selected albums.

--- a/mobile/apps/photos/lib/services/album_home_widget_service.dart
+++ b/mobile/apps/photos/lib/services/album_home_widget_service.dart
@@ -26,6 +26,8 @@ import "package:photos/ui/viewer/file/detail_page.dart";
 import 'package:photos/ui/viewer/gallery/collection_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+enum _AlbumWidgetCacheUpdateReason { none, changed, stale }
+
 class AlbumHomeWidgetService {
   // Constants
   static const String SELECTED_ALBUMS_KEY = "selectedAlbumsHW";
@@ -34,8 +36,11 @@ class AlbumHomeWidgetService {
   static const String IOS_CLASS_NAME = "EnteAlbumWidget";
   static const String ALBUMS_CHANGED_KEY = "albumsChanged.widget";
   static const String ALBUMS_STATUS_KEY = "albumsStatusKey.widget";
+  static const String ALBUMS_LAST_CACHE_REFRESH_TIME_KEY =
+      "albumsLastCacheRefreshTime";
   static const String TOTAL_ALBUMS_KEY = "totalAlbums";
   static const int MAX_ALBUMS_LIMIT = 50;
+  static const Duration ALBUMS_CACHE_REFRESH_INTERVAL = Duration(hours: 24);
 
   // Singleton pattern
   static final AlbumHomeWidgetService instance =
@@ -104,10 +109,13 @@ class AlbumHomeWidgetService {
 
       _logger.info("Initializing albums widget");
 
-      final bool forceFetchNewAlbums = await _shouldUpdateWidgetCache();
+      final cacheUpdateReason = await _getWidgetCacheUpdateReason();
 
-      if (forceFetchNewAlbums) {
-        await _updateAlbumsWidgetCache();
+      if (cacheUpdateReason != _AlbumWidgetCacheUpdateReason.none) {
+        await _updateAlbumsWidgetCache(
+          isStaleRefresh:
+              cacheUpdateReason == _AlbumWidgetCacheUpdateReason.stale,
+        );
         await setSelectionChange(false);
         _logger.info("Force fetch new albums complete");
       } else {
@@ -123,6 +131,7 @@ class AlbumHomeWidgetService {
     }
 
     await setAlbumsLastHash("");
+    await _clearAlbumsLastCacheRefreshTime();
     await _setTotalAlbums(null);
     await updateAlbumsStatus(WidgetStatus.syncedEmpty);
     await _refreshWidget(message: "AlbumsHomeWidget cleared & updated");
@@ -294,7 +303,7 @@ class AlbumHomeWidgetService {
     }
 
     bool foundLegacyMetadata = false;
-    for (int index = 0; index <= totalAlbums; index++) {
+    for (int index = 0; index < totalAlbums; index++) {
       final metadata = await _getWidgetEntryMetadata(index);
       if (metadata == null) {
         continue;
@@ -356,15 +365,20 @@ class AlbumHomeWidgetService {
   }
 
   Future<bool> _shouldUpdateWidgetCache() async {
+    return await _getWidgetCacheUpdateReason() !=
+        _AlbumWidgetCacheUpdateReason.none;
+  }
+
+  Future<_AlbumWidgetCacheUpdateReason> _getWidgetCacheUpdateReason() async {
     // Check if albums changed flag is set
     if (hasSelectionChanged() == true) {
-      return true;
+      return _AlbumWidgetCacheUpdateReason.changed;
     }
 
     // Check if we have any albums selected
     final selectedAlbumIds = await _getEffectiveSelectedAlbumIds();
     if (selectedAlbumIds.isEmpty) {
-      return false;
+      return _AlbumWidgetCacheUpdateReason.none;
     }
 
     // Check if hash has changed
@@ -375,15 +389,50 @@ class AlbumHomeWidgetService {
       final saveStatus = getAlbumsStatus();
       switch (saveStatus) {
         case WidgetStatus.syncedPartially:
-          return await countHomeWidgets() > 0;
-        case WidgetStatus.syncedEmpty:
+          return await countHomeWidgets() > 0
+              ? _AlbumWidgetCacheUpdateReason.changed
+              : _AlbumWidgetCacheUpdateReason.none;
         case WidgetStatus.syncedAll:
-          return false;
+          return await _shouldRefreshStaleWidgetCache()
+              ? _AlbumWidgetCacheUpdateReason.stale
+              : _AlbumWidgetCacheUpdateReason.none;
+        case WidgetStatus.syncedEmpty:
+          return _AlbumWidgetCacheUpdateReason.none;
         default:
       }
     }
 
-    return true;
+    return _AlbumWidgetCacheUpdateReason.changed;
+  }
+
+  Future<bool> _shouldRefreshStaleWidgetCache() async {
+    if (await countHomeWidgets() == 0) {
+      return false;
+    }
+
+    final lastRefreshTime = _prefs.getInt(ALBUMS_LAST_CACHE_REFRESH_TIME_KEY);
+    if (lastRefreshTime == null || lastRefreshTime <= 0) {
+      return true;
+    }
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (lastRefreshTime > now) {
+      return false;
+    }
+
+    return now - lastRefreshTime >=
+        ALBUMS_CACHE_REFRESH_INTERVAL.inMilliseconds;
+  }
+
+  Future<void> _setAlbumsLastCacheRefreshTime() async {
+    await _prefs.setInt(
+      ALBUMS_LAST_CACHE_REFRESH_TIME_KEY,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  Future<void> _clearAlbumsLastCacheRefreshTime() async {
+    await _prefs.remove(ALBUMS_LAST_CACHE_REFRESH_TIME_KEY);
   }
 
   Future<List<int>> _getEffectiveSelectedAlbumIds([bool isBg = false]) async {
@@ -465,7 +514,7 @@ class AlbumHomeWidgetService {
     await HomeWidgetService.instance.setData(TOTAL_ALBUMS_KEY, total);
   }
 
-  Future<void> _updateAlbumsWidgetCache() async {
+  Future<void> _updateAlbumsWidgetCache({bool isStaleRefresh = false}) async {
     final selectedAlbumIds = await _getEffectiveSelectedAlbumIds();
     final albumsWithFiles = await _getAlbumsWithFiles();
 
@@ -558,6 +607,7 @@ class AlbumHomeWidgetService {
           return;
         }
 
+        renderedCount++;
         await _setTotalAlbums(renderedCount);
 
         // Show update toast after first item is rendered
@@ -566,7 +616,6 @@ class AlbumHomeWidgetService {
           await updateAlbumsStatus(WidgetStatus.syncedPartially);
         }
 
-        renderedCount++;
         attemptsCount++;
       } else {
         // Track failed renders to avoid retrying known-bad files
@@ -587,8 +636,14 @@ class AlbumHomeWidgetService {
     await setAlbumsLastHash(hash);
 
     if (renderedCount == 0) {
+      if (isStaleRefresh) {
+        await _setAlbumsLastCacheRefreshTime();
+        await updateAlbumsStatus(WidgetStatus.syncedAll);
+      }
       return;
     }
+
+    await _setAlbumsLastCacheRefreshTime();
 
     if (isWidgetPresent) {
       await updateAlbumsStatus(WidgetStatus.syncedAll);


### PR DESCRIPTION
## Summary
- Fix album widgets repeatedly recycling the same cached subset even when users selected albums containing many more photos.
- Periodically rebuild the album widget cache, fix cached count semantics, and keep failed stale refreshes throttled.
- Performance impact is bounded to the existing 50-thumbnail cache cap and at most one periodic rebuild per refresh interval when widgets are installed.

## Tests
- `dart format --output=none --set-exit-if-changed .` from `mobile/apps/photos`
- `flutter analyze lib/services/album_home_widget_service.dart` from `mobile/apps/photos`
- `npm ci` from `docs`
- `npm audit --audit-level=critical` from `docs`
- `npm run build` from `docs`
- `flutter analyze` from `mobile/apps/photos` fails on unrelated `lib/utils/delete_file_util.dart:276` missing localization getter
- `flutter test` from `mobile/apps/photos` fails on the same unrelated localization compile error