### PR TITLE
[mobile][auth] Fix Auth AppImage C++ runtime shadowing

### DIFF
--- a/mobile/apps/auth/changes/linux-appimage-cxx-runtime.md
+++ b/mobile/apps/auth/changes/linux-appimage-cxx-runtime.md
@@ -1,0 +1,1 @@
+- Fixed Auth AppImage startup on Linux systems where bundled C++ runtime libraries could conflict with host graphics drivers.

--- a/mobile/apps/auth/linux/packaging/post_process_appimage.sh
+++ b/mobile/apps/auth/linux/packaging/post_process_appimage.sh
@@ -34,6 +34,20 @@ chmod +x "$workdir/input.AppImage"
 appdir="$workdir/squashfs-root"
 
 if [[ -d "$appdir/usr/lib" ]]; then
+    runtime_libs="$(
+        find "$appdir/usr/lib" \( -type f -o -type l \) \( \
+            -name 'libstdc++.so*' -o \
+            -name 'libgcc_s.so*' \
+        \) -print
+    )"
+    if [[ -n "$runtime_libs" ]]; then
+        echo "Removing bundled C++ runtime libraries from the AppImage:"
+        echo "$runtime_libs"
+        printf '%s\n' "$runtime_libs" | while IFS= read -r runtime_lib; do
+            rm -f "$runtime_lib"
+        done
+    fi
+
     blocked_libs="$(
         find "$appdir/usr/lib" \( -type f -o -type l \) \( \
             -name 'libGL.so*' -o \


### PR DESCRIPTION
Fixes #11171.
Refs #1765.

Summary:
- Remove bundled `libstdc++.so*` and `libgcc_s.so*` from Auth AppImage post-processing.
- Keep `$APPDIR/usr/lib` in `LD_LIBRARY_PATH` for bundled `libffi.so.8` and retain the graphics/Wayland library blocklist.