### PR TITLE
[mobile] Enable Git long paths for Auth Windows build

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -351,6 +351,11 @@ jobs:
               shell: bash
               run: node ../../../.github/scripts/flutter-version.mjs auth set-build "${RELEASE_VERSION}" "${BUILD_NUMBER}"
 
+            # Needed for Pub to checkout flutter/packages on Windows.
+            # https://github.com/dart-lang/pub/issues/3803
+            - name: Enable Git long paths
+              run: git config --global core.longpaths true
+
             - run: flutter pub get --enforce-lockfile
 
             - name: Create artifacts directory


### PR DESCRIPTION
Fixes the failed Auth Windows build: https://github.com/ente/ente/actions/runs/28338304505/job/83948282524

This started after mobile moved to a pub workspace, which made Pub checkout our flutter/packages fork on Windows.