### PR TITLE
[mob][photos] Add received album filters

### DIFF
--- a/mobile/apps/photos/changes/shared-received-album-filters.md
+++ b/mobile/apps/photos/changes/shared-received-album-filters.md
@@ -1,0 +1,1 @@
+- Added separate Shared and Received filters to Albums.

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1545,6 +1545,10 @@
   "@searchResultShared": {
     "description": "Search result subtitle label for shared-with-you results"
   },
+  "received": "Received",
+  "@received": {
+    "description": "Albums tab filter label for albums received from other people"
+  },
   "searchResultUploadedBy": "Uploaded by",
   "@searchResultUploadedBy": {
     "description": "Search result subtitle label for uploader results"

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1542,8 +1542,12 @@
     "description": "Search result subtitle label for person results"
   },
   "shared": "Shared",
-  "received": "Received",
-  "@received": {
+  "sharedAlbumsLabel": "Shared",
+  "@sharedAlbumsLabel": {
+    "description": "Albums tab label for albums shared by you"
+  },
+  "receivedAlbumsLabel": "Received",
+  "@receivedAlbumsLabel": {
     "description": "Albums tab filter label for albums received from other people"
   },
   "searchResultUploadedBy": "Uploaded by",

--- a/mobile/apps/photos/lib/l10n/intl_en.arb
+++ b/mobile/apps/photos/lib/l10n/intl_en.arb
@@ -1541,10 +1541,7 @@
   "@searchResultPerson": {
     "description": "Search result subtitle label for person results"
   },
-  "searchResultShared": "Shared",
-  "@searchResultShared": {
-    "description": "Search result subtitle label for shared-with-you results"
-  },
+  "shared": "Shared",
   "received": "Received",
   "@received": {
     "description": "Albums tab filter label for albums received from other people"
@@ -1728,7 +1725,6 @@
   "nothingSharedWithYouYet": "Nothing shared with you yet",
   "noAlbumsSharedByYouYet": "No albums shared by you yet",
   "sharedWithYou": "Shared with you",
-  "sharedByYou": "Shared by you",
   "inviteYourFriendsToEnte": "Invite your friends to Ente",
   "failedToDownloadVideo": "Failed to download video",
   "hiding": "Hiding...",

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -35,7 +35,7 @@ import "package:photos/ui/viewer/actions/album_selection_overlay_bar.dart";
 import "package:photos/ui/viewer/actions/delete_empty_albums.dart";
 import "package:photos/utils/local_settings.dart";
 
-enum _AlbumsFilter { ente, onDevice, shared }
+enum _AlbumsFilter { ente, onDevice, shared, received }
 
 enum _AlbumsMenuAction { toggleView, name, lastUpdated }
 
@@ -71,6 +71,9 @@ class _AlbumsTabState extends State<AlbumsTab>
   );
   final ValueNotifier<List<Collection>?> _enteCollections = ValueNotifier(null);
   final ValueNotifier<List<Collection>?> _sharedCollections = ValueNotifier(
+    null,
+  );
+  final ValueNotifier<List<Collection>?> _receivedCollections = ValueNotifier(
     null,
   );
   final ValueNotifier<bool> _shouldShowDeleteEmptyAlbums = ValueNotifier(false);
@@ -161,6 +164,7 @@ class _AlbumsTabState extends State<AlbumsTab>
     _loggedOutEvent = Bus.instance.on<UserLoggedOutEvent>().listen((_) {
       _enteCollections.value = null;
       _sharedCollections.value = null;
+      _receivedCollections.value = null;
     });
     _tabChangedEvent = Bus.instance.on<TabChangedEvent>().listen(
       _handleTabChanged,
@@ -225,6 +229,7 @@ class _AlbumsTabState extends State<AlbumsTab>
     if (!Configuration.instance.hasConfiguredAccount()) {
       _enteCollections.value = <Collection>[];
       _sharedCollections.value = <Collection>[];
+      _receivedCollections.value = <Collection>[];
       _shouldShowDeleteEmptyAlbums.value = false;
       return;
     }
@@ -281,7 +286,8 @@ class _AlbumsTabState extends State<AlbumsTab>
   Future<void> _loadSharedCollections() async {
     final shared = await CollectionsService.instance.getSharedCollections();
     if (!mounted) return;
-    _sharedCollections.value = shared.incoming;
+    _sharedCollections.value = shared.outgoing;
+    _receivedCollections.value = shared.incoming;
   }
 
   void _selectFilter(_AlbumsFilter filter) {
@@ -487,17 +493,24 @@ class _AlbumsTabState extends State<AlbumsTab>
 
     final enteCollections = _enteCollections.value;
     final sharedCollections = _sharedCollections.value;
+    final receivedCollections = _receivedCollections.value;
     final filteredEnteCollections = enteCollections == null
         ? null
         : _filterCollectionsByQuery(enteCollections);
     final filteredSharedCollections = sharedCollections == null
         ? null
         : _filterCollectionsByQuery(sharedCollections);
+    final filteredReceivedCollections = receivedCollections == null
+        ? null
+        : _filterCollectionsByQuery(receivedCollections);
     final hasRemoteCollections =
         (filteredEnteCollections?.isNotEmpty ?? false) ||
-        (filteredSharedCollections?.isNotEmpty ?? false);
+        (filteredSharedCollections?.isNotEmpty ?? false) ||
+        (filteredReceivedCollections?.isNotEmpty ?? false);
     final hasFinishedLoadingRemoteCollections =
-        enteCollections != null && sharedCollections != null;
+        enteCollections != null &&
+        sharedCollections != null &&
+        receivedCollections != null;
     final shouldShowDeviceSearchState =
         hasFinishedLoadingRemoteCollections && !hasRemoteCollections;
 
@@ -527,6 +540,11 @@ class _AlbumsTabState extends State<AlbumsTab>
           tag: "album_search_shared",
           collections: filteredSharedCollections,
         ),
+        ..._buildCollectionSearchSectionSlivers(
+          title: strings.received,
+          tag: "album_search_received",
+          collections: filteredReceivedCollections,
+        ),
         SliverToBoxAdapter(child: SizedBox(height: bottomPadding)),
       ],
     );
@@ -547,6 +565,10 @@ class _AlbumsTabState extends State<AlbumsTab>
         emptyState = const OnEnteEmptyState();
       case _AlbumsFilter.shared:
         collections = _sharedCollections.value;
+        showCreateAlbum = false;
+        emptyState = const SharedEmptyState();
+      case _AlbumsFilter.received:
+        collections = _receivedCollections.value;
         showCreateAlbum = false;
         emptyState = const SharedEmptyState();
       case _AlbumsFilter.onDevice:
@@ -583,6 +605,10 @@ class _AlbumsTabState extends State<AlbumsTab>
         _enteCollections.value == null ? "ente_loading" : "ente_ready",
       _AlbumsFilter.shared =>
         _sharedCollections.value == null ? "shared_loading" : "shared_ready",
+      _AlbumsFilter.received =>
+        _receivedCollections.value == null
+            ? "received_loading"
+            : "received_ready",
       _AlbumsFilter.onDevice => "device",
     };
 
@@ -726,6 +752,7 @@ class _AlbumsTabState extends State<AlbumsTab>
     _filter.dispose();
     _enteCollections.dispose();
     _sharedCollections.dispose();
+    _receivedCollections.dispose();
     _shouldShowDeleteEmptyAlbums.dispose();
     _viewType.dispose();
     _sortKey.dispose();
@@ -866,7 +893,7 @@ class _AlbumsTabState extends State<AlbumsTab>
                       : Padding(
                           key: const ValueKey("album_filters"),
                           padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
+                            horizontal: 16,
                             vertical: 8,
                           ),
                           child: Row(
@@ -878,59 +905,70 @@ class _AlbumsTabState extends State<AlbumsTab>
                                     final effectiveFilter = localGalleryMode
                                         ? _AlbumsFilter.onDevice
                                         : selected;
-                                    return SingleChildScrollView(
-                                      scrollDirection: Axis.horizontal,
-                                      physics: const BouncingScrollPhysics(),
-                                      child: Row(
-                                        children: [
-                                          if (!localGalleryMode) ...[
-                                            _AlbumsFilterChip(
-                                              label: strings.ente,
-                                              selected:
-                                                  effectiveFilter ==
-                                                  _AlbumsFilter.ente,
-                                              onTap: () => _selectFilter(
-                                                _AlbumsFilter.ente,
-                                              ),
-                                            ),
-                                            const SizedBox(width: 8),
-                                          ],
-                                          _AlbumsFilterChip(
-                                            label: strings.onDevice,
-                                            selected:
-                                                effectiveFilter ==
-                                                _AlbumsFilter.onDevice,
-                                            onTap: () => _selectFilter(
-                                              _AlbumsFilter.onDevice,
-                                            ),
+                                    return Stack(
+                                      children: [
+                                        SingleChildScrollView(
+                                          scrollDirection: Axis.horizontal,
+                                          physics:
+                                              const BouncingScrollPhysics(),
+                                          padding: const EdgeInsets.only(
+                                            right: 44,
                                           ),
-                                          if (!localGalleryMode) ...[
-                                            const SizedBox(width: 8),
-                                            _AlbumsFilterChip(
-                                              label: strings.searchResultShared,
-                                              selected:
-                                                  effectiveFilter ==
-                                                  _AlbumsFilter.shared,
-                                              onTap: () => _selectFilter(
-                                                _AlbumsFilter.shared,
-                                              ),
-                                            ),
-                                            const SizedBox(width: 8),
-                                            _AlbumsFilterChip(
-                                              label: strings.more,
-                                              selected: false,
-                                              trailing: const Icon(
-                                                Icons.keyboard_arrow_down,
-                                                size: 18,
-                                              ),
-                                              onTap: () =>
-                                                  showAlbumsManageSheet(
-                                                    context,
+                                          child: Row(
+                                            children: [
+                                              if (!localGalleryMode) ...[
+                                                _AlbumsFilterChip(
+                                                  label: strings.ente,
+                                                  selected:
+                                                      effectiveFilter ==
+                                                      _AlbumsFilter.ente,
+                                                  onTap: () => _selectFilter(
+                                                    _AlbumsFilter.ente,
                                                   ),
-                                            ),
-                                          ],
-                                        ],
-                                      ),
+                                                ),
+                                                const SizedBox(width: 8),
+                                              ],
+                                              _AlbumsFilterChip(
+                                                label: strings.onDevice,
+                                                selected:
+                                                    effectiveFilter ==
+                                                    _AlbumsFilter.onDevice,
+                                                onTap: () => _selectFilter(
+                                                  _AlbumsFilter.onDevice,
+                                                ),
+                                              ),
+                                              if (!localGalleryMode) ...[
+                                                const SizedBox(width: 8),
+                                                _AlbumsFilterChip(
+                                                  label: strings
+                                                      .searchResultShared,
+                                                  selected:
+                                                      effectiveFilter ==
+                                                      _AlbumsFilter.shared,
+                                                  onTap: () => _selectFilter(
+                                                    _AlbumsFilter.shared,
+                                                  ),
+                                                ),
+                                                const SizedBox(width: 8),
+                                                _AlbumsFilterChip(
+                                                  label: strings.received,
+                                                  selected:
+                                                      effectiveFilter ==
+                                                      _AlbumsFilter.received,
+                                                  onTap: () => _selectFilter(
+                                                    _AlbumsFilter.received,
+                                                  ),
+                                                ),
+                                              ],
+                                            ],
+                                          ),
+                                        ),
+                                        _AlbumsMoreButtonOverlay(
+                                          tooltip: strings.more,
+                                          onTap: () =>
+                                              showAlbumsManageSheet(context),
+                                        ),
+                                      ],
                                     );
                                   },
                                 ),
@@ -946,6 +984,7 @@ class _AlbumsTabState extends State<AlbumsTab>
                     _filter,
                     _enteCollections,
                     _sharedCollections,
+                    _receivedCollections,
                     _shouldShowDeleteEmptyAlbums,
                     _viewType,
                     _sortKey,
@@ -994,6 +1033,7 @@ class _AlbumsTabState extends State<AlbumsTab>
               _filter,
               _enteCollections,
               _sharedCollections,
+              _receivedCollections,
             ]),
             builder: (context, _) {
               final filter = _effectiveFilter;
@@ -1004,8 +1044,11 @@ class _AlbumsTabState extends State<AlbumsTab>
                   sectionType = UISectionType.homeCollections;
                   collections = _enteCollections.value;
                 case _AlbumsFilter.shared:
-                  sectionType = UISectionType.incomingCollections;
+                  sectionType = UISectionType.outgoingCollections;
                   collections = _sharedCollections.value;
+                case _AlbumsFilter.received:
+                  sectionType = UISectionType.incomingCollections;
+                  collections = _receivedCollections.value;
                 case _AlbumsFilter.onDevice:
                   return const SizedBox.shrink();
               }
@@ -1035,23 +1078,75 @@ class _AlbumsFilterChip extends StatelessWidget {
     required this.label,
     required this.selected,
     required this.onTap,
-    this.trailing,
   });
 
   final String label;
   final bool selected;
   final VoidCallback onTap;
-  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
     return TagChipComponent(
       label: label,
-      trailing: trailing,
       state: selected
           ? TagChipComponentState.selected
           : TagChipComponentState.unselected,
       onTap: onTap,
+    );
+  }
+}
+
+class _AlbumsMoreButtonOverlay extends StatelessWidget {
+  const _AlbumsMoreButtonOverlay({required this.tooltip, required this.onTap});
+
+  final String tooltip;
+  final FutureOr<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final componentColors = context.componentColors;
+
+    return Positioned.fill(
+      child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            right: 0,
+            bottom: 0,
+            child: IgnorePointer(
+              child: Container(
+                width: 96,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.centerRight,
+                    end: Alignment.centerLeft,
+                    colors: [
+                      componentColors.backgroundBase,
+                      componentColors.backgroundBase.withValues(alpha: 0.92),
+                      componentColors.backgroundBase.withValues(alpha: 0.62),
+                      componentColors.backgroundBase.withValues(alpha: 0.32),
+                      componentColors.backgroundBase.withValues(alpha: 0.12),
+                      componentColors.backgroundBase.withValues(alpha: 0.12),
+                    ],
+                    stops: const [0, 0.34, 0.56, 0.76, 0.92, 1],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 4,
+            right: 0,
+            child: IconButtonComponent(
+              variant: IconButtonComponentVariant.primary,
+              shouldSurfaceExecutionStates: false,
+              tooltip: tooltip,
+              icon: const Icon(Icons.keyboard_arrow_down, size: 18),
+              onTap: onTap,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:ui" show BlendMode, ImageFilter;
 
 import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
@@ -1104,6 +1105,7 @@ class _AlbumsMoreButtonOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final componentColors = context.componentColors;
+    final maskColor = componentColors.backgroundBase;
 
     return Positioned.fill(
       child: Stack(
@@ -1113,21 +1115,30 @@ class _AlbumsMoreButtonOverlay extends StatelessWidget {
             right: 0,
             bottom: 0,
             child: IgnorePointer(
-              child: Container(
-                width: 96,
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.centerRight,
-                    end: Alignment.centerLeft,
-                    colors: [
-                      componentColors.backgroundBase,
-                      componentColors.backgroundBase.withValues(alpha: 0.92),
-                      componentColors.backgroundBase.withValues(alpha: 0.62),
-                      componentColors.backgroundBase.withValues(alpha: 0.32),
-                      componentColors.backgroundBase.withValues(alpha: 0.12),
-                      componentColors.backgroundBase.withValues(alpha: 0.12),
-                    ],
-                    stops: const [0, 0.34, 0.56, 0.76, 0.92, 1],
+              child: ShaderMask(
+                blendMode: BlendMode.dstIn,
+                shaderCallback: (bounds) => LinearGradient(
+                  begin: Alignment.centerRight,
+                  end: Alignment.centerLeft,
+                  colors: [
+                    maskColor,
+                    maskColor,
+                    maskColor.withValues(alpha: 0),
+                  ],
+                  stops: const [0, 0.48, 1],
+                ).createShader(bounds),
+                child: SizedBox(
+                  width: 72,
+                  child: ClipRect(
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                      child: ColoredBox(
+                        color: componentColors.backgroundBase.withValues(
+                          alpha: 0.66,
+                        ),
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
                   ),
                 ),
               ),

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -537,12 +537,12 @@ class _AlbumsTabState extends State<AlbumsTab>
               : null,
         ),
         ..._buildCollectionSearchSectionSlivers(
-          title: strings.shared,
+          title: strings.sharedAlbumsLabel,
           tag: "album_search_shared",
           collections: filteredSharedCollections,
         ),
         ..._buildCollectionSearchSectionSlivers(
-          title: strings.received,
+          title: strings.receivedAlbumsLabel,
           tag: "album_search_received",
           collections: filteredReceivedCollections,
         ),
@@ -941,7 +941,8 @@ class _AlbumsTabState extends State<AlbumsTab>
                                               if (!localGalleryMode) ...[
                                                 const SizedBox(width: 8),
                                                 _AlbumsFilterChip(
-                                                  label: strings.shared,
+                                                  label:
+                                                      strings.sharedAlbumsLabel,
                                                   selected:
                                                       effectiveFilter ==
                                                       _AlbumsFilter.shared,
@@ -951,7 +952,8 @@ class _AlbumsTabState extends State<AlbumsTab>
                                                 ),
                                                 const SizedBox(width: 8),
                                                 _AlbumsFilterChip(
-                                                  label: strings.received,
+                                                  label: strings
+                                                      .receivedAlbumsLabel,
                                                   selected:
                                                       effectiveFilter ==
                                                       _AlbumsFilter.received,

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -536,7 +536,7 @@ class _AlbumsTabState extends State<AlbumsTab>
               : null,
         ),
         ..._buildCollectionSearchSectionSlivers(
-          title: strings.searchResultShared,
+          title: strings.shared,
           tag: "album_search_shared",
           collections: filteredSharedCollections,
         ),
@@ -940,8 +940,7 @@ class _AlbumsTabState extends State<AlbumsTab>
                                               if (!localGalleryMode) ...[
                                                 const SizedBox(width: 8),
                                                 _AlbumsFilterChip(
-                                                  label: strings
-                                                      .searchResultShared,
+                                                  label: strings.shared,
                                                   selected:
                                                       effectiveFilter ==
                                                       _AlbumsFilter.shared,

--- a/mobile/apps/photos/lib/ui/viewer/search/result/search_result_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/search_result_widget.dart
@@ -122,7 +122,7 @@ class SearchResultWidget extends StatelessWidget {
       case ResultType.faces:
         return localizations.searchResultPerson;
       case ResultType.shared:
-        return localizations.searchResultShared;
+        return localizations.shared;
       case ResultType.uploader:
         return localizations.searchResultUploadedBy;
       case ResultType.cameraMake:

--- a/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
@@ -315,7 +315,7 @@ String _sectionTitle(BuildContext context, _SearchResultsSection section) {
     case _SearchResultsSection.people:
       return AppLocalizations.of(context).people;
     case _SearchResultsSection.shared:
-      return AppLocalizations.of(context).searchResultShared;
+      return AppLocalizations.of(context).shared;
     case _SearchResultsSection.albums:
       return AppLocalizations.of(context).albums;
     case _SearchResultsSection.magic:


### PR DESCRIPTION
## Summary
- Split Albums shared collections into Shared and Received filters.
- Kept the right-pinned more button with the fade overlay for hidden filters.
