### PR TITLE
[mobile][server] Gate Cast sessions v2 for internal users

### DIFF
--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -122,15 +122,6 @@ class _SettingsBody extends StatelessWidget {
                 },
               ),
               const SizedBox(height: 8),
-              if (flagService.enableMultiCast)
-                _buildMenuItem(
-                  title: AppLocalizations.of(context).cast,
-                  icon: HugeIcons.strokeRoundedTv02,
-                  onTap: () async {
-                    await routeToPage(context, const CastSettingsPage());
-                  },
-                ),
-              if (flagService.enableMultiCast) const SizedBox(height: 8),
             ],
             // Privacy and personalization section
             _buildMenuItem(
@@ -438,6 +429,14 @@ class _SettingsBody extends StatelessWidget {
             await routeToPage(context, const VideoStreamingSettingsPage());
           },
         ),
+        if (flagService.enableMultiCast)
+          _buildMenuItem(
+            title: AppLocalizations.of(context).cast,
+            icon: HugeIcons.strokeRoundedTv02,
+            onTap: () async {
+              await routeToPage(context, const CastSettingsPage());
+            },
+          ),
         _buildMapsMenuItem(context),
       ],
     );

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -14,6 +14,7 @@ import "model.dart";
 class FlagService {
   static const int _commentsFlag = 1 << 1;
   static const int _videoStreamingFlag = 1 << 3;
+  static const int _castSessionsV2Flag = 1 << 4;
   static const int _cfUploadWorkerRolloutPercent = 10;
   static const int _rustMlRolloutPercent = 70;
 
@@ -128,7 +129,8 @@ class FlagService {
 
   bool get mLHydrationStaleFileRecovery => internalUser;
 
-  bool get enableMultiCast => internalUser;
+  bool get enableMultiCast =>
+      internalUser || _isServerFlagEnabled(_castSessionsV2Flag);
 
   Future<void> tryRefreshFlags() async {
     try {

--- a/server/ente/remotestore.go
+++ b/server/ente/remotestore.go
@@ -57,6 +57,8 @@ const (
 	BackupOptions int64 = 1 << 2
 	// VideoStreaming gates video streaming feature.
 	VideoStreaming int64 = 1 << 3
+	// CastSessionsV2 gates cast sessions v2 support.
+	CastSessionsV2 int64 = 1 << 4
 )
 
 type FlagKey string

--- a/server/pkg/controller/remotestore/controller.go
+++ b/server/pkg/controller/remotestore/controller.go
@@ -129,7 +129,7 @@ func (c *Controller) GetFeatureFlags(ctx *gin.Context) (*ente.FeatureFlagRespons
 		case ente.IsInternalUser:
 			response.InternalUser = value == "true"
 			if response.InternalUser {
-				response.ServerApiFlag |= ente.Comments
+				response.ServerApiFlag |= ente.CastSessionsV2
 			}
 		case ente.IsBetaUser:
 			response.BetaUser = value == "true"


### PR DESCRIPTION
- Return Cast sessions v2 in `serverApiFlag` for internal users.
- Use the server flag in Photos and move Cast below Video streaming.