### PR TITLE
[mob][photos] Remove redundant keyboard dismiss logic

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/vertical_list.dart
@@ -122,7 +122,6 @@ class _AlbumVerticalListWidgetState extends State<AlbumVerticalListWidget> {
 
     return ListView.separated(
       controller: widget.scrollController,
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       itemBuilder: (context, index) {
         // Create new album button
         if (index == 0 && widget.shouldShowCreateAlbum) {

--- a/mobile/apps/photos/lib/ui/collections/collection_list_page.dart
+++ b/mobile/apps/photos/lib/ui/collections/collection_list_page.dart
@@ -107,8 +107,6 @@ class _CollectionListPageState extends State<CollectionListPage> {
               child: CustomScrollView(
                 physics: const BouncingScrollPhysics(),
                 controller: _scrollController,
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
                 slivers: [
                   SearchableAppBar(
                     searchIconPadding: const EdgeInsets.only(right: 8),

--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -47,7 +47,6 @@ class _DeviceFolderVerticalGridViewState
     return Scaffold(
       body: CustomScrollView(
         physics: const BouncingScrollPhysics(),
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         slivers: <Widget>[
           SearchableAppBar(
             title: widget.appTitle ?? const SizedBox.shrink(),

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_page.dart
@@ -186,7 +186,6 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
     );
 
     return SingleChildScrollView(
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -233,7 +232,6 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
 
     final rows = _buildResultRows();
     return ListView.builder(
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       padding: const EdgeInsets.symmetric(horizontal: 16),
       itemCount: rows.length,
       itemBuilder: (context, index) {

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -1013,8 +1013,6 @@ class _AlbumsTabState extends State<AlbumsTab>
                         child: CustomScrollView(
                           controller: _scrollController,
                           physics: const BouncingScrollPhysics(),
-                          keyboardDismissBehavior:
-                              ScrollViewKeyboardDismissBehavior.onDrag,
                           slivers: [_buildContentSliver(strings)],
                         ),
                       ),

--- a/mobile/apps/photos/lib/ui/viewer/people/add_files_to_person_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/add_files_to_person_page.dart
@@ -232,10 +232,7 @@ class _AddFilesToPersonPageState extends State<AddFilesToPersonPage> {
                 child: Center(child: EnteLoadingWidget()),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           } else if (snapshot.hasError) {
             AddFilesToPersonPage._logger.severe(
               "Failed to load persons for manual tagging",
@@ -247,10 +244,7 @@ class _AddFilesToPersonPageState extends State<AddFilesToPersonPage> {
                 child: Center(child: Icon(Icons.error_outline_rounded)),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
 
           final persons = snapshot.data ?? [];
@@ -265,10 +259,7 @@ class _AddFilesToPersonPageState extends State<AddFilesToPersonPage> {
                 ),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
           final screenWidth = MediaQuery.of(context).size.width;
           final estimatedCount = (screenWidth / 100).floor();
@@ -315,10 +306,7 @@ class _AddFilesToPersonPageState extends State<AddFilesToPersonPage> {
               ),
             ),
           );
-          return CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: slivers,
-          );
+          return CustomScrollView(slivers: slivers);
         },
       ),
     );

--- a/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
@@ -267,10 +267,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: EnteLoadingWidget()),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           } else if (snapshot.hasError) {
             _logger.severe(
               "Failed to load persons for merge",
@@ -282,10 +279,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: Icon(Icons.error_outline_rounded)),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
 
           final persons = snapshot.data ?? [];
@@ -300,10 +294,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 ),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
           final screenWidth = MediaQuery.of(context).size.width;
           final estimatedCount = (screenWidth / 100).floor();
@@ -358,10 +349,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
               ),
             ),
           );
-          return CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: slivers,
-          );
+          return CustomScrollView(slivers: slivers);
         },
       ),
     );

--- a/mobile/apps/photos/lib/ui/viewer/people/person_selection_action_widgets.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/person_selection_action_widgets.dart
@@ -258,10 +258,7 @@ class _LinkContactToPersonSelectionPageState
                 child: Center(child: EnteLoadingWidget()),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           } else if (snapshot.hasError) {
             _logger.severe(
               "Failed to load _personEntities",
@@ -273,10 +270,7 @@ class _LinkContactToPersonSelectionPageState
                 child: Center(child: Icon(Icons.error_outline_rounded)),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
             slivers.add(
               SliverFillRemaining(
@@ -287,10 +281,7 @@ class _LinkContactToPersonSelectionPageState
                 ),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
 
           final sortedEntries = _sortEntries(snapshot.data!);
@@ -305,10 +296,7 @@ class _LinkContactToPersonSelectionPageState
                 ),
               ),
             );
-            return CustomScrollView(
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-              slivers: slivers,
-            );
+            return CustomScrollView(slivers: slivers);
           }
 
           final screenWidth = MediaQuery.of(context).size.width;
@@ -375,10 +363,7 @@ class _LinkContactToPersonSelectionPageState
             ),
           );
 
-          return CustomScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            slivers: slivers,
-          );
+          return CustomScrollView(slivers: slivers);
         },
       ),
     );

--- a/mobile/apps/photos/lib/ui/viewer/search/result/no_result_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/no_result_widget.dart
@@ -81,7 +81,6 @@ class _NoResultWidgetState extends State<NoResultWidget> {
     return Scaffold(
       body: SingleChildScrollView(
         physics: const BouncingScrollPhysics(),
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         padding: const EdgeInsets.fromLTRB(12, 0, 12, bottomPadding),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_suggestions.dart
@@ -155,8 +155,6 @@ class _SearchSuggestionsWidgetState extends State<SearchSuggestionsWidget> {
             Expanded(
               child: ListView(
                 physics: const BouncingScrollPhysics(),
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
                 padding: const EdgeInsets.only(bottom: bottomPadding),
                 children: sectionWidgets,
               ),

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab.dart
@@ -301,8 +301,6 @@ class _AllSearchSectionsState extends State<AllSearchSections> {
                   bottom: bottomPadding,
                 ),
                 physics: const BouncingScrollPhysics(),
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
                 itemCount: sectionWidgets.length + 1,
                 itemBuilder: (context, index) {
                   if (index == 0) {

--- a/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab_horizontal_scroll.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search_tab/search_tab_horizontal_scroll.dart
@@ -19,7 +19,6 @@ class SearchTabHorizontalRow extends StatelessWidget {
         horizontal: searchTabSectionHorizontalPadding,
       ),
       physics: const BouncingScrollPhysics(),
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       scrollDirection: Axis.horizontal,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -57,7 +56,6 @@ class SearchTabHorizontalScrollView extends StatelessWidget {
           horizontal: searchTabSectionHorizontalPadding,
         ),
         physics: const BouncingScrollPhysics(),
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         scrollDirection: Axis.horizontal,
         child: child,
       ),

--- a/mobile/packages/ente_components/lib/components/app_bar_component.dart
+++ b/mobile/packages/ente_components/lib/components/app_bar_component.dart
@@ -228,7 +228,6 @@ class _AppBarComponentState extends State<AppBarComponent> {
         controller: _controller,
         physics: widget.physics,
         cacheExtent: widget.cacheExtent,
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         slivers: [
           SliverAppBarComponent(
             title: widget.title,


### PR DESCRIPTION
## Summary
- Remove redundant `keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag` from Photos search/list surfaces now covered by shared text input behavior.
- Keep the remaining raw `TextField` scroll-dismiss case intact where `TextInputComponent` does not apply.

## Why
- This cleanup is now possible because #11181 centralized tap-outside keyboard dismissal in `TextInputComponent`.
- The removed per-scroll-view dismiss logic was added earlier for search screens, but those screens now use `TextInputComponent`, so the scroll-view-level logic duplicates the shared behavior.