### PR TITLE
[mob][photos] New translation strings + fixed missing translation links

### DIFF
--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -1120,5 +1120,6 @@
     }
   },
   "sendFeedback": "Send feedback",
-  "deleteAccountPermanentWarning": "This will permanently delete your Ente Auth, Photos, and Locker data"
+  "deleteAccountPermanentWarning": "This will permanently delete your Ente Auth, Photos, and Locker data",
+  "addItem": "Add item"
 }

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -695,7 +695,7 @@ class _HomePageState extends UploaderPageState<HomePage>
                             return const SizedBox.shrink();
                           }
                           return FloatingActionButton(
-                            tooltip: 'Add item',
+                            tooltip: context.l10n.addItem,
                             onPressed: _openSavePage,
                             shape: const CircleBorder(),
                             backgroundColor: colorScheme.primary700,

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1621,9 +1621,9 @@
   "@storageBreakupYou": {
     "description": "Label to indicate how much storage you are using when you are part of a family plan"
   },
-  "storageUsageInfo": "{usedAmount} {usedStorageUnit} of {totalAmount} {totalStorageUnit} used",
+  "storageUsageInfo": "{usedAmount} {usedStorageUnit} <muted>of</muted> {totalAmount} {totalStorageUnit} used",
   "@storageUsageInfo": {
-    "description": "Example: 1.2 GB of 2 GB used or 100 GB or 2TB used"
+    "description": "Example: 1.2 GB of 2 GB used or 100 GB or 2TB used. Part between <muted> and </muted> will be shown in a slightly different color."
   },
   "availableStorageSpace": "{freeAmount} {storageUnit} free",
   "appVersion": "Version {versionValue}",
@@ -3217,5 +3217,21 @@
   "archiveCollectionName": "Archive",
   "@archiveCollectionName": {
     "description": "Name of the 'Archive' collection"
+  },
+  "startNewRitual": "Start new ritual",
+  "@startNewRitual": {
+    "description": "Title of the placeholder section shown when no ritual has been created. Should be short."
+  },
+  "createRitualBuildStreaksShareProgress": "Create a ritual, build streaks, and share your progress.",
+  "@createRitualBuildStreaksShareProgress": {
+    "description": "Content of the placeholder section shown when no ritual has been created."
+  },
+  "waitingForNetwork: "Waiting for network...",
+  "@waitingForNetwork": {
+    "description": "Sync status shown when uploads are pending and no network is available."
+  },
+  "sharePreparing": "Preparing...",
+  "@sharePreparing": {
+    "description": "Message shown while files are being prepared for sharing."
   }
 }

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -3226,7 +3226,7 @@
   "@createRitualBuildStreaksShareProgress": {
     "description": "Content of the placeholder section shown when no ritual has been created."
   },
-  "waitingForNetwork: "Waiting for network...",
+  "waitingForNetwork": "Waiting for network...",
   "@waitingForNetwork": {
     "description": "Sync status shown when uploads are pending and no network is available."
   },

--- a/mobile/apps/photos/lib/services/sync/sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/sync_service.dart
@@ -121,8 +121,9 @@ class SyncService {
       successful = true;
     } on WiFiUnavailableError {
       _logger.warning("Not uploading over mobile data");
+      final s = await LanguageService.locals;
       Bus.instance.fire(
-        SyncStatusUpdate(SyncStatus.paused, reason: "Waiting for WiFi..."),
+        SyncStatusUpdate(SyncStatus.paused, reason: s.waitingForWiFi),
       );
     } on SyncStopRequestedError {
       _syncStopRequested = false;
@@ -153,10 +154,11 @@ class SyncService {
             e.type == DioExceptionType.receiveTimeout ||
             e.type == DioExceptionType.connectionError ||
             e.type == DioExceptionType.unknown) {
+          final s = await LanguageService.locals;
           Bus.instance.fire(
             SyncStatusUpdate(
               SyncStatus.paused,
-              reason: "Waiting for network...",
+              reason: s.waitingForNetwork,
             ),
           );
           _logger.severe("unable to connect", e, StackTrace.current);

--- a/mobile/apps/photos/lib/ui/account/login_page.dart
+++ b/mobile/apps/photos/lib/ui/account/login_page.dart
@@ -149,7 +149,7 @@ class _LoginPageState extends State<LoginPage> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text("Don't have an account?", style: textTheme.bodyMuted),
+            Text(AppLocalizations.of(context).dontHaveAnAccount, style: textTheme.bodyMuted),
             ButtonWidgetV2(
               buttonType: ButtonTypeV2.link,
               labelText: AppLocalizations.of(context).signUp,

--- a/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
+++ b/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
@@ -177,7 +177,7 @@ class StartNewRitualCard extends StatelessWidget {
                                   const SizedBox(width: 10),
                                   Expanded(
                                     child: Text(
-                                      "Start new ritual",
+                                      context.l10n.startNewRitual,
                                       style: textTheme.body,
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
@@ -189,7 +189,7 @@ class StartNewRitualCard extends StatelessWidget {
                               ),
                               const SizedBox(height: 3),
                               Text(
-                                "Create a ritual, build streaks, and share your progress.",
+                                context.l10n.createRitualBuildStreaksShareProgress,
                                 style: textTheme.miniMuted,
                                 maxLines: 3,
                                 overflow: TextOverflow.ellipsis,

--- a/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
+++ b/mobile/apps/photos/lib/ui/rituals/start_new_ritual_card.dart
@@ -5,6 +5,7 @@ import "package:ente_components/ente_components.dart";
 import "package:ente_icons/ente_icons.dart";
 import "package:flutter/material.dart";
 import "package:flutter_svg/flutter_svg.dart";
+import "package:photos/l10n/l10n.dart";
 import "package:photos/theme/ente_theme.dart";
 
 enum StartNewRitualCardVariant { compact, wide }
@@ -89,7 +90,7 @@ class StartNewRitualCard extends StatelessWidget {
 
                       final titlePainter = TextPainter(
                         text: TextSpan(
-                          text: "Start new ritual",
+                          text: context.l10n.startNewRitual,
                           style: textTheme.body,
                         ),
                         maxLines: 1,
@@ -103,7 +104,7 @@ class StartNewRitualCard extends StatelessWidget {
                       final subtitlePainter = TextPainter(
                         text: TextSpan(
                           text:
-                              "Create a ritual, build streaks, and share your progress.",
+                              context.l10n.createRitualBuildStreaksShareProgress,
                           style: textTheme.miniMuted,
                         ),
                         maxLines: 3,

--- a/mobile/apps/photos/lib/ui/settings/storage_card_widget.dart
+++ b/mobile/apps/photos/lib/ui/settings/storage_card_widget.dart
@@ -11,6 +11,8 @@ import 'package:photos/theme/colors.dart';
 import "package:photos/ui/common/loading_widget.dart";
 import 'package:photos/ui/payment/subscription.dart';
 import 'package:photos/ui/settings/storage_progress_widget.dart';
+import 'package:styled_text/tags/styled_text_tag.dart';
+import 'package:styled_text/widgets/styled_text.dart';
 
 class StorageCardWidget extends StatefulWidget {
   const StorageCardWidget({super.key});
@@ -317,13 +319,18 @@ class _StorageCardWidgetState extends State<StorageCardWidget> {
       totalStorageUnit = "GB";
     }
 
-    return [
-      TextSpan(text: '$currentUsage $currentUsageUnit  '),
-      const TextSpan(
-        text: 'of',
-        style: TextStyle(color: textMutedDark),
+    return StyledText(
+      text: context.l10n.storageUsageInfo(
+        currentUsage,
+        currentUsageUnit,
+        totalStorage,
+        totalStorageUnit,
       ),
-      TextSpan(text: '  $totalStorage $totalStorageUnit used'),
-    ];
+      tags: {
+        'muted': StyledTextTag(
+          style: const TextStyle(color: textMutedDark),
+        ),
+      },
+    );
   }
 }

--- a/mobile/apps/photos/lib/utils/share_util.dart
+++ b/mobile/apps/photos/lib/utils/share_util.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart';
 import "package:photo_manager/photo_manager.dart";
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/constants.dart';
+import "package:photos/l10n/l10n.dart";
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import 'package:photos/utils/dialog_util.dart';
@@ -28,7 +29,7 @@ Future<void> share(
   final remoteFileCount = files.where((element) => element.isRemoteFile).length;
   final dialog = createProgressDialog(
     context,
-    "Preparing...",
+    context.l10n.sharePreparing,
     isDismissible: remoteFileCount > 2,
   );
   await dialog.show();


### PR DESCRIPTION
## Description
In this PR, I have : 
- Created new translation strings for english texts that were still hardcoded
- Adapted part of the code to make use of existing translation strings not yet used (missing link)

I followed instructions in [translations.md](https://github.com/ente-io/ente/blob/main/mobile/apps/photos/docs/translations.md) document.

I also made sure to use the build context when available. For one file where build context is not available, I followed the existing pattern of `final s = await LanguageService.locals;`.

PS: I also fixed a Locker translation string "by mistake".

## Tests
Ran `flutter gen-l10n` succesfully.