### PR TITLE
[web] Show link icon on albums shared with both people and a link

### DIFF
--- a/desktop/changes/show-link-icon-for-mixed-shared-albums.md
+++ b/desktop/changes/show-link-icon-for-mixed-shared-albums.md
@@ -1,0 +1,1 @@
+- Fix link icon visibility for albums shared with people and a public link. By @yashs33244.

--- a/web/packages/new/photos/components/gallery/BarImpl.tsx
+++ b/web/packages/new/photos/components/gallery/BarImpl.tsx
@@ -567,31 +567,31 @@ interface CollectionBarCardIconProps {
 const CollectionBarCardIcon: React.FC<CollectionBarCardIconProps> = ({
     attributes,
 }) => (
-    // Under current scenarios, there are no cases where more than 3 of these
-    // will be true simultaneously even in the rarest of cases (a pinned and
-    // shared album that is also archived), and there is enough space for 3.
+    // In the rarest of cases up to 4 of these can be true at once: a pinned
+    // album that is shared both with people and via a public link, and is also
+    // archived. The container is sized so that all 4 still fit on the tile.
     <CollectionBarCardIcon_>
         {attributes.has("userFavorites") && <StarIcon fontSize="small" />}
         {(attributes.has("pinned") || attributes.has("shareePinned")) && (
             // Need && to override the 20px set in the container.
             <HugeiconsIcon icon={PinIcon} size={18} />
         )}
-        {attributes.has("shared") &&
-            (attributes.has("sharedOnlyViaLink") ? (
-                <HugeiconsIcon icon={Link05Icon} size={20} />
-            ) : (
-                <PeopleIcon />
-            ))}
+        {attributes.has("shared") && !attributes.has("sharedOnlyViaLink") && (
+            <PeopleIcon />
+        )}
+        {attributes.has("sharedViaLink") && (
+            <HugeiconsIcon icon={Link05Icon} size={20} />
+        )}
         {attributes.has("archived") && <ArchiveIcon sx={{ opacity: 0.48 }} />}
     </CollectionBarCardIcon_>
 );
 
 const CollectionBarCardIcon_ = styled(Overlay)`
-    padding: 4px;
+    padding: 3px;
     display: flex;
     justify-content: flex-start;
     align-items: flex-end;
-    gap: 4px;
+    gap: 2px;
     & > .MuiSvgIcon-root {
         font-size: 20px;
     }

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -1697,9 +1697,17 @@ const createCollectionSummaries = (
             attributes.add("shared");
             attributes.add("sharedOutgoing");
         }
-        if (collection.publicURLs.length && !collection.sharees.length) {
+        if (collection.publicURLs.length) {
             attributes.add("shared");
-            attributes.add("sharedOnlyViaLink");
+            attributes.add("sharedViaLink");
+            // "sharedOnlyViaLink" stays reserved for the case where the only
+            // way the collection is shared is via a public link (no sharees),
+            // which decides the primary icon. "sharedViaLink" instead tracks
+            // the mere presence of a link, so an album that is shared with
+            // people and also has a link still shows the link indicator.
+            if (!collection.sharees.length) {
+                attributes.add("sharedOnlyViaLink");
+            }
         }
         if (isArchivedCollection(collection)) {
             attributes.add("archived");

--- a/web/packages/new/photos/services/collection-summary.ts
+++ b/web/packages/new/photos/services/collection-summary.ts
@@ -18,6 +18,7 @@ export type CollectionSummaryAttribute =
     | "sharedIncomingViewer"
     | "sharedIncomingCollaborator"
     | "sharedIncomingAdmin"
+    | "sharedViaLink"
     | "sharedOnlyViaLink"
     | "system"
     | "archived"


### PR DESCRIPTION
Closes #2052

When an album was shared with people and also had a public link, the album tile only showed the people icon and hid the link icon, because the two states were treated as mutually exclusive.

Track the presence of a public link with a separate `sharedViaLink` attribute and render the people and link icons independently, so an album shared both ways shows both. `sharedOnlyViaLink` keeps its meaning (the link-only case that picks the primary icon), so no other consumer changes. Tightened the tile icon spacing so all icons still fit when both are shown.
