### PR TITLE
[infra] Authenticate Postgres binary downloads in Rust E2E tests

### DIFF
--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -47,7 +47,7 @@ jobs:
               # GITHUB_TOKEN lifts GitHub API rate limit when fetching
               # postgresql_embedded binaries.
               env:
-                  GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.token || '' }}
+                  GITHUB_TOKEN: ${{ github.token }}
 
             - name: Run E2E suite
               run: cargo test -p ente-e2e --features museum --locked

--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -42,14 +42,12 @@ jobs:
                   shared-key: rust-cli
                   save-if: false
 
-            # GITHUB_TOKEN lifts postgresql_embedded's GitHub API rate limit
-            # for fetching Postgres binaries (60/hr unauthenticated -> 1000/hr).
             - name: Run CLI integration tests
               run: cargo test -p ente-rs --features museum --locked
+              # GITHUB_TOKEN lifts GitHub API rate limit when fetching
+              # postgresql_embedded binaries.
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.token || '' }}
 
             - name: Run E2E suite
               run: cargo test -p ente-e2e --features museum --locked
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-e2e-test.yml
+++ b/.github/workflows/rust-e2e-test.yml
@@ -42,8 +42,14 @@ jobs:
                   shared-key: rust-cli
                   save-if: false
 
+            # GITHUB_TOKEN lifts postgresql_embedded's GitHub API rate limit
+            # for fetching Postgres binaries (60/hr unauthenticated -> 1000/hr).
             - name: Run CLI integration tests
               run: cargo test -p ente-rs --features museum --locked
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Run E2E suite
               run: cargo test -p ente-e2e --features museum --locked
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the GitHub API rate-limit failure (HTTP 403) when fetching Postgres binaries in https://github.com/ente-io/ente/actions/runs/28076587955/job/83122010211