### PR TITLE
[web] Fix locker delete confirmation filename rendering

### DIFF
--- a/web/apps/locker/src/components/lockerPage/useLockerActions.tsx
+++ b/web/apps/locker/src/components/lockerPage/useLockerActions.tsx
@@ -555,13 +555,14 @@ export const useLockerActions = ({
                 message: (
                     <Trans
                         i18nKey="deleteFileConfirmation"
-                        values={{ fileName: getItemTitle(item) }}
                         components={{
-                            strong: (
+                            fileName: (
                                 <Box
                                     component="span"
                                     sx={{ fontWeight: 700, color: "text.base" }}
-                                />
+                                >
+                                    {getItemTitle(item)}
+                                </Box>
                             ),
                         }}
                     />

--- a/web/apps/locker/src/locales/en-US/translation.json
+++ b/web/apps/locker/src/locales/en-US/translation.json
@@ -101,7 +101,7 @@
     "close": "Close",
     "logout": "Logout",
     "failedToLoadCollections": "Failed to load collections: {{error}}",
-    "deleteFileConfirmation": "Are you sure you want to delete <strong>{{fileName}}</strong>?",
+    "deleteFileConfirmation": "Are you sure you want to delete <fileName/>?",
     "allItems": "All Items",
     "results": "Results",
     "lockerCollectionsCount": "{{count, number}} collections",

--- a/web/apps/locker/src/locales/fr-FR/translation.json
+++ b/web/apps/locker/src/locales/fr-FR/translation.json
@@ -83,7 +83,7 @@
     "close": "Fermer",
     "logout": "Déconnexion",
     "failedToLoadCollections": "Echec du chargement des collections : {{error}}",
-    "deleteFileConfirmation": "Es-tu sur de vouloir supprimer <strong>{{fileName}}</strong> ?",
+    "deleteFileConfirmation": "Es-tu sur de vouloir supprimer <fileName/> ?",
     "personalNote": "Note",
     "uploadFileCountLimitErrorBodyWithUpgrade": "Vous avez atteint votre limite de fichiers. Veuillez <cta>passer a une offre payante</cta>.",
     "saveDocumentTitle": "Document",

--- a/web/apps/locker/src/locales/ja-JP/translation.json
+++ b/web/apps/locker/src/locales/ja-JP/translation.json
@@ -89,7 +89,7 @@
     "close": "閉じる",
     "logout": "ログアウト",
     "failedToLoadCollections": "コレクションの読み込みに失敗しました: {{error}}",
-    "deleteFileConfirmation": "<strong>{{fileName}}</strong> を削除してもよろしいですか？",
+    "deleteFileConfirmation": "<fileName/> を削除してもよろしいですか？",
     "document": "ドキュメント",
     "results": "結果",
     "thing": "物品",


### PR DESCRIPTION
Fixes Locker delete confirmation rendering so filenames stay styled without interpolating filename text inside translation markup.