### PR TITLE
[mob][photos] align search section header typography

### DIFF
--- a/mobile/apps/photos/changes/search-section-header-style.md
+++ b/mobile/apps/photos/changes/search-section-header-style.md
@@ -1,0 +1,1 @@
+- Fixed inconsistent section header typography on the search tab.

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/contacts_section.dart
@@ -147,7 +147,7 @@ class _ContactsSectionState extends State<ContactsSection> {
                 children: [
                   Text(
                     SectionType.contacts.sectionTitle(context),
-                    style: TextStyles.h2.copyWith(color: colors.textBase),
+                    style: TextStyles.display3.copyWith(color: colors.textBase),
                   ),
                   const SizedBox(height: 16),
                   Text(

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/file_type_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/file_type_section.dart
@@ -41,7 +41,7 @@ class FileTypeSection extends StatelessWidget {
                 children: [
                   Text(
                     SectionType.fileTypesAndExtension.sectionTitle(context),
-                    style: TextStyles.h2.copyWith(
+                    style: TextStyles.display3.copyWith(
                       color: textTheme.largeBold.color,
                     ),
                   ),

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/locations_section.dart
@@ -91,7 +91,7 @@ class _LocationsSectionState extends State<LocationsSection> {
                 children: [
                   Text(
                     SectionType.location.sectionTitle(context),
-                    style: TextStyles.h2.copyWith(color: colors.textBase),
+                    style: TextStyles.display3.copyWith(color: colors.textBase),
                   ),
                   const SizedBox(height: 16),
                   Text(

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/people_section.dart
@@ -126,7 +126,7 @@ class _PeopleSectionState extends State<PeopleSection> {
                       children: [
                         Text(
                           widget.sectionType.sectionTitle(context),
-                          style: TextStyles.h2.copyWith(
+                          style: TextStyles.display3.copyWith(
                             color: textTheme.largeBold.color,
                           ),
                         ),


### PR DESCRIPTION
## Summary
- Align empty search section header typography with the populated section header style
- Add a Photos changelog entry for the search tab typography fix

## Testing
- dart analyze lib/ui/viewer/search_tab/file_type_section.dart lib/ui/viewer/search_tab/locations_section.dart lib/ui/viewer/search_tab/people_section.dart lib/ui/viewer/search_tab/contacts_section.dart
- Rebuilt and checked the iOS simulator in local gallery mode on the Search tab