### PR TITLE
[mob][locker] Fix empty trash, logs viewer

### DIFF
--- a/mobile/apps/locker/changes/empty-trash-logs-onboarding.md
+++ b/mobile/apps/locker/changes/empty-trash-logs-onboarding.md
@@ -1,0 +1,1 @@
+- Fixed empty trash handling, log viewer header styling, and signup recovery UI issues.

--- a/mobile/apps/locker/lib/services/trash/trash_service.dart
+++ b/mobile/apps/locker/lib/services/trash/trash_service.dart
@@ -211,6 +211,10 @@ class TrashService {
     final params = <String, dynamic>{};
     params["lastUpdatedAt"] = _getSyncTime();
     final trashFiles = await _db.getTrashFiles();
+    if (trashFiles.isEmpty) {
+      _logger.info("Skipping empty trash because local trash is empty");
+      return;
+    }
     final fileIDs = trashFiles
         .map((trashFile) => trashFile.uploadedFileID!)
         .toList();

--- a/mobile/apps/locker/lib/ui/pages/trash_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/trash_page.dart
@@ -17,7 +17,6 @@ import 'package:locker/services/files/sync/models/file.dart';
 import 'package:locker/services/trash/models/trash_file.dart';
 import 'package:locker/services/trash/trash_service.dart';
 import "package:locker/ui/components/delete_confirmation_sheet.dart";
-import "package:locker/ui/components/empty_state_widget.dart";
 import 'package:locker/ui/components/item_list_view.dart';
 import "package:locker/ui/viewer/actions/file_selection_overlay_bar.dart";
 
@@ -61,6 +60,11 @@ class _TrashPageState extends State<TrashPage> {
   }
 
   Future<void> _emptyTrash() async {
+    if (_trashFiles.isEmpty) {
+      showToast(context, context.l10n.trashIsEmpty);
+      return;
+    }
+
     final result = await showDeleteConfirmationSheet(
       context,
       title: context.l10n.emptyTrash,
@@ -75,6 +79,11 @@ class _TrashPageState extends State<TrashPage> {
   }
 
   Future<void> _performEmptyTrash() async {
+    if (_trashFiles.isEmpty) {
+      showToast(context, context.l10n.trashIsEmpty);
+      return;
+    }
+
     final dialog = createProgressDialog(
       context,
       context.l10n.clearingTrash,
@@ -83,6 +92,7 @@ class _TrashPageState extends State<TrashPage> {
     await dialog.show();
     try {
       await TrashService.instance.emptyTrash();
+      await dialog.hide();
       _selectedFiles.clearAll();
       setState(() {
         _trashFiles.clear();
@@ -90,9 +100,10 @@ class _TrashPageState extends State<TrashPage> {
       showToast(context, context.l10n.trashClearedSuccessfully);
       Navigator.of(context).pop();
     } catch (error) {
-      await showGenericErrorBottomSheet(context: context, error: error);
-    } finally {
       await dialog.hide();
+      if (mounted) {
+        await showGenericErrorBottomSheet(context: context, error: error);
+      }
     }
   }
 
@@ -137,38 +148,34 @@ class _TrashPageState extends State<TrashPage> {
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           TitleBarTitleWidget(
             title: context.l10n.trash,
             trailingWidgets: [
-              GestureDetector(
-                onTap: _emptyTrash,
-                child: Container(
-                  height: 44,
-                  width: 44,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    color: colorScheme.backdropBase,
-                  ),
-                  padding: const EdgeInsets.all(12),
-                  child: HugeIcon(
-                    icon: HugeIcons.strokeRoundedDelete02,
-                    color: colorScheme.textBase,
+              if (_trashFiles.isNotEmpty)
+                GestureDetector(
+                  onTap: _emptyTrash,
+                  child: Container(
+                    height: 44,
+                    width: 44,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      color: colorScheme.backdropBase,
+                    ),
+                    padding: const EdgeInsets.all(12),
+                    child: HugeIcon(
+                      icon: HugeIcons.strokeRoundedDelete02,
+                      color: colorScheme.textBase,
+                    ),
                   ),
                 ),
-              ),
             ],
           ),
           const SizedBox(height: 24),
           Expanded(
             child: _trashFiles.isEmpty
-                ? Center(
-                    child: EmptyStateWidget(
-                      assetPath: 'assets/empty_state.png',
-                      title: context.l10n.yourTrashIsEmpty,
-                      showBorder: false,
-                    ),
-                  )
+                ? _TrashEmptyState(title: context.l10n.yourTrashIsEmpty)
                 : ItemListView(
                     files: _trashFiles.cast<EnteFile>(),
                     physics: const BouncingScrollPhysics(),
@@ -178,6 +185,36 @@ class _TrashPageState extends State<TrashPage> {
                   ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _TrashEmptyState extends StatelessWidget {
+  const _TrashEmptyState({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = getEnteColorScheme(context);
+    final textTheme = getEnteTextTheme(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Image.asset('assets/empty_state.png', height: 112),
+            const SizedBox(height: 20),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: textTheme.largeBold.copyWith(color: colorScheme.textBase),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/packages/accounts/lib/pages/email_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/email_entry_page.dart
@@ -47,6 +47,12 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
   bool _password2InFocus = false;
   bool _passwordIsValid = false;
 
+  bool get _hasValidMatchingPasswords =>
+      _passwordIsValid &&
+      (_password?.isNotEmpty ?? false) &&
+      _cnfPassword.isNotEmpty &&
+      _password == _cnfPassword;
+
   @override
   void initState() {
     _email = widget.config.getEmail();
@@ -299,7 +305,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                                 _passwordIsValid =
                                     _passwordStrength >=
                                     kMildPasswordStrengthThreshold;
-                                _passwordsMatch = _password == _cnfPassword;
+                                _passwordsMatch = _hasValidMatchingPasswords;
                               });
                             }
                           },
@@ -372,9 +378,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                           onChanged: (cnfPassword) {
                             setState(() {
                               _cnfPassword = cnfPassword;
-                              if (_password != null || _password != '') {
-                                _passwordsMatch = _password == _cnfPassword;
-                              }
+                              _passwordsMatch = _hasValidMatchingPasswords;
                             });
                           },
                         ),

--- a/mobile/packages/accounts/lib/pages/password_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_entry_page.dart
@@ -53,6 +53,12 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
   bool _passwordsMatch = false;
   bool _isPasswordValid = false;
 
+  bool get _hasValidMatchingPasswords =>
+      _isPasswordValid &&
+      _passwordInInputBox.isNotEmpty &&
+      _passwordInInputConfirmationBox.isNotEmpty &&
+      _passwordInInputBox == _passwordInInputConfirmationBox;
+
   @override
   void initState() {
     super.initState();
@@ -296,9 +302,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
                               _isPasswordValid =
                                   _passwordStrength >=
                                   kMildPasswordStrengthThreshold;
-                              _passwordsMatch =
-                                  _passwordInInputBox ==
-                                  _passwordInInputConfirmationBox;
+                              _passwordsMatch = _hasValidMatchingPasswords;
                             });
                           },
                           textInputAction: TextInputAction.next,
@@ -382,11 +386,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
                           onChanged: (cnfPassword) {
                             setState(() {
                               _passwordInInputConfirmationBox = cnfPassword;
-                              if (_passwordInInputBox != '') {
-                                _passwordsMatch =
-                                    _passwordInInputBox ==
-                                    _passwordInInputConfirmationBox;
-                              }
+                              _passwordsMatch = _hasValidMatchingPasswords;
                             });
                           },
                         ),

--- a/mobile/packages/accounts/lib/pages/recovery_key_page.dart
+++ b/mobile/packages/accounts/lib/pages/recovery_key_page.dart
@@ -15,6 +15,7 @@ import 'package:file_saver/file_saver.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'package:share_plus/share_plus.dart';
 
 class RecoveryKeyPage extends StatefulWidget {
@@ -128,36 +129,54 @@ class _RecoveryKeyPageState extends State<RecoveryKeyPage> {
                         ),
                         child: Builder(
                           builder: (context) {
-                            final content = Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 22,
-                                vertical: 24,
-                              ),
-                              child: Text(
-                                recoveryKey,
-                                textAlign: TextAlign.justify,
-                                style: textTheme.body.copyWith(
-                                  color: Colors.white,
-                                  fontFamily: 'monospace',
-                                  letterSpacing: 0.5,
-                                  height: 1.5,
-                                ),
+                            final text = Text(
+                              recoveryKey,
+                              textAlign: TextAlign.justify,
+                              style: textTheme.body.copyWith(
+                                color: Colors.white,
+                                fontFamily: 'monospace',
+                                letterSpacing: 0.5,
+                                height: 1.5,
                               ),
                             );
 
-                            if (PlatformDetector.isMobile()) {
-                              return GestureDetector(
-                                onTap: () async => await copy(),
-                                child: content,
-                              );
-                            } else {
-                              return SelectableRegion(
-                                focusNode: FocusNode(),
-                                selectionControls:
-                                    PlatformUtil.selectionControls,
-                                child: content,
-                              );
-                            }
+                            final keyContent = PlatformDetector.isMobile()
+                                ? GestureDetector(
+                                    onTap: () async => await copy(),
+                                    child: text,
+                                  )
+                                : SelectableRegion(
+                                    focusNode: FocusNode(),
+                                    selectionControls:
+                                        PlatformUtil.selectionControls,
+                                    child: text,
+                                  );
+
+                            return Stack(
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    22,
+                                    24,
+                                    64,
+                                    24,
+                                  ),
+                                  child: keyContent,
+                                ),
+                                Positioned(
+                                  right: 0,
+                                  top: 0,
+                                  child: IconButton(
+                                    onPressed: () async => await copy(),
+                                    icon: const HugeIcon(
+                                      icon: HugeIcons.strokeRoundedCopy01,
+                                      color: Colors.white,
+                                      size: 24,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            );
                           },
                         ),
                       ),

--- a/mobile/packages/ui/lib/pages/log_file_viewer.dart
+++ b/mobile/packages/ui/lib/pages/log_file_viewer.dart
@@ -27,7 +27,12 @@ class _LogFileViewerState extends State<LogFileViewer> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(elevation: 0, title: const Text("Today's logs")),
+      appBar: AppBar(
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
+        title: const Text("Today's logs"),
+      ),
       body: _getBody(),
     );
   }


### PR DESCRIPTION
## Summary

- Skip empty-trash execution when local trash is already empty, and hide the empty-trash action from the empty state.
- Prevent stale password-match UI state when password or confirm-password fields are cleared during signup/password setup.
- Add a visible copy action to the signup recovery-key card.
- Remove the log viewer app bar surface tint so the header does not show a grey bar while scrolling.
