### PR TITLE
[rust] Build codegen native host libraries on the debug profile

### DIFF
--- a/rust/apps/codegen/src/main.rs
+++ b/rust/apps/codegen/src/main.rs
@@ -277,7 +277,6 @@ fn build_host_library(crate_dir: &Path) -> Result<(), DynError> {
         Command::new("cargo")
             .arg("build")
             .arg("--locked")
-            .arg("--release")
             .arg("--target-dir")
             .arg(target_dir)
             .current_dir(crate_dir),
@@ -318,7 +317,7 @@ fn generate_bindings(
     out_dir: &Path,
     uniffi_crate: &UniffiCrate<'_>,
 ) -> Result<(), DynError> {
-    let source = target_dir()?.join("release").join(format!(
+    let source = target_dir()?.join("debug").join(format!(
         "{}{}{}",
         env::consts::DLL_PREFIX,
         uniffi_crate.crate_name,


### PR DESCRIPTION
These are just the bindings, the code is anyways compiled by the relevant target with the apropos profile.