### PR TITLE
[mobile] Pin Auth Windows build to VS2022 runner

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -331,7 +331,8 @@ jobs:
     build-windows:
         needs: build-metadata
         if: needs.build-metadata.outputs.should_build == 'true'
-        runs-on: windows-latest
+        # VS2022 is required until local_auth_windows builds cleanly on VS2026.
+        runs-on: windows-2022
         environment:
             name: production
         env:

--- a/mobile/apps/auth/windows/CMakeLists.txt
+++ b/mobile/apps/auth/windows/CMakeLists.txt
@@ -57,12 +57,6 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
-# local_auth_windows 2.0.1 still passes /await, which MSVC 14.51 rejects via
-# STL1011 unless this deprecation warning is silenced.
-target_compile_definitions(local_auth_windows_plugin PRIVATE
-  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
-
-
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can
 # run in place. This is done instead of making a separate bundle (as on Linux)


### PR DESCRIPTION
The run failed again - [https://github.com/ente-io/ente/actions/runs/27581710630/job/81543280918](https://github.com/ente-io/ente/actions/runs/27581710630/job/81543280918) - , this time on a different known issue with the local auth plugin (see commit message for details)