### PR TITLE
[mobile] Add app-specific configuration contracts for Auth and Locker

### DIFF
--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -57,8 +57,7 @@ class Configuration extends BaseConfiguration {
   @override
   // This includes both base keys (key, secretKey) and auth-specific keys.
   List<String> get secureStorageKeys => [
-    BaseConfiguration.keyKey,
-    BaseConfiguration.secretKeyKey,
+    ...BaseConfiguration.accountSecureStorageKeys,
     authSecretKeyKey,
     // Note: offlineAuthSecretKey is intentionally not included here
     // as it persists across logouts for offline mode

--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -12,6 +12,14 @@ class Configuration extends BaseConfiguration {
   Configuration._privateConstructor();
 
   static final Configuration instance = Configuration._privateConstructor();
+  @override
+  EnteAppIdentity get appIdentity => const EnteAppIdentity(
+    app: "auth",
+    clientPackageName: "io.ente.auth",
+    passkeyRedirectUrl: "enteauth://passkey",
+    referralSourcePrefix: "auth",
+  );
+
   static const authSecretKeyKey = "auth_secret_key";
   static const offlineAuthSecretKey = "offline_auth_secret_key";
   static const hasOptedForOfflineModeKey = "has_opted_for_offline_mode";

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -174,12 +174,7 @@ Future<void> _init(bool bool, {String? via}) async {
   await Configuration.instance.init([AuthenticatorDB.instance]);
   await cleanupPickedImagesOnStartup(logger: _logger);
   await Network.instance.init(Configuration.instance);
-  await UserService.instance.init(
-    Configuration.instance,
-    const HomePage(),
-    clientPackageName: 'io.ente.auth',
-    passkeyRedirectUrl: 'enteauth://passkey',
-  );
+  await UserService.instance.init(Configuration.instance, const HomePage());
   await AuthenticatorService.instance.init();
   await BillingService.instance.init();
   await NotificationService.instance.init();

--- a/mobile/apps/auth/test/core/configuration_test.dart
+++ b/mobile/apps/auth/test/core/configuration_test.dart
@@ -1,0 +1,19 @@
+import 'package:ente_auth/core/configuration.dart';
+import 'package:ente_configuration/base_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('secure storage cleanup does not include offline auth key', () {
+    final secureStorageKeys = Configuration.instance.secureStorageKeys;
+
+    expect(
+      secureStorageKeys,
+      containsAll(BaseConfiguration.accountSecureStorageKeys),
+    );
+    expect(secureStorageKeys, contains(Configuration.authSecretKeyKey));
+    expect(
+      secureStorageKeys,
+      isNot(contains(Configuration.offlineAuthSecretKey)),
+    );
+  });
+}

--- a/mobile/apps/locker/lib/main.dart
+++ b/mobile/apps/locker/lib/main.dart
@@ -186,12 +186,7 @@ Future<void> _init(bool bool, {String? via}) async {
     await Configuration.instance.init([LockerDB.instance]);
 
     await Network.instance.init(Configuration.instance);
-    await UserService.instance.init(
-      Configuration.instance,
-      const HomePage(),
-      clientPackageName: 'io.ente.locker',
-      passkeyRedirectUrl: 'entelocker://passkey',
-    );
+    await UserService.instance.init(Configuration.instance, const HomePage());
     await LockScreenSettings.instance.init(Configuration.instance);
     await CollectionApiClient.instance.init();
     await CollectionService.instance.init(preferences);

--- a/mobile/apps/locker/lib/services/configuration.dart
+++ b/mobile/apps/locker/lib/services/configuration.dart
@@ -8,6 +8,14 @@ class Configuration extends BaseConfiguration {
   static final Configuration instance = Configuration._privateConstructor();
 
   @override
+  EnteAppIdentity get appIdentity => const EnteAppIdentity(
+    app: "locker",
+    clientPackageName: "io.ente.locker",
+    passkeyRedirectUrl: "entelocker://passkey",
+    referralSourcePrefix: "locker",
+  );
+
+  @override
   // Provide all secure storage keys that should be wiped on logout.
   // Locker app uses the standard keys defined in BaseConfiguration.
   List<String> get secureStorageKeys => [

--- a/mobile/apps/locker/lib/services/configuration.dart
+++ b/mobile/apps/locker/lib/services/configuration.dart
@@ -18,10 +18,8 @@ class Configuration extends BaseConfiguration {
   @override
   // Provide all secure storage keys that should be wiped on logout.
   // Locker app uses the standard keys defined in BaseConfiguration.
-  List<String> get secureStorageKeys => [
-    BaseConfiguration.keyKey,
-    BaseConfiguration.secretKeyKey,
-  ];
+  List<String> get secureStorageKeys =>
+      BaseConfiguration.accountSecureStorageKeys;
 
   @override
   Future<void> logout({bool autoLogout = false}) async {

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -60,23 +60,14 @@ class UserService {
   late ValueNotifier<String?> emailValueNotifier;
   late BaseConfiguration _config;
   late BaseHomePage _homePage;
-  late String _clientPackageName;
-  late String _passkeyRedirectUrl;
 
   UserService._privateConstructor();
 
   static final UserService instance = UserService._privateConstructor();
 
-  Future<void> init(
-    BaseConfiguration config,
-    BaseHomePage homePage, {
-    required String clientPackageName,
-    required String passkeyRedirectUrl,
-  }) async {
+  Future<void> init(BaseConfiguration config, BaseHomePage homePage) async {
     _config = config;
     _homePage = homePage;
-    _clientPackageName = clientPackageName;
-    _passkeyRedirectUrl = passkeyRedirectUrl;
     emailValueNotifier = ValueNotifier<String?>(config.getEmail());
     _preferences = await SharedPreferences.getInstance();
   }
@@ -456,7 +447,8 @@ class UserService {
     await dialog.show();
     final verifyData = {"email": _config.getEmail(), "ott": ott};
     if (!_config.isLoggedIn()) {
-      verifyData["source"] = 'auth:${_getRefSource()}';
+      verifyData["source"] =
+          '${_config.appIdentity.referralSourcePrefix}:${_getRefSource()}';
     }
     try {
       final response = await _dio.post(
@@ -480,8 +472,8 @@ class UserService {
             passkeySessionID,
             totp2FASessionID: twoFASessionID,
             accountsUrl: accountsUrl,
-            redirectUrl: _passkeyRedirectUrl,
-            clientPackage: _clientPackageName,
+            redirectUrl: _config.appIdentity.passkeyRedirectUrl,
+            clientPackage: _config.appIdentity.clientPackageName,
           );
         } else if (twoFASessionID.isNotEmpty) {
           page = TwoFactorAuthenticationPage(twoFASessionID);
@@ -796,8 +788,8 @@ class UserService {
           passkeySessionID,
           totp2FASessionID: twoFASessionID,
           accountsUrl: accountsUrl,
-          redirectUrl: _passkeyRedirectUrl,
-          clientPackage: _clientPackageName,
+          redirectUrl: _config.appIdentity.passkeyRedirectUrl,
+          clientPackage: _config.appIdentity.clientPackageName,
         );
       } else if (twoFASessionID.isNotEmpty) {
         page = TwoFactorAuthenticationPage(twoFASessionID);

--- a/mobile/packages/configuration/lib/app_identity.dart
+++ b/mobile/packages/configuration/lib/app_identity.dart
@@ -1,0 +1,13 @@
+class EnteAppIdentity {
+  const EnteAppIdentity({
+    required this.app,
+    required this.clientPackageName,
+    required this.passkeyRedirectUrl,
+    required this.referralSourcePrefix,
+  });
+
+  final String app;
+  final String clientPackageName;
+  final String passkeyRedirectUrl;
+  final String referralSourcePrefix;
+}

--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -6,6 +6,7 @@ import 'package:ente_base/models/database.dart';
 import 'package:ente_base/models/key_attributes.dart';
 import 'package:ente_base/models/key_gen_result.dart';
 import 'package:ente_base/models/private_key_attributes.dart';
+import 'package:ente_configuration/app_identity.dart';
 import 'package:ente_configuration/constants.dart';
 import 'package:ente_crypto_api/ente_crypto_api.dart';
 import 'package:ente_events/event_bus.dart';
@@ -20,7 +21,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tuple/tuple.dart';
 
-class BaseConfiguration {
+export 'package:ente_configuration/app_identity.dart';
+
+abstract class BaseConfiguration {
   static const endpoint = String.fromEnvironment(
     "endpoint",
     defaultValue: kDefaultProductionEndpoint,
@@ -49,6 +52,8 @@ class BaseConfiguration {
   late List<EnteBaseDatabase> _databases;
 
   String? _volatilePassword;
+
+  EnteAppIdentity get appIdentity;
 
   // Descendants can override to append keys that must be cleared.
   List<String> get secureStorageKeys => [];

--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -37,6 +37,7 @@ abstract class BaseConfiguration {
   static const userIDKey = "user_id";
   static const endPointKey = "endpoint";
   static const lastTempFolderClearTimeKey = "last_temp_folder_clear_time";
+  static const accountSecureStorageKeys = [keyKey, secretKeyKey];
 
   final kTempFolderDeletionTimeBuffer = const Duration(days: 1).inMicroseconds;
 
@@ -55,8 +56,7 @@ abstract class BaseConfiguration {
 
   EnteAppIdentity get appIdentity;
 
-  // Descendants can override to append keys that must be cleared.
-  List<String> get secureStorageKeys => [];
+  List<String> get secureStorageKeys;
 
   Future<void> init(List<EnteBaseDatabase> dbs) async {
     _databases = dbs;

--- a/mobile/packages/sharing/test/user_avator_widget_test.dart
+++ b/mobile/packages/sharing/test/user_avator_widget_test.dart
@@ -102,6 +102,10 @@ class _TestConfiguration extends BaseConfiguration {
   );
 
   @override
+  List<String> get secureStorageKeys =>
+      BaseConfiguration.accountSecureStorageKeys;
+
+  @override
   String? getEmail() => 'me@test.test';
 
   @override

--- a/mobile/packages/sharing/test/user_avator_widget_test.dart
+++ b/mobile/packages/sharing/test/user_avator_widget_test.dart
@@ -94,6 +94,14 @@ void main() {
 
 class _TestConfiguration extends BaseConfiguration {
   @override
+  EnteAppIdentity get appIdentity => const EnteAppIdentity(
+    app: 'test',
+    clientPackageName: 'io.ente.test',
+    passkeyRedirectUrl: 'entetest://passkey',
+    referralSourcePrefix: 'test',
+  );
+
+  @override
   String? getEmail() => 'me@test.test';
 
   @override


### PR DESCRIPTION
- Add shared app identity config for app name, package name, passkey redirect, and referral source prefix.
- Move Auth and Locker passkey/referral values out of UserService init callsites.
- Require app configs to define secure-storage cleanup keys and keep Auth offline key out of cleanup.