### PR TITLE
[mobile] Fix Auth Windows local_auth build

### DIFF
--- a/mobile/apps/auth/windows/CMakeLists.txt
+++ b/mobile/apps/auth/windows/CMakeLists.txt
@@ -57,6 +57,11 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# local_auth_windows 2.0.1 still passes /await, which MSVC 14.51 rejects via
+# STL1011 unless this deprecation warning is silenced.
+target_compile_definitions(local_auth_windows_plugin PRIVATE
+  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
Works around the MSVC 14.51 STL1011 failure in local_auth_windows 2.0.1 during the build: https://github.com/ente-io/ente/actions/runs/27514273346/job/81320021240