### PR TITLE
[mobile][auth] Initialize X11 threading for Linux Auth

### DIFF
--- a/mobile/apps/auth/changes/linux-x11-threading.md
+++ b/mobile/apps/auth/changes/linux-x11-threading.md
@@ -1,0 +1,1 @@
+- Fixed Auth startup crashes on Linux X11 sessions caused by Xlib threading initialization.

--- a/mobile/apps/auth/linux/CMakeLists.txt
+++ b/mobile/apps/auth/linux/CMakeLists.txt
@@ -55,6 +55,7 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # System-level dependencies.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11)
 
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 
@@ -75,6 +76,7 @@ apply_standard_settings(${BINARY_NAME})
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::X11)
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)

--- a/mobile/apps/auth/linux/main.cc
+++ b/mobile/apps/auth/linux/main.cc
@@ -1,6 +1,13 @@
 #include "my_application.h"
 
+#ifdef GDK_WINDOWING_X11
+#include <X11/Xlib.h>
+#endif
+
 int main(int argc, char** argv) {
+#ifdef GDK_WINDOWING_X11
+  XInitThreads();
+#endif
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }


### PR DESCRIPTION
- Initialize Xlib threading before GTK/Flutter startup on Linux X11 sessions.
- Link the Auth Linux runner with X11 for the XInitThreads() call.

Fixes #8562
Refs flutter/flutter#169470, flutter/flutter#170937

Validation: git diff --check; release-note generation; Docker compile check on ubuntu:22.04 for main.cc with GTK/X11