### PR TITLE
[mobile][photos] Move lock screen prefs out of configuration

### DIFF
--- a/mobile/apps/photos/integration_test/ml_parity_shared.dart
+++ b/mobile/apps/photos/integration_test/ml_parity_shared.dart
@@ -296,7 +296,7 @@ Future<void> _ensureModelNetworkContext() async {
     NetworkClient.instance.downloadDio,
     packageInfo,
   );
-  await Configuration.instance.init();
+  await Configuration.instance.init(prefs);
   _modelNetworkContextInitialized = true;
 }
 

--- a/mobile/apps/photos/integration_test/video_editor_test.dart
+++ b/mobile/apps/photos/integration_test/video_editor_test.dart
@@ -219,7 +219,7 @@ void main() {
         NetworkClient.instance.downloadDio,
         packageInfo,
       );
-      await Configuration.instance.init();
+      await Configuration.instance.init(prefs);
 
       // Verify configuration
       expect(

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -44,7 +44,6 @@ import 'package:photos/services/search_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
 import 'package:photos/services/video_preview_service.dart';
 import 'package:photos/utils/file_uploader.dart';
-import "package:photos/utils/lock_screen_settings.dart";
 import 'package:photos/utils/validator_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import "package:tuple/tuple.dart";
@@ -58,7 +57,6 @@ class Configuration {
   static const emailKey = "email";
   static const keyAttributesKey = "key_attributes";
   static const keyKey = "key";
-  static const keyShowSystemLockScreen = "should_show_lock_screen";
   static const lastTempFolderClearTimeKey = "last_temp_folder_clear_time";
   static const secretKeyKey = "secret_key";
   static const tokenKey = "token";
@@ -81,9 +79,9 @@ class Configuration {
   late String _sharedDocumentsMediaDirectory;
   String? _volatilePassword;
 
-  Future<void> init() async {
+  Future<void> init(SharedPreferences preferences) async {
     try {
-      _preferences = await SharedPreferences.getInstance();
+      _preferences = preferences;
       _secureStorage = const FlutterSecureStorage(
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,
@@ -623,24 +621,6 @@ class Configuration {
 
   bool hasConfiguredAccount() {
     return isLoggedIn() && _key != null;
-  }
-
-  Future<bool> shouldShowLockScreen() async {
-    final bool isPin = await LockScreenSettings.instance.isPinSet();
-    final bool isPass = await LockScreenSettings.instance.isPasswordSet();
-    return isPin || isPass || shouldShowSystemLockScreen();
-  }
-
-  bool shouldShowSystemLockScreen() {
-    if (_preferences.containsKey(keyShowSystemLockScreen)) {
-      return _preferences.getBool(keyShowSystemLockScreen)!;
-    } else {
-      return false;
-    }
-  }
-
-  Future<void> setSystemLockScreen(bool value) {
-    return _preferences.setBool(keyShowSystemLockScreen, value);
   }
 
   void setVolatilePassword(String volatilePassword) {

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -146,7 +146,7 @@ Future<void> _runInForeground(
         ),
         lockScreen: const LockScreen(),
         enabled:
-            await Configuration.instance.shouldShowLockScreen() ||
+            await LockScreenSettings.instance.shouldShowLockScreen() ||
             localSettings.isOnGuestView(),
         locale: locale,
         lightTheme: lightThemeData,
@@ -263,7 +263,7 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     NotificationService.instance.init(prefs);
 
     _logger.info("(for debugging) Configuration init $tlog");
-    await Configuration.instance.init();
+    await Configuration.instance.init(prefs);
     _logger.info("(for debugging) Configuration done $tlog");
 
     // App LifeCycle
@@ -408,10 +408,10 @@ Future<void> _init(
     );
 
     _logger.info("Lockscreen init $tlog");
-    unawaited(LockScreenSettings.instance.init(preferences));
+    LockScreenSettings.instance.init(preferences);
 
     _logger.info("Configuration init $tlog");
-    await Configuration.instance.init();
+    await Configuration.instance.init(preferences);
     _logger.info("Configuration done $tlog");
 
     await MemoryShareService.instance.init();

--- a/mobile/apps/photos/lib/services/local_authentication_service.dart
+++ b/mobile/apps/photos/lib/services/local_authentication_service.dart
@@ -2,13 +2,13 @@ import "dart:async";
 
 import 'package:flutter/material.dart';
 import 'package:local_auth/local_auth.dart';
-import 'package:photos/core/configuration.dart';
 import 'package:photos/ui/notification/toast.dart';
 import "package:photos/ui/settings/lock_screen/lock_screen_password.dart";
 import "package:photos/ui/settings/lock_screen/lock_screen_pin.dart";
 import 'package:photos/ui/tools/app_lock.dart';
 import 'package:photos/utils/auth_util.dart';
 import 'package:photos/utils/dialog_util.dart';
+import "package:photos/utils/lock_screen_settings.dart";
 
 class LocalAuthenticationService {
   LocalAuthenticationService._privateConstructor();
@@ -28,7 +28,7 @@ class LocalAuthenticationService {
       );
       AppLock.of(
         context,
-      )!.setEnabled(await Configuration.instance.shouldShowLockScreen());
+      )!.setEnabled(await LockScreenSettings.instance.shouldShowLockScreen());
       if (!result) {
         showToast(context, infoMessage);
         return false;
@@ -96,14 +96,14 @@ class LocalAuthenticationService {
       if (result) {
         AppLock.of(context)!.setEnabled(shouldEnableLockScreen);
 
-        await Configuration.instance.setSystemLockScreen(
+        await LockScreenSettings.instance.setSystemLockScreen(
           shouldEnableLockScreen,
         );
         return true;
       } else {
         AppLock.of(
           context,
-        )!.setEnabled(await Configuration.instance.shouldShowLockScreen());
+        )!.setEnabled(await LockScreenSettings.instance.shouldShowLockScreen());
       }
     } else {
       unawaited(showErrorDialog(context, errorDialogTitle, errorDialogContent));

--- a/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_options.dart
+++ b/mobile/apps/photos/lib/ui/settings/lock_screen/lock_screen_options.dart
@@ -4,7 +4,6 @@ import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
-import "package:photos/core/configuration.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/ui/settings/components/settings_item.dart";
@@ -26,7 +25,6 @@ class LockScreenOptions extends StatefulWidget {
 enum LockType { device, pin, password }
 
 class _LockScreenOptionsState extends State<LockScreenOptions> {
-  final Configuration _configuration = Configuration.instance;
   final LocalSettings _localSettings = localSettings;
   final LockScreenSettings _lockscreenSetting = LockScreenSettings.instance;
   late bool appLock;
@@ -58,7 +56,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
     final bool isAppLockEnabled =
         pinEnabled ||
         passwordEnabled ||
-        _configuration.shouldShowSystemLockScreen();
+        _lockscreenSetting.shouldShowSystemLockScreen();
 
     setState(() {
       hideAppContent = shouldShowAppContent;
@@ -73,7 +71,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
     if (appLock) {
       // Turning off app lock
       AppLock.of(context)!.setEnabled(false);
-      await _configuration.setSystemLockScreen(false);
+      await _lockscreenSetting.setSystemLockScreen(false);
       await _lockscreenSetting.removePinAndPassword();
       setState(() {
         appLock = false;
@@ -82,7 +80,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
     } else {
       // Turning on app lock - default to device lock
       AppLock.of(context)!.setEnabled(true);
-      await _configuration.setSystemLockScreen(true);
+      await _lockscreenSetting.setSystemLockScreen(true);
       setState(() {
         appLock = true;
         _currentLockType = LockType.device;
@@ -94,7 +92,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
   Future<void> _onSelectDeviceLock() async {
     // Remove any existing PIN/password and use device lock
     await _lockscreenSetting.removePinAndPassword();
-    await _configuration.setSystemLockScreen(true);
+    await _lockscreenSetting.setSystemLockScreen(true);
     AppLock.of(context)!.setEnabled(true);
     setState(() {
       _currentLockType = LockType.device;
@@ -105,7 +103,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
   Future<void> _onSelectPinLock() async {
     final result = await routeToPage(context, const LockScreenPin());
     if (result == true) {
-      await _configuration.setSystemLockScreen(false);
+      await _lockscreenSetting.setSystemLockScreen(false);
       setState(() {
         _currentLockType = LockType.pin;
       });
@@ -116,7 +114,7 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
   Future<void> _onSelectPasswordLock() async {
     final result = await routeToPage(context, const LockScreenPassword());
     if (result == true) {
-      await _configuration.setSystemLockScreen(false);
+      await _lockscreenSetting.setSystemLockScreen(false);
       setState(() {
         _currentLockType = LockType.password;
       });

--- a/mobile/apps/photos/lib/utils/lock_screen_settings.dart
+++ b/mobile/apps/photos/lib/utils/lock_screen_settings.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 
 import "package:ente_crypto/ente_crypto.dart";
@@ -20,6 +21,8 @@ class LockScreenSettings {
   static const lastInvalidAttemptTime = "ls_last_invalid_attempt_time";
   static const keyHideAppContent = "ls_hide_app_content";
   static const autoLockTime = "ls_auto_lock_time";
+  static const keyShowSystemLockScreen = "should_show_lock_screen";
+  static final _logger = Logger("LockScreenSettings");
   late FlutterSecureStorage _secureStorage;
   late SharedPreferences _preferences;
   static const List<Duration> autoLockDurations = [
@@ -30,22 +33,21 @@ class LockScreenSettings {
     Duration(minutes: 5),
     Duration(minutes: 30),
   ];
-  Future<void> init(SharedPreferences prefs) async {
+  void init(SharedPreferences prefs) {
     _secureStorage = const FlutterSecureStorage();
     _preferences = prefs;
+    unawaited(_restorePrivacyScreenPreference());
+  }
 
-    await Future.delayed(const Duration(milliseconds: 500), () {
-      // Note: PrivacyScreen status isn't persisted across app restarts
-      // So we need to re-enable it if the user had it enabled
+  Future<void> _restorePrivacyScreenPreference() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    try {
       if (getShouldHideAppContent()) {
-        setHideAppContent(true).onError((error, stackTrace) {
-          Logger(
-            "LockScreenSettings",
-          ).severe("Error enabling PrivacyScreen", error, stackTrace);
-          return null;
-        });
+        await setHideAppContent(true);
       }
-    });
+    } catch (error, stackTrace) {
+      _logger.severe("Error enabling PrivacyScreen", error, stackTrace);
+    }
   }
 
   Future<void> setHideAppContent(bool hideContent) async {
@@ -88,6 +90,20 @@ class LockScreenSettings {
 
   Future<void> setInvalidAttemptCount(int count) async {
     await _preferences.setInt(keyInvalidAttempts, count);
+  }
+
+  Future<bool> shouldShowLockScreen() async {
+    return shouldShowSystemLockScreen() ||
+        await isPinSet() ||
+        await isPasswordSet();
+  }
+
+  bool shouldShowSystemLockScreen() {
+    return _preferences.getBool(keyShowSystemLockScreen) ?? false;
+  }
+
+  Future<void> setSystemLockScreen(bool value) {
+    return _preferences.setBool(keyShowSystemLockScreen, value);
   }
 
   static Uint8List _generateSalt() {


### PR DESCRIPTION
Move Photos lock-screen prefs to LockScreenSettings and pass existing prefs into Configuration.

Validation: `dart format --output=none --set-exit-if-changed .` and `flutter analyze .`