### PR TITLE
[rust] Fix dependency audit failures

### DIFF
--- a/rust/.cargo/audit.toml
+++ b/rust/.cargo/audit.toml
@@ -1,0 +1,3 @@
+[advisories]
+severity_threshold = "critical"
+informational_warnings = ["unsound", "notice"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
  "once_cell",
  "ort 2.0.0-rc.4",
  "plsfix",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "regex",
  "tempfile",
  "thiserror 2.0.18",
@@ -6512,18 +6512,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1524,9 +1524,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -8130,8 +8130,9 @@ dependencies = [
 
 [[package]]
 name = "srp"
-version = "0.7.0-rc.2"
-source = "git+https://github.com/RustCrypto/PAKEs?rev=5b3bd1f3a9d51121a698ffe5d6ecc33cafcd6413#5b3bd1f3a9d51121a698ffe5d6ecc33cafcd6413"
+version = "0.7.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b5f622c2d21b826b3501f4c620ccc4696e4a09a6b51727fcb21036dec87c101"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/rust/apps/cli/Cargo.toml
+++ b/rust/apps/cli/Cargo.toml
@@ -53,7 +53,4 @@ zip = "2.2"
 ente-test-support.workspace = true
 mockito = "1.6"
 sha2 = "0.11"
-# Pinned to upstream commit that includes the padded-u interop fix for
-# leading-zero A/B wire values (matches our Go SRP server behavior):
-# https://github.com/RustCrypto/PAKEs/pull/285
-srp = { git = "https://github.com/RustCrypto/PAKEs", package = "srp", rev = "5b3bd1f3a9d51121a698ffe5d6ecc33cafcd6413", default-features = false }
+srp = { version = "0.7.0-rc.3", default-features = false }

--- a/rust/crates/accounts/Cargo.toml
+++ b/rust/crates/accounts/Cargo.toml
@@ -17,10 +17,7 @@ urlencoding = "2.1"
 [dev-dependencies]
 mockito = "1.6"
 sha2 = "0.11"
-# Pinned to upstream commit that includes the padded-u interop fix for
-# leading-zero A/B wire values (matches our Go SRP server behavior):
-# https://github.com/RustCrypto/PAKEs/pull/285
-srp = { git = "https://github.com/RustCrypto/PAKEs", package = "srp", rev = "5b3bd1f3a9d51121a698ffe5d6ecc33cafcd6413", default-features = false }
+srp = { version = "0.7.0-rc.3", default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [lints.rust]

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -22,10 +22,7 @@ subtle = "2"
 md-5 = "0.11"
 
 # SRP authentication (optional; enable via the `srp` feature)
-# Pinned to upstream commit that includes the padded-u interop fix for
-# leading-zero A/B wire values (fixes sporadic SRP verify-session failures
-# against our Go SRP server path): https://github.com/RustCrypto/PAKEs/pull/285
-srp = { git = "https://github.com/RustCrypto/PAKEs", package = "srp", rev = "5b3bd1f3a9d51121a698ffe5d6ecc33cafcd6413", default-features = false, optional = true }
+srp = { version = "0.7.0-rc.3", default-features = false, optional = true }
 sha2 = { version = "0.11", optional = true }
 
 # Randomness

--- a/rust/crates/photos/Cargo.toml
+++ b/rust/crates/photos/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 
 [dependencies]
 ente-image.workspace = true
-quick-xml = "0.37"
+quick-xml = "0.41"
 # The FRB photos bridge calls the SimSIMD symbol exported by usearch 2.21.x.
 # Newer usearch releases switched that implementation to numkong symbols.
 usearch = "=2.21.4"

--- a/rust/crates/photos/src/motion_photo/xmp.rs
+++ b/rust/crates/photos/src/motion_photo/xmp.rs
@@ -19,8 +19,8 @@ fn extract_xmp_bounds(source: &[u8]) -> Option<(usize, usize)> {
 }
 
 fn parse_xmp_attributes(xml_bytes: &[u8]) -> Result<HashMap<String, String>, MotionPhotoError> {
-    use quick_xml::Reader;
     use quick_xml::events::Event;
+    use quick_xml::{Reader, XmlVersion};
 
     let xml_buffer = String::from_utf8_lossy(xml_bytes);
     let mut reader = Reader::from_str(&xml_buffer);
@@ -43,7 +43,7 @@ fn parse_xmp_attributes(xml_bytes: &[u8]) -> Result<HashMap<String, String>, Mot
                     }
 
                     let value = attribute
-                        .decode_and_unescape_value(reader.decoder())
+                        .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                         .map_err(|err| MotionPhotoError::Xml(format!("invalid value: {err}")))?
                         .to_string();
                     result.insert(key, value);


### PR DESCRIPTION
Updates Rust dependencies to resolve audit failures and adds a cargo-audit policy for critical-only blocking.