### PR TITLE
[mob][packages] Add toast componenet

### DIFF
--- a/mobile/packages/ente_components/changes/toast-component.md
+++ b/mobile/packages/ente_components/changes/toast-component.md
@@ -1,0 +1,1 @@
+- Add reusable toast component with banner-style states and example previews.

--- a/mobile/packages/ente_components/example/lib/main.dart
+++ b/mobile/packages/ente_components/example/lib/main.dart
@@ -234,6 +234,18 @@ class _CatalogHomeState extends State<CatalogHome> {
         previewBuilder: (_) => const _BannerPreview(),
       ),
       CatalogSection(
+        title: 'Toast',
+        icon: HugeIcons.strokeRoundedCheckmarkCircle02,
+        components: const [
+          'States',
+          'Title only',
+          'Custom leading',
+          'Custom trailing',
+          'Short vs long',
+        ],
+        previewBuilder: (_) => const _ToastPreview(),
+      ),
+      CatalogSection(
         title: 'Buttons',
         icon: HugeIcons.strokeRoundedCursorPointer02,
         components: const ['Button', 'Icon button'],
@@ -1258,6 +1270,163 @@ class _BannerStatePreview extends StatelessWidget {
           context,
         ).showSnackBar(SnackBar(content: Text('${spec.title} tapped')));
       },
+    );
+  }
+}
+
+const _toastStateSpecs = [
+  _ToastStateSpec(
+    state: BannerComponentState.failure,
+    label: 'Failure',
+    title: 'Failure!',
+    subtitle: 'Some subtext that describes the failure',
+  ),
+  _ToastStateSpec(
+    state: BannerComponentState.informative,
+    label: 'Informative',
+    title: 'Informative!',
+    subtitle: 'Some subtext that describes the info',
+  ),
+  _ToastStateSpec(
+    state: BannerComponentState.success,
+    label: 'Success',
+    title: 'Success!',
+    subtitle: 'Some subtext that describes the success',
+  ),
+  _ToastStateSpec(
+    state: BannerComponentState.warning,
+    label: 'Warning',
+    title: 'Warning!',
+    subtitle: 'Some subtext that describes the warning',
+  ),
+  _ToastStateSpec(
+    state: BannerComponentState.neutral,
+    label: 'Neutral',
+    title: 'Neutral!',
+    subtitle: 'Some subtext that describes the neutral text',
+  ),
+];
+
+class _ToastStateSpec {
+  const _ToastStateSpec({
+    required this.state,
+    required this.label,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final BannerComponentState state;
+  final String label;
+  final String title;
+  final String subtitle;
+}
+
+class _ToastPreview extends StatelessWidget {
+  const _ToastPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return _CatalogPreviewList(
+      children: [
+        _CatalogPreviewGroup(
+          title: 'States (tap to show)',
+          child: Column(
+            children: [
+              for (var index = 0; index < _toastStateSpecs.length; index++) ...[
+                _ToastTriggerButton(
+                  label: 'Show ${_toastStateSpecs[index].label.toLowerCase()}',
+                  onTap: () => showToastComponent(
+                    context,
+                    _toastStateSpecs[index].title,
+                    subtitle: _toastStateSpecs[index].subtitle,
+                    state: _toastStateSpecs[index].state,
+                  ),
+                ),
+                if (index != _toastStateSpecs.length - 1)
+                  const SizedBox(height: Spacing.sm),
+              ],
+            ],
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Title only',
+          child: _ToastTriggerButton(
+            label: 'Show title-only toast',
+            onTap: () => showToastComponent(context, 'Saved to your library'),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Custom leading (spinner)',
+          child: _ToastTriggerButton(
+            label: 'Show custom leading',
+            onTap: () => showToastComponent(
+              context,
+              'Syncing your data',
+              subtitle: 'Preparing secure upload',
+              state: BannerComponentState.informative,
+              leadingWidget: const _BannerLoadingLeading(),
+            ),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Custom trailing',
+          child: _ToastTriggerButton(
+            label: 'Show custom trailing',
+            onTap: () => showToastComponent(
+              context,
+              'Item moved to trash',
+              subtitle: 'Tap the icon to undo',
+              state: BannerComponentState.neutral,
+              trailingWidget: const _CatalogHugeIcon(
+                HugeIcons.strokeRoundedDelete02,
+                size: IconSizes.small,
+              ),
+            ),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Duration (short vs long)',
+          child: Column(
+            children: [
+              _ToastTriggerButton(
+                label: 'Short (2s)',
+                onTap: () => showToastComponent(
+                  context,
+                  'Short toast (2s)',
+                  state: BannerComponentState.informative,
+                  duration: const Duration(seconds: 2),
+                ),
+              ),
+              const SizedBox(height: Spacing.sm),
+              _ToastTriggerButton(
+                label: 'Long (default 4s)',
+                onTap: () => showToastComponent(
+                  context,
+                  'Long toast (4s)',
+                  state: BannerComponentState.informative,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ToastTriggerButton extends StatelessWidget {
+  const _ToastTriggerButton({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ButtonComponent(
+      variant: ButtonComponentVariant.secondary,
+      label: label,
+      shouldSurfaceExecutionStates: false,
+      onTap: onTap,
     );
   }
 }

--- a/mobile/packages/ente_components/lib/components/toast_component.dart
+++ b/mobile/packages/ente_components/lib/components/toast_component.dart
@@ -1,0 +1,99 @@
+import 'package:ente_components/components/banner_component.dart';
+import 'package:ente_components/theme/motion.dart';
+import 'package:ente_components/theme/spacing.dart';
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+/// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=7255-38447&m=dev
+/// Section: Snack bar states
+/// Specs: bottom-anchored toast built on [BannerComponent] (failure /
+/// informative / success / warning / neutral), slide-up + fade, auto-dismiss,
+/// tap to dismiss.
+///
+/// Backed by [FToast], so a new toast replaces any currently-visible one
+/// (latest wins, no overlap) and it survives route changes. Only [message] is
+/// required; [state] sets the accent + default leading icon (defaults to
+/// neutral), [subtitle] adds a second line, [leadingWidget] / [trailingWidget]
+/// override the default leading icon / close affordance (trailing shows nothing
+/// when omitted), and [duration] sets how long it stays.
+void showToastComponent(
+  BuildContext context,
+  String message, {
+  BannerComponentState state = BannerComponentState.neutral,
+  String? subtitle,
+  Widget? leadingWidget,
+  Widget? trailingWidget,
+  Duration duration = const Duration(seconds: 4),
+}) {
+  final fToast = FToast();
+  fToast.init(context);
+  fToast.removeQueuedCustomToasts();
+  fToast.showToast(
+    toastDuration: duration,
+    fadeDuration: Motion.standard,
+    positionedToastBuilder: (context, child, _) {
+      final viewPadding = MediaQuery.viewPaddingOf(context);
+      return Positioned(
+        left: Spacing.lg,
+        right: Spacing.lg,
+        bottom: viewPadding.bottom + Spacing.xl,
+        child: child,
+      );
+    },
+    child: _BannerToast(
+      message: message,
+      subtitle: subtitle,
+      state: state,
+      leadingWidget: leadingWidget,
+      trailingWidget: trailingWidget,
+      onDismiss: fToast.removeCustomToast,
+    ),
+  );
+}
+
+class _BannerToast extends StatelessWidget {
+  const _BannerToast({
+    required this.message,
+    required this.subtitle,
+    required this.state,
+    required this.leadingWidget,
+    required this.trailingWidget,
+    required this.onDismiss,
+  });
+
+  final String message;
+  final String? subtitle;
+  final BannerComponentState state;
+  final Widget? leadingWidget;
+  final Widget? trailingWidget;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0.0, end: 1.0),
+      duration: const Duration(milliseconds: 360),
+      curve: Curves.easeOutBack,
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: value.clamp(0.0, 1.0),
+          child: Transform.translate(
+            offset: Offset(0, (1 - value) * 24),
+            child: child,
+          ),
+        );
+      },
+      child: Material(
+        type: MaterialType.transparency,
+        child: BannerComponent(
+          title: message,
+          subtitle: subtitle,
+          state: state,
+          leadingWidget: leadingWidget,
+          trailingWidget: trailingWidget ?? const SizedBox.shrink(),
+          onTap: onDismiss,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -18,6 +18,7 @@ export 'components/slider_component.dart';
 export 'components/stepper_component.dart';
 export 'components/tag_chip_component.dart';
 export 'components/text_input_component.dart';
+export 'components/toast_component.dart';
 export 'components/tooltip_component.dart';
 export 'models/component_execution_state.dart';
 export 'theme/colors.dart';

--- a/mobile/packages/ente_components/pubspec.yaml
+++ b/mobile/packages/ente_components/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  fluttertoast: 8.2.14
   hugeicons: 1.1.7
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Add a reusable banner-style toast component to ente_components
- Export the component and add example previews
- Add a changes entry for the component package

## Testing
- dart analyze packages/ente_components/lib/components/toast_component.dart