### PR TITLE
[mobile][auth] Fix compact code list overlap with add button

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1739,7 +1739,9 @@ class _HomePageState extends State<HomePage> {
     final crossAxisCount = _calculateGridColumnCount(context);
     _currentGridColumns = crossAxisCount;
     final double keyboardInset = MediaQuery.of(context).viewInsets.bottom;
-    final double gridBottomPadding = 80 + (_showSearchBox ? keyboardInset : 0);
+    final double bottomSafeArea = MediaQuery.of(context).padding.bottom;
+    final double gridBottomPadding =
+        80 + bottomSafeArea + (_showSearchBox ? keyboardInset : 0);
     if (_hasLoaded) {
       final bool noCodesAnywhere = !hasNonTrashedCodes && !hasTrashedCodes;
       if (_filteredCodes.isEmpty && _searchText.isEmpty && noCodesAnywhere) {


### PR DESCRIPTION
Fixes #4443

Adds the iOS bottom safe-area inset to the Auth home grid bottom padding so the last compact-mode code row can scroll above the floating add button.