### PR TITLE
[server] Restrict contact target updates

### DIFF
--- a/server/pkg/controller/contact/controller.go
+++ b/server/pkg/controller/contact/controller.go
@@ -122,6 +122,7 @@ func (c *Controller) Update(ctx *gin.Context, contactID string, req contactmodel
 	if err := req.Validate(); err != nil {
 		return nil, stacktrace.Propagate(err, "invalid update contact request")
 	}
+	userID := auth.GetUserID(ctx.Request.Header)
 	exists, err := c.Repo.ContactUserExists(ctx, req.ContactUserID)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to validate contact user")
@@ -132,7 +133,22 @@ func (c *Controller) Update(ctx *gin.Context, contactID string, req contactmodel
 			"",
 		)
 	}
-	userID := auth.GetUserID(ctx.Request.Header)
+	currentContactUserID, err := c.Repo.GetContactUserID(ctx, userID, contactID)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to fetch contact")
+	}
+	if currentContactUserID != req.ContactUserID {
+		canUpdate, err := c.Repo.CanCreateContact(ctx, userID, req.ContactUserID)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "failed to validate contact eligibility")
+		}
+		if !canUpdate {
+			return nil, stacktrace.Propagate(
+				ente.NewBadRequestWithMessage("contactUserID is not eligible to be added as a contact"),
+				"",
+			)
+		}
+	}
 	if err := c.Repo.Update(ctx, userID, contactID, req); err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/controller/contact/controller.go
+++ b/server/pkg/controller/contact/controller.go
@@ -133,11 +133,11 @@ func (c *Controller) Update(ctx *gin.Context, contactID string, req contactmodel
 			"",
 		)
 	}
-	currentContactUserID, err := c.Repo.GetContactUserID(ctx, userID, contactID)
+	updateState, err := c.Repo.GetContactUpdateState(ctx, userID, contactID)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to fetch contact")
 	}
-	if currentContactUserID != req.ContactUserID {
+	if updateState.IsDeleted || updateState.ContactUserID != req.ContactUserID {
 		canUpdate, err := c.Repo.CanCreateContact(ctx, userID, req.ContactUserID)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "failed to validate contact eligibility")

--- a/server/pkg/controller/contact/controller_test.go
+++ b/server/pkg/controller/contact/controller_test.go
@@ -396,6 +396,70 @@ func TestCreateContactRequiresEligibleRelationship(t *testing.T) {
 	}
 }
 
+func TestUpdateContactRequiresEligibleRelationshipWhenContactUserIDChanges(t *testing.T) {
+	ctrl, db, ctx, _ := setupContactControllerTest(t)
+	created := createContactForTest(t, db, ctrl, ctx, 21, "wrapped-key-1", "payload-1")
+	mustInsertTestUser(t, db, 22)
+
+	_, err := ctrl.Update(ctx, created.ID, contactmodel.UpdateRequest{
+		ContactUserID: 22,
+		EncryptedData: []byte("payload-2"),
+	})
+	if err == nil {
+		t.Fatal("expected ineligible contact update to fail")
+	}
+	if !strings.Contains(err.Error(), "not eligible to be added as a contact") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := ctrl.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.ContactUserID != 21 {
+		t.Fatalf("contactUserID = %d, want 21", got.ContactUserID)
+	}
+	if got.Email == nil || *got.Email != "contacts-21@ente.com" {
+		t.Fatalf("email = %v, want contacts-21@ente.com", got.Email)
+	}
+	if got.EncryptedData == nil || string(*got.EncryptedData) != "payload-1" {
+		t.Fatalf("encryptedData = %v, want payload-1", got.EncryptedData)
+	}
+}
+
+func TestUpdateContactAllowsSameContactUserIDAfterRelationshipEnds(t *testing.T) {
+	ctrl, db, ctx, _ := setupContactControllerTest(t)
+	created := createContactForTest(t, db, ctrl, ctx, 31, "wrapped-key-1", "payload-1")
+	if _, err := db.Exec(
+		`UPDATE emergency_contact
+		    SET state = $1,
+		        encrypted_key = NULL
+		  WHERE user_id = $2 AND emergency_contact_id = $3`,
+		ente.ContactLeft,
+		int64(1),
+		int64(31),
+	); err != nil {
+		t.Fatalf("failed to end emergency contact relationship: %v", err)
+	}
+
+	updated, err := ctrl.Update(ctx, created.ID, contactmodel.UpdateRequest{
+		ContactUserID: 31,
+		EncryptedData: []byte("payload-2"),
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.ContactUserID != 31 {
+		t.Fatalf("contactUserID = %d, want 31", updated.ContactUserID)
+	}
+	if updated.Email == nil || *updated.Email != "contacts-31@ente.com" {
+		t.Fatalf("email = %v, want contacts-31@ente.com", updated.Email)
+	}
+	if updated.EncryptedData == nil || string(*updated.EncryptedData) != "payload-2" {
+		t.Fatalf("encryptedData = %v, want payload-2", updated.EncryptedData)
+	}
+}
+
 func TestCreateAndUpdateRejectUnknownContactUserID(t *testing.T) {
 	ctrl, db, ctx, _ := setupContactControllerTest(t)
 	mustInsertTestUser(t, db, 1)

--- a/server/pkg/controller/contact/controller_test.go
+++ b/server/pkg/controller/contact/controller_test.go
@@ -460,6 +460,53 @@ func TestUpdateContactAllowsSameContactUserIDAfterRelationshipEnds(t *testing.T)
 	}
 }
 
+func TestUpdateContactRequiresEligibleRelationshipToReviveDeletedContact(t *testing.T) {
+	ctrl, db, ctx, _ := setupContactControllerTest(t)
+	created := createContactForTest(t, db, ctrl, ctx, 41, "wrapped-key-1", "payload-1")
+	if err := ctrl.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := db.Exec(
+		`UPDATE emergency_contact
+		    SET state = $1,
+		        encrypted_key = NULL
+		  WHERE user_id = $2 AND emergency_contact_id = $3`,
+		ente.ContactLeft,
+		int64(1),
+		int64(41),
+	); err != nil {
+		t.Fatalf("failed to end emergency contact relationship: %v", err)
+	}
+
+	_, err := ctrl.Update(ctx, created.ID, contactmodel.UpdateRequest{
+		ContactUserID: 41,
+		EncryptedData: []byte("payload-2"),
+	})
+	if err == nil {
+		t.Fatal("expected ineligible deleted contact update to fail")
+	}
+	if !strings.Contains(err.Error(), "not eligible to be added as a contact") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := ctrl.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !got.IsDeleted {
+		t.Fatalf("contact should remain deleted: %+v", got)
+	}
+	if got.ContactUserID != 41 {
+		t.Fatalf("contactUserID = %d, want 41", got.ContactUserID)
+	}
+	if got.Email != nil {
+		t.Fatalf("deleted contact leaked email: %v", got.Email)
+	}
+	if got.EncryptedData != nil {
+		t.Fatalf("deleted contact restored encryptedData: %v", got.EncryptedData)
+	}
+}
+
 func TestCreateAndUpdateRejectUnknownContactUserID(t *testing.T) {
 	ctrl, db, ctx, _ := setupContactControllerTest(t)
 	mustInsertTestUser(t, db, 1)

--- a/server/pkg/repo/contact/contact.go
+++ b/server/pkg/repo/contact/contact.go
@@ -179,23 +179,28 @@ func (r *Repository) Get(ctx context.Context, userID int64, id string) (*contact
 	return entity, nil
 }
 
-func (r *Repository) GetContactUserID(ctx context.Context, userID int64, id string) (int64, error) {
-	var contactUserID int64
+type ContactUpdateState struct {
+	ContactUserID int64
+	IsDeleted     bool
+}
+
+func (r *Repository) GetContactUpdateState(ctx context.Context, userID int64, id string) (ContactUpdateState, error) {
+	var state ContactUpdateState
 	err := r.DB.QueryRowContext(
 		ctx,
-		`SELECT contact_user_id
+		`SELECT contact_user_id, is_deleted
 		   FROM contact_entity
 		  WHERE id = $1 AND user_id = $2`,
 		id,
 		userID,
-	).Scan(&contactUserID)
+	).Scan(&state.ContactUserID, &state.IsDeleted)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, &ente.ErrNotFoundError
+			return ContactUpdateState{}, &ente.ErrNotFoundError
 		}
-		return 0, stacktrace.Propagate(err, "failed to get contact user id")
+		return ContactUpdateState{}, stacktrace.Propagate(err, "failed to get contact update state")
 	}
-	return contactUserID, nil
+	return state, nil
 }
 
 func (r *Repository) Update(ctx context.Context, userID int64, id string, req contactmodel.UpdateRequest) error {

--- a/server/pkg/repo/contact/contact.go
+++ b/server/pkg/repo/contact/contact.go
@@ -179,6 +179,25 @@ func (r *Repository) Get(ctx context.Context, userID int64, id string) (*contact
 	return entity, nil
 }
 
+func (r *Repository) GetContactUserID(ctx context.Context, userID int64, id string) (int64, error) {
+	var contactUserID int64
+	err := r.DB.QueryRowContext(
+		ctx,
+		`SELECT contact_user_id
+		   FROM contact_entity
+		  WHERE id = $1 AND user_id = $2`,
+		id,
+		userID,
+	).Scan(&contactUserID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, &ente.ErrNotFoundError
+		}
+		return 0, stacktrace.Propagate(err, "failed to get contact user id")
+	}
+	return contactUserID, nil
+}
+
 func (r *Repository) Update(ctx context.Context, userID int64, id string, req contactmodel.UpdateRequest) error {
 	result, err := r.DB.ExecContext(
 		ctx,


### PR DESCRIPTION
Require eligibility when contact updates change the target user.

Keep same-target updates working for retained contacts.