### PR TITLE
[mob][photos] Fix add-to-album bottom sheet behavior

### DIFF
--- a/mobile/apps/photos/changes/add-to-album-bottom-sheet.md
+++ b/mobile/apps/photos/changes/add-to-album-bottom-sheet.md
@@ -1,0 +1,1 @@
+- Fixed the add-to-album sheet layout and shared-album confirmation flow.

--- a/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import "package:flutter/services.dart";
@@ -15,14 +16,13 @@ import 'package:photos/models/selected_files.dart';
 import 'package:photos/services/collections_service.dart';
 import "package:photos/services/hidden_service.dart";
 import 'package:photos/services/sync/remote_sync_service.dart';
-import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/actions/collection/collection_file_actions.dart";
 import "package:photos/ui/actions/collection/collection_sharing_actions.dart";
 import "package:photos/ui/collections/album/column_item.dart";
 import "package:photos/ui/collections/album/new_list_item.dart";
 import 'package:photos/ui/collections/collection_action_sheet.dart';
-import "package:photos/ui/components/buttons/button_widget.dart";
-import "package:photos/ui/components/thumbnail_list_item.dart";
+import "package:photos/ui/components/buttons/button_widget.dart"
+    show ButtonAction;
 import 'package:photos/ui/notification/toast.dart';
 import "package:photos/ui/sharing/share_collection_page.dart";
 import 'package:photos/ui/viewer/gallery/collection_page.dart';
@@ -89,7 +89,10 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
         !hasRecentCollections &&
         !hasSharedCollections) {
       if (widget.shouldShowCreateAlbum) {
-        return _getNewAlbumWidget(context, filesCount);
+        return Align(
+          alignment: Alignment.topCenter,
+          child: _getNewAlbumWidget(context, filesCount),
+        );
       }
       return const EmptyState();
     }
@@ -181,8 +184,7 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
 
         return const SizedBox.shrink();
       },
-      separatorBuilder: (context, index) =>
-          const SizedBox(height: ThumbnailListItem.defaultItemSpacing),
+      separatorBuilder: (context, index) => const SizedBox(height: Spacing.sm),
       itemCount: totalItemCount,
       shrinkWrap: false,
       physics: const BouncingScrollPhysics(),
@@ -190,22 +192,20 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
   }
 
   Widget _buildSectionHeader(BuildContext context, String title) {
-    final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
     return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 4),
+      padding: const EdgeInsets.only(top: 12, bottom: 8),
       child: Text(
         title,
-        style: textTheme.smallMuted.copyWith(color: colorScheme.textMuted),
+        style: TextStyles.large.copyWith(
+          color: context.componentColors.textBase,
+        ),
       ),
     );
   }
 
   Widget _buildDivider(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: Divider(height: 1, thickness: 1, color: colorScheme.strokeFaint),
+    return const DividerComponent(
+      padding: EdgeInsets.symmetric(vertical: Spacing.sm),
     );
   }
 

--- a/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
@@ -21,8 +21,6 @@ import "package:photos/ui/actions/collection/collection_sharing_actions.dart";
 import "package:photos/ui/collections/album/column_item.dart";
 import "package:photos/ui/collections/album/new_list_item.dart";
 import 'package:photos/ui/collections/collection_action_sheet.dart';
-import "package:photos/ui/components/buttons/button_widget.dart"
-    show ButtonAction;
 import 'package:photos/ui/notification/toast.dart';
 import "package:photos/ui/sharing/share_collection_page.dart";
 import 'package:photos/ui/viewer/gallery/collection_page.dart';
@@ -234,32 +232,51 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
   }
 
   Future<void> _sharedAlbumOnTap(BuildContext context, Collection item) async {
-    // Show dialog asking if user wants to add instead of move
-    final result = await showChoiceActionSheet(
-      context,
-      title: AppLocalizations.of(context).cannotMoveToSharedAlbums,
-      body: AppLocalizations.of(context).cannotMoveToSharedAlbumsMessage,
-      icon: Icons.info_outline,
-      firstButtonLabel: AppLocalizations.of(context).add,
-      secondButtonLabel: AppLocalizations.of(context).cancel,
-    );
-    if (result?.action == ButtonAction.first) {
-      // Perform add operation after dialog is dismissed
-      final success = await _addToCollection(context, item.id, true);
-      if (success) {
-        showShortToast(
-          context,
-          AppLocalizations.of(
-            context,
-          ).addedSuccessfullyTo(albumName: item.displayName),
-        );
-        Navigator.pop(context);
-        await _navigateToCollection(context, item);
-      }
-    } else if (result?.action == ButtonAction.error &&
-        result?.exception != null) {
-      await showGenericErrorDialog(context: context, error: result!.exception);
+    final shouldAdd = await _showAddToSharedAlbumSheet(context);
+    if (!shouldAdd) {
+      return;
     }
+
+    final success = await _addToCollection(context, item.id, true);
+    if (success) {
+      showShortToast(
+        context,
+        AppLocalizations.of(
+          context,
+        ).addedSuccessfullyTo(albumName: item.displayName),
+      );
+      Navigator.pop(context);
+      await _navigateToCollection(context, item);
+    }
+  }
+
+  Future<bool> _showAddToSharedAlbumSheet(BuildContext context) async {
+    final l10n = AppLocalizations.of(context);
+    final result = await showBottomSheetComponent<bool>(
+      context: context,
+      builder: (sheetContext) => BottomSheetComponent(
+        title: l10n.cannotMoveToSharedAlbums,
+        content: Text(
+          l10n.cannotMoveToSharedAlbumsMessage,
+          style: TextStyles.body.copyWith(
+            color: sheetContext.componentColors.textLight,
+          ),
+        ),
+        closeTooltip: l10n.close,
+        closeResult: false,
+        actions: [
+          ButtonComponent(
+            label: l10n.add,
+            variant: ButtonComponentVariant.neutral,
+            shouldSurfaceExecutionStates: false,
+            onTap: () async {
+              Navigator.of(sheetContext).pop(true);
+            },
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
   }
 
   Future<void> _toggleCollectionSelection(Collection collection) async {

--- a/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
+++ b/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import "package:ente_components/ente_components.dart";
 import 'package:flutter/material.dart';
 import "package:hugeicons/hugeicons.dart";
 import "package:logging/logging.dart";
@@ -13,15 +14,11 @@ import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/selected_files.dart';
 import "package:photos/service_locator.dart";
 import 'package:photos/services/collections_service.dart';
-import 'package:photos/theme/ente_theme.dart';
 import "package:photos/ui/actions/collection/collection_file_actions.dart";
 import "package:photos/ui/actions/collection/collection_sharing_actions.dart";
 import 'package:photos/ui/collections/album/vertical_list.dart';
 import 'package:photos/ui/common/loading_widget.dart';
 import "package:photos/ui/common/progress_dialog.dart";
-import "package:photos/ui/components/base_bottom_sheet.dart";
-import 'package:photos/ui/components/buttons/button_widget_v2.dart';
-import "package:photos/ui/components/text_input_widget_v2.dart";
 import "package:photos/ui/notification/toast.dart";
 import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/separators_util.dart";
@@ -102,19 +99,20 @@ void showCollectionActionSheet(
       ? selectedPeople.length
       : selectedFiles?.files.length ?? 0;
 
-  showBaseBottomSheet<void>(
-    context,
-    title: _actionName(context, actionType, filesCount),
-    isKeyboardAware: false,
-    backgroundColor: getEnteColorScheme(context).backgroundColour,
-    child: SizedBox(
-      height: height,
-      child: CollectionActionSheet(
-        selectedFiles: selectedFiles,
-        sharedFiles: sharedFiles,
-        actionType: actionType,
-        showOptionToCreateNewAlbum: showOptionToCreateNewAlbum,
-        selectedPeople: selectedPeople,
+  showBottomSheetComponent<void>(
+    context: context,
+    builder: (_) => BottomSheetComponent(
+      title: _actionName(context, actionType, filesCount),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+      content: SizedBox(
+        height: height,
+        child: CollectionActionSheet(
+          selectedFiles: selectedFiles,
+          sharedFiles: sharedFiles,
+          actionType: actionType,
+          showOptionToCreateNewAlbum: showOptionToCreateNewAlbum,
+          selectedPeople: selectedPeople,
+        ),
       ),
     ),
   );
@@ -179,7 +177,6 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
     final isKeyboardUp = bottomInset > 100;
     final double bottomPadding = max(
@@ -197,16 +194,16 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
               Expanded(
                 child: Column(
                   children: [
-                    TextInputWidgetV2(
+                    TextInputComponent(
                       hintText: AppLocalizations.of(
                         context,
                       ).searchByAlbumNameHint,
-                      leadingWidget: HugeIcon(
+                      prefix: HugeIcon(
                         icon: HugeIcons.strokeRoundedSearch01,
                         size: 18,
-                        color: colorScheme.textMuted,
+                        color: context.componentColors.textLight,
                       ),
-                      onChange: (value) {
+                      onChanged: (value) {
                         setState(() {
                           _searchQuery = value.trim();
                         });
@@ -218,11 +215,9 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
                   ],
                 ),
               ),
-              SafeArea(
-                child: Container(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: Column(children: [..._actionButtons()]),
-                ),
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Column(children: [..._actionButtons()]),
               ),
             ],
           ),
@@ -235,12 +230,11 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
     final List<Widget> widgets = [];
     if (_enableSelection) {
       widgets.add(
-        ButtonWidgetV2(
+        ButtonComponent(
           key: const ValueKey('add_button'),
-          buttonType: ButtonTypeV2.primary,
-          isInAlert: true,
-          labelText: AppLocalizations.of(context).add,
+          label: AppLocalizations.of(context).add,
           shouldSurfaceExecutionStates: false,
+          dismissModalOnSuccess: true,
           isDisabled: _selectedCollections.isEmpty,
           onTap: () async {
             if (widget.selectedPeople != null) {

--- a/mobile/packages/ente_components/lib/components/buttons/button_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/button_component.dart
@@ -40,6 +40,7 @@ class ButtonComponent extends StatefulWidget {
     this.shouldShowSuccessConfirmation = false,
     this.progressStatus,
     this.leading,
+    this.dismissModalOnSuccess = false,
   });
 
   final String label;
@@ -52,6 +53,12 @@ class ButtonComponent extends StatefulWidget {
   final bool shouldShowSuccessConfirmation;
   final ValueListenable<String>? progressStatus;
   final Widget? leading;
+
+  /// Dismisses the current modal route after [onTap] completes without throwing.
+  ///
+  /// This only applies to popup routes such as dialogs and bottom sheets. Normal
+  /// page routes are not dismissed.
+  final bool dismissModalOnSuccess;
 
   @override
   State<ButtonComponent> createState() => _ButtonComponentState();
@@ -438,6 +445,7 @@ class _ButtonComponentState extends State<ButtonComponent>
           _isPressed = false;
         });
         _syncLoadingController();
+        _dismissRouteOnSuccess();
       }
     } catch (_) {
       _loadingTimer?.cancel();
@@ -463,12 +471,31 @@ class _ButtonComponentState extends State<ButtonComponent>
     _successResetTimer?.cancel();
     _successResetTimer = Timer(_successDisplayDuration, () {
       if (!mounted) return;
+      if (_dismissRouteOnSuccess()) {
+        return;
+      }
       setState(() {
         _executionState = ComponentExecutionState.idle;
         _loadingVisible = false;
       });
       _syncLoadingController();
     });
+  }
+
+  bool _dismissRouteOnSuccess() {
+    if (!widget.dismissModalOnSuccess || !mounted) {
+      return false;
+    }
+    final navigator = Navigator.of(context);
+    if (!navigator.canPop()) {
+      return false;
+    }
+    final route = ModalRoute.of(context);
+    if (route is! PopupRoute || !route.isCurrent) {
+      return false;
+    }
+    navigator.pop();
+    return true;
   }
 
   Color _background(BuildContext context) {

--- a/mobile/packages/ente_components/test/components/button_test.dart
+++ b/mobile/packages/ente_components/test/components/button_test.dart
@@ -285,6 +285,105 @@ void main() {
   });
 
   testWidgets(
+    "ButtonComponent dismisses modal routes after success when configured",
+    (tester) async {
+      var modalDismissed = false;
+
+      await tester.pumpWidget(
+        _wrapModalTestApp(
+          onModalDismissed: () => modalDismissed = true,
+          child: ButtonComponent(
+            label: "Done",
+            shouldSurfaceExecutionStates: false,
+            dismissModalOnSuccess: true,
+            onTap: () {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Done"), findsOneWidget);
+
+      await tester.tap(find.text("Done"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Open"), findsOneWidget);
+      expect(modalDismissed, isTrue);
+    },
+  );
+
+  testWidgets("ButtonComponent does not dismiss modal routes by default", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrapModalTestApp(
+        child: ButtonComponent(
+          label: "Stay",
+          shouldSurfaceExecutionStates: false,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.text("Open"));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Stay"));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Stay"), findsOneWidget);
+  });
+
+  testWidgets(
+    "ButtonComponent does not dismiss normal page routes when configured",
+    (tester) async {
+      await tester.pumpWidget(
+        _wrapRouteTestApp(
+          child: ButtonComponent(
+            label: "Save",
+            shouldSurfaceExecutionStates: false,
+            dismissModalOnSuccess: true,
+            onTap: () {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Save"));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Save"), findsOneWidget);
+    },
+  );
+
+  testWidgets("ButtonComponent does not dismiss modal routes after errors", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrapModalTestApp(
+        child: ButtonComponent(
+          label: "Fail",
+          shouldSurfaceExecutionStates: false,
+          dismissModalOnSuccess: true,
+          onTap: () async => throw StateError("failed"),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text("Open"));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Fail"));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Fail"), findsOneWidget);
+  });
+
+  testWidgets(
     "ButtonComponent remains disabled when onTap is null or disabled",
     (tester) async {
       var tapCount = 0;
@@ -648,6 +747,58 @@ Widget _wrap(
     themeAnimationDuration: Duration.zero,
     theme: ComponentTheme.themeForApp(app, brightness: brightness),
     home: Scaffold(body: Center(child: child)),
+  );
+}
+
+Widget _wrapRouteTestApp({required Widget child}) {
+  return MaterialApp(
+    themeAnimationDuration: Duration.zero,
+    theme: ComponentTheme.themeForApp(ComponentApp.photos),
+    home: Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (context) {
+            return TextButton(
+              onPressed: () async {
+                await Navigator.of(context).push<Object?>(
+                  MaterialPageRoute(
+                    builder: (_) => Scaffold(body: Center(child: child)),
+                  ),
+                );
+              },
+              child: const Text("Open"),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _wrapModalTestApp({
+  required Widget child,
+  VoidCallback? onModalDismissed,
+}) {
+  return MaterialApp(
+    themeAnimationDuration: Duration.zero,
+    theme: ComponentTheme.themeForApp(ComponentApp.photos),
+    home: Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (context) {
+            return TextButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  builder: (_) => Center(child: child),
+                ).whenComplete(() => onModalDismissed?.call());
+              },
+              child: const Text("Open"),
+            );
+          },
+        ),
+      ),
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary
- Fix the add-to-album bottom sheet empty-state layout so the create-album row sits at the top instead of vertically centered.
- Move the add-to-album sheet and shared-album confirmation path onto `ente_components` bottom sheet/button/input components.
- Add opt-in modal dismissal support to `ButtonComponent` and cover it with component tests.
- Add the Photos release note.

<img width="300" height="650" alt="image png" src="https://github.com/user-attachments/assets/47060b5f-92e7-4691-abdd-5e3722288386" />

<img width="300" height="650" alt="Screenshot_20260609_142046_Ente_Photos jpg-2" src="https://github.com/user-attachments/assets/ebc00a10-fc4f-4dff-8084-b567af74a4b9" />


After
<img width="300" height="650" alt="Screenshot 2026-06-16 at 11 27 57 AM" src="https://github.com/user-attachments/assets/98d5012e-f320-4a15-be2f-922a4639f0d5" />
