### PR TITLE
[web][albums] Support path-token public album links

### DIFF
--- a/web/apps/albums/next.config.js
+++ b/web/apps/albums/next.config.js
@@ -1,1 +1,20 @@
-module.exports = require("ente-base/next.config.base.js");
+const baseConfig = require("ente-base/next.config.base.js");
+
+module.exports = {
+    ...baseConfig,
+    // Keep static export in production; in development, serve path-token links
+    // through the index page so local browser loads match Cloudflare fallback.
+    ...(process.env.NODE_ENV === "development" && {
+        output: undefined,
+        async rewrites() {
+            return {
+                fallback: [
+                    {
+                        source: "/:path((?!_next|images|favicon.ico).*)",
+                        destination: "/",
+                    },
+                ],
+            };
+        },
+    }),
+};

--- a/web/apps/albums/public/_redirects
+++ b/web/apps/albums/public/_redirects
@@ -1,0 +1,7 @@
+/_next/*    /_next/:splat    200
+/fonts/*    /fonts/:splat    200
+/images/*    /images/:splat    200
+/.well-known/*    /.well-known/:splat    200
+/robots.txt    /robots.txt    200
+/:token    /index.html    200
+/:token/    /index.html    200

--- a/web/apps/albums/src/public-album/page/PublicAlbumPage.tsx
+++ b/web/apps/albums/src/public-album/page/PublicAlbumPage.tsx
@@ -137,6 +137,9 @@ const isDeviceLimitExceededError = async (e: unknown) =>
     isHTTPErrorWithStatus(e, 429) ||
     (await isMuseumHTTPError(e, 403, "LINK_DEVICE_LIMIT_EXCEEDED"));
 
+const accessTokenFromURL = (url: URL) =>
+    url.searchParams.get("t") || url.pathname.split("/").find(Boolean);
+
 export default function PublicAlbumPage() {
     const { showMiniDialog, onGenericError } = useBaseContext();
     const { showLoadingBar, hideLoadingBar } = useAlbumsAppContext();
@@ -266,6 +269,7 @@ export default function PublicAlbumPage() {
 
         isRedirectingToAlbumsAppRef.current = true;
 
+        albumsURL.pathname = currentURL.pathname;
         albumsURL.search = currentURL.search;
         albumsURL.hash = currentURL.hash;
 
@@ -282,7 +286,7 @@ export default function PublicAlbumPage() {
             let redirectingToWebsite = false;
             try {
                 const currentURL = new URL(window.location.href);
-                const t = currentURL.searchParams.get("t");
+                const accessToken = accessTokenFromURL(currentURL);
                 const [
                     { extractCollectionKeyFromShareURL },
                     {
@@ -296,19 +300,18 @@ export default function PublicAlbumPage() {
                     loadPublicAlbumsFDB(),
                 ]);
                 const ck = await extractCollectionKeyFromShareURL(currentURL);
-                if (!t && !ck) {
+                if (!accessToken && !ck) {
                     // Only redirect to ente.com if this is not a self-hosted instance.
                     if (!isCustomAPIOrigin) {
                         window.location.href = "https://ente.com";
                         redirectingToWebsite = true;
                     }
                 }
-                if (!t || !ck) {
+                if (!accessToken || !ck) {
                     return;
                 }
                 collectionKey.current = ck;
                 const collection = await savedPublicCollectionByKey(ck);
-                const accessToken = t;
                 const currentAPIOrigin = await apiOrigin();
                 let accessTokenJWT: string | undefined;
                 const linkDeviceToken =


### PR DESCRIPTION
## Description

Supports both public album URL formats:

- `https://albums.ente.com/?t=TOKEN#KEY`
- `https://albums.ente.com/TOKEN#KEY`