### PR TITLE
[mobile] Bound desktop QR decoding

### DIFF
--- a/mobile/packages/ente_qr/lib/src/dart_zxing_qr_platform.dart
+++ b/mobile/packages/ente_qr/lib/src/dart_zxing_qr_platform.dart
@@ -1,10 +1,24 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:ente_qr/ente_qr_platform_interface.dart';
 import 'package:image/image.dart' as img;
 import 'package:zxing2/qrcode.dart';
 
 final class DartZxingQrPlatform extends EnteQrPlatform {
+  static const int _defaultMaxInputBytes = 16 * 1024 * 1024;
+  static const int _defaultMaxInputPixels = 4096 * 4096;
+  static const int _maxScanDimension = 1200;
+
+  DartZxingQrPlatform({
+    int maxInputBytes = _defaultMaxInputBytes,
+    int maxInputPixels = _defaultMaxInputPixels,
+  }) : _maxInputBytes = maxInputBytes,
+       _maxInputPixels = maxInputPixels;
+
+  final int _maxInputBytes;
+  final int _maxInputPixels;
+
   @override
   Future<String?> getPlatformVersion() async {
     return 'Dart zxing2';
@@ -16,7 +30,12 @@ final class DartZxingQrPlatform extends EnteQrPlatform {
     bool tryOriginalResolution = false,
   }) async {
     try {
-      final content = await _decodeQrFromImagePath(imagePath);
+      final content = await _decodeQrFromImagePath(
+        imagePath,
+        maxInputBytes: _maxInputBytes,
+        maxInputPixels: _maxInputPixels,
+        tryOriginalResolution: tryOriginalResolution,
+      );
       return QrScanResult.success(content);
     } catch (e) {
       return QrScanResult.error(e.toString());
@@ -36,45 +55,54 @@ final class DartZxingQrPlatform extends EnteQrPlatform {
   }
 }
 
-Future<String> _decodeQrFromImagePath(String imagePath) async {
+Future<String> _decodeQrFromImagePath(
+  String imagePath, {
+  required int maxInputBytes,
+  required int maxInputPixels,
+  required bool tryOriginalResolution,
+}) async {
   final file = File(imagePath);
   if (!await file.exists()) {
     throw StateError('Image file not found: $imagePath');
   }
 
+  final fileSize = await file.length();
+  if (fileSize > maxInputBytes) {
+    throw StateError('Image file is too large for QR scanning');
+  }
+
   final bytes = await file.readAsBytes();
-  final image = img.decodeImage(bytes);
+  if (bytes.length > maxInputBytes) {
+    throw StateError('Image file is too large for QR scanning');
+  }
+
+  final decoder = _validatedDecoder(bytes, maxInputPixels: maxInputPixels);
+  final image = decoder.decodeFrame(0);
   if (image == null) {
     throw StateError('Unable to decode image file');
   }
 
-  return _decodeImage(image).text;
+  return _decodeImage(image, tryOriginalResolution: tryOriginalResolution).text;
 }
 
-Result _decodeImage(img.Image source) {
-  final maxDimension = source.width > source.height
-      ? source.width
-      : source.height;
-  final attempts = <img.Image>[
-    source,
-    img.invert(img.Image.from(source)),
-    if (maxDimension < 600)
-      img.copyResize(
-        source,
-        width: source.width * 2,
-        height: source.height * 2,
-        interpolation: img.Interpolation.linear,
-      ),
-    if (source.width > 1200 || source.height > 1200)
-      img.copyResize(
-        source,
-        width: source.width >= source.height ? 1200 : null,
-        height: source.height > source.width ? 1200 : null,
-      ),
-  ];
+img.Decoder _validatedDecoder(Uint8List bytes, {required int maxInputPixels}) {
+  final decoder = img.findDecoderForData(bytes);
+  final info = decoder?.startDecode(bytes);
+  if (decoder == null || info == null) {
+    throw StateError('Unable to decode image file');
+  }
+  if (info.width <= 0 || info.height <= 0) {
+    throw StateError('Unable to decode image file');
+  }
+  if (info.width * info.height > maxInputPixels) {
+    throw StateError('Image dimensions are too large for QR scanning');
+  }
+  return decoder;
+}
 
+Result _decodeImage(img.Image source, {required bool tryOriginalResolution}) {
   Object? lastError;
-  for (final attempt in attempts) {
+  Result? tryDecode(img.Image attempt) {
     final converted = attempt.convert(numChannels: 4);
     final pixels = converted
         .getBytes(order: img.ChannelOrder.abgr)
@@ -97,6 +125,63 @@ Result _decodeImage(img.Image source) {
         lastError = error;
       }
     }
+    return null;
   }
+
+  Result? tryDecodeVariants(img.Image attempt) {
+    final result = tryDecode(attempt);
+    if (result != null) {
+      return result;
+    }
+    return tryDecode(img.invert(img.Image.from(attempt)));
+  }
+
+  if (tryOriginalResolution) {
+    final result = tryDecodeVariants(source);
+    if (result != null) {
+      return result;
+    }
+  }
+
+  final scanSource = _scanSource(source);
+  if (!tryOriginalResolution || !identical(scanSource, source)) {
+    final result = tryDecodeVariants(scanSource);
+    if (result != null) {
+      return result;
+    }
+  }
+
+  if (_maxDimension(scanSource) < 600) {
+    final upscaled = img.copyResize(
+      scanSource,
+      width: scanSource.width * 2,
+      height: scanSource.height * 2,
+      interpolation: img.Interpolation.linear,
+    );
+    final result = tryDecodeVariants(upscaled);
+    if (result != null) {
+      return result;
+    }
+  }
+
   throw StateError(lastError?.toString() ?? 'No QR code found in image');
+}
+
+img.Image _scanSource(img.Image source) {
+  if (_maxDimension(source) <= DartZxingQrPlatform._maxScanDimension) {
+    return source;
+  }
+  return img.copyResize(
+    source,
+    width: source.width >= source.height
+        ? DartZxingQrPlatform._maxScanDimension
+        : null,
+    height: source.height > source.width
+        ? DartZxingQrPlatform._maxScanDimension
+        : null,
+  );
+}
+
+int _maxDimension(img.Image image) {
+  return image.width > image.height ? image.width : image.height;
 }

--- a/mobile/packages/ente_qr/test/dart_zxing_qr_platform_test.dart
+++ b/mobile/packages/ente_qr/test/dart_zxing_qr_platform_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:ente_qr/src/dart_zxing_qr_platform.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,6 +29,31 @@ void main() {
 
     expect(result.success, true);
     expect(result.content, payload);
+  });
+
+  test('scanQrFromImage rejects files above the byte limit', () async {
+    final imagePath = '${tempDir.path}/oversized.bin';
+    await File(imagePath).writeAsBytes(List<int>.filled(32, 0));
+
+    final result = await DartZxingQrPlatform(
+      maxInputBytes: 16,
+    ).scanQrFromImage(imagePath);
+
+    expect(result.success, false);
+    expect(result.error, contains('too large for QR scanning'));
+  });
+
+  test('scanQrFromImage rejects images above the pixel limit', () async {
+    final imagePath = '${tempDir.path}/oversized.bmp';
+    await File(imagePath).writeAsBytes(_bmpHeader(width: 50, height: 50));
+
+    final result = await DartZxingQrPlatform(
+      maxInputBytes: 1024,
+      maxInputPixels: 100,
+    ).scanQrFromImage(imagePath);
+
+    expect(result.success, false);
+    expect(result.error, contains('dimensions are too large'));
   });
 
   test('scanQrFromImage returns an error when no QR is present', () async {
@@ -96,4 +122,19 @@ img.Image _lowResolutionScreenshot(String payload) {
   );
   img.compositeImage(screenshot, qr, dstX: 44, dstY: 29);
   return screenshot;
+}
+
+Uint8List _bmpHeader({required int width, required int height}) {
+  final bytes = Uint8List(54);
+  final data = ByteData.sublistView(bytes);
+  bytes[0] = 0x42;
+  bytes[1] = 0x4d;
+  data.setUint32(2, bytes.length, Endian.little);
+  data.setUint32(10, 54, Endian.little);
+  data.setUint32(14, 40, Endian.little);
+  data.setInt32(18, width, Endian.little);
+  data.setInt32(22, height, Endian.little);
+  data.setUint16(26, 1, Endian.little);
+  data.setUint16(28, 24, Endian.little);
+  return bytes;
 }


### PR DESCRIPTION
Limit Dart desktop QR scans before decode to avoid image-bomb crashes.