### PR TITLE
[mobile][auth] Fix QR scanner black screens

### DIFF
--- a/mobile/apps/auth/changes/qr-scanner-ios-black-screen.md
+++ b/mobile/apps/auth/changes/qr-scanner-ios-black-screen.md
@@ -1,0 +1,1 @@
+- Fixed QR scanner black screens when adding codes.

--- a/mobile/apps/auth/ios/Podfile.lock
+++ b/mobile/apps/auth/ios/Podfile.lock
@@ -68,14 +68,12 @@ PODS:
     - FlutterMacOS
   - move_to_background (0.0.1):
     - Flutter
-  - MTBBarcodeScanner (5.0.11)
   - package_info_plus (0.4.5):
     - Flutter
   - privacy_screen (0.0.1):
     - Flutter
-  - qr_code_scanner (0.2.0):
+  - qr_code_scanner_plus (0.2.6):
     - Flutter
-    - MTBBarcodeScanner
   - scoped_dir_access (1.0.0):
     - Flutter
   - SDWebImage (5.21.5):
@@ -146,7 +144,7 @@ DEPENDENCIES:
   - move_to_background (from `.symlinks/plugins/move_to_background/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - privacy_screen (from `.symlinks/plugins/privacy_screen/ios`)
-  - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
+  - qr_code_scanner_plus (from `.symlinks/plugins/qr_code_scanner_plus/ios`)
   - scoped_dir_access (from `.symlinks/plugins/scoped_dir_access/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -161,7 +159,6 @@ SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
-    - MTBBarcodeScanner
     - SDWebImage
     - Sentry
     - sqlite3
@@ -208,8 +205,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   privacy_screen:
     :path: ".symlinks/plugins/privacy_screen/ios"
-  qr_code_scanner:
-    :path: ".symlinks/plugins/qr_code_scanner/ios"
+  qr_code_scanner_plus:
+    :path: ".symlinks/plugins/qr_code_scanner_plus/ios"
   scoped_dir_access:
     :path: ".symlinks/plugins/scoped_dir_access/ios"
   sentry_flutter:
@@ -250,10 +247,9 @@ SPEC CHECKSUMS:
   launcher_icon_switcher: 84c218d233505aa7d8655d8fa61a3ba802c022da
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   move_to_background: 7e3467dd2a1d1013e98c9c1cb93fd53cd7ef9d84
-  MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   privacy_screen: 3159a541f5d3a31bea916cfd4e58f9dc722b3fd4
-  qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
+  qr_code_scanner_plus: 1fb59fd4576edb53ec7560c3746f454dee54300c
   scoped_dir_access: 4a89af7a2435a101b0cff856d6b6e7021df676de
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854

--- a/mobile/apps/auth/lib/ui/components/scanner_camera_view.dart
+++ b/mobile/apps/auth/lib/ui/components/scanner_camera_view.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
+
+class ScannerCameraView extends StatefulWidget {
+  const ScannerCameraView({
+    required this.qrKey,
+    required this.onQRViewCreated,
+    required this.formatsAllowed,
+    this.overlay,
+    super.key,
+  });
+
+  final GlobalKey qrKey;
+  final QRViewCreatedCallback onQRViewCreated;
+  final List<BarcodeFormat> formatsAllowed;
+  final QrScannerOverlayShape? overlay;
+
+  @override
+  State<ScannerCameraView> createState() => _ScannerCameraViewState();
+}
+
+class _ScannerCameraViewState extends State<ScannerCameraView> {
+  late final Future<bool> _isCameraScannerAvailable =
+      _isCameraScannerAvailableOnDevice();
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isIOS) {
+      return _buildQRView();
+    }
+
+    return FutureBuilder<bool>(
+      future: _isCameraScannerAvailable,
+      builder: (context, snapshot) {
+        if (snapshot.data == true) {
+          return _buildQRView();
+        }
+        return const ColoredBox(color: Colors.black);
+      },
+    );
+  }
+
+  Widget _buildQRView() {
+    return QRView(
+      key: widget.qrKey,
+      overlay: widget.overlay,
+      onQRViewCreated: widget.onQRViewCreated,
+      formatsAllowed: widget.formatsAllowed,
+    );
+  }
+}
+
+Future<bool> _isCameraScannerAvailableOnDevice() async {
+  if (!Platform.isIOS) {
+    return true;
+  }
+
+  try {
+    final iosInfo = await DeviceInfoPlugin().iosInfo;
+    return iosInfo.isPhysicalDevice;
+  } catch (_) {
+    return true;
+  }
+}

--- a/mobile/apps/auth/lib/ui/scanner_gauth_page.dart
+++ b/mobile/apps/auth/lib/ui/scanner_gauth_page.dart
@@ -1,12 +1,14 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
+import 'package:ente_auth/ui/components/scanner_camera_view.dart';
 import 'package:ente_auth/ui/settings/data/import/google_auth_import.dart';
 import 'package:ente_auth/utils/toast_util.dart';
 import 'package:flutter/material.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
 
 class ScannerGoogleAuthPage extends StatefulWidget {
   const ScannerGoogleAuthPage({super.key});
@@ -18,7 +20,9 @@ class ScannerGoogleAuthPage extends StatefulWidget {
 class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
   QRViewController? controller;
+  StreamSubscription<Barcode>? _scanSubscription;
   String? totp;
+  bool _hasCompletedScan = false;
 
   // In order to get hot reload to work we need to pause the camera if the platform
   // is android, or resume the camera if the platform is iOS.
@@ -26,9 +30,9 @@ class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
   void reassemble() {
     super.reassemble();
     if (Platform.isAndroid) {
-      controller!.pauseCamera();
+      unawaited(controller?.pauseCamera());
     } else if (Platform.isIOS) {
-      controller!.resumeCamera();
+      unawaited(controller?.resumeCamera());
     }
   }
 
@@ -41,8 +45,8 @@ class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
         children: <Widget>[
           Expanded(
             flex: 5,
-            child: QRView(
-              key: qrKey,
+            child: ScannerCameraView(
+              qrKey: qrKey,
               overlay: QrScannerOverlayShape(
                 borderColor: getEnteColorScheme(context).primary700,
               ),
@@ -63,34 +67,74 @@ class ScannerGoogleAuthPageState extends State<ScannerGoogleAuthPage> {
 
   void _onQRViewCreated(QRViewController controller) {
     this.controller = controller;
-    // h4ck to remove black screen on Android scanners: https://github.com/juliuscanute/qr_code_scanner/issues/560#issuecomment-1159611301
+    // Retain the Android camera restart workaround for scanner black screens.
     if (Platform.isAndroid) {
-      controller.pauseCamera();
-      controller.resumeCamera();
+      unawaited(controller.pauseCamera());
+      unawaited(controller.resumeCamera());
     }
-    controller.scannedDataStream.listen((scanData) {
-      try {
-        if (scanData.code == null) {
-          return;
-        }
-        if (scanData.code!.startsWith(kGoogleAuthExportPrefix)) {
-          List<Code> codes = parseGoogleAuth(scanData.code!);
-          controller.dispose();
-          Navigator.of(context).pop(codes);
-        } else {
-          showToast(context, "Invalid QR code");
-        }
-      } catch (e) {
-        controller.dispose();
-        Navigator.of(context).pop();
-        showToast(context, "Error $e");
+    _cancelScanSubscription();
+    _scanSubscription = controller.scannedDataStream.listen(_handleScanData);
+  }
+
+  void _handleScanData(Barcode scanData) {
+    if (_hasCompletedScan) {
+      return;
+    }
+
+    final qrCode = scanData.code;
+    if (qrCode == null) {
+      return;
+    }
+
+    if (!qrCode.startsWith(kGoogleAuthExportPrefix)) {
+      if (mounted) {
+        showToast(context, "Invalid QR code");
       }
-    });
+      return;
+    }
+
+    try {
+      final codes = parseGoogleAuth(qrCode);
+      _completeWithCodes(codes);
+    } catch (e) {
+      _completeWithError(e);
+    }
+  }
+
+  void _completeWithCodes(List<Code> codes) {
+    if (_hasCompletedScan) {
+      return;
+    }
+    _hasCompletedScan = true;
+    _cancelScanSubscription();
+    if (!mounted) {
+      return;
+    }
+    Navigator.of(context).pop(codes);
+  }
+
+  void _completeWithError(Object error) {
+    if (_hasCompletedScan) {
+      return;
+    }
+    _hasCompletedScan = true;
+    _cancelScanSubscription();
+    if (!mounted) {
+      return;
+    }
+    Navigator.of(context).pop();
+    showToast(context, "Error $error");
+  }
+
+  void _cancelScanSubscription() {
+    final scanSubscription = _scanSubscription;
+    _scanSubscription = null;
+    unawaited(scanSubscription?.cancel());
   }
 
   @override
   void dispose() {
-    controller?.dispose();
+    _cancelScanSubscription();
     super.dispose();
   }
 }

--- a/mobile/apps/auth/lib/ui/scanner_page.dart
+++ b/mobile/apps/auth/lib/ui/scanner_page.dart
@@ -1,14 +1,16 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/ui/components/buttons/icon_button_widget.dart';
+import 'package:ente_auth/ui/components/scanner_camera_view.dart';
 import 'package:ente_auth/utils/gallery_import_util.dart';
 import 'package:ente_auth/utils/toast_util.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
 
 class ScannerPageResult {
   final Code code;
@@ -28,8 +30,10 @@ class ScannerPageState extends State<ScannerPage> {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
   final Logger _logger = Logger('ScannerPage');
   QRViewController? controller;
+  StreamSubscription<Barcode>? _scanSubscription;
   String? totp;
   bool _isImportingFromGallery = false;
+  bool _hasCompletedScan = false;
 
   // In order to get hot reload to work we need to pause the camera if the platform
   // is android, or resume the camera if the platform is iOS.
@@ -37,9 +41,9 @@ class ScannerPageState extends State<ScannerPage> {
   void reassemble() {
     super.reassemble();
     if (Platform.isAndroid) {
-      controller!.pauseCamera();
+      unawaited(controller?.pauseCamera());
     } else if (Platform.isIOS) {
-      controller!.resumeCamera();
+      unawaited(controller?.resumeCamera());
     }
   }
 
@@ -62,61 +66,67 @@ class ScannerPageState extends State<ScannerPage> {
         children: <Widget>[
           Expanded(
             flex: 5,
-            child: QRView(
-              key: qrKey,
+            child: ScannerCameraView(
+              qrKey: qrKey,
               onQRViewCreated: _onQRViewCreated,
               formatsAllowed: const [BarcodeFormat.qrcode],
             ),
           ),
           Expanded(
             flex: 1,
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-                child: showGalleryImport
-                    ? Row(
-                        children: [
-                          Expanded(
-                            child: totp != null
-                                ? Text(
-                                    totp!,
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.titleMedium,
-                                  )
-                                : const SizedBox.shrink(),
-                          ),
-                          Semantics(
-                            button: true,
-                            label: l10n.importFromGallery,
-                            child: Opacity(
-                              opacity: _isImportingFromGallery ? 0.5 : 1,
-                              child: Padding(
-                                padding: const EdgeInsets.only(left: 12),
-                                child: IconButtonWidget(
-                                  icon: Icons.photo_library_outlined,
-                                  iconButtonType: IconButtonType.rounded,
-                                  onTap: _isImportingFromGallery
-                                      ? null
-                                      : _handleImportFromGallery,
-                                  defaultColor: galleryBackgroundColor,
-                                  iconColor: galleryIconColor,
-                                  pressedColor: galleryPressedColor,
-                                  size: 28,
-                                  padding: const EdgeInsets.all(14),
+            child: SafeArea(
+              top: false,
+              left: false,
+              right: false,
+              minimum: const EdgeInsets.only(bottom: 16),
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  child: showGalleryImport
+                      ? Row(
+                          children: [
+                            Expanded(
+                              child: totp != null
+                                  ? Text(
+                                      totp!,
+                                      style: Theme.of(
+                                        context,
+                                      ).textTheme.titleMedium,
+                                    )
+                                  : const SizedBox.shrink(),
+                            ),
+                            Semantics(
+                              button: true,
+                              label: l10n.importFromGallery,
+                              child: Opacity(
+                                opacity: _isImportingFromGallery ? 0.5 : 1,
+                                child: Padding(
+                                  padding: const EdgeInsets.only(left: 12),
+                                  child: IconButtonWidget(
+                                    icon: Icons.photo_library_outlined,
+                                    iconButtonType: IconButtonType.rounded,
+                                    onTap: _isImportingFromGallery
+                                        ? null
+                                        : _handleImportFromGallery,
+                                    defaultColor: galleryBackgroundColor,
+                                    iconColor: galleryIconColor,
+                                    pressedColor: galleryPressedColor,
+                                    size: 28,
+                                    padding: const EdgeInsets.all(14),
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                        ],
-                      )
-                    : Text(
-                        totp ?? l10n.scanACode,
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
+                          ],
+                        )
+                      : Text(
+                          totp ?? l10n.scanACode,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                ),
               ),
             ),
           ),
@@ -127,46 +137,56 @@ class ScannerPageState extends State<ScannerPage> {
 
   void _onQRViewCreated(QRViewController controller) {
     this.controller = controller;
-    // h4ck to remove black screen on Android scanners: https://github.com/juliuscanute/qr_code_scanner/issues/560#issuecomment-1159611301
+    // Retain the Android camera restart workaround for scanner black screens.
     if (Platform.isAndroid) {
-      controller.pauseCamera();
-      controller.resumeCamera();
+      unawaited(controller.pauseCamera());
+      unawaited(controller.resumeCamera());
     }
-    controller.scannedDataStream.listen((scanData) {
-      try {
-        final code = Code.fromOTPAuthUrl(scanData.code!);
-        controller.dispose();
-        Navigator.of(
-          context,
-        ).pop(ScannerPageResult(code: code, fromGallery: false));
-      } catch (e) {
-        // Log
+    _cancelScanSubscription();
+    _scanSubscription = controller.scannedDataStream.listen(_handleScanData);
+  }
+
+  void _handleScanData(Barcode scanData) {
+    if (_hasCompletedScan || _isImportingFromGallery) {
+      return;
+    }
+
+    final qrCode = scanData.code;
+    if (qrCode == null) {
+      return;
+    }
+
+    try {
+      final code = Code.fromOTPAuthUrl(qrCode);
+      _completeWithResult(ScannerPageResult(code: code, fromGallery: false));
+    } catch (e) {
+      if (mounted) {
         showToast(context, context.l10n.invalidQRCode);
       }
-    });
+    }
   }
 
   Future<void> _handleImportFromGallery() async {
-    if (_isImportingFromGallery) {
+    if (_isImportingFromGallery || _hasCompletedScan) {
       return;
     }
     setState(() {
       _isImportingFromGallery = true;
     });
+    bool shouldResumeCamera = true;
     try {
+      await controller?.pauseCamera();
       final Code? code = await pickCodeFromGallery(context, logger: _logger);
       if (code == null) {
         return;
       }
-      controller?.dispose();
-      if (!mounted) {
-        return;
-      }
-      Navigator.of(
-        context,
-      ).pop(ScannerPageResult(code: code, fromGallery: true));
+      shouldResumeCamera = false;
+      _completeWithResult(ScannerPageResult(code: code, fromGallery: true));
     } finally {
-      if (mounted) {
+      if (shouldResumeCamera && mounted && !_hasCompletedScan) {
+        await controller?.resumeCamera();
+      }
+      if (mounted && !_hasCompletedScan) {
         setState(() {
           _isImportingFromGallery = false;
         });
@@ -176,9 +196,27 @@ class ScannerPageState extends State<ScannerPage> {
     }
   }
 
+  void _completeWithResult(ScannerPageResult result) {
+    if (_hasCompletedScan) {
+      return;
+    }
+    _hasCompletedScan = true;
+    _cancelScanSubscription();
+    if (!mounted) {
+      return;
+    }
+    Navigator.of(context).pop(result);
+  }
+
+  void _cancelScanSubscription() {
+    final scanSubscription = _scanSubscription;
+    _scanSubscription = null;
+    unawaited(scanSubscription?.cancel());
+  }
+
   @override
   void dispose() {
-    controller?.dispose();
+    _cancelScanSubscription();
     super.dispose();
   }
 }

--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -1368,15 +1368,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  qr_code_scanner:
+  qr_code_scanner_plus:
     dependency: "direct main"
     description:
-      path: "."
-      ref: a2d31633d4744f72ada87cfa85d221358ab082af
-      resolved-ref: a2d31633d4744f72ada87cfa85d221358ab082af
-      url: "https://github.com/juliuscanute/qr_code_scanner"
-    source: git
-    version: "1.0.0"
+      name: qr_code_scanner_plus
+      sha256: "2bcf9df32aa639fba07c183b1ab9c3f03eb6b1d688ab4f4f6bc868a75afd824d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   qr_flutter:
     dependency: "direct main"
     description:

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -115,10 +115,7 @@ dependencies:
   pointycastle: 3.9.1
   privacy_screen: 0.0.8
   protobuf: 4.1.0
-  qr_code_scanner: # no package updates on pub.dev
-    git:
-      url: https://github.com/juliuscanute/qr_code_scanner
-      ref: a2d31633d4744f72ada87cfa85d221358ab082af
+  qr_code_scanner_plus: 2.1.2
   qr_flutter: 4.1.0
   saf_stream: 2.0.0
   saf_util: 2.0.0


### PR DESCRIPTION
Fixes #9086.

Migrate Auth mobile QR scanning to `qr_code_scanner_plus` and tighten scanner lifecycle handling to avoid black-screen/hang cases after scanning.