### PR TITLE
[infra] Fix Auth AppImage libffi lookup

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -258,7 +258,7 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y libsecret-1-dev libsodium-dev libfuse2 ninja-build libgtk-3-dev dpkg-dev pkg-config rpm patchelf libsqlite3-dev locate libayatana-appindicator3-dev libffi-dev libtiff5 xz-utils libarchive-tools libcurl4-openssl-dev
-                  sudo updatedb --localpaths='/usr/lib/x86_64-linux-gnu'
+                  sudo updatedb --localpaths='/usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu'
 
             - name: Install fpm for RPM packaging
               run: sudo gem install fpm


### PR DESCRIPTION
Fixes the Auth Linux AppImage packaging failure from https://github.com/ente-io/ente/actions/runs/28061970830.