### PR TITLE
[mobile][auth] Remove scanner device preflight

### DIFF
--- a/mobile/apps/auth/lib/ui/components/scanner_camera_view.dart
+++ b/mobile/apps/auth/lib/ui/components/scanner_camera_view.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:ente_qr_scanner/ente_qr_scanner.dart';
 import 'package:flutter/material.dart';
 
@@ -21,44 +18,12 @@ class ScannerCameraView extends StatefulWidget {
 }
 
 class _ScannerCameraViewState extends State<ScannerCameraView> {
-  late final Future<bool> _isCameraScannerAvailable =
-      _isCameraScannerAvailableOnDevice();
-
   @override
   Widget build(BuildContext context) {
-    if (!Platform.isIOS) {
-      return _buildScannerView();
-    }
-
-    return FutureBuilder<bool>(
-      future: _isCameraScannerAvailable,
-      builder: (context, snapshot) {
-        if (snapshot.data == true) {
-          return _buildScannerView();
-        }
-        return const ColoredBox(color: Colors.black);
-      },
-    );
-  }
-
-  Widget _buildScannerView() {
     return EnteQrScannerView(
       overlay: widget.overlay,
       onScannerCreated: widget.onScannerCreated,
       onError: widget.onError,
     );
-  }
-}
-
-Future<bool> _isCameraScannerAvailableOnDevice() async {
-  if (!Platform.isIOS) {
-    return true;
-  }
-
-  try {
-    final iosInfo = await DeviceInfoPlugin().iosInfo;
-    return iosInfo.isPhysicalDevice;
-  } catch (_) {
-    return true;
   }
 }

--- a/mobile/apps/auth/pubspec.lock
+++ b/mobile/apps/auth/pubspec.lock
@@ -249,7 +249,7 @@ packages:
     source: hosted
     version: "0.7.12"
   device_info_plus:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: device_info_plus
       sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   confetti: 0.8.0
   connectivity_plus: 6.1.4
   convert: 3.1.2
-  device_info_plus: 11.5.0
   dio: 5.9.2
   dots_indicator: 4.0.1
   dotted_border: 3.1.0


### PR DESCRIPTION
## Summary
- Remove the Auth scanner wrapper's iOS device-info preflight before creating the native camera view.
- Let `ente_qr_scanner` handle simulator/no-camera fallback natively.
- Drop Auth's direct `device_info_plus` dependency; it remains transitive via crypto code.

Follow-up to the merged QR scanner migration.