### PR TITLE
[server][web][mobile][docs] Generate path-token public album links

### DIFF
--- a/docs/docs/photos/faq/sharing-and-collaboration.md
+++ b/docs/docs/photos/faq/sharing-and-collaboration.md
@@ -83,13 +83,13 @@ Yes! Ente's custom domains feature lets you serve your public album links using 
 For example, instead of:
 
 ```
-https://albums.ente.com/?t=...
+https://albums.ente.com/...#...
 ```
 
 You can use:
 
 ```
-https://pics.example.org/?t=...
+https://pics.example.org/...#...
 ```
 
 **Requirements:**
@@ -629,7 +629,7 @@ Create a public link for your album, then add an iframe to your HTML with the UR
 
 ```html
 <iframe
-    src="https://embed.ente.com/?t=...#..."
+    src="https://embed.ente.com/...#..."
     width="800"
     height="600"
     frameborder="0"
@@ -649,7 +649,7 @@ If you're using the easy method (copy embed HTML button), the app automatically 
 If you're creating the embed code manually and have a custom domain configured:
 
 - Replace your custom domain with `embed.ente.com` in the iframe src
-- For example: `https://embed.ente.com/?t=...` (not `https://pics.example.org/?t=...`)
+- For example: `https://embed.ente.com/...#...` (not `https://pics.example.org/...#...`)
 
 The embed will still work perfectly - it's just served from the embed subdomain instead of your custom domain.
 

--- a/docs/docs/photos/features/sharing-and-collaboration/custom-domains/index.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/custom-domains/index.md
@@ -10,13 +10,13 @@ Custom domains allow you to serve your public links with your own personalized d
 For example, if I have an Ente album and wish to share it with my friends, I can open the album's sharing settings and create a public link. When I copy this link, it will be of the form of
 
 ```
-https://albums.ente.com/?t=...
+https://albums.ente.com/...#...
 ```
 
 The custom domains feature allows you to instead create a link that uses your own domain, say
 
 ```
-https://pics.example.org/?t=...
+https://pics.example.org/...#...
 ```
 
 You don't need to run any servers or manage any services, Ente will still host and serve your album for you, the only thing that changes is that you can serve your links using your personalized domain.

--- a/docs/docs/photos/features/sharing-and-collaboration/embed.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/embed.md
@@ -48,7 +48,7 @@ First, you need to create a public link for the album you want to embed:
 1. Open the album in Ente (web or mobile app)
 2. Open the album's sharing settings
 3. Create a public link
-4. Copy the link (it will look like `https://albums.ente.com/?t=...#...`)
+4. Copy the link (it will look like `https://albums.ente.com/...#...`)
 
 #### Step 2 - Add iframe to your website
 
@@ -56,7 +56,7 @@ Add an iframe to your HTML with the public link as the source, replacing `albums
 
 ```html
 <iframe
-    src="https://embed.ente.com/?t=...#..."
+    src="https://embed.ente.com/...#..."
     width="800"
     height="600"
     frameborder="0"
@@ -98,7 +98,7 @@ You can customize the appearance by adjusting the iframe attributes:
     style="position: relative; padding-bottom: 75%; height: 0; overflow: hidden;"
 >
     <iframe
-        src="https://embed.ente.com/?t=...#..."
+        src="https://embed.ente.com/...#..."
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
         frameborder="0"
         allowfullscreen

--- a/docs/docs/photos/features/sharing-and-collaboration/public-links.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/public-links.md
@@ -199,7 +199,7 @@ Learn more in the [Collaboration guide](/photos/features/sharing-and-collaborati
 
 Use your own domain instead of `albums.ente.com` for your public links.
 
-For example: `https://pics.example.org/?t=...` instead of `https://albums.ente.com/?t=...`
+For example: `https://pics.example.org/...#...` instead of `https://albums.ente.com/...#...`
 
 Learn more in the [Custom domains guide](/photos/features/sharing-and-collaboration/custom-domains/).
 

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -1144,7 +1144,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
             MaterialPageRoute(
               builder: (context) => WebPage(
                 widget.title ?? "",
-                "https://albums.ente.com/?t=$authToken#$albumKey",
+                "https://albums.ente.com/$authToken#$albumKey",
               ),
             ),
           );

--- a/server/pkg/repo/public/collection_link.go
+++ b/server/pkg/repo/public/collection_link.go
@@ -41,7 +41,7 @@ func (pcr *CollectionLinkRepo) GetAlbumUrl(app ente.App, token string) string {
 	if app == ente.Locker {
 		return fmt.Sprintf("%s/c/%s", pcr.lockerHost, token)
 	}
-	return fmt.Sprintf("%s/?t=%s", pcr.albumHost, token)
+	return fmt.Sprintf("%s/%s", pcr.albumHost, token)
 }
 
 func (pcr *CollectionLinkRepo) Insert(ctx context.Context,

--- a/web/apps/albums/src/public-album/data/api/public-collection.ts
+++ b/web/apps/albums/src/public-album/data/api/public-collection.ts
@@ -86,8 +86,8 @@ export const verifyPublicAlbumPassword = async (
  *
  * This function modifies local state.
  *
- * @param accessToken A public collection access key obtained from the "t="
- * query parameter of the public URL.
+ * @param accessToken A public collection access key obtained from the public
+ * URL path token, or from the legacy "t" query parameter.
  *
  * The access key serves to both identify the public collection, and also
  * authenticate the request. See: [Note: Public album access token].

--- a/web/apps/embed/src/services/public-collection.ts
+++ b/web/apps/embed/src/services/public-collection.ts
@@ -92,8 +92,8 @@ export const verifyPublicAlbumPassword = async (
  *
  * This function modifies local state.
  *
- * @param accessToken A public collection access key obtained from the "t="
- * query parameter of the public URL.
+ * @param accessToken A public collection access key obtained from the public
+ * URL path token, or from the legacy "t" query parameter.
  *
  * The access key serves to both identify the public collection, and also
  * authenticate the request. See: [Note: Public album access token].

--- a/web/packages/media/collection.ts
+++ b/web/packages/media/collection.ts
@@ -283,15 +283,15 @@ export interface PublicURL {
     /**
      * A URL that can be used access the shared collection.
      *
-     * This will be of the form "https://<public-albums-app>/?t=<token>", e.g.,
-     * "https://albums.ente.com/?t=xxxxxx".
+     * This will be of the form "https://<public-albums-app>/<token>", e.g.,
+     * "https://albums.ente.com/xxxxxx".
      *
      * In particular, this URL does not contain the URL fragment (the part after
      * the "#"). URL fragments are client side only, and not sent to remote.
      * They contain the decryption key.
      *
-     * The client can use this field to form the fully usable URL (e.g.
-     * "https://albums.ente.com/?t=xxxxxx#yyy...yyy") and provide it to the user
+     * The client can use this field to form the fully usable URL, e.g.
+     * "https://albums.ente.com/xxxxxx#yyy...yyy", and provide it to the user
      * for sharing.
      */
     url: string;


### PR DESCRIPTION
## Description

- Generate Photos public album links as `albums.ente.com/TOKEN#KEY` instead of `albums.ente.com/?t=TOKEN#KEY`
- Update mobile browser fallback and public album/embed docs examples

To be merged and deployed after it's been 1-2 weeks since https://github.com/ente/ente/pull/11127 's roll out.

This is just one part of going from links like https://albums.ente.com/?t=XPA3OZ38DC#4VNZGZNbmOPj2CUesHYGKyvVUEyr6Gr6nMST61pfuQft to https://albums.ente.com/XPA3OZ38DC#5d2a9WhmD2NU