### PR TITLE
[mob][photos] Hide gallery filters in local gallery mode

### DIFF
--- a/mobile/apps/photos/changes/local-gallery-filter-row.md
+++ b/mobile/apps/photos/changes/local-gallery-filter-row.md
@@ -1,0 +1,1 @@
+- Fixed extra app bar space in local gallery mode galleries.

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
@@ -572,8 +572,11 @@ class GalleryState extends State<Gallery> {
         if (!mounted) {
           return result;
         }
+        final inheritedSearchFilterData = _inheritedSearchFilterData;
         final searchFilterDataProvider =
-            _inheritedSearchFilterData?.searchFilterDataProvider;
+            inheritedSearchFilterData?.isHierarchicalSearchable == true
+            ? inheritedSearchFilterData!.searchFilterDataProvider
+            : null;
         if (searchFilterDataProvider != null &&
             !searchFilterDataProvider.isSearchingNotifier.value) {
           unawaited(

--- a/mobile/apps/photos/lib/ui/viewer/gallery/state/inherited_search_filter_data.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/state/inherited_search_filter_data.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:photos/service_locator.dart" show isLocalGalleryMode;
 import "package:photos/ui/viewer/gallery/state/search_filter_data_provider.dart";
 
 class InheritedSearchFilterDataWrapper extends StatefulWidget {
@@ -45,7 +46,8 @@ class InheritedSearchFilterData extends InheritedWidget {
   /// Pass null if gallery doesn't need hierarchical search
   final SearchFilterDataProvider? searchFilterDataProvider;
 
-  bool get isHierarchicalSearchable => searchFilterDataProvider != null;
+  bool get isHierarchicalSearchable =>
+      searchFilterDataProvider != null && !isLocalGalleryMode;
 
   static InheritedSearchFilterData? maybeOf(BuildContext context) {
     return context


### PR DESCRIPTION
## Description

Gallery app bars of galleries when the app is in local gallery mode were reserving space for gallery filters. Filters are never curated in local gallery mode since there are no uploaded files (filters are curated by running over uploaded files).

Disabling filters when app is in local gallery mode fixes this issue. 


