### PR TITLE
[Docs] Add setup guide video to Ente Auth documentation

### DIFF
--- a/docs/docs/auth/index.md
+++ b/docs/docs/auth/index.md
@@ -7,6 +7,10 @@ description: User guide for Ente Auth
 
 Ente Auth is a free, cross-platform, end-to-end encrypted authenticator app. You can use it to safely store your 2FA codes (second-factor authentication codes).
 
+## Set up Guide
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/wyz9tcBP8Pw" title="Set up Guide" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Changelog
 
 For a list of recent changes, see the [Changelog](/auth/changelog).

--- a/docs/docs/auth/index.md
+++ b/docs/docs/auth/index.md
@@ -7,9 +7,9 @@ description: User guide for Ente Auth
 
 Ente Auth is a free, cross-platform, end-to-end encrypted authenticator app. You can use it to safely store your 2FA codes (second-factor authentication codes).
 
-## Set up Guide
+## Setup Guide
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/wyz9tcBP8Pw" title="Set up Guide" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/wyz9tcBP8Pw" title="Setup Guide" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Changelog
 


### PR DESCRIPTION

Added an embedded YouTube video to the Ente Auth documentation homepage to provide users with a visual setup guide.