### PR TITLE
docs: fix port number for locker

### DIFF
--- a/docs/docs/self-hosting/installation/env-var.md
+++ b/docs/docs/self-hosting/installation/env-var.md
@@ -42,9 +42,10 @@ If you are using `quickstart.sh`, note that only `3000` (Photos) and `3002` (Alb
 | Ente Albums                                              | Web      | 3002      | 3002           |
 | [Ente Auth](https://ente.com/auth/)                      | Web      | 3003      | 3003           |
 | [Ente Cast](https://ente.com/help/photos/features/cast/) | Web      | 3004      | 3004           |
+| Ente Public Locker                                       | Web      | 3005      | 3005           |
 | Ente Embed                                               | Web      | 3006      | 3006           |
 | Ente Paste (if deployed separately)                      | Web      | 3008      | 3008           |
-| Ente Public Locker                                       | Web      | 3009      | 3009           |
+| Ente Locker                                              | Web      | 3009      | 3009           |
 | Ente Memories                                            | Web      | 3010      | 3010           |
 | MinIO                                                    | S3       | 3200      | 3200           |
 | PostgreSQL                                               | Database |           | 5432           |

--- a/docs/docs/self-hosting/installation/env-var.md
+++ b/docs/docs/self-hosting/installation/env-var.md
@@ -42,9 +42,9 @@ If you are using `quickstart.sh`, note that only `3000` (Photos) and `3002` (Alb
 | Ente Albums                                              | Web      | 3002      | 3002           |
 | [Ente Auth](https://ente.com/auth/)                      | Web      | 3003      | 3003           |
 | [Ente Cast](https://ente.com/help/photos/features/cast/) | Web      | 3004      | 3004           |
-| Ente Public Locker                                       | Web      | 3005      | 3005           |
 | Ente Embed                                               | Web      | 3006      | 3006           |
 | Ente Paste (if deployed separately)                      | Web      | 3008      | 3008           |
+| Ente Public Locker                                       | Web      | 3009      | 3009           |
 | Ente Memories                                            | Web      | 3010      | 3010           |
 | MinIO                                                    | S3       | 3200      | 3200           |
 | PostgreSQL                                               | Database |           | 5432           |


### PR DESCRIPTION
## Description

The documentation lists the incorrect port used by Locker. Based on the current configuration it should be 3009 instead of 3005. The actual port used can be found in web/Dockerfile config.
