### PR TITLE
[mob][photos] Delete iOS ML origin exports after processing

### DIFF
--- a/mobile/apps/photos/changes/ios-ml-cache-cleanup.md
+++ b/mobile/apps/photos/changes/ios-ml-cache-cleanup.md
@@ -1,0 +1,1 @@
+- Reduced app storage growth on iOS by clearing temporary copies of on-device photos right after they are processed for machine learning.

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -988,8 +988,7 @@ class MLService {
     final file = instruction.file;
     return Platform.isIOS &&
         file.fileType != FileType.video &&
-        !file.isRemoteFile &&
-        !file.isSharedMediaToAppSandbox;
+        !file.isRemoteFile;
   }
 
   bool _canRunMLFunction({required String function}) {

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -14,6 +14,7 @@ import "package:photos/db/offline_files_db.dart";
 import "package:photos/events/compute_control_event.dart";
 import "package:photos/events/people_changed_event.dart";
 import "package:photos/main.dart";
+import "package:photos/models/file/file_type.dart";
 import "package:photos/models/ml/clip.dart";
 import "package:photos/models/ml/face/face.dart";
 import "package:photos/models/ml/ml_versions.dart";
@@ -749,13 +750,16 @@ class MLService {
     bool actuallyRanML = false;
 
     final mlDataDB = _dbForMode(instruction.mode);
-    MLImageSource? source;
+    String? pathToDeleteAfterMLProcessing;
     try {
-      source = await getImagePathForML(instruction.file);
+      final String filePath = await getImagePathForML(instruction.file);
+      if (_shouldDeleteAfterMLProcessing(instruction)) {
+        pathToDeleteAfterMLProcessing = filePath;
+      }
 
       final MLResult? result = await MLIndexingIsolate.instance.analyzeImage(
         instruction,
-        source.imagePath,
+        filePath,
       );
       // Check if there's no result simply because MLController paused indexing
       if (result == null) {
@@ -964,20 +968,28 @@ class MLService {
       }
       return false;
     } finally {
-      if (source != null && source.shouldDeleteAfterMLProcessing) {
+      if (pathToDeleteAfterMLProcessing != null) {
         try {
-          await File(source.imagePath).delete();
+          await File(pathToDeleteAfterMLProcessing).delete();
         } on PathNotFoundException {
           // Already deleted.
         } catch (e, s) {
           _logger.warning(
-            "Failed to delete origin file exported for ML at ${source.imagePath}",
+            "Failed to delete origin file exported for ML at $pathToDeleteAfterMLProcessing",
             e,
             s,
           );
         }
       }
     }
+  }
+
+  bool _shouldDeleteAfterMLProcessing(FileMLInstruction instruction) {
+    final file = instruction.file;
+    return Platform.isIOS &&
+        file.fileType != FileType.video &&
+        !file.isRemoteFile &&
+        !file.isSharedMediaToAppSandbox;
   }
 
   bool _canRunMLFunction({required String function}) {

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -1,6 +1,6 @@
 import "dart:async";
 import "dart:convert" show jsonEncode;
-import "dart:io" show File, PathNotFoundException, Platform;
+import "dart:io" show File, Platform;
 import "dart:math" show min;
 import "dart:typed_data" show Uint8List;
 
@@ -972,8 +972,6 @@ class MLService {
       if (pathToDeleteAfterMLProcessing != null) {
         try {
           await File(pathToDeleteAfterMLProcessing).delete();
-        } on PathNotFoundException {
-          // Already deleted.
         } catch (e, s) {
           _logger.warning(
             "Failed to delete origin file exported for ML at $pathToDeleteAfterMLProcessing",

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -14,6 +14,7 @@ import "package:photos/db/offline_files_db.dart";
 import "package:photos/events/compute_control_event.dart";
 import "package:photos/events/people_changed_event.dart";
 import "package:photos/main.dart";
+import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/ml/clip.dart";
 import "package:photos/models/ml/face/face.dart";
@@ -753,7 +754,7 @@ class MLService {
     String? pathToDeleteAfterMLProcessing;
     try {
       final String filePath = await getImagePathForML(instruction.file);
-      if (_shouldDeleteAfterMLProcessing(instruction)) {
+      if (_shouldDeleteAfterMLProcessing(instruction.file)) {
         pathToDeleteAfterMLProcessing = filePath;
       }
 
@@ -984,8 +985,7 @@ class MLService {
     }
   }
 
-  bool _shouldDeleteAfterMLProcessing(FileMLInstruction instruction) {
-    final file = instruction.file;
+  bool _shouldDeleteAfterMLProcessing(EnteFile file) {
     return Platform.isIOS &&
         file.fileType != FileType.video &&
         !file.isRemoteFile;

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -1,6 +1,6 @@
 import "dart:async";
 import "dart:convert" show jsonEncode;
-import "dart:io" show Platform;
+import "dart:io" show File, PathNotFoundException, Platform;
 import "dart:math" show min;
 import "dart:typed_data" show Uint8List;
 
@@ -749,12 +749,13 @@ class MLService {
     bool actuallyRanML = false;
 
     final mlDataDB = _dbForMode(instruction.mode);
+    MLImageSource? source;
     try {
-      final String filePath = await getImagePathForML(instruction.file);
+      source = await getImagePathForML(instruction.file);
 
       final MLResult? result = await MLIndexingIsolate.instance.analyzeImage(
         instruction,
-        filePath,
+        source.imagePath,
       );
       // Check if there's no result simply because MLController paused indexing
       if (result == null) {
@@ -962,6 +963,20 @@ class MLService {
         await mlDataDB.deletePetDataForFiles([instruction.fileKey]);
       }
       return false;
+    } finally {
+      if (source != null && source.shouldDeleteAfterMLProcessing) {
+        try {
+          await File(source.imagePath).delete();
+        } on PathNotFoundException {
+          // Already deleted.
+        } catch (e, s) {
+          _logger.warning(
+            "Failed to delete origin file exported for ML at ${source.imagePath}",
+            e,
+            s,
+          );
+        }
+      }
     }
   }
 

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -696,8 +696,17 @@ Future<int> _getIndexableFileCount({required MLMode mode}) async {
   return getIndexableFileCount();
 }
 
-Future<String> getImagePathForML(EnteFile enteFile) async {
+typedef MLImageSource = ({
+  String imagePath,
+  bool shouldDeleteAfterMLProcessing,
+});
+
+/// Returns the path to use for ML processing of [enteFile], and whether the
+/// caller must delete that file afterwards (true only for iOS photo_manager
+/// origin exports).
+Future<MLImageSource> getImagePathForML(EnteFile enteFile) async {
   String? imagePath;
+  bool shouldDeleteAfterMLProcessing = false;
 
   final stopwatch = Stopwatch()..start();
   File? file;
@@ -725,6 +734,11 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
         trackOriginFetchForUploadOrML.put(enteFile.localID!, true);
       }
       file = await getFile(enteFile, isOrigin: true);
+      shouldDeleteAfterMLProcessing =
+          Platform.isIOS &&
+          file != null &&
+          !enteFile.isRemoteFile &&
+          !enteFile.isSharedMediaToAppSandbox;
     } catch (e, s) {
       _logger.severe("Could not get file for $enteFile", e, s);
     }
@@ -742,7 +756,10 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
     throw CouldNotRetrieveAnyFileData();
   }
 
-  return imagePath;
+  return (
+    imagePath: imagePath,
+    shouldDeleteAfterMLProcessing: shouldDeleteAfterMLProcessing,
+  );
 }
 
 bool _shouldRunIndexing(

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -696,17 +696,8 @@ Future<int> _getIndexableFileCount({required MLMode mode}) async {
   return getIndexableFileCount();
 }
 
-typedef MLImageSource = ({
-  String imagePath,
-  bool shouldDeleteAfterMLProcessing,
-});
-
-/// Returns the path to use for ML processing of [enteFile], and whether the
-/// caller must delete that file afterwards (true only for iOS photo_manager
-/// origin exports).
-Future<MLImageSource> getImagePathForML(EnteFile enteFile) async {
+Future<String> getImagePathForML(EnteFile enteFile) async {
   String? imagePath;
-  bool shouldDeleteAfterMLProcessing = false;
 
   final stopwatch = Stopwatch()..start();
   File? file;
@@ -734,11 +725,6 @@ Future<MLImageSource> getImagePathForML(EnteFile enteFile) async {
         trackOriginFetchForUploadOrML.put(enteFile.localID!, true);
       }
       file = await getFile(enteFile, isOrigin: true);
-      shouldDeleteAfterMLProcessing =
-          Platform.isIOS &&
-          file != null &&
-          !enteFile.isRemoteFile &&
-          !enteFile.isSharedMediaToAppSandbox;
     } catch (e, s) {
       _logger.severe("Could not get file for $enteFile", e, s);
     }
@@ -756,10 +742,7 @@ Future<MLImageSource> getImagePathForML(EnteFile enteFile) async {
     throw CouldNotRetrieveAnyFileData();
   }
 
-  return (
-    imagePath: imagePath,
-    shouldDeleteAfterMLProcessing: shouldDeleteAfterMLProcessing,
-  );
+  return imagePath;
 }
 
 bool _shouldRunIndexing(


### PR DESCRIPTION
## Summary
- Delete iOS `photo_manager` origin exports after ML processing finishes.

## Why
On iOS, fetching an origin file from the device library for ML can create a full-size temporary export under the app sandbox. When ML processes many local photos, these exports can accumulate and increase app storage until a later cache cleanup. The ML caller owns those temporary exports after a successful origin fetch, so they should be removed as soon as processing exits, including early-return and failure paths.

## Checks
- `dart format --set-exit-if-changed lib/utils/ml_util.dart lib/services/machine_learning/ml_service.dart`
- `flutter analyze lib/utils/ml_util.dart lib/services/machine_learning/ml_service.dart`
- Manual iOS Simulator check on iPhone 17 / iOS 26.5:
  - Seeded the simulator photo library with 24 generated PNGs.
  - Logged into a test account, granted full Photos access, selected backup folders, and completed backup.
  - Enabled Machine Learning and Local processing.
  - Confirmed ML reached 100% processed with `Shown IndexStatus: indexedFiles: 939, pendingFiles: 0`.
  - Confirmed all 24 generated uploaded images had ML clip rows and face-marker rows in `ente.ml.db`.
  - Watched `<app container>/tmp/.image` during ML: transient exports appeared while images were analyzed and returned to 0 files / 0B after completion.
  - Confirmed no `Failed to delete origin file exported for ML` warnings in logs.

## Notes
- The cleanup predicate is guarded by `Platform.isIOS`; non-iOS platforms never enter the deletion path.
- The manual simulator pass covered uploaded local image ML processing, including PNG/JPG/HEIC library items.
- Video-thumbnail and remote-only hydration paths were not part of this manual pass.


## TODO
- Consider clearing ML processing cache for remote-only files fetched from remote after processing, so downloaded temporary files do not linger beyond their use.
