### PR TITLE
[codex] Merge upload filters in search sheet

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/hierarchicial_search/filter_options_bottom_sheet.dart
+++ b/mobile/apps/photos/lib/ui/viewer/hierarchicial_search/filter_options_bottom_sheet.dart
@@ -115,8 +115,7 @@ class _FilterOptionsBottomSheetState extends State<FilterOptionsBottomSheet> {
         ..._filters("magicFilters"),
         ..._filters("topLevelGenericFilter"),
       ]),
-      _FilterGroup(l10n.contacts, _filters("contactsFilters")),
-      _FilterGroup(l10n.searchResultUploadedBy, _filters("uploaderFilters")),
+      _FilterGroup(l10n.searchResultUploadedBy, _uploadedByFilters),
       _FilterGroup(l10n.camera, _filters("cameraFilters")),
       _FilterGroup(l10n.albums, _filters("albumFilters")),
       _FilterGroup(l10n.locations, _filters("locationFilters")),
@@ -135,6 +134,10 @@ class _FilterOptionsBottomSheetState extends State<FilterOptionsBottomSheet> {
       ...onlyThemFilters.where((filter) => !filter.isApplied),
       ...faceFilters.where((filter) => !filter.isApplied),
     ];
+  }
+
+  List<HierarchicalSearchFilter> get _uploadedByFilters {
+    return [..._filters("contactsFilters"), ..._filters("uploaderFilters")];
   }
 
   List<HierarchicalSearchFilter> _filters(String type) {


### PR DESCRIPTION
## Summary
- Merge Contacts and Uploaded by chips into a single Uploaded by section in the search filter sheet.
- Keep the underlying filter sources unchanged and only combine them for the sheet presentation.

## Validation
- dart format mobile/apps/photos/lib/ui/viewer/hierarchicial_search/filter_options_bottom_sheet.dart
- dart analyze lib/ui/viewer/hierarchicial_search/filter_options_bottom_sheet.dart
- Hot reload on iPhone 17 simulator