### PR TITLE
[mobile][auth] Add libsodium pacman dependency

### DIFF
--- a/mobile/apps/auth/changes/linux-pacman-libsodium.md
+++ b/mobile/apps/auth/changes/linux-pacman-libsodium.md
@@ -1,0 +1,1 @@
+- Fixed Auth Linux pacman package dependency metadata so libsodium is installed for crypto initialization.

--- a/mobile/apps/auth/linux/packaging/pacman/make_config.yaml
+++ b/mobile/apps/auth/linux/packaging/pacman/make_config.yaml
@@ -12,6 +12,7 @@ metainfo: linux/packaging/enteauth.appdata.xml
 
 dependencies:
   - sqlite
+  - libsodium
   - libsecret
   - libappindicator-gtk3
   - polkit


### PR DESCRIPTION
Ref: #6010

Summary:
- Add `libsodium` to Auth Linux pacman package dependencies.