### PR TITLE
[mobile][photos] Re-enable AutoFill on account email fields

### DIFF
--- a/mobile/apps/photos/changes/ios-login-autofill.md
+++ b/mobile/apps/photos/changes/ios-login-autofill.md
@@ -1,0 +1,1 @@
+- Improved iOS Password AutoFill detection on Photos login and sign-up screens.

--- a/mobile/apps/photos/lib/ui/account/email_entry_page.dart
+++ b/mobile/apps/photos/lib/ui/account/email_entry_page.dart
@@ -186,6 +186,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                     hintText: AppLocalizations.of(context).email,
                     textEditingController: _emailController,
                     keyboardType: TextInputType.emailAddress,
+                    autofillHints: const [AutofillHints.email],
                     autoCorrect: false,
                     isRequired: true,
                     onChange: _onEmailChanged,

--- a/mobile/apps/photos/lib/ui/account/login_page.dart
+++ b/mobile/apps/photos/lib/ui/account/login_page.dart
@@ -119,6 +119,7 @@ class _LoginPageState extends State<LoginPage> {
               hintText: AppLocalizations.of(context).enterYourEmailAddress,
               textEditingController: _emailController,
               keyboardType: TextInputType.emailAddress,
+              autofillHints: const [AutofillHints.email],
               autoCorrect: false,
               autoFocus: true,
               isRequired: true,


### PR DESCRIPTION
- Restore email autofill hints on Photos login and sign-up email inputs after the account screen UI refresh dropped them.
- Align Photos account forms with the shared Auth/Locker account flow so iOS can recognize the email step for Password AutoFill.

Fixes #10966