### PR TITLE
[Docs] Adapt Polkit policy installation instructions for immutable distros

### DIFF
--- a/docs/docs/auth/troubleshooting/linux-system-auth.md
+++ b/docs/docs/auth/troubleshooting/linux-system-auth.md
@@ -33,6 +33,10 @@ Flatpak apps cannot install host Polkit policies by themselves, and AppImage or
 manual builds may also need manual setup. Download the policy from GitHub and
 verify its SHA-256 checksum before installing it:
 
+The script automatically selects the correct install path: `/usr/share/polkit-1/actions/`
+on traditional distros, or `/etc/polkit-1/actions/` on immutable distros (such as
+Fedora Atomic, Universal Blue, or similar) where `/usr/share` is read-only.
+
 ```sh
 policy_url="https://raw.githubusercontent.com/ente-io/ente/main/mobile/apps/auth/assets/polkit/com.ente.auth.policy"
 policy_sha256="efba0409db9a0a53196fa8a7c9f4d4e874234b48287eb5242cf399f466e4c695"
@@ -40,30 +44,41 @@ policy="$(mktemp)"
 
 if curl -fsSL "$policy_url" -o "$policy" &&
   printf "%s  %s\n" "$policy_sha256" "$policy" | sha256sum -c -; then
-  sudo install -D -o root -g root -m 0644 \
-    "$policy" \
-    /usr/share/polkit-1/actions/com.ente.auth.policy
-
-  if command -v chcon >/dev/null 2>&1; then
-    sudo chcon system_u:object_r:usr_t:s0 \
-      /usr/share/polkit-1/actions/com.ente.auth.policy || true
+ 
+  # Use /etc on immutable distros, /usr/share on traditional ones
+  if [ -w /usr/share/polkit-1/actions ]; then
+    install_path="/usr/share/polkit-1/actions/com.ente.auth.policy"
+  else
+    install_path="/etc/polkit-1/actions/com.ente.auth.policy"
   fi
-
+ 
+  sudo install -D -o root -g root -m 0644 "$policy" "$install_path"
+ 
+  if command -v restorecon >/dev/null 2>&1; then
+    sudo restorecon -v "$install_path" || true
+  fi
+ 
+  # Give polkit time to pick up the new action via inotify
+  sleep 1
+ 
   pkaction --action-id com.ente.auth.unlock --verbose
 else
   echo "Policy download or checksum verification failed. Not installing."
 fi
-
+ 
 rm -f "$policy"
 ```
 
 ### Remove the Policy
 
 If you manually installed the Polkit policy and no longer want Ente Auth to use
-Linux system authentication, remove it:
+Linux system authentication, remove it from whichever path was used during install:
 
 ```sh
 sudo rm -f /usr/share/polkit-1/actions/com.ente.auth.policy
+# or, on immutable distros:
+sudo rm -f /etc/polkit-1/actions/com.ente.auth.policy
+
 ```
 
 ## Fingerprint Prompts

--- a/docs/docs/auth/troubleshooting/linux-system-auth.md
+++ b/docs/docs/auth/troubleshooting/linux-system-auth.md
@@ -45,11 +45,11 @@ policy="$(mktemp)"
 if curl -fsSL "$policy_url" -o "$policy" &&
   printf "%s  %s\n" "$policy_sha256" "$policy" | sha256sum -c -; then
  
-  # Use /etc on immutable distros, /usr/share on traditional ones
-  if [ -w /usr/share/polkit-1/actions ]; then
-    install_path="/usr/share/polkit-1/actions/com.ente.auth.policy"
+  # Use /etc on immutable distros (read-only /usr), /usr/share on traditional ones
+  if findmnt -n -o OPTIONS --target /usr/share/polkit-1/actions 2>/dev/null | grep -qw ro; then
+     install_path="/etc/polkit-1/actions/com.ente.auth.policy"
   else
-    install_path="/etc/polkit-1/actions/com.ente.auth.policy"
+     install_path="/usr/share/polkit-1/actions/com.ente.auth.policy"
   fi
  
   sudo install -D -o root -g root -m 0644 "$policy" "$install_path"


### PR DESCRIPTION
Update installation instructions for Polkit policy on Linux systems to handle both traditional and immutable distros.

## Description
Updates the manual Polkit policy setup script to work correctly on immutable distributions (Fedora Atomic, Universal Blue, Bluefin, etc.) where `/usr/share` is read-only.

Changes:
- Auto-detect install path: `/usr/share/polkit-1/actions/` on traditional distros, `/etc/polkit-1/actions/` on immutable ones
- Replace `chcon` with `restorecon` to apply the correct SELinux context regardless of install path
- Add `sleep 1` before `pkaction` verification to avoid a race with polkit's inotify watcher
- Update the removal instructions to cover both paths

## Tests

Tested on Bluefin Version: 44.20260609 and ente-auth flatpak v4.4.23