### PR TITLE
[infra] Warm lint caches nightly from main

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -120,7 +120,6 @@ jobs:
               with:
                   channel: "stable"
                   flutter-version: ${{ env.FLUTTER_VERSION }}
-                  cache: true
 
             - name: Generate strings localizations
               run: flutter gen-l10n
@@ -249,7 +248,6 @@ jobs:
               with:
                   channel: "stable"
                   flutter-version: ${{ env.FLUTTER_VERSION }}
-                  cache: true
 
             - name: Generate strings localizations
               run: flutter gen-l10n
@@ -368,7 +366,6 @@ jobs:
               with:
                   channel: "stable"
                   flutter-version: ${{ env.FLUTTER_VERSION }}
-                  cache: true
 
             - name: Generate strings localizations
               run: flutter gen-l10n

--- a/.github/workflows/locker-build.yml
+++ b/.github/workflows/locker-build.yml
@@ -119,7 +119,6 @@ jobs:
               with:
                   channel: "stable"
                   flutter-version: ${{ env.FLUTTER_VERSION }}
-                  cache: true
 
             - name: Generate strings localizations
               run: flutter gen-l10n

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -72,6 +72,14 @@ jobs:
                   flutter-version: ${{ env.FLUTTER_VERSION }}
                   cache: true
 
+            # Restore-only; primed on main by warm-caches.yml.
+            - name: Restore Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-flutter
+                  save-if: false
+
             - run: cargo codegen frb
               working-directory: rust
 

--- a/.github/workflows/photos-build.yml
+++ b/.github/workflows/photos-build.yml
@@ -119,7 +119,6 @@ jobs:
               with:
                   channel: "stable"
                   flutter-version: ${{ env.FLUTTER_VERSION }}
-                  cache: true
 
             - name: Set build version
               run: node ../../../.github/scripts/flutter-version.mjs photos set-build "${RELEASE_VERSION}" "${BUILD_NUMBER}"

--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -42,6 +42,14 @@ jobs:
               with:
                   node-version: 24
 
+            # Restore-only; primed on main by warm-caches.yml.
+            - name: Restore Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-cli
+                  save-if: false
+
             - name: Install PGlite test dependency
               run: npm ci --prefix tests/pglite
 

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -31,6 +31,14 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
+            # Restore-only; primed on main by warm-caches.yml.
+            - name: Restore Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-workspace
+                  save-if: false
+
             - run: cargo fmt --check
 
             - run: cargo clippy --all-targets --locked

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,157 @@
+name: "Warm caches"
+
+# Nightly priming of the caches used by the PR lint workflows.
+#
+# A PR run can only restore caches that were saved on the PR's own ref or on
+# main. The lint workflows never run on main, so anything they save is scoped
+# to their own PR and only churns the repository's shared 10 GB cache pool.
+# Instead, this workflow (which runs on main's ref) saves the caches, and the
+# lint workflows restore them without saving (save-if: false).
+#
+# Each job must mirror the commands, features and RUSTFLAGS of the workflow it
+# primes, otherwise the saved cache will not match what that workflow needs.
+
+on:
+    schedule:
+        - cron: "17 2 * * *"
+    # For bootstrapping the caches (dispatch on main, otherwise the caches get
+    # saved against the wrong ref).
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    rust-workspace:
+        # For rust-lint.yml.
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: rust
+        env:
+            RUSTFLAGS: -D warnings
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Install Linux dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+
+            - name: Setup Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-workspace
+
+            - run: cargo clippy --all-targets --locked
+
+            - run: cargo test --locked --workspace --no-run
+
+    rust-flutter:
+        # For the cargo steps of mobile-lint.yml.
+        runs-on: macos-26
+        defaults:
+            run:
+                working-directory: rust
+        steps:
+            - name: Checkout code and submodules
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  submodules: recursive
+
+            - name: Install Flutter
+              uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+              with:
+                  channel: "stable"
+                  flutter-version: "3.38.10" # Keep in sync with mobile-lint.yml
+                  cache: true
+
+            - name: Setup Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-flutter
+
+            - run: cargo codegen frb
+
+            - run: cargo clippy -p ente_photos_rust --features flutter --all-targets --locked -- -D warnings
+
+            - run: cargo clippy -p ente_rust --features flutter --all-targets --locked -- -D warnings
+
+    rust-wasm:
+        # For web-lint.yml's npm run build:wasm.
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: web
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Setup node
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 24
+                  cache: "npm"
+                  cache-dependency-path: "web/package-lock.json"
+
+            - name: Setup Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-wasm
+
+            - run: npm ci
+
+            - run: npm run build:wasm
+
+    rust-cli:
+        # For rust-e2e-test.yml's cli-integration job.
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: rust/apps/cli
+        env:
+            RUSTFLAGS: -D warnings
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Setup go
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+              with:
+                  go-version-file: server/go.mod
+                  cache: false
+
+            - name: Setup Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-cli
+
+            - run: cargo test --features museum,pglite --locked --no-run
+
+    go-server:
+        # For server-lint.yml.
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: server
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Setup go
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+              with:
+                  go-version-file: server/go.mod
+                  cache-dependency-path: server/go.sum
+                  cache: true
+
+            - name: Install dependencies
+              run: sudo apt-get update && sudo apt-get install libsodium-dev
+
+            - name: Lint
+              run: "./scripts/lint.sh"

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -37,6 +37,14 @@ jobs:
                   cache: "npm"
                   cache-dependency-path: "web/package-lock.json"
 
+            # Restore-only; primed on main by warm-caches.yml.
+            - name: Restore Rust cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  workspaces: rust
+                  shared-key: rust-wasm
+                  save-if: false
+
             - run: npm ci
 
             - run: npm audit --audit-level critical


### PR DESCRIPTION
PR caches are only restorable from main or the PR's own ref, and the lint workflows never run on main — so Rust builds were entirely uncached. Adds a nightly warm-caches workflow that primes cargo/Go caches on main; lint workflows restore them read-only. Also drops the Flutter SDK/pub caches for the non-macOS nightly build jobs to make room in the 10 GB pool.