### PR TITLE
[web][photos] Supporting the EXIF Orientation during rendering

### DIFF
--- a/desktop/changes/respect-exif-orientation.md
+++ b/desktop/changes/respect-exif-orientation.md
@@ -1,0 +1,1 @@
+- Respect the EXIF orientation when displaying photos and generating their thumbnails.

--- a/web/packages/gallery/components/viewer/data-source.ts
+++ b/web/packages/gallery/components/viewer/data-source.ts
@@ -567,13 +567,14 @@ const enqueueUpdates = async (
                     imageURL,
                     originalImageBlob,
                 );
+                const displayImageURL =
+                    oriented.orientedImageURL ?? oriented.imageURL;
                 updateFileInfoExifIfAvailable(fileID, oriented.exif);
-                const itemData = await withDimensionsIfPossible(
-                    oriented.imageURL,
-                );
+                const itemData =
+                    await withDimensionsIfPossible(displayImageURL);
                 update({
                     ...itemData,
-                    imageURL: oriented.imageURL,
+                    imageURL: displayImageURL,
                     originalImageBlob,
                     orientedImageURL: oriented.orientedImageURL,
                 });
@@ -608,10 +609,12 @@ const enqueueUpdates = async (
                     imageURL,
                     originalImageBlob,
                 );
+                const displayImageURL =
+                    oriented.orientedImageURL ?? oriented.imageURL;
                 updateFileInfoExifIfAvailable(fileID, oriented.exif);
                 update({
-                    ...(await withDimensionsIfPossible(oriented.imageURL)),
-                    imageURL: oriented.imageURL,
+                    ...(await withDimensionsIfPossible(displayImageURL)),
+                    imageURL: displayImageURL,
                     originalImageBlob,
                     videoURL,
                     orientedImageURL: oriented.orientedImageURL,

--- a/web/packages/gallery/components/viewer/data-source.ts
+++ b/web/packages/gallery/components/viewer/data-source.ts
@@ -1,7 +1,16 @@
 import log from "ente-base/log";
 import type { FileInfoExif } from "ente-gallery/components/FileInfo";
 import { downloadManager } from "ente-gallery/services/download";
-import { extractRawExif, parseExif } from "ente-gallery/services/exif";
+import {
+    extractRawExif,
+    parseExif,
+    parseExifOrientation,
+    type ExifOrientation,
+} from "ente-gallery/services/exif";
+import {
+    dimensionsForExifOrientation,
+    drawImageWithExifOrientation,
+} from "ente-gallery/services/image-orientation";
 import {
     hlsPlaylistDataForFile,
     type HLSPlaylistDataForFile,
@@ -89,6 +98,14 @@ export type ItemData = PhotoSwipeSlideData & {
      * - For videos, this will be not be present.
      */
     originalImageBlob?: Blob;
+    /**
+     * An object URL created by this module for an orientation-corrected image.
+     *
+     * This is separate from {@link imageURL} because object URLs returned by
+     * the download manager are owned by the download manager, while this one
+     * needs to be revoked when we forget the item data.
+     */
+    orientedImageURL?: string;
     /**
      * The renderable object URL of the video associated with the file.
      *
@@ -208,6 +225,7 @@ class FileViewerDataSourceState {
 let _state = new FileViewerDataSourceState();
 
 const resetState = () => {
+    _state.itemDataByFileID.forEach(revokeOrientedImageURL);
     _state = new FileViewerDataSourceState();
 };
 
@@ -357,8 +375,14 @@ export const itemDataForFile = (
  * and so would like to clear any previously cached data.
  */
 export const forgetItemDataForFileID = (fileID: number) => {
+    const itemData = _state.itemDataByFileID.get(fileID);
+    if (itemData) revokeOrientedImageURL(itemData);
     _state.itemDataByFileID.delete(fileID);
     _state.itemDataValidTillByFileID.delete(fileID);
+};
+
+const revokeOrientedImageURL = ({ orientedImageURL }: ItemData) => {
+    if (orientedImageURL) URL.revokeObjectURL(orientedImageURL);
 };
 
 /**
@@ -547,8 +571,20 @@ const enqueueUpdates = async (
         switch (sourceURLs.type) {
             case "image": {
                 const { imageURL, originalImageBlob } = sourceURLs;
-                const itemData = await withDimensionsIfPossible(imageURL);
-                update({ ...itemData, imageURL, originalImageBlob });
+                const oriented = await orientedImageURL(
+                    imageURL,
+                    originalImageBlob,
+                );
+                updateFileInfoExifIfAvailable(fileID, oriented.exif);
+                const itemData = await withDimensionsIfPossible(
+                    oriented.imageURL,
+                );
+                update({
+                    ...itemData,
+                    imageURL: oriented.imageURL,
+                    originalImageBlob,
+                    orientedImageURL: oriented.orientedImageURL,
+                });
                 break;
             }
 
@@ -576,11 +612,17 @@ const enqueueUpdates = async (
                 });
                 const imageURL = await sourceURLs.imageURL();
                 const originalImageBlob = sourceURLs.originalImageBlob;
-                update({
-                    ...(await withDimensionsIfPossible(imageURL)),
+                const oriented = await orientedImageURL(
                     imageURL,
                     originalImageBlob,
+                );
+                updateFileInfoExifIfAvailable(fileID, oriented.exif);
+                update({
+                    ...(await withDimensionsIfPossible(oriented.imageURL)),
+                    imageURL: oriented.imageURL,
+                    originalImageBlob,
                     videoURL,
+                    orientedImageURL: oriented.orientedImageURL,
                 });
                 break;
             }
@@ -608,6 +650,83 @@ const enqueueUpdates = async (
         markFailed();
     }
 };
+
+interface OrientedImageURLResult {
+    imageURL: string;
+    exif?: FileInfoExif;
+    orientedImageURL?: string;
+}
+
+const orientedImageURL = async (
+    imageURL: string,
+    originalImageBlob: Blob,
+): Promise<OrientedImageURLResult> => {
+    let exif: FileInfoExif | undefined;
+    let orientation: ExifOrientation | undefined;
+
+    try {
+        const file = new File([originalImageBlob], "");
+        const tags = await extractRawExif(file);
+        const parsed = parseExif(tags);
+        exif = { tags, parsed };
+        orientation = parseExifOrientation(tags);
+    } catch (e) {
+        log.warn("Failed to extract exif for image orientation", e);
+        return { imageURL };
+    }
+
+    if (!orientation || orientation == 1) return { imageURL, exif };
+
+    const correctedImageURL = await canvasOrientedImageURL(
+        imageURL,
+        orientation,
+    );
+    return {
+        imageURL: correctedImageURL,
+        exif,
+        orientedImageURL: correctedImageURL,
+    };
+};
+
+const canvasOrientedImageURL = async (
+    imageURL: string,
+    orientation: ExifOrientation,
+) => {
+    const image = await loadImage(imageURL);
+    const width = image.naturalWidth;
+    const height = image.naturalHeight;
+    const canvasDimensions = dimensionsForExifOrientation(
+        width,
+        height,
+        orientation,
+    );
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasDimensions.width;
+    canvas.height = canvasDimensions.height;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Failed to get canvas 2D context");
+
+    drawImageWithExifOrientation(ctx, image, orientation, width, height);
+
+    return URL.createObjectURL(await canvasBlob(canvas));
+};
+
+const loadImage = (imageURL: string) =>
+    new Promise<HTMLImageElement>((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = reject;
+        image.src = imageURL;
+    });
+
+const canvasBlob = (canvas: HTMLCanvasElement) =>
+    new Promise<Blob>((resolve, reject) =>
+        canvas.toBlob((blob) =>
+            blob ? resolve(blob) : reject(new Error("toBlob failed")),
+        ),
+    );
 
 /**
  * Take a image URL, determine its dimensions using browser APIs if possible,
@@ -723,14 +842,9 @@ export const updateFileInfoExifIfNeeded = async (itemData: ItemData) => {
     // We already have it available.
     if (_state.fileInfoExifByFileID.has(fileID)) return;
 
-    const update = (exifData: FileInfoExif) => {
-        _state.fileInfoExifByFileID.set(fileID, exifData);
-        _state.exifObserverByFileID.get(fileID)?.(exifData);
-    };
-
     // For videos, insert a placeholder.
     if (fileType == FileType.video) {
-        update(createPlaceholderFileInfoExif());
+        updateFileInfoExif(fileID, createPlaceholderFileInfoExif());
         return;
     }
 
@@ -741,13 +855,27 @@ export const updateFileInfoExifIfNeeded = async (itemData: ItemData) => {
         const file = new File([originalImageBlob], "");
         const tags = await extractRawExif(file);
         const parsed = parseExif(tags);
-        update({ tags, parsed });
+        updateFileInfoExif(fileID, { tags, parsed });
     } catch (e) {
         log.error("Failed to extract exif", e);
         // Save the empty placeholder exif corresponding to the file, no point
         // in unnecessarily retrying this, it will deterministically fail again.
-        update(createPlaceholderFileInfoExif());
+        updateFileInfoExif(fileID, createPlaceholderFileInfoExif());
     }
+};
+
+const updateFileInfoExifIfAvailable = (
+    fileID: number,
+    exifData: FileInfoExif | undefined,
+) => {
+    if (exifData && !_state.fileInfoExifByFileID.has(fileID)) {
+        updateFileInfoExif(fileID, exifData);
+    }
+};
+
+const updateFileInfoExif = (fileID: number, exifData: FileInfoExif) => {
+    _state.fileInfoExifByFileID.set(fileID, exifData);
+    _state.exifObserverByFileID.get(fileID)?.(exifData);
 };
 
 const createPlaceholderFileInfoExif = (): FileInfoExif => ({

--- a/web/packages/gallery/components/viewer/data-source.ts
+++ b/web/packages/gallery/components/viewer/data-source.ts
@@ -1,16 +1,8 @@
 import log from "ente-base/log";
 import type { FileInfoExif } from "ente-gallery/components/FileInfo";
 import { downloadManager } from "ente-gallery/services/download";
-import {
-    extractRawExif,
-    parseExif,
-    parseExifOrientation,
-    type ExifOrientation,
-} from "ente-gallery/services/exif";
-import {
-    dimensionsForExifOrientation,
-    drawImageWithExifOrientation,
-} from "ente-gallery/services/image-orientation";
+import { extractRawExif, parseExif } from "ente-gallery/services/exif";
+import { orientedImageURL } from "ente-gallery/services/image-orientation";
 import {
     hlsPlaylistDataForFile,
     type HLSPlaylistDataForFile,
@@ -99,7 +91,7 @@ export type ItemData = PhotoSwipeSlideData & {
      */
     originalImageBlob?: Blob;
     /**
-     * An object URL created by this module for an orientation-corrected image.
+     * An object URL created for an orientation-corrected image.
      *
      * This is separate from {@link imageURL} because object URLs returned by
      * the download manager are owned by the download manager, while this one
@@ -650,83 +642,6 @@ const enqueueUpdates = async (
         markFailed();
     }
 };
-
-interface OrientedImageURLResult {
-    imageURL: string;
-    exif?: FileInfoExif;
-    orientedImageURL?: string;
-}
-
-const orientedImageURL = async (
-    imageURL: string,
-    originalImageBlob: Blob,
-): Promise<OrientedImageURLResult> => {
-    let exif: FileInfoExif | undefined;
-    let orientation: ExifOrientation | undefined;
-
-    try {
-        const file = new File([originalImageBlob], "");
-        const tags = await extractRawExif(file);
-        const parsed = parseExif(tags);
-        exif = { tags, parsed };
-        orientation = parseExifOrientation(tags);
-    } catch (e) {
-        log.warn("Failed to extract exif for image orientation", e);
-        return { imageURL };
-    }
-
-    if (!orientation || orientation == 1) return { imageURL, exif };
-
-    const correctedImageURL = await canvasOrientedImageURL(
-        imageURL,
-        orientation,
-    );
-    return {
-        imageURL: correctedImageURL,
-        exif,
-        orientedImageURL: correctedImageURL,
-    };
-};
-
-const canvasOrientedImageURL = async (
-    imageURL: string,
-    orientation: ExifOrientation,
-) => {
-    const image = await loadImage(imageURL);
-    const width = image.naturalWidth;
-    const height = image.naturalHeight;
-    const canvasDimensions = dimensionsForExifOrientation(
-        width,
-        height,
-        orientation,
-    );
-
-    const canvas = document.createElement("canvas");
-    canvas.width = canvasDimensions.width;
-    canvas.height = canvasDimensions.height;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("Failed to get canvas 2D context");
-
-    drawImageWithExifOrientation(ctx, image, orientation, width, height);
-
-    return URL.createObjectURL(await canvasBlob(canvas));
-};
-
-const loadImage = (imageURL: string) =>
-    new Promise<HTMLImageElement>((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.src = imageURL;
-    });
-
-const canvasBlob = (canvas: HTMLCanvasElement) =>
-    new Promise<Blob>((resolve, reject) =>
-        canvas.toBlob((blob) =>
-            blob ? resolve(blob) : reject(new Error("toBlob failed")),
-        ),
-    );
 
 /**
  * Take a image URL, determine its dimensions using browser APIs if possible,

--- a/web/packages/gallery/components/viewer/data-source.ts
+++ b/web/packages/gallery/components/viewer/data-source.ts
@@ -569,7 +569,6 @@ const enqueueUpdates = async (
                 );
                 const displayImageURL =
                     oriented.orientedImageURL ?? oriented.imageURL;
-                updateFileInfoExifIfAvailable(fileID, oriented.exif);
                 const itemData =
                     await withDimensionsIfPossible(displayImageURL);
                 update({
@@ -611,7 +610,6 @@ const enqueueUpdates = async (
                 );
                 const displayImageURL =
                     oriented.orientedImageURL ?? oriented.imageURL;
-                updateFileInfoExifIfAvailable(fileID, oriented.exif);
                 update({
                     ...(await withDimensionsIfPossible(displayImageURL)),
                     imageURL: displayImageURL,
@@ -760,9 +758,14 @@ export const updateFileInfoExifIfNeeded = async (itemData: ItemData) => {
     // We already have it available.
     if (_state.fileInfoExifByFileID.has(fileID)) return;
 
+    const update = (exifData: FileInfoExif) => {
+        _state.fileInfoExifByFileID.set(fileID, exifData);
+        _state.exifObserverByFileID.get(fileID)?.(exifData);
+    };
+
     // For videos, insert a placeholder.
     if (fileType == FileType.video) {
-        updateFileInfoExif(fileID, createPlaceholderFileInfoExif());
+        update(createPlaceholderFileInfoExif());
         return;
     }
 
@@ -773,27 +776,13 @@ export const updateFileInfoExifIfNeeded = async (itemData: ItemData) => {
         const file = new File([originalImageBlob], "");
         const tags = await extractRawExif(file);
         const parsed = parseExif(tags);
-        updateFileInfoExif(fileID, { tags, parsed });
+        update({ tags, parsed });
     } catch (e) {
         log.error("Failed to extract exif", e);
         // Save the empty placeholder exif corresponding to the file, no point
         // in unnecessarily retrying this, it will deterministically fail again.
-        updateFileInfoExif(fileID, createPlaceholderFileInfoExif());
+        update(createPlaceholderFileInfoExif());
     }
-};
-
-const updateFileInfoExifIfAvailable = (
-    fileID: number,
-    exifData: FileInfoExif | undefined,
-) => {
-    if (exifData && !_state.fileInfoExifByFileID.has(fileID)) {
-        updateFileInfoExif(fileID, exifData);
-    }
-};
-
-const updateFileInfoExif = (fileID: number, exifData: FileInfoExif) => {
-    _state.fileInfoExifByFileID.set(fileID, exifData);
-    _state.exifObserverByFileID.get(fileID)?.(exifData);
 };
 
 const createPlaceholderFileInfoExif = (): FileInfoExif => ({

--- a/web/packages/gallery/services/exif.ts
+++ b/web/packages/gallery/services/exif.ts
@@ -52,6 +52,34 @@ export const parseExif = (tags: RawExifTags) => {
     return metadata;
 };
 
+export type ExifOrientation = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+/**
+ * Parse the Exif orientation tag from already extracted {@link RawExifTags}.
+ *
+ * Exif orientation can also be present in XMP as a TIFF tag. The Exif value, if
+ * present, takes precedence.
+ */
+export const parseExifOrientation = (
+    tags: RawExifTags,
+): ExifOrientation | undefined => {
+    const exifOrientation = tags.exif?.Orientation?.value;
+    if (exifOrientation != undefined) {
+        return isExifOrientation(exifOrientation) ? exifOrientation : undefined;
+    }
+
+    const xmpOrientation = tags.xmp?.Orientation?.value;
+    if (typeof xmpOrientation != "string") return undefined;
+
+    const orientation = Number(xmpOrientation);
+    return isExifOrientation(orientation) ? orientation : undefined;
+};
+
+const isExifOrientation = (
+    orientation: number,
+): orientation is ExifOrientation =>
+    Number.isInteger(orientation) && orientation >= 1 && orientation <= 8;
+
 /**
  * Parse GPS location from the metadata embedded in the file.
  *

--- a/web/packages/gallery/services/exif.ts
+++ b/web/packages/gallery/services/exif.ts
@@ -63,6 +63,9 @@ export type ExifOrientation = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 export const parseExifOrientation = (
     tags: RawExifTags,
 ): ExifOrientation | undefined => {
+    // Getting the EXIF Orientation value from the tags and checking validity of the same
+    // and if valid(i.e. between 1 to 8) then returning it. Else falling back to the
+    // xmpOrientation and doing the same validations.
     const exifOrientation = tags.exif?.Orientation?.value;
     if (exifOrientation != undefined) {
         return isExifOrientation(exifOrientation) ? exifOrientation : undefined;
@@ -75,6 +78,14 @@ export const parseExifOrientation = (
     return isExifOrientation(orientation) ? orientation : undefined;
 };
 
+/**
+ *
+ * @param orientation
+ * @returns the validity of a orientation.
+ *
+ * To be a valid orientation, it's value should be between
+ * 1 and 8.
+ */
 const isExifOrientation = (
     orientation: number,
 ): orientation is ExifOrientation =>

--- a/web/packages/gallery/services/image-orientation.ts
+++ b/web/packages/gallery/services/image-orientation.ts
@@ -1,4 +1,18 @@
-import type { ExifOrientation } from "ente-gallery/services/exif";
+import log from "ente-base/log";
+import {
+    extractRawExif,
+    parseExif,
+    parseExifOrientation,
+    type ExifOrientation,
+    type RawExifTags,
+} from "ente-gallery/services/exif";
+import type { ParsedMetadata } from "ente-media/file-metadata";
+
+export interface OrientedImageURLResult {
+    imageURL: string;
+    exif?: { tags: RawExifTags; parsed: ParsedMetadata };
+    orientedImageURL?: string;
+}
 
 // For the orientations 5 and above, the height and width of the images are
 // to be swapped for properly rendering them.
@@ -68,3 +82,73 @@ export const drawImageWithExifOrientation = (
     applyExifOrientationTransform(ctx, orientation, width, height);
     ctx.drawImage(image, 0, 0, width, height);
 };
+
+export const orientedImageURL = async (
+    imageURL: string,
+    originalImageBlob: Blob,
+): Promise<OrientedImageURLResult> => {
+    let exif: OrientedImageURLResult["exif"] | undefined;
+    let orientation: ExifOrientation | undefined;
+
+    try {
+        const tags = await extractRawExif(originalImageBlob);
+        const parsed = parseExif(tags);
+        exif = { tags, parsed };
+        orientation = parseExifOrientation(tags);
+    } catch (e) {
+        log.warn("Failed to extract exif for image orientation", e);
+        return { imageURL };
+    }
+
+    if (!orientation || orientation == 1) return { imageURL, exif };
+
+    const correctedImageURL = await canvasOrientedImageURL(
+        imageURL,
+        orientation,
+    );
+    return {
+        imageURL: correctedImageURL,
+        exif,
+        orientedImageURL: correctedImageURL,
+    };
+};
+
+const canvasOrientedImageURL = async (
+    imageURL: string,
+    orientation: ExifOrientation,
+) => {
+    const image = await loadImage(imageURL);
+    const width = image.naturalWidth;
+    const height = image.naturalHeight;
+    const canvasDimensions = dimensionsForExifOrientation(
+        width,
+        height,
+        orientation,
+    );
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasDimensions.width;
+    canvas.height = canvasDimensions.height;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Failed to get canvas 2D context");
+
+    drawImageWithExifOrientation(ctx, image, orientation, width, height);
+
+    return URL.createObjectURL(await canvasBlob(canvas));
+};
+
+const loadImage = (imageURL: string) =>
+    new Promise<HTMLImageElement>((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = reject;
+        image.src = imageURL;
+    });
+
+const canvasBlob = (canvas: HTMLCanvasElement) =>
+    new Promise<Blob>((resolve, reject) =>
+        canvas.toBlob((blob) =>
+            blob ? resolve(blob) : reject(new Error("toBlob failed")),
+        ),
+    );

--- a/web/packages/gallery/services/image-orientation.ts
+++ b/web/packages/gallery/services/image-orientation.ts
@@ -83,6 +83,17 @@ export const drawImageWithExifOrientation = (
     ctx.drawImage(image, 0, 0, width, height);
 };
 
+/**
+ * Return the original display URL and, when needed, an orientation-corrected
+ * object URL for the image.
+ *
+ * @param imageURL The renderable object URL of the image associated with the file.
+ * @param originalImageBlob The original image associated with the file, as a Blob.
+ *
+ * This is currently shared by the file viewer and the image editor. Callers
+ * should use `orientedImageURL ?? imageURL` for display, and only revoke
+ * `orientedImageURL` because it is created here.
+ */
 export const orientedImageURL = async (
     imageURL: string,
     originalImageBlob: Blob,
@@ -90,6 +101,8 @@ export const orientedImageURL = async (
     let exif: OrientedImageURLResult["exif"] | undefined;
     let orientation: ExifOrientation | undefined;
 
+    // Extract and parse the embedded metadata once, then read the orientation
+    // tag from the raw Exif/XMP tags.
     try {
         const tags = await extractRawExif(originalImageBlob);
         const parsed = parseExif(tags);
@@ -100,19 +113,24 @@ export const orientedImageURL = async (
         return { imageURL };
     }
 
+    // Missing orientation and orientation 1 are both no-op cases, so keep the
+    // original display URL and return any metadata we were able to parse.
     if (!orientation || orientation == 1) return { imageURL, exif };
 
     const correctedImageURL = await canvasOrientedImageURL(
         imageURL,
         orientation,
     );
-    return {
-        imageURL: correctedImageURL,
-        exif,
-        orientedImageURL: correctedImageURL,
-    };
+    return { imageURL, exif, orientedImageURL: correctedImageURL };
 };
 
+/**
+ * Draw the image into a new canvas with the requested Exif orientation applied,
+ * returning a new object URL for that canvas output.
+ *
+ * @param imageURL The renderable object URL of the image associated with the file.
+ * @param orientation The Exif orientation extracted from the image metadata.
+ */
 const canvasOrientedImageURL = async (
     imageURL: string,
     orientation: ExifOrientation,

--- a/web/packages/gallery/services/image-orientation.ts
+++ b/web/packages/gallery/services/image-orientation.ts
@@ -1,0 +1,51 @@
+import type { ExifOrientation } from "ente-gallery/services/exif";
+
+export const dimensionsForExifOrientation = (
+    width: number,
+    height: number,
+    orientation: ExifOrientation,
+) => (orientation >= 5 ? { width: height, height: width } : { width, height });
+
+export const applyExifOrientationTransform = (
+    ctx: CanvasRenderingContext2D,
+    orientation: ExifOrientation,
+    width: number,
+    height: number,
+) => {
+    switch (orientation) {
+        case 1:
+            break;
+        case 2:
+            ctx.transform(-1, 0, 0, 1, width, 0);
+            break;
+        case 3:
+            ctx.transform(-1, 0, 0, -1, width, height);
+            break;
+        case 4:
+            ctx.transform(1, 0, 0, -1, 0, height);
+            break;
+        case 5:
+            ctx.transform(0, 1, 1, 0, 0, 0);
+            break;
+        case 6:
+            ctx.transform(0, 1, -1, 0, height, 0);
+            break;
+        case 7:
+            ctx.transform(0, -1, -1, 0, height, width);
+            break;
+        case 8:
+            ctx.transform(0, -1, 1, 0, 0, width);
+            break;
+    }
+};
+
+export const drawImageWithExifOrientation = (
+    ctx: CanvasRenderingContext2D,
+    image: CanvasImageSource,
+    orientation: ExifOrientation,
+    width: number,
+    height: number,
+) => {
+    applyExifOrientationTransform(ctx, orientation, width, height);
+    ctx.drawImage(image, 0, 0, width, height);
+};

--- a/web/packages/gallery/services/image-orientation.ts
+++ b/web/packages/gallery/services/image-orientation.ts
@@ -1,11 +1,20 @@
 import type { ExifOrientation } from "ente-gallery/services/exif";
 
+// For the orientations 5 and above, the height and width of the images are
+// to be swapped for properly rendering them.
 export const dimensionsForExifOrientation = (
     width: number,
     height: number,
     orientation: ExifOrientation,
 ) => (orientation >= 5 ? { width: height, height: width } : { width, height });
 
+// Applies the correct canvas affine transform (mirror/rotate/flip) for each of
+// the 8 orientation cases.
+//
+// Note: the width and height passed here must be the pre-rotation (un-swapped)
+// dimensions. For orientations >= 5 this function does not swap them; it instead
+// rotates the canvas coordinate system via ctx.transform(), and that rotation is
+// what produces the visually swapped result.
 export const applyExifOrientationTransform = (
     ctx: CanvasRenderingContext2D,
     orientation: ExifOrientation,
@@ -14,31 +23,41 @@ export const applyExifOrientationTransform = (
 ) => {
     switch (orientation) {
         case 1:
+            // Horizontal (normal)
             break;
         case 2:
+            // Mirror horizontal
             ctx.transform(-1, 0, 0, 1, width, 0);
             break;
         case 3:
+            // Rotate 180
             ctx.transform(-1, 0, 0, -1, width, height);
             break;
         case 4:
+            // Mirror vertical
             ctx.transform(1, 0, 0, -1, 0, height);
             break;
         case 5:
+            // Mirror horizontal and rotate 270 CW
             ctx.transform(0, 1, 1, 0, 0, 0);
             break;
         case 6:
+            // Rotate 90 CW
             ctx.transform(0, 1, -1, 0, height, 0);
             break;
         case 7:
+            // Mirror horizontal and rotate 90 CW
             ctx.transform(0, -1, -1, 0, height, width);
             break;
         case 8:
+            // Rotate 270 CW
             ctx.transform(0, -1, 1, 0, 0, width);
             break;
     }
 };
 
+// Wrapper function which applies the transformation and then
+// draws the image.
 export const drawImageWithExifOrientation = (
     ctx: CanvasRenderingContext2D,
     image: CanvasImageSource,

--- a/web/packages/gallery/services/image-orientation.ts
+++ b/web/packages/gallery/services/image-orientation.ts
@@ -1,16 +1,12 @@
 import log from "ente-base/log";
 import {
     extractRawExif,
-    parseExif,
     parseExifOrientation,
     type ExifOrientation,
-    type RawExifTags,
 } from "ente-gallery/services/exif";
-import type { ParsedMetadata } from "ente-media/file-metadata";
 
 export interface OrientedImageURLResult {
     imageURL: string;
-    exif?: { tags: RawExifTags; parsed: ParsedMetadata };
     orientedImageURL?: string;
 }
 
@@ -98,15 +94,12 @@ export const orientedImageURL = async (
     imageURL: string,
     originalImageBlob: Blob,
 ): Promise<OrientedImageURLResult> => {
-    let exif: OrientedImageURLResult["exif"] | undefined;
     let orientation: ExifOrientation | undefined;
 
     // Extract and parse the embedded metadata once, then read the orientation
     // tag from the raw Exif/XMP tags.
     try {
         const tags = await extractRawExif(originalImageBlob);
-        const parsed = parseExif(tags);
-        exif = { tags, parsed };
         orientation = parseExifOrientation(tags);
     } catch (e) {
         log.warn("Failed to extract exif for image orientation", e);
@@ -114,14 +107,14 @@ export const orientedImageURL = async (
     }
 
     // Missing orientation and orientation 1 are both no-op cases, so keep the
-    // original display URL and return any metadata we were able to parse.
-    if (!orientation || orientation == 1) return { imageURL, exif };
+    // original display URL.
+    if (!orientation || orientation == 1) return { imageURL };
 
     const correctedImageURL = await canvasOrientedImageURL(
         imageURL,
         orientation,
     );
-    return { imageURL, exif, orientedImageURL: correctedImageURL };
+    return { imageURL, orientedImageURL: correctedImageURL };
 };
 
 /**

--- a/web/packages/gallery/services/upload/thumbnail.ts
+++ b/web/packages/gallery/services/upload/thumbnail.ts
@@ -1,6 +1,15 @@
 import log from "ente-base/log";
 import { type Electron } from "ente-base/types/ipc";
+import {
+    extractRawExif,
+    parseExifOrientation,
+    type ExifOrientation,
+} from "ente-gallery/services/exif";
 import * as ffmpeg from "ente-gallery/services/ffmpeg";
+import {
+    dimensionsForExifOrientation,
+    drawImageWithExifOrientation,
+} from "ente-gallery/services/image-orientation";
 import {
     toPathOrZipEntry,
     type FileSystemUploadItem,
@@ -60,15 +69,29 @@ const generateImageThumbnailWeb = async (
     blob: Blob,
     { extension }: FileTypeInfo,
 ) => {
+    const orientation = await exifOrientation(blob);
+
     if (isHEICExtension(extension)) {
         log.debug(() => `Pre-converting HEIC to JPEG for thumbnail generation`);
         blob = await heicToJPEG(blob);
     }
 
-    return generateImageThumbnailUsingCanvas(blob);
+    return generateImageThumbnailUsingCanvas(blob, orientation ?? 1);
 };
 
-const generateImageThumbnailUsingCanvas = async (blob: Blob) => {
+const exifOrientation = async (blob: Blob) => {
+    try {
+        return parseExifOrientation(await extractRawExif(new File([blob], "")));
+    } catch (e) {
+        log.warn("Failed to extract exif for thumbnail orientation", e);
+        return undefined;
+    }
+};
+
+const generateImageThumbnailUsingCanvas = async (
+    blob: Blob,
+    orientation: ExifOrientation,
+) => {
     const canvas = document.createElement("canvas");
     const canvasCtx = canvas.getContext("2d")!;
 
@@ -80,14 +103,30 @@ const generateImageThumbnailUsingCanvas = async (blob: Blob) => {
             image.onload = () => {
                 try {
                     URL.revokeObjectURL(imageURL);
-                    const { width, height } = scaledImageDimensions(
+                    const orientedDimensions = dimensionsForExifOrientation(
                         image.width,
                         image.height,
+                        orientation,
+                    );
+                    const { width, height } = scaledImageDimensions(
+                        orientedDimensions.width,
+                        orientedDimensions.height,
                         maxThumbnailDimension,
+                    );
+                    const drawDimensions = dimensionsForExifOrientation(
+                        width,
+                        height,
+                        orientation,
                     );
                     canvas.width = width;
                     canvas.height = height;
-                    canvasCtx.drawImage(image, 0, 0, width, height);
+                    drawImageWithExifOrientation(
+                        canvasCtx,
+                        image,
+                        orientation,
+                        drawDimensions.width,
+                        drawDimensions.height,
+                    );
                     resolve(undefined);
                 } catch (e: unknown) {
                     // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors

--- a/web/packages/gallery/services/upload/thumbnail.ts
+++ b/web/packages/gallery/services/upload/thumbnail.ts
@@ -76,11 +76,18 @@ const generateImageThumbnailWeb = async (
         blob = await heicToJPEG(blob);
     }
 
+    // Thumbnails are now rotated to match the EXIF orientation, so pass the
+    // extracted orientation through (defaulting to 1, i.e. no-op, when absent).
     return generateImageThumbnailUsingCanvas(blob, orientation ?? 1);
 };
 
 const exifOrientation = async (blob: Blob) => {
     try {
+        /**
+         * extractRawExif extracts and returns the file's tags using the
+         * ExifReader library; parseExifOrientation then pulls the orientation
+         * value out of those tags.
+         */
         return parseExifOrientation(await extractRawExif(new File([blob], "")));
     } catch (e) {
         log.warn("Failed to extract exif for thumbnail orientation", e);
@@ -103,16 +110,28 @@ const generateImageThumbnailUsingCanvas = async (
             image.onload = () => {
                 try {
                     URL.revokeObjectURL(imageURL);
+                    // Passing the width and height of the original image to
+                    // get them swapped if the EXIF Orientation is >= 5
                     const orientedDimensions = dimensionsForExifOrientation(
                         image.width,
                         image.height,
                         orientation,
                     );
+
+                    // Using the orientation-corrected width and height to
+                    // compute the thumbnail's dimensions, scaling down to fit
+                    // within maxThumbnailDimension.
                     const { width, height } = scaledImageDimensions(
                         orientedDimensions.width,
                         orientedDimensions.height,
                         maxThumbnailDimension,
                     );
+
+                    // drawImageWithExifOrientation rotates the canvas
+                    // coordinate system when orientation is >= 5, so drawImage's
+                    // destination rectangle must be expressed in the
+                    // pre-rotation (un-swapped) frame. Swap back here so the
+                    // image is not distorted.
                     const drawDimensions = dimensionsForExifOrientation(
                         width,
                         height,

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -47,6 +47,7 @@ import { nameAndExtension } from "ente-base/file-name";
 import log from "ente-base/log";
 import { saveAsFileAndRevokeObjectURL } from "ente-base/utils/web";
 import { downloadManager } from "ente-gallery/services/download";
+import { orientedImageURL } from "ente-gallery/services/image-orientation";
 import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
 import { fileFileName } from "ente-media/file-metadata";
@@ -111,6 +112,10 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const originalSizeCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const parentRef = useRef<HTMLDivElement | null>(null);
+    const editorOrientedImageURLRef = useRef<string | undefined>(undefined);
+    const loadCanvasRequestIDRef = useRef(0);
+    const openRef = useRef(open);
+    openRef.current = open;
 
     const [fileURL, setFileURL] = useState<string | undefined>(undefined);
     // The MIME type of the original file that we are editing.
@@ -159,6 +164,17 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
     const [isGrowing, setIsGrowing] = useState(false);
 
     const cropBoxRef = useRef<HTMLDivElement>(null);
+
+    const revokeEditorOrientedImageURL = () => {
+        if (editorOrientedImageURLRef.current) {
+            URL.revokeObjectURL(editorOrientedImageURLRef.current);
+            editorOrientedImageURLRef.current = undefined;
+        }
+    };
+
+    const invalidateLoadCanvasRequests = () => {
+        loadCanvasRequestIDRef.current += 1;
+    };
 
     const getCanvasBoundsOffsets = () => {
         const canvasBounds = {
@@ -361,6 +377,11 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
     };
 
     const loadCanvas = async () => {
+        const loadCanvasRequestID = (loadCanvasRequestIDRef.current += 1);
+        const isStaleLoad = () =>
+            loadCanvasRequestID != loadCanvasRequestIDRef.current ||
+            !openRef.current;
+
         try {
             if (
                 !canvasRef.current ||
@@ -384,8 +405,21 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                 if (sourceURLs.type != "image") {
                     throw new Error("Image editor invoked for non-image file");
                 }
-                img.src = sourceURLs.imageURL;
-                setFileURL(sourceURLs.imageURL);
+                if (isStaleLoad()) return;
+                const oriented = await orientedImageURL(
+                    sourceURLs.imageURL,
+                    sourceURLs.originalImageBlob,
+                );
+                if (isStaleLoad()) {
+                    if (oriented.orientedImageURL) {
+                        URL.revokeObjectURL(oriented.orientedImageURL);
+                    }
+                    return;
+                }
+                revokeEditorOrientedImageURL();
+                editorOrientedImageURLRef.current = oriented.orientedImageURL;
+                img.src = oriented.imageURL;
+                setFileURL(oriented.imageURL);
                 setMIMEType(sourceURLs.mimeType);
             } else {
                 img.src = fileURL;
@@ -394,6 +428,10 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
             await new Promise((resolve, reject) => {
                 img.onload = () => {
                     try {
+                        if (isStaleLoad()) {
+                            resolve(true);
+                            return;
+                        }
                         const scale = Math.min(
                             parentRef.current!.clientWidth / img.width,
                             parentRef.current!.clientHeight / img.height,
@@ -445,7 +483,19 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
         void loadCanvas();
     }, [open, file]);
 
+    useEffect(() => {
+        if (!open) {
+            invalidateLoadCanvasRequests();
+            revokeEditorOrientedImageURL();
+            setFileURL(undefined);
+        }
+    }, [open]);
+
+    useEffect(() => () => revokeEditorOrientedImageURL(), []);
+
     const handleClose = () => {
+        invalidateLoadCanvasRequests();
+        revokeEditorOrientedImageURL();
         setFileURL(undefined);
         onClose();
     };
@@ -483,6 +533,8 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                 (c) => c.id == file.collectionID,
             );
             onSaveEditedCopy(await getEditedFile(), collection!, file);
+            invalidateLoadCanvasRequests();
+            revokeEditorOrientedImageURL();
             setFileURL(undefined);
         } catch (e) {
             log.error("Error saving copy to ente", e);

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -112,6 +112,15 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const originalSizeCanvasRef = useRef<HTMLCanvasElement | null>(null);
     const parentRef = useRef<HTMLDivElement | null>(null);
+
+    /**
+     * The below refs are for rendering the image file in the proper
+     * EXIF Orientation respected manner.
+     *
+     * editorOrientedImageURLRef: remembers the object URL for orientation correction, for later revocation.
+     * loadCanvasRequestIDRef: gives each async canvas load a generation ID, so older loads can be ignored.
+     * openRef: for letting async callbacks check whether modal is open or not.
+     */
     const editorOrientedImageURLRef = useRef<string | undefined>(undefined);
     const loadCanvasRequestIDRef = useRef(0);
     const openRef = useRef(open);
@@ -165,6 +174,11 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
 
     const cropBoxRef = useRef<HTMLDivElement>(null);
 
+    /**
+     * Since the OrientedImageURL is created in this module,
+     * on close/reset this URL needs to be revoked to and this
+     * function facilitates that using the editorOrientedImageURLRef
+     */
     const revokeEditorOrientedImageURL = () => {
         if (editorOrientedImageURLRef.current) {
             URL.revokeObjectURL(editorOrientedImageURLRef.current);

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -418,8 +418,10 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                 }
                 revokeEditorOrientedImageURL();
                 editorOrientedImageURLRef.current = oriented.orientedImageURL;
-                img.src = oriented.imageURL;
-                setFileURL(oriented.imageURL);
+                const displayImageURL =
+                    oriented.orientedImageURL ?? oriented.imageURL;
+                img.src = displayImageURL;
+                setFileURL(displayImageURL);
                 setMIMEType(sourceURLs.mimeType);
             } else {
                 img.src = fileURL;


### PR DESCRIPTION
## Description

This PR parses the EXIF Orientation and rotates the image accordingly while showing it in the FileViewer. For thumbnails, during generation itself, if EXIF Orientation is present, the thumbnail is rotated first before being sent to the backend.

Nuance:

Existing files whose thumbnails are already generated will remain in their current state, since thumbnails aren't regenerated at the moment.

The ideal fix would be to rotate thumbnails during rendering at the gallery, but my initial assumption is that this could be compute-heavy - the check needs to run for every thumbnail regardless of whether it has EXIF Orientation or not.
So for now, sticking to the fix at generation time. if i find an optimal method to handle existing thumbnails during rendering, it'll be done as a separate PR.

Current Rendering

<img width="1352" height="730" alt="image" src="https://github.com/user-attachments/assets/f50146ff-7894-4942-ae7d-83ee2e4f957f" />

Post Implementation Result

<img width="1374" height="657" alt="image" src="https://github.com/user-attachments/assets/321b7acb-1120-475b-b1b0-47ac1d093cac" />


