### PR TITLE
[server] Restore deleted smart album configs

### DIFF
--- a/server/ente/userentity/entity.go
+++ b/server/ente/userentity/entity.go
@@ -36,6 +36,10 @@ func (et EntityType) GetNewID() (*string, error) {
 	return base.NewID(strings.ToLower(string(et)))
 }
 
+func (et EntityType) CanRestoreDeletedData() bool {
+	return et == SmartAlbum
+}
+
 type EntityKey struct {
 	UserID       int64      `json:"userID" binding:"required"`
 	Type         EntityType `json:"type" binding:"required"`

--- a/server/pkg/api/userentity_test.go
+++ b/server/pkg/api/userentity_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ente-io/museum/ente"
+	model "github.com/ente-io/museum/ente/userentity"
 	"github.com/ente-io/museum/internal/testutil"
 	userentitycontroller "github.com/ente-io/museum/pkg/controller/userentity"
 	userentityrepo "github.com/ente-io/museum/pkg/repo/userentity"
@@ -71,6 +73,61 @@ func TestCreateUserEntityKeyReturnsAlreadyExistsForConflictingCreate(t *testing.
 	assertAPIErrorResponse(t, second, http.StatusConflict, ente.AlreadyExists, "Key already exists")
 }
 
+func TestCreateSmartAlbumEntityRestoresDeletedEntry(t *testing.T) {
+	handler, db := setupUserEntityHandlerTest(t)
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       203,
+		Email:        "smart-album-restore@ente.com",
+		CreationTime: 1,
+	})
+
+	ctx := context.Background()
+	id := "sa_203_12345"
+	if err := handler.Controller.Repo.CreateKey(ctx, userID, model.EntityKeyRequest{
+		Type:         model.SmartAlbum,
+		EncryptedKey: "encrypted-key",
+		Header:       "key-header",
+	}); err != nil {
+		t.Fatalf("failed to create entity key: %v", err)
+	}
+	if _, err := handler.Controller.Repo.Create(ctx, userID, model.EntityDataRequest{
+		ID:            &id,
+		Type:          model.SmartAlbum,
+		EncryptedData: "old-data",
+		Header:        "old-header",
+	}); err != nil {
+		t.Fatalf("failed to create smart album entity: %v", err)
+	}
+	if deleted, err := handler.Controller.Repo.Delete(ctx, userID, id); err != nil || !deleted {
+		t.Fatalf("failed to delete smart album entity: deleted=%t err=%v", deleted, err)
+	}
+
+	recorder := performCreateUserEntityRequest(t, handler, userID, map[string]any{
+		"id":            id,
+		"type":          string(model.SmartAlbum),
+		"encryptedData": "new-data",
+		"header":        "new-header",
+	})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status code on recreate: got %d want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var entity model.EntityData
+	if err := json.Unmarshal(recorder.Body.Bytes(), &entity); err != nil {
+		t.Fatalf("failed to decode entity response %q: %v", recorder.Body.String(), err)
+	}
+	if entity.ID != id || entity.UserID != userID || entity.Type != model.SmartAlbum || entity.IsDeleted {
+		t.Fatalf("unexpected restored entity: %+v", entity)
+	}
+	if entity.EncryptedData == nil || *entity.EncryptedData != "new-data" {
+		t.Fatalf("unexpected encryptedData: got %v want %q", entity.EncryptedData, "new-data")
+	}
+	if entity.Header == nil || *entity.Header != "new-header" {
+		t.Fatalf("unexpected header: got %v want %q", entity.Header, "new-header")
+	}
+}
+
 func setupUserEntityHandlerTest(t *testing.T) (*UserEntityHandler, *sql.DB) {
 	t.Helper()
 
@@ -111,6 +168,33 @@ func performCreateUserEntityKeyRequest(
 
 	router := gin.New()
 	router.POST("/user-entity/key", handler.CreateKey)
+	router.ServeHTTP(recorder, req)
+
+	return recorder
+}
+
+func performCreateUserEntityRequest(
+	t *testing.T,
+	handler *UserEntityHandler,
+	userID int64,
+	body map[string]any,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/user-entity/entity", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+
+	router := gin.New()
+	router.POST("/user-entity/entity", handler.CreateEntity)
 	router.ServeHTTP(recorder, req)
 
 	return recorder

--- a/server/pkg/repo/userentity/data.go
+++ b/server/pkg/repo/userentity/data.go
@@ -23,6 +23,9 @@ func (r *Repository) Create(ctx context.Context, userID int64, entry model.Entit
 		}
 		id = *idPrt
 	}
+	if entry.Type.CanRestoreDeletedData() {
+		return r.createOrRestoreDeleted(ctx, userID, id, entry)
+	}
 	err := r.DB.QueryRow(`INSERT into entity_data(
                          id,
                          user_id,
@@ -37,6 +40,36 @@ func (r *Repository) Create(ctx context.Context, userID int64, entry model.Entit
 		Scan(&id)
 	if err != nil {
 		return id, stacktrace.Propagate(err, "failed to create enity data")
+	}
+	return id, nil
+}
+
+func (r *Repository) createOrRestoreDeleted(ctx context.Context, userID int64, id string, entry model.EntityDataRequest) (string, error) {
+	err := r.DB.QueryRowContext(ctx, `INSERT into entity_data(
+                         id,
+                         user_id,
+                         type,
+                         encrypted_data,
+                         header) VALUES ($1,$2,$3,$4,$5)
+                         ON CONFLICT (id) DO UPDATE SET
+                         encrypted_data = EXCLUDED.encrypted_data,
+                         header = EXCLUDED.header,
+                         is_deleted = FALSE
+                         WHERE entity_data.user_id = EXCLUDED.user_id
+                         AND entity_data.type = EXCLUDED.type
+                         AND entity_data.is_deleted = TRUE
+                         RETURNING id`,
+		id,
+		userID,
+		entry.Type,
+		entry.EncryptedData,
+		entry.Header).
+		Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return id, ente.NewAlreadyExistsError("Entity already exists")
+	}
+	if err != nil {
+		return id, stacktrace.Propagate(err, "failed to create entity data")
 	}
 	return id, nil
 }


### PR DESCRIPTION
## Summary
- Restore soft-deleted smart album config entities when reusing deterministic IDs after album rejoin.
- Keep active duplicate entity creates as conflicts.