### PR TITLE
[desktop][photos] Parsing takeout file titles from the json sidecar

### DIFF
--- a/web/packages/gallery/services/upload/metadata-json.ts
+++ b/web/packages/gallery/services/upload/metadata-json.ts
@@ -23,6 +23,7 @@ import { readStream } from "ente-gallery/utils/native-stream";
  * existing third party tools for working with the takeout format.
  */
 export interface ParsedMetadataJSON {
+    title?: string;
     creationTime?: number;
     modificationTime?: number;
     location?: Location;
@@ -225,6 +226,8 @@ const parseMetadataJSONText = (text: string) => {
 
     const parsedMetadataJSON: ParsedMetadataJSON = {};
 
+    parsedMetadataJSON.title = parseGTTitle(metadataJSON.title);
+
     parsedMetadataJSON.creationTime =
         parseGTTimestamp(metadataJSON.photoTakenTime) ??
         parseGTTimestamp(metadataJSON.creationTime);
@@ -305,3 +308,13 @@ const parseGTLocation = (o: unknown): Location | undefined => {
  */
 const parseGTNonEmptyString = (o: unknown): string | undefined =>
     o && typeof o == "string" ? o : undefined;
+
+/**
+ * Parse the title from a Google Takeout JSON, trimming whitespace and treating
+ * blank titles as undefined so the upload can fall back to the file name.
+ */
+const parseGTTitle = (o: unknown): string | undefined => {
+    if (!o || typeof o != "string") return undefined;
+    const title = o.trim();
+    return title ? title : undefined;
+};

--- a/web/packages/gallery/services/upload/upload-service.ts
+++ b/web/packages/gallery/services/upload/upload-service.ts
@@ -1198,12 +1198,7 @@ const extractLivePhotoMetadata = async (
     const hash = `${imageHash}:${videoHash}`;
 
     return {
-        metadata: {
-            ...imageMetadata,
-            title: uploadItemFileName(livePhotoAssets.image),
-            fileType: FileType.livePhoto,
-            hash,
-        },
+        metadata: { ...imageMetadata, fileType: FileType.livePhoto, hash },
         publicMagicMetadata,
     };
 };
@@ -1290,7 +1285,7 @@ const extractImageOrVideoMetadata = async (
 
     const metadata: FileMetadata = {
         fileType,
-        title: fileName,
+        title: parsedMetadataJSON?.title ?? fileName,
         creationTime: ensureInteger(creationTime),
         modificationTime: ensureInteger(modificationTime),
         hash,


### PR DESCRIPTION
## Description

Currently, takeout files with long names get truncated by Google within the takeout itself, and we use this truncated name during upload.

This PR updates the logic to prioritize the title from the JSON sidecar instead, avoiding the truncation done by Google.