### PR TITLE
[mobile] Enable Sentry ANR capture on Android

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -251,6 +251,8 @@ class SuperLogging {
       await SentryFlutter.init(
         (options) {
           options.dsn = appConfig!.sentryDsn;
+          options.anrEnabled = true;
+          options.anrTimeoutInterval = const Duration(seconds: 5);
           options.httpClient = http.Client();
           if (appConfig.tunnel != null) {
             options.transport = TunneledTransport(

--- a/mobile/packages/logging/lib/super_logging.dart
+++ b/mobile/packages/logging/lib/super_logging.dart
@@ -201,6 +201,8 @@ class SuperLogging {
 
     if (enable && sentryIsEnabled) {
       await SentryFlutter.init((options) {
+        options.anrEnabled = true;
+        options.anrTimeoutInterval = const Duration(seconds: 5);
         options.dsn = appConfig!.sentryDsn;
         options.httpClient = http.Client();
         if (appConfig.tunnel != null) {


### PR DESCRIPTION
Enable Android ANR (Application Not Responding) reporting in Sentry via anrEnabled + a 5s timeout, across Photos, Auth, and Locker.