### PR TITLE
Explicitly use `int64` to avoid int overflow on 32-bit

### DIFF
--- a/server/ente/user.go
+++ b/server/ente/user.go
@@ -12,7 +12,7 @@ const (
 	SignUpOTTPurpose      = "signup"
 	LoginOTTPurpose       = "login"
 
-	ExpectedKDFStrength = 1073741824 * 4
+	ExpectedKDFStrength int64 = 1073741824 * 4
 )
 
 // User represents a user in the system
@@ -94,7 +94,7 @@ type SetUserAttributesRequest struct {
 }
 
 func (sk *SetUserAttributesRequest) Validate() error {
-	strength := sk.KeyAttributes.MemLimit * sk.KeyAttributes.OpsLimit
+	strength := int64(sk.KeyAttributes.MemLimit) * int64(sk.KeyAttributes.OpsLimit)
 	if strength != ExpectedKDFStrength {
 		return NewBadRequestWithMessage("Unexpected KDF strength")
 	}
@@ -119,7 +119,7 @@ type UpdateKeysRequest struct {
 }
 
 func (u *UpdateKeysRequest) Validate() error {
-	strength := u.MemLimit * u.OpsLimit
+	strength := int64(u.MemLimit) * int64(u.OpsLimit)
 	if strength != ExpectedKDFStrength {
 		return NewBadRequestWithMessage("Unexpected KDF strength")
 	}

--- a/server/pkg/controller/email/storage_warning.go
+++ b/server/pkg/controller/email/storage_warning.go
@@ -25,7 +25,7 @@ const (
 	storageWarningFromName     = "Ente"
 	storageWarningFromEmail    = "support@ente.com"
 
-	storageWarningOverageThreshold             = 25 * (1 << 30)
+	storageWarningOverageThreshold int64       = 25 * (1 << 30)
 	storageWarningPreviousStageFreshnessWindow = 35 * 24 * time.MicroSecondsInOneHour
 	storageWarningOneDayInMicroseconds         = 24 * time.MicroSecondsInOneHour
 	storageWarningBufferedCadenceExtraGrace    = 2 * storageWarningOneDayInMicroseconds

--- a/server/pkg/controller/emergency/recovery.go
+++ b/server/pkg/controller/emergency/recovery.go
@@ -128,7 +128,7 @@ func (c *Controller) SendRecoveryReminder() {
 		return
 	}
 	log.Info(fmt.Sprintf("Found %d recovery rows", len(*rows)))
-	microsecondsInDay := 1000 * 1000 * 24 * 60 * 60
+	microsecondsInDay := int64(1000 * 1000 * 24 * 60) * 60
 	for _, row := range *rows {
 		logger := log.WithFields(log.Fields{
 			"userID":         row.UserID,


### PR DESCRIPTION
## Description
In order to build Ente on ARM, I had to switch from `untyped int` to `int64`, as it seems `untyped int` defaults to `int32` in Go.

Fixes:
```
ente/user.go:98:17: ExpectedKDFStrength (untyped int constant 4294967296) overflows int
ente/user.go:120:17: ExpectedKDFStrength (untyped int constant 4294967296) overflows int
../../pkg/controller/email/storage_warning.go:628:36: cannot use storageWarningOverageThreshold (untyped int constant 26843545600) as int value in map literal (overflows)
../../pkg/controller/emergency/recovery.go:131:23: cannot use 1000 * 1000 * 24 * 60 * 60 (untyped int constant 86400000000) as int value in assignment (overflows)
```

## Tests
I just built this project on a Cortex-A7, it builds and starts but I haven’t tried interacting with it yet.