### PR TITLE
[mobile][photos] Fix bulk download progress crash

### DIFF
--- a/mobile/apps/photos/changes/bulk-download-errors.md
+++ b/mobile/apps/photos/changes/bulk-download-errors.md
@@ -1,0 +1,1 @@
+- Fixed bulk album downloads failing with an error.

--- a/mobile/apps/photos/lib/ui/common/progress_dialog.dart
+++ b/mobile/apps/photos/lib/ui/common/progress_dialog.dart
@@ -44,6 +44,8 @@ Widget _progressWidget = Image.asset(
 class ProgressDialog {
   _Body? _dialog;
 
+  bool get _isThisDialogShowing => _isShowing && _dialog != null;
+
   ProgressDialog(
     BuildContext context, {
     ProgressDialogType? type,
@@ -117,7 +119,9 @@ class ProgressDialog {
     _messageStyle = messageTextStyle ?? _messageStyle;
     _progressTextStyle = progressTextStyle ?? _progressTextStyle;
 
-    if (_isShowing) _dialog!.update();
+    if (_isThisDialogShowing) {
+      _dialog!.update();
+    }
   }
 
   bool isShowing() {
@@ -126,11 +130,12 @@ class ProgressDialog {
 
   Future<bool> hide() async {
     try {
-      if (_isShowing) {
+      if (_isThisDialogShowing) {
         _isShowing = false;
         if (_dismissingContext != null) {
           Navigator.of(_dismissingContext!).pop();
         }
+        _dialog = null;
         if (_showLogs) debugPrint('ProgressDialog dismissed');
         return Future.value(true);
       } else {
@@ -147,6 +152,7 @@ class ProgressDialog {
   Future<bool> show() async {
     try {
       if (!_isShowing) {
+        _isShowing = true;
         _dialog = _Body();
         unawaited(
           showDialog<dynamic>(
@@ -178,7 +184,6 @@ class ProgressDialog {
         // [Default transitionDuration of DialogRoute]
         await Future.delayed(const Duration(milliseconds: 200));
         if (_showLogs) debugPrint('ProgressDialog shown');
-        _isShowing = true;
         return true;
       } else {
         if (_showLogs) debugPrint("ProgressDialog already shown/showing");
@@ -186,6 +191,7 @@ class ProgressDialog {
       }
     } catch (err) {
       _isShowing = false;
+      _dialog = null;
       debugPrint('Exception while showing the dialog');
       debugPrint(err.toString());
       return false;

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -1148,14 +1148,14 @@ class _FileSelectionActionsWidgetState
       } else {
         final totalFiles = filesToDownload.length;
         int downloadedFiles = 0;
+        final downloadingMessage = l10n.downloading;
 
         final dialog = createProgressDialog(
           context,
-          AppLocalizations.of(context).downloading +
-              " ($downloadedFiles/$totalFiles)",
+          "$downloadingMessage ($downloadedFiles/$totalFiles)",
           isDismissible: true,
         );
-        await dialog.show();
+        final didShowDialog = await dialog.show();
         try {
           final taskQueue = SimpleTaskQueue(maxConcurrent: 5);
           final futures = <Future>[];
@@ -1168,21 +1168,28 @@ class _FileSelectionActionsWidgetState
                       widget.type != GalleryType.sharedPublicCollection,
                 );
                 downloadedFiles++;
-                dialog.update(
-                  message:
-                      AppLocalizations.of(context).downloading +
-                      " ($downloadedFiles/$totalFiles)",
-                );
+                if (didShowDialog) {
+                  dialog.update(
+                    message:
+                        "$downloadingMessage ($downloadedFiles/$totalFiles)",
+                  );
+                }
               }),
             );
           }
           await Future.wait(futures);
           addedToQueueCount = downloadedFiles;
-          await dialog.hide();
-        } catch (e) {
-          _logger.warning("Failed to save files", e);
-          await dialog.hide();
-          await showGenericErrorDialog(context: context, error: e);
+          if (didShowDialog) {
+            await dialog.hide();
+          }
+        } catch (e, s) {
+          _logger.warning("Failed to save files", e, s);
+          if (didShowDialog) {
+            await dialog.hide();
+          }
+          if (mounted) {
+            await showGenericErrorDialog(context: context, error: e);
+          }
           return;
         }
       }

--- a/mobile/apps/photos/test/ui/common/progress_dialog_test.dart
+++ b/mobile/apps/photos/test/ui/common/progress_dialog_test.dart
@@ -1,0 +1,45 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ui/common/progress_dialog.dart";
+
+void main() {
+  testWidgets("ignores updates from a dialog instance that was not shown", (
+    tester,
+  ) async {
+    late BuildContext context;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (ctx) {
+            context = ctx;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    final firstDialog = ProgressDialog(context);
+    firstDialog.style(
+      message: "Downloading (0/2)",
+      progressWidget: const SizedBox.shrink(),
+    );
+
+    final firstShow = firstDialog.show();
+    await tester.pump();
+
+    final secondDialog = ProgressDialog(context);
+    final secondShown = await secondDialog.show();
+
+    expect(secondShown, isFalse);
+    expect(
+      () => secondDialog.update(message: "Downloading (1/2)"),
+      returnsNormally,
+    );
+
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(await firstShow, isTrue);
+
+    await firstDialog.hide();
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
Fixes a null assertion in the Photos bulk-download progress dialog path and adds regression coverage.