### PR TITLE
[mobile] Support path tokens for public album links

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -48,6 +48,14 @@ import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/file_key.dart";
 import 'package:shared_preferences/shared_preferences.dart';
 
+String? _resolvePublicAlbumAccessToken(Uri uri) {
+  final tokenFromQuery = uri.queryParameters["t"];
+  if (tokenFromQuery != null && tokenFromQuery.isNotEmpty) {
+    return tokenFromQuery;
+  }
+  return uri.pathSegments.firstWhereOrNull((segment) => segment.isNotEmpty);
+}
+
 class CollectionsService {
   static const _collectionSyncTimeKeyPrefix = "collection_sync_time_";
   static const _collectionsSyncTimeKey = "collections_sync_time_x";
@@ -1565,7 +1573,7 @@ class CollectionsService {
     BuildContext context,
     Uri uri,
   ) async {
-    final String? authToken = uri.queryParameters["t"];
+    final String? authToken = _resolvePublicAlbumAccessToken(uri);
     final String albumKey = uri.fragment;
     try {
       final responseData = await collectionShareGateway.getPublicCollectionInfo(

--- a/web/apps/albums/public/.well-known/apple-app-site-association
+++ b/web/apps/albums/public/.well-known/apple-app-site-association
@@ -12,6 +12,11 @@
             "?": { "t": "*" },
             "#": "*",
             "comment": "Matches URLs with no path, any query item 't', and any or no fragment"
+          },
+          {
+            "/": "/??????????",
+            "#": "*",
+            "comment": "Matches URLs with a path token and any or no fragment"
           }
         ]
       }

--- a/web/apps/albums/public/_redirects
+++ b/web/apps/albums/public/_redirects
@@ -4,4 +4,3 @@
 /.well-known/*    /.well-known/:splat    200
 /robots.txt    /robots.txt    200
 /:token    /    200
-/:token/    /    200

--- a/web/apps/albums/public/_redirects
+++ b/web/apps/albums/public/_redirects
@@ -4,3 +4,4 @@
 /.well-known/*    /.well-known/:splat    200
 /robots.txt    /robots.txt    200
 /:token    /    200
+/:token/    /    200


### PR DESCRIPTION
## Description

Support both public album URL formats in mobile deep links:

- `https://albums.ente.com/?t=TOKEN#KEY`
- `https://albums.ente.com/TOKEN#KEY`

This is just one part of going from links like https://albums.ente.com/?t=XPA3OZ38DC#4VNZGZNbmOPj2CUesHYGKyvVUEyr6Gr6nMST61pfuQft to https://albums.ente.com/XPA3OZ38DC#5d2a9WhmD2NU