### PR TITLE
Add web/desktop instructions for viewing shared albums

### DIFF
--- a/docs/docs/photos/features/sharing-and-collaboration/public-links.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/public-links.md
@@ -212,6 +212,11 @@ Learn more in the [Custom domains guide](/photos/features/sharing-and-collaborat
 - Go to the Sharing tab (bottom navigation)
 - See "Shared albums" and "Quick links" sections
 
+**On web/desktop:**
+
+- Shared albums appear in your album list
+- They're marked with a sharing icon
+
 ### Edit link settings
 
 1. Find the link in your sharing list


### PR DESCRIPTION
## Description

Added clarification to the public links documentation explaining how shared albums appear on web/desktop platforms. This complements the existing mobile-specific instructions by documenting that shared albums appear in the album list with a sharing icon indicator.

## Tests

N/A - Documentation only change

https://claude.ai/code/session_01FPeuPY6poWK7cDkfDLdcD1