### PR TITLE
[server] Preserve public magic metadata on file copy

### DIFF
--- a/server/pkg/controller/file_copy/file_copy.go
+++ b/server/pkg/controller/file_copy/file_copy.go
@@ -56,6 +56,7 @@ func (fci fileCopyInternal) newFile(ownedID int64) ente.File {
 		File:               newFileAttributes,
 		Thumbnail:          newThumbAttributes,
 		Metadata:           fci.SourceFile.Metadata,
+		PubicMagicMetadata: fci.SourceFile.PubicMagicMetadata,
 		UpdationTime:       enteTime.Microseconds(),
 		IsDeleted:          false,
 	}


### PR DESCRIPTION
## Issue

Copying files through /files/copy created a new file row with the encrypted file metadata, thumbnail metadata, and object references, but it did not carry over public magic metadata from the source file.

That meant metadata stored in pubMagicMetadata, such as uploader display information and client-side public metadata fields, was silently dropped when a user copied files from a shared album into an album they own.

## Fix

When building the copied file record, also copy SourceFile.PubicMagicMetadata into the new file.

The server treats this field as an encrypted blob, so the safest behavior for file copy is to preserve it byte-for-byte alongside the existing metadata copy behavior.

## Validation

- go test ./pkg/controller/file_copy
- Manually verified against local server/database that copied file rows now preserve pub_magic_metadata from source files.