### PR TITLE
[mobile] Free runner disk space for Photos Android build

### DIFF
--- a/.github/workflows/photos-build.yml
+++ b/.github/workflows/photos-build.yml
@@ -123,6 +123,9 @@ jobs:
             - run: cargo codegen frb
               working-directory: rust
 
+            - name: Free runner disk space
+              run: sudo rm -rf /usr/share/dotnet
+
             - name: Prepare whatsnew
               run: |
                   mkdir -p whatsnew


### PR DESCRIPTION
Free runner disk space before the Photos Android build by removing the preinstalled .NET SDK.

Added after https://github.com/ente/ente/actions/runs/28622850925 failed during the Android build.