### PR TITLE
[mobile][auth] Bundle libffi in AppImage

### DIFF
--- a/mobile/apps/auth/changes/linux-appimage-libffi.md
+++ b/mobile/apps/auth/changes/linux-appimage-libffi.md
@@ -1,0 +1,1 @@
+- Fixed Auth AppImage startup on Linux systems where bundled dependencies could not find libffi.

--- a/mobile/apps/auth/linux/packaging/appimage/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/appimage/make_config.yaml
@@ -23,10 +23,9 @@ startup_wm_class: io.ente.auth
 # flutter_distributor automatically detects the shared libraries that your app
 # depends on, but you can also specify them manually here.
 #
-# The following example shows how to bundle the libcurl library with your app.
-#
-# include:
-#   - libcurl.so.4
+# Bundled libp11-kit from the Ubuntu build depends on libffi.so.8.
+include:
+  - libffi.so.8
 
 supported_mime_type:
   - x-scheme-handler/enteauth


### PR DESCRIPTION
## Summary

Bundle `libffi.so.8` in the Auth AppImage so bundled Linux dependencies can load on distros that do not ship that ABI.

Refs #2552