### PR TITLE
[mobile][auth] Fix Linux deb runtime dependencies

### DIFF
--- a/mobile/apps/auth/changes/linux-deb-runtime-deps.md
+++ b/mobile/apps/auth/changes/linux-deb-runtime-deps.md
@@ -1,0 +1,1 @@
+- Fixed Auth deb installs missing Linux runtime dependencies on fresh systems.

--- a/mobile/apps/auth/linux/packaging/deb/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/deb/make_config.yaml
@@ -15,12 +15,13 @@ installed_size: 36000
 metainfo: linux/packaging/enteauth.appdata.xml
 
 dependencies:
+  - libcurl4
   - libsqlite3-0
   - libsodium23
   - libsecret-1-0
   - policykit-1 | polkitd
-  - libappindicator3-1 | libayatana-appindicator3-1
-  - gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1
+  - libayatana-appindicator3-1 | libappindicator3-1
+  - gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1
   - libayatana-ido3-0.4-0
 
 postinstall_scripts:

--- a/mobile/apps/auth/linux/packaging/deb/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/deb/make_config.yaml
@@ -20,8 +20,8 @@ dependencies:
   - libsodium23
   - libsecret-1-0
   - policykit-1 | polkitd
-  - libayatana-appindicator3-1 | libappindicator3-1
-  - gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1
+  - libayatana-appindicator3-1
+  - gir1.2-ayatanaappindicator3-0.1
   - libayatana-ido3-0.4-0
 
 postinstall_scripts:


### PR DESCRIPTION
- Add the missing libcurl4 runtime dependency for bundled Sentry native library loading in the Auth Linux deb.
- Require Ayatana AppIndicator runtime packages so both fresh installs and upgrades resolve the libraries linked by the current Linux build.

Refs #1870, #2070, #2531, #2987, #1911

Validation: git diff --check; release-note generation; Docker apt resolver checks on ubuntu:24.04 fresh/upgrade path and debian:trixie-slim; ruby mobile/scripts/check_frozen_pubspecs.rb mobile