### PR TITLE
[server] Add account deletion summary endpoint

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -420,6 +420,7 @@ func main() {
 		twoFactorRepo,
 		twoFactorRecoveryRepo,
 		passkeysRepo,
+		authRepo,
 		storagBonusRepo,
 		fileRepo,
 		collectionController,
@@ -697,6 +698,7 @@ func main() {
 	privateAPI.GET("/users/families-token", userHandler.GetFamiliesToken)
 	privateAPI.GET("/users/accounts-token", userHandler.GetAccountsToken)
 	privateAPI.GET("/users/details/v2", userHandler.GetDetailsV2)
+	privateAPI.GET("/users/deletion-summary", userHandler.GetAccountDeletionSummary)
 	privateAPI.GET("/users/locker-usage", userHandler.GetLockerUsage)
 	privateAPI.POST("/users/change-email", userHandler.ChangeEmail)
 	privateAPI.GET("/users/sessions", userHandler.GetActiveSessions)

--- a/server/ente/details/account_deletion_summary.go
+++ b/server/ente/details/account_deletion_summary.go
@@ -1,0 +1,7 @@
+package details
+
+type AccountDeletionSummaryResponse struct {
+	PhotosAndVideosCount    int64 `json:"photosAndVideosCount"`
+	AuthenticatorCodesCount int64 `json:"authenticatorCodesCount"`
+	LockerRecordsCount      int64 `json:"lockerRecordsCount"`
+}

--- a/server/pkg/api/user.go
+++ b/server/pkg/api/user.go
@@ -73,6 +73,17 @@ func (h *UserHandler) GetDetailsV2(c *gin.Context) {
 	c.JSON(http.StatusOK, details)
 }
 
+// GetAccountDeletionSummary returns counts for data that will be deleted.
+func (h *UserHandler) GetAccountDeletionSummary(c *gin.Context) {
+	userID := auth.GetUserID(c.Request.Header)
+	summary, err := h.UserController.GetAccountDeletionSummary(c.Request.Context(), userID)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	c.JSON(http.StatusOK, summary)
+}
+
 // GetLockerUsage returns locker usage details for the requesting user.
 func (h *UserHandler) GetLockerUsage(c *gin.Context) {
 	userID := auth.GetUserID(c.Request.Header)

--- a/server/pkg/controller/user/account_deletion_summary.go
+++ b/server/pkg/controller/user/account_deletion_summary.go
@@ -1,0 +1,52 @@
+package user
+
+import (
+	"context"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/ente/details"
+	"github.com/ente/stacktrace"
+	"golang.org/x/sync/errgroup"
+)
+
+func (c *UserController) GetAccountDeletionSummary(ctx context.Context, userID int64) (details.AccountDeletionSummaryResponse, error) {
+	var photosAndVideosCount int64
+	var authenticatorCodesCount int64
+	var lockerRecordsCount int64
+
+	g := new(errgroup.Group)
+	g.Go(func() error {
+		count, err := c.FileRepo.GetDeletableFileCount(ctx, userID, ente.Photos)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to get photos file count")
+		}
+		photosAndVideosCount = count
+		return nil
+	})
+	g.Go(func() error {
+		count, err := c.FileRepo.GetDeletableFileCount(ctx, userID, ente.Locker)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to get locker file count")
+		}
+		lockerRecordsCount = count
+		return nil
+	})
+	g.Go(func() error {
+		count, err := c.AuthenticatorRepo.GetAuthCodeCount(ctx, userID)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to get authenticator code count")
+		}
+		authenticatorCodesCount = count
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return details.AccountDeletionSummaryResponse{}, stacktrace.Propagate(err, "")
+	}
+
+	return details.AccountDeletionSummaryResponse{
+		PhotosAndVideosCount:    photosAndVideosCount,
+		AuthenticatorCodesCount: authenticatorCodesCount,
+		LockerRecordsCount:      lockerRecordsCount,
+	}, nil
+}

--- a/server/pkg/controller/user/account_deletion_summary.go
+++ b/server/pkg/controller/user/account_deletion_summary.go
@@ -16,7 +16,7 @@ func (c *UserController) GetAccountDeletionSummary(ctx context.Context, userID i
 
 	g := new(errgroup.Group)
 	g.Go(func() error {
-		count, err := c.FileRepo.GetDeletableFileCount(ctx, userID, ente.Photos)
+		count, err := c.FileRepo.GetFileCountForUser(userID, ente.Photos)
 		if err != nil {
 			return stacktrace.Propagate(err, "failed to get photos file count")
 		}
@@ -24,7 +24,7 @@ func (c *UserController) GetAccountDeletionSummary(ctx context.Context, userID i
 		return nil
 	})
 	g.Go(func() error {
-		count, err := c.FileRepo.GetDeletableFileCount(ctx, userID, ente.Locker)
+		count, err := c.FileRepo.GetFileCountForUser(userID, ente.Locker)
 		if err != nil {
 			return stacktrace.Propagate(err, "failed to get locker file count")
 		}

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ente/museum/pkg/controller"
 	"github.com/ente/museum/pkg/controller/family"
 	"github.com/ente/museum/pkg/repo"
+	authenticatorRepo "github.com/ente/museum/pkg/repo/authenticator"
 	contactrepo "github.com/ente/museum/pkg/repo/contact"
 	"github.com/ente/museum/pkg/repo/datacleanup"
 	"github.com/ente/museum/pkg/repo/passkey"
@@ -43,6 +44,7 @@ type UserController struct {
 	TwoFactorRepo           *repo.TwoFactorRepository
 	PasskeyRepo             *passkey.Repository
 	StorageBonusRepo        *storageBonusRepo.Repository
+	AuthenticatorRepo       *authenticatorRepo.Repository
 	FileRepo                *repo.FileRepository
 	CollectionRepo          *repo.CollectionRepository
 	DataCleanupRepo         *datacleanup.Repository
@@ -114,6 +116,7 @@ func NewUserController(
 	twoFactorRepo *repo.TwoFactorRepository,
 	twoFactorRecoveryRepo *two_factor_recovery.Repository,
 	passkeyRepo *passkey.Repository,
+	authenticatorRepo *authenticatorRepo.Repository,
 	storageBonusRepo *storageBonusRepo.Repository,
 	fileRepo *repo.FileRepository,
 	collectionController *collections.CollectionController,
@@ -144,6 +147,7 @@ func NewUserController(
 		UserAuthRepo:            userAuthRepo,
 		StorageBonusRepo:        storageBonusRepo,
 		TwoFactorRepo:           twoFactorRepo,
+		AuthenticatorRepo:       authenticatorRepo,
 		PasskeyRepo:             passkeyRepo,
 		FileRepo:                fileRepo,
 		CollectionCtrl:          collectionController,

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -653,6 +653,40 @@ func (repo *FileRepository) GetFileCountForUser(userID int64, app ente.App) (int
 	return fileCount, nil
 }
 
+// GetDeletableFileCount returns the owned file count that will be removed on account deletion.
+// It includes active files and files currently in trash, since account deletion empties both.
+func (repo *FileRepository) GetDeletableFileCount(ctx context.Context, userID int64, app ente.App) (int64, error) {
+	row := repo.DB.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT file_id)
+		FROM (
+			SELECT files.file_id
+			FROM collection_files
+			JOIN collections c ON c.owner_id = $1
+				AND c.collection_id = collection_files.collection_id
+			JOIN files ON files.owner_id = $1
+				AND files.file_id = collection_files.file_id
+			WHERE c.app = $2
+				AND collection_files.is_deleted = false
+			UNION ALL
+			SELECT t.file_id
+			FROM trash t
+			JOIN collections c ON c.collection_id = t.collection_id
+			JOIN files f ON f.file_id = t.file_id
+				AND f.owner_id = $1
+			WHERE t.user_id = $1
+				AND c.app = $2
+				AND t.is_deleted = false
+				AND t.is_restored = false
+		) files_for_delete;`, userID, app)
+
+	var fileCount int64
+	err := row.Scan(&fileCount)
+	if err != nil {
+		return -1, stacktrace.Propagate(err, "")
+	}
+	return fileCount, nil
+}
+
 func (repo *FileRepository) GetFileAttributesFromObjectKey(objectKey string) (ente.File, error) {
 	s3ObjectKeys, err := repo.ObjectRepo.GetAllFileObjectsByObjectKey(objectKey)
 	if err != nil {

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -653,40 +653,6 @@ func (repo *FileRepository) GetFileCountForUser(userID int64, app ente.App) (int
 	return fileCount, nil
 }
 
-// GetDeletableFileCount returns the owned file count that will be removed on account deletion.
-// It includes active files and files currently in trash, since account deletion empties both.
-func (repo *FileRepository) GetDeletableFileCount(ctx context.Context, userID int64, app ente.App) (int64, error) {
-	row := repo.DB.QueryRowContext(ctx, `
-		SELECT COUNT(DISTINCT file_id)
-		FROM (
-			SELECT files.file_id
-			FROM collection_files
-			JOIN collections c ON c.owner_id = $1
-				AND c.collection_id = collection_files.collection_id
-			JOIN files ON files.owner_id = $1
-				AND files.file_id = collection_files.file_id
-			WHERE c.app = $2
-				AND collection_files.is_deleted = false
-			UNION ALL
-			SELECT t.file_id
-			FROM trash t
-			JOIN collections c ON c.collection_id = t.collection_id
-			JOIN files f ON f.file_id = t.file_id
-				AND f.owner_id = $1
-			WHERE t.user_id = $1
-				AND c.app = $2
-				AND t.is_deleted = false
-				AND t.is_restored = false
-		) files_for_delete;`, userID, app)
-
-	var fileCount int64
-	err := row.Scan(&fileCount)
-	if err != nil {
-		return -1, stacktrace.Propagate(err, "")
-	}
-	return fileCount, nil
-}
-
 func (repo *FileRepository) GetFileAttributesFromObjectKey(objectKey string) (ente.File, error) {
 	s3ObjectKeys, err := repo.ObjectRepo.GetAllFileObjectsByObjectKey(objectKey)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `GET /users/deletion-summary` for account deletion impact details.
- Return counts for Photos files, Locker records, and Authenticator codes.
- Count deletable files from both active collections and trash.