### PR TITLE
[mobile][photos] preserve exif information when saving edited copies

### DIFF
--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -81,8 +81,8 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         quality: 95,
         format: CompressFormat.jpeg,
       );
-      late final img.Image? image;
-      late final img.ExifData? originalImageExif;
+      img.Image? image;
+      img.ExifData? originalImageExif;
       if (flagService.internalUser) {
         originalImageExif = await _readOriginalImageExif(widget.originalFile);
         image = img.decodeJpg(result);

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -81,17 +81,14 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         quality: 95,
         format: CompressFormat.jpeg,
       );
+      late final img.Image? image;
+      late final img.ExifData? originalImageExif;
       if (flagService.internalUser) {
-        final originalImageExif = await _readOriginalImageExif(
-          widget.originalFile,
-        );
-        final image = img.decodeJpg(result);
-        if (image == null) {
-          throw Exception("Failed to decode image");
-        }
-        if (originalImageExif != null) {
-          image.exif = originalImageExif;
-        }
+        originalImageExif = await _readOriginalImageExif(widget.originalFile);
+        image = img.decodeJpg(result);
+      }
+      if (originalImageExif != null && image != null) {
+        image.exif = originalImageExif;
         for (final key in [
           "Orientation",
           "WhitePoint",

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import "package:flutter/services.dart";
 import "package:flutter_image_compress/flutter_image_compress.dart";
 import "package:hugeicons/hugeicons.dart";
+import 'package:image/image.dart' as img;
 import "package:logging/logging.dart";
 import 'package:path/path.dart' as path;
 import "package:photo_manager/photo_manager.dart";
@@ -18,6 +19,7 @@ import "package:photos/events/local_photos_updated_event.dart";
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/file/file.dart' as ente;
 import "package:photos/models/location/location.dart";
+import "package:photos/service_locator.dart";
 import "package:photos/services/sync/sync_service.dart";
 import "package:photos/ui/components/action_sheet_widget.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
@@ -33,6 +35,7 @@ import "package:photos/ui/tools/editor/image_editor/image_editor_text_bar.dart";
 import "package:photos/ui/tools/editor/image_editor/image_editor_tune_bar.dart";
 import "package:photos/ui/viewer/file/detail_page.dart";
 import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/exif_util.dart";
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 class ImageEditorPage extends StatefulWidget {
@@ -71,13 +74,59 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
 
     try {
       final ui.Image decodedResult = await decodeImageFromList(bytes);
-      final result = await FlutterImageCompress.compressWithList(
+      var result = await FlutterImageCompress.compressWithList(
         bytes,
         minWidth: decodedResult.width,
         minHeight: decodedResult.height,
         quality: 95,
         format: CompressFormat.jpeg,
       );
+      if (flagService.internalUser) {
+        final originalImageExif = await getExif2(widget.originalFile);
+        final image = img.decodeJpg(result);
+        if (image == null) {
+          throw Exception("Failed to decode image");
+        }
+        image.exif = originalImageExif;
+        for (final key in [
+          "Orientation",
+          "ColorSpace",
+          "Gamma",
+          "WhitePoint",
+          "PrimaryChromaticities",
+          "PhotometricInterpretation",
+          "BitsPerSample",
+          "SamplesPerPixel",
+          "Compression",
+          "ImageWidth",
+          "ImageHeight",
+          "ExifImageWidth",
+          "ExifImageHeight",
+          "ComponentsConfiguration",
+          "YCbCrPositioning",
+          "YCbCrSubSampling",
+          "YCbCrCoefficients",
+          "ReferenceBlackWhite",
+          "XResolution",
+          "YResolution",
+          "ResolutionUnit",
+          "JPEGInterchangeFormat",
+          "JPEGInterchangeFormatLength",
+          "CustomRendered",
+          "SceneCaptureType",
+          "WhiteBalance",
+          "LightSource",
+          "Flash",
+          "GainControl",
+          "Contrast",
+          "Saturation",
+          "Sharpness",
+          "SubjectDistanceRange",
+        ]) {
+          image.exif.exifIfd[key] = null;
+        }
+        result = img.encodeJpg(image);
+      }
       _logger.info('Size after compression = ${result.length}');
       final Duration diff = DateTime.now().difference(start);
       _logger.info('image_editor time : $diff');

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui show Image, ImageByteFormat;
 
 import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
+import "package:exif_reader/exif_reader.dart";
 import 'package:flutter/material.dart';
 import "package:flutter/services.dart";
 import "package:flutter_image_compress/flutter_image_compress.dart";
@@ -35,6 +36,7 @@ import "package:photos/ui/tools/editor/image_editor/image_editor_text_bar.dart";
 import "package:photos/ui/tools/editor/image_editor/image_editor_tune_bar.dart";
 import "package:photos/ui/viewer/file/detail_page.dart";
 import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/exif_util.dart";
 import 'package:photos/utils/file_util.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
@@ -83,12 +85,19 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       );
       img.Image? image;
       img.ExifData? originalImageExif;
+      Map<String, IfdTag>? originalExifReaderTags;
       if (flagService.internalUser) {
+        try {
+          originalExifReaderTags = await getExif(widget.originalFile);
+        } catch (e, s) {
+          _logger.warning("Image Editor: getExif failed", e, s);
+        }
         originalImageExif = await _readOriginalImageExif(widget.originalFile);
         image = img.decodePng(bytes);
       }
-      if (originalImageExif != null && image != null) {
-        image.exif = originalImageExif;
+      if (image != null &&
+          (originalImageExif != null || originalExifReaderTags != null)) {
+        image.exif = originalImageExif ?? img.ExifData();
         for (final key in [
           "Orientation",
           "WhitePoint",
@@ -133,6 +142,37 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
           "SubjectDistanceRange",
         ]) {
           image.exif.exifIfd[key] = null;
+        }
+
+        final make = originalExifReaderTags?["Image Make"]?.toString();
+        final model = originalExifReaderTags?["Image Model"]?.toString();
+        if (make != null) {
+          image.exif.imageIfd["Make"] = make;
+        }
+        if (model != null) {
+          image.exif.imageIfd["Model"] = model;
+        }
+
+        void copyRatio(String sourceKey, String targetKey) {
+          final values = originalExifReaderTags?[sourceKey]?.values.toList();
+          if (values == null || values.isEmpty || values.first is! Ratio) {
+            return;
+          }
+          final value = values.first as Ratio;
+          image!.exif.exifIfd[targetKey] = img.IfdValueRational(
+            value.numerator,
+            value.denominator,
+          );
+        }
+
+        copyRatio("EXIF FocalLength", "FocalLength");
+        copyRatio("EXIF FNumber", "FNumber");
+        copyRatio("EXIF ExposureTime", "ExposureTime");
+
+        final isoValues =
+            originalExifReaderTags?["EXIF ISOSpeedRatings"]?.values;
+        if (isoValues != null && isoValues.length != 0) {
+          image.exif.exifIfd["ISOSpeed"] = isoValues.firstAsInt();
         }
         result = img.encodeJpg(image, quality: 95);
       }

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -85,7 +85,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       img.ExifData? originalImageExif;
       if (flagService.internalUser) {
         originalImageExif = await _readOriginalImageExif(widget.originalFile);
-        image = img.decodeJpg(result);
+        image = img.decodePng(bytes);
       }
       if (originalImageExif != null && image != null) {
         image.exif = originalImageExif;
@@ -134,7 +134,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         ]) {
           image.exif.exifIfd[key] = null;
         }
-        result = img.encodeJpg(image);
+        result = img.encodeJpg(image, quality: 95);
       }
       _logger.info('Size after compression = ${result.length}');
       final Duration diff = DateTime.now().difference(start);

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -35,7 +35,7 @@ import "package:photos/ui/tools/editor/image_editor/image_editor_text_bar.dart";
 import "package:photos/ui/tools/editor/image_editor/image_editor_tune_bar.dart";
 import "package:photos/ui/viewer/file/detail_page.dart";
 import "package:photos/utils/dialog_util.dart";
-import "package:photos/utils/exif_util.dart";
+import 'package:photos/utils/file_util.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 class ImageEditorPage extends StatefulWidget {
@@ -82,16 +82,18 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         format: CompressFormat.jpeg,
       );
       if (flagService.internalUser) {
-        final originalImageExif = await getExif2(widget.originalFile);
+        final originalImageExif = await _readOriginalImageExif(
+          widget.originalFile,
+        );
         final image = img.decodeJpg(result);
         if (image == null) {
           throw Exception("Failed to decode image");
         }
-        image.exif = originalImageExif;
+        if (originalImageExif != null) {
+          image.exif = originalImageExif;
+        }
         for (final key in [
           "Orientation",
-          "ColorSpace",
-          "Gamma",
           "WhitePoint",
           "PrimaryChromaticities",
           "PhotometricInterpretation",
@@ -100,9 +102,6 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
           "Compression",
           "ImageWidth",
           "ImageHeight",
-          "ExifImageWidth",
-          "ExifImageHeight",
-          "ComponentsConfiguration",
           "YCbCrPositioning",
           "YCbCrSubSampling",
           "YCbCrCoefficients",
@@ -110,8 +109,21 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
           "XResolution",
           "YResolution",
           "ResolutionUnit",
+        ]) {
+          image.exif.imageIfd[key] = null;
+        }
+        for (final key in [
           "JPEGInterchangeFormat",
           "JPEGInterchangeFormatLength",
+        ]) {
+          image.exif.thumbnailIfd[key] = null;
+        }
+        for (final key in [
+          "ColorSpace",
+          "Gamma",
+          "ExifImageWidth",
+          "ExifImageHeight",
+          "ComponentsConfiguration",
           "CustomRendered",
           "SceneCaptureType",
           "WhiteBalance",
@@ -196,6 +208,25 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     } finally {
       if (hasStoppedChangeNotify) {
         await PhotoManager.startChangeNotify();
+      }
+    }
+  }
+
+  Future<img.ExifData?> _readOriginalImageExif(ente.EnteFile enteFile) async {
+    final file = await getFile(enteFile, isOrigin: true);
+    if (file == null) {
+      return null;
+    }
+    try {
+      final bytes = await file.readAsBytes();
+      final image = img.decodeImage(bytes);
+      if (image == null) {
+        return null;
+      }
+      return image.exif;
+    } finally {
+      if (!enteFile.isRemoteFile && Platform.isIOS) {
+        await file.delete();
       }
     }
   }

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -129,6 +129,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
           "Gamma",
           "ExifImageWidth",
           "ExifImageHeight",
+          "ExifImageLength",
           "ComponentsConfiguration",
           "CustomRendered",
           "SceneCaptureType",

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -224,6 +224,9 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         return null;
       }
       return image.exif;
+    } catch (e, s) {
+      _logger.warning("Image Editor: _readOriginalImageExif failed: ", e, s);
+      return null;
     } finally {
       if (!enteFile.isRemoteFile && Platform.isIOS) {
         await file.delete();

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -83,99 +83,22 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         quality: 95,
         format: CompressFormat.jpeg,
       );
-      img.Image? image;
-      img.ExifData? originalImageExif;
-      Map<String, IfdTag>? originalExifReaderTags;
       if (flagService.internalUser) {
-        try {
-          originalExifReaderTags = await getExif(widget.originalFile);
-        } catch (e, s) {
-          _logger.warning("Image Editor: getExif failed", e, s);
-        }
-        originalImageExif = await _readOriginalImageExif(widget.originalFile);
-        image = img.decodePng(bytes);
-      }
-      if (image != null &&
-          (originalImageExif != null || originalExifReaderTags != null)) {
-        image.exif = originalImageExif ?? img.ExifData();
-        for (final key in [
-          "Orientation",
-          "WhitePoint",
-          "PrimaryChromaticities",
-          "PhotometricInterpretation",
-          "BitsPerSample",
-          "SamplesPerPixel",
-          "Compression",
-          "ImageWidth",
-          "ImageHeight",
-          "YCbCrPositioning",
-          "YCbCrSubSampling",
-          "YCbCrCoefficients",
-          "ReferenceBlackWhite",
-          "XResolution",
-          "YResolution",
-          "ResolutionUnit",
-        ]) {
-          image.exif.imageIfd[key] = null;
-        }
-        for (final key in [
-          "JPEGInterchangeFormat",
-          "JPEGInterchangeFormatLength",
-        ]) {
-          image.exif.thumbnailIfd[key] = null;
-        }
-        for (final key in [
-          "ColorSpace",
-          "Gamma",
-          "ExifImageWidth",
-          "ExifImageHeight",
-          "ExifImageLength",
-          "ComponentsConfiguration",
-          "CustomRendered",
-          "SceneCaptureType",
-          "WhiteBalance",
-          "LightSource",
-          "Flash",
-          "GainControl",
-          "Contrast",
-          "Saturation",
-          "Sharpness",
-          "SubjectDistanceRange",
-        ]) {
-          image.exif.exifIfd[key] = null;
-        }
-
-        final make = originalExifReaderTags?["Image Make"]?.toString();
-        final model = originalExifReaderTags?["Image Model"]?.toString();
-        if (make != null) {
-          image.exif.imageIfd["Make"] = make;
-        }
-        if (model != null) {
-          image.exif.imageIfd["Model"] = model;
-        }
-
-        void copyRatio(String sourceKey, String targetKey) {
-          final values = originalExifReaderTags?[sourceKey]?.values.toList();
-          if (values == null || values.isEmpty || values.first is! Ratio) {
-            return;
-          }
-          final value = values.first as Ratio;
-          image!.exif.exifIfd[targetKey] = img.IfdValueRational(
-            value.numerator,
-            value.denominator,
+        final image = img.decodePng(bytes);
+        if (image != null) {
+          final originalExifTags = await _getOriginalExifTags(
+            widget.originalFile,
           );
+          final originalImageExif = await _readOriginalImageExif(
+            widget.originalFile,
+          );
+          if (originalImageExif != null || originalExifTags.isNotEmpty) {
+            image.exif = originalImageExif ?? img.ExifData();
+            _clearEditorExifTags(image.exif);
+            _copyCameraExif(originalExifTags, image.exif);
+            result = img.encodeJpg(image, quality: 95);
+          }
         }
-
-        copyRatio("EXIF FocalLength", "FocalLength");
-        copyRatio("EXIF FNumber", "FNumber");
-        copyRatio("EXIF ExposureTime", "ExposureTime");
-
-        final isoValues =
-            originalExifReaderTags?["EXIF ISOSpeedRatings"]?.values;
-        if (isoValues != null && isoValues.length != 0) {
-          image.exif.exifIfd["ISOSpeed"] = isoValues.firstAsInt();
-        }
-        result = img.encodeJpg(image, quality: 95);
       }
       _logger.info('Size after compression = ${result.length}');
       final Duration diff = DateTime.now().difference(start);
@@ -250,6 +173,17 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     }
   }
 
+  Future<Map<String, IfdTag>> _getOriginalExifTags(
+    ente.EnteFile enteFile,
+  ) async {
+    try {
+      return await getExif(enteFile);
+    } catch (e, s) {
+      _logger.warning("Image Editor: getExif failed", e, s);
+      return const {};
+    }
+  }
+
   Future<img.ExifData?> _readOriginalImageExif(ente.EnteFile enteFile) async {
     final file = await getFile(enteFile, isOrigin: true);
     if (file == null) {
@@ -258,17 +192,98 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     try {
       final bytes = await file.readAsBytes();
       final image = img.decodeImage(bytes);
-      if (image == null) {
-        return null;
-      }
-      return image.exif;
+      return image?.exif;
     } catch (e, s) {
       _logger.warning("Image Editor: _readOriginalImageExif failed: ", e, s);
       return null;
     } finally {
-      if (!enteFile.isRemoteFile && Platform.isIOS) {
+      if (!enteFile.isRemoteOnlyFile && Platform.isIOS) {
         await file.delete();
       }
+    }
+  }
+
+  void _clearEditorExifTags(img.ExifData exif) {
+    final imageIfdKeys = [
+      "Orientation",
+      "WhitePoint",
+      "PrimaryChromaticities",
+      "PhotometricInterpretation",
+      "BitsPerSample",
+      "SamplesPerPixel",
+      "Compression",
+      "ImageWidth",
+      "ImageHeight",
+      "YCbCrPositioning",
+      "YCbCrSubSampling",
+      "YCbCrCoefficients",
+      "ReferenceBlackWhite",
+      "XResolution",
+      "YResolution",
+      "ResolutionUnit",
+    ];
+    final thumbnailIfdKeys = [
+      "JPEGInterchangeFormat",
+      "JPEGInterchangeFormatLength",
+    ];
+    final exifIfdKeys = [
+      "ColorSpace",
+      "Gamma",
+      "ExifImageWidth",
+      "ExifImageHeight",
+      "ExifImageLength",
+      "ComponentsConfiguration",
+      "CustomRendered",
+      "SceneCaptureType",
+      "WhiteBalance",
+      "LightSource",
+      "Flash",
+      "GainControl",
+      "Contrast",
+      "Saturation",
+      "Sharpness",
+      "SubjectDistanceRange",
+    ];
+
+    void clear(img.IfdDirectory ifd, List<String> keys) {
+      for (final key in keys) {
+        ifd[key] = null;
+      }
+    }
+
+    clear(exif.imageIfd, imageIfdKeys);
+    clear(exif.thumbnailIfd, thumbnailIfdKeys);
+    clear(exif.exifIfd, exifIfdKeys);
+  }
+
+  void _copyCameraExif(Map<String, IfdTag> tags, img.ExifData exif) {
+    for (final entry in {
+      "Image Make": "Make",
+      "Image Model": "Model",
+    }.entries) {
+      final value = tags[entry.key]?.toString();
+      if (value != null) {
+        exif.imageIfd[entry.value] = value;
+      }
+    }
+
+    for (final entry in {
+      "EXIF FocalLength": "FocalLength",
+      "EXIF FNumber": "FNumber",
+      "EXIF ExposureTime": "ExposureTime",
+    }.entries) {
+      final value = tags[entry.key]?.values.toList().firstOrNull;
+      if (value is Ratio) {
+        exif.exifIfd[entry.value] = img.IfdValueRational(
+          value.numerator,
+          value.denominator,
+        );
+      }
+    }
+
+    final iso = tags["EXIF ISOSpeedRatings"]?.values;
+    if (iso != null && iso.length > 0) {
+      exif.exifIfd["ISOSpeed"] = iso.firstAsInt();
     }
   }
 

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -3,6 +3,7 @@ import "dart:io";
 
 import "package:computer/computer.dart";
 import 'package:exif_reader/exif_reader.dart';
+import "package:image/image.dart" as img;
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import "package:photos/models/ffmpeg/ffprobe_props.dart";
@@ -37,6 +38,19 @@ final _offsetPattern = RegExp(r'^([Zz]|[+-](?:[01]\d|2[0-3]):?[0-5]\d)$');
 
 bool shouldReadExif(EnteFile file) {
   return file.fileType == FileType.image || file.fileType == FileType.livePhoto;
+}
+
+Future<img.ExifData> getExif2(EnteFile enteFile) async {
+  final file = await getFile(enteFile, isOrigin: true);
+  if (file == null) {
+    throw Exception("Failed to fetch origin file");
+  }
+  final bytes = await file.readAsBytes();
+  final image = img.decodeImage(bytes);
+  if (image == null) {
+    throw Exception("Failed to decode image");
+  }
+  return image.exif;
 }
 
 Future<Map<String, IfdTag>> getExif(EnteFile file) async {

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -3,7 +3,6 @@ import "dart:io";
 
 import "package:computer/computer.dart";
 import 'package:exif_reader/exif_reader.dart';
-import "package:image/image.dart" as img;
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import "package:photos/models/ffmpeg/ffprobe_props.dart";
@@ -38,19 +37,6 @@ final _offsetPattern = RegExp(r'^([Zz]|[+-](?:[01]\d|2[0-3]):?[0-5]\d)$');
 
 bool shouldReadExif(EnteFile file) {
   return file.fileType == FileType.image || file.fileType == FileType.livePhoto;
-}
-
-Future<img.ExifData> getExif2(EnteFile enteFile) async {
-  final file = await getFile(enteFile, isOrigin: true);
-  if (file == null) {
-    throw Exception("Failed to fetch origin file");
-  }
-  final bytes = await file.readAsBytes();
-  final image = img.decodeImage(bytes);
-  if (image == null) {
-    throw Exception("Failed to decode image");
-  }
-  return image.exif;
 }
 
 Future<Map<String, IfdTag>> getExif(EnteFile file) async {


### PR DESCRIPTION
Preserves EXIF fields, ignoring the fields which could potentially affect rendering (not verified from a source) when saving edited copies from the photo editor.

The flutter package `image` is able to read and write EXIF from JPEG images, it was used for simplicity over the existing EXIF utilities.
