### PR TITLE
[mob][locker] Improve onboarding and upload flows

### DIFF
--- a/mobile/apps/locker/changes/locker-upload-onboarding-recovery.md
+++ b/mobile/apps/locker/changes/locker-upload-onboarding-recovery.md
@@ -1,0 +1,1 @@
+- Improved Locker onboarding, recovery key, drawer gesture, and document upload collection selection flows.

--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -842,6 +842,8 @@
   },
   "locker": "Locker",
   "loginToEnteAccount": "Log in to your Ente account",
+  "createAnEnteAccount": "Create an Ente account",
+  "loginToExistingAccount": "Login to existing account",
   "unlockLockerNewUserTitle": "Join Ente to use Locker",
   "unlockLockerNewUserBody": "Locker is currently available only to existing Ente users. You can create an account on Ente Photos to use Locker.",
   "checkoutEntePhotos": "Checkout Ente Photos",

--- a/mobile/apps/locker/lib/ui/components/recovery_key_sheet.dart
+++ b/mobile/apps/locker/lib/ui/components/recovery_key_sheet.dart
@@ -69,7 +69,7 @@ class _RecoveryKeySheetState extends State<RecoveryKeySheet> {
         const SizedBox(height: 24),
         Container(
           decoration: BoxDecoration(
-            color: colors.primaryDarker,
+            color: colors.primary,
             borderRadius: BorderRadius.circular(16),
           ),
           child: Stack(
@@ -110,7 +110,7 @@ class _RecoveryKeySheetState extends State<RecoveryKeySheet> {
         const SizedBox(height: 16),
         Text(
           context.strings.recoveryKeySaveDescription,
-          style: TextStyles.mini.copyWith(color: colors.textLight),
+          style: TextStyles.body.copyWith(color: colors.textLight),
         ),
         const SizedBox(height: 24),
         ButtonComponent(

--- a/mobile/apps/locker/lib/ui/pages/file_upload_screen.dart
+++ b/mobile/apps/locker/lib/ui/pages/file_upload_screen.dart
@@ -44,6 +44,13 @@ class _FileUploadScreenState extends State<FileUploadScreen> {
     if (widget.selectedCollection != null &&
         widget.selectedCollection!.type != CollectionType.uncategorized) {
       _selectedCollectionIds.add(widget.selectedCollection!.id);
+    } else {
+      for (final collection in _availableCollections) {
+        if (collection.type == CollectionType.uncategorized) {
+          _selectedCollectionIds.add(collection.id);
+          break;
+        }
+      }
     }
   }
 
@@ -185,20 +192,16 @@ class _FileUploadScreenState extends State<FileUploadScreen> {
                 child: SizedBox(
                   width: double.infinity,
                   child: GradientButton(
-                    onTap: _selectedCollectionIds.isEmpty
-                        ? null
-                        : () async {
-                            final selectedCollections = _availableCollections
-                                .where(
-                                  (c) => _selectedCollectionIds.contains(c.id),
-                                )
-                                .toList();
-                            final result = FileUploadSheetResult(
-                              note: '',
-                              selectedCollections: selectedCollections,
-                            );
-                            Navigator.of(context).pop(result);
-                          },
+                    onTap: () async {
+                      final selectedCollections = _availableCollections
+                          .where((c) => _selectedCollectionIds.contains(c.id))
+                          .toList();
+                      final result = FileUploadSheetResult(
+                        note: '',
+                        selectedCollections: selectedCollections,
+                      );
+                      Navigator.of(context).pop(result);
+                    },
                     text: context.l10n.save,
                   ),
                 ),

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -208,6 +208,8 @@ class HomePage extends UploaderPage {
 
 class _HomePageState extends UploaderPageState<HomePage>
     with TickerProviderStateMixin, SearchMixin {
+  static const double _drawerOpenDragThreshold = 45;
+
   late final _settingsPage = DrawerPage(
     emailNotifier: UserService.instance.emailValueNotifier,
     scaffoldKey: scaffoldKey,
@@ -216,6 +218,7 @@ class _HomePageState extends UploaderPageState<HomePage>
   final _searchFocusNode = FocusNode();
   final _selectedFiles = SelectedFiles();
   final _scrollController = ScrollController();
+  final _drawerPageController = PageController();
   bool _isLoading = true;
   bool _hasCompletedInitialLoad = false;
   bool _isSettingsOpen = false;
@@ -282,6 +285,8 @@ class _HomePageState extends UploaderPageState<HomePage>
   void initState() {
     super.initState();
 
+    _drawerPageController.addListener(_handleDrawerPageOverscroll);
+
     _loadCollections();
 
     // Initialize sharing functionality to handle shared files
@@ -324,6 +329,8 @@ class _HomePageState extends UploaderPageState<HomePage>
 
   @override
   void dispose() {
+    _drawerPageController.removeListener(_handleDrawerPageOverscroll);
+    _drawerPageController.dispose();
     _searchFocusNode.dispose();
     _scrollController.dispose();
     _displayedFilesNotifier.dispose();
@@ -652,7 +659,7 @@ class _HomePageState extends UploaderPageState<HomePage>
                   backgroundColor: componentColors.backgroundBase,
                   child: _settingsPage,
                 ),
-                drawerEnableOpenDragGesture: true,
+                drawerEnableOpenDragGesture: false,
                 onDrawerChanged: (isOpened) {
                   _isSettingsOpen = isOpened;
                   if (isOpened) {
@@ -671,7 +678,13 @@ class _HomePageState extends UploaderPageState<HomePage>
                 ),
                 body: Stack(
                   children: [
-                    _buildBody(),
+                    PageView(
+                      controller: _drawerPageController,
+                      physics: const BouncingScrollPhysics(
+                        parent: AlwaysScrollableScrollPhysics(),
+                      ),
+                      children: [_buildBody()],
+                    ),
                     ValueListenableBuilder<List<EnteFile>>(
                       valueListenable: _displayedFilesNotifier,
                       builder: (context, displayedFiles, _) {
@@ -792,6 +805,15 @@ class _HomePageState extends UploaderPageState<HomePage>
               );
       },
     );
+  }
+
+  void _handleDrawerPageOverscroll() {
+    if (_isSettingsOpen) {
+      return;
+    }
+    if (_drawerPageController.offset < -_drawerOpenDragThreshold) {
+      scaffoldKey.currentState?.openDrawer();
+    }
   }
 
   void _openSavePage() {

--- a/mobile/apps/locker/lib/ui/pages/onboarding_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/onboarding_page.dart
@@ -5,6 +5,7 @@ import 'package:ente_accounts/pages/email_entry_page.dart';
 import 'package:ente_accounts/pages/login_page.dart';
 import 'package:ente_accounts/pages/password_entry_page.dart';
 import 'package:ente_accounts/pages/password_reentry_page.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_ui/components/alert_bottom_sheet.dart';
 import "package:ente_ui/pages/developer_settings_page.dart";
 import "package:ente_ui/theme/ente_theme.dart";
@@ -107,6 +108,9 @@ class _OnboardingPageState extends State<OnboardingPage> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = getEnteColorScheme(context);
+    final lightComponentTheme = ComponentTheme.lightTheme(
+      app: ComponentApp.locker,
+    );
     debugPrint("Building OnboardingPage");
     final l10n = context.l10n;
     return Scaffold(
@@ -197,42 +201,31 @@ class _OnboardingPageState extends State<OnboardingPage> {
                     ),
                     const SizedBox(height: 48),
                     Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        children: [
-                          GradientButton(
-                            text: l10n.loginToEnteAccount,
-                            backgroundColor: Colors.white,
-                            textColor: colorScheme.primary700,
-                            onTap: _navigateToSignInPage,
-                          ),
-                          const SizedBox(height: 20),
-                          Center(
-                            child: GestureDetector(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Theme(
+                        data: lightComponentTheme,
+                        child: Column(
+                          children: [
+                            ButtonComponent(
+                              variant: ButtonComponentVariant.neutral,
+                              label: l10n.createAnEnteAccount,
                               onTap: _navigateToSignUpPage,
-                              child: Text.rich(
-                                TextSpan(
-                                  text: "${l10n.dontHaveAccount} ",
-                                  style: getEnteTextTheme(
-                                    context,
-                                  ).body.copyWith(color: Colors.white),
-                                  children: [
-                                    TextSpan(
-                                      text: l10n.signUp,
-                                      style: getEnteTextTheme(context).bodyBold
-                                          .copyWith(
-                                            color: Colors.white,
-                                            decoration:
-                                                TextDecoration.underline,
-                                            decorationColor: Colors.white,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                              ),
+                              shouldSurfaceExecutionStates: false,
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    TextButton(
+                      onPressed: _navigateToSignInPage,
+                      child: Text(
+                        l10n.loginToExistingAccount,
+                        style: getEnteTextTheme(context).body.copyWith(
+                          decoration: TextDecoration.underline,
+                          decorationColor: Colors.white,
+                          color: Colors.white,
+                        ),
                       ),
                     ),
                   ],

--- a/mobile/apps/locker/lib/ui/pages/uploader_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/uploader_page.dart
@@ -69,7 +69,7 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
       final List<Future> futures = [];
 
       final regularCollections = await CollectionService.instance
-          .getCollectionsForUI();
+          .getCollectionsForUI(includeUncategorized: true);
 
       // Navigate to upload screen to get collection selection
       final uploadResult = await Navigator.of(context)

--- a/mobile/packages/accounts/lib/pages/email_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/email_entry_page.dart
@@ -36,7 +36,6 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
   double _passwordStrength = 0.0;
   bool _emailIsValid = false;
   bool _hasAgreedToTOS = true;
-  bool _hasAgreedToE2E = false;
   bool _password1Visible = false;
   bool _password2Visible = false;
   bool _passwordsMatch = false;
@@ -440,9 +439,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                     ),
                   ),
                   const SizedBox(height: 16),
-                  Column(
-                    children: [_getTOSAgreement(), _getPasswordAgreement()],
-                  ),
+                  _getTOSAgreement(),
                 ],
               ),
             ),
@@ -514,64 +511,10 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
     );
   }
 
-  Widget _getPasswordAgreement() {
-    final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
-
-    return GestureDetector(
-      onTap: () {
-        setState(() {
-          _hasAgreedToE2E = !_hasAgreedToE2E;
-        });
-      },
-      behavior: HitTestBehavior.translucent,
-      child: Row(
-        children: [
-          Checkbox(
-            value: _hasAgreedToE2E,
-            side: CheckboxTheme.of(context).side,
-            fillColor: WidgetStateProperty.resolveWith((states) {
-              if (states.contains(WidgetState.selected)) {
-                return colorScheme.primary700;
-              }
-              return Colors.transparent;
-            }),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(4),
-            ),
-            onChanged: (value) {
-              setState(() {
-                _hasAgreedToE2E = value!;
-              });
-            },
-          ),
-          Expanded(
-            child: StyledText(
-              text: context.strings.ackPasswordLostWarning,
-              style: textTheme.small.copyWith(color: colorScheme.textMuted),
-              tags: {
-                'underline': StyledTextActionTag(
-                  (String? text, Map<String?, String?> attrs) =>
-                      PlatformUtil.openWebView(
-                        context,
-                        context.strings.encryption,
-                        "https://ente.com/architecture",
-                      ),
-                  style: const TextStyle(decoration: TextDecoration.underline),
-                ),
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   bool _isFormValid() {
     return _emailIsValid &&
         _passwordsMatch &&
         _hasAgreedToTOS &&
-        _hasAgreedToE2E &&
         _passwordIsValid;
   }
 }

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -515,7 +515,7 @@
   "@recoveryKeyOnForgotPassword": {
     "description": "Recovery key importance explanation"
   },
-  "recoveryKeySaveDescription": "We don't store this key, please save this 24 word key in a safe place.",
+  "recoveryKeySaveDescription": "Please save this key in a safe place.",
   "@recoveryKeySaveDescription": {
     "description": "Recovery key save description"
   },


### PR DESCRIPTION
## Description
- Adds a Locker change note.
- Aligns Locker onboarding CTA copy/layout with Photos and removes the extra signup checkbox.
- Updates Locker recovery key copy/styling to match Photos.
- Supports uploading to Uncategorized by default while allowing users to unselect it.
- Restores drawer opening through a Photos-style overscroll gesture.

## Tests
- Verified in iOS Simulator via VS Code-attached Flutter run:
  - Landing CTA copy/layout.
  - Signup page only shows the TOS/privacy checkbox.
  - Recovery key sheet copy, text size, and key box color.
  - Upload picker opens with Uncategorized preselected and allows unselecting it.
  - Left-to-right drag opens the drawer.
