### PR TITLE
[mob][photos] Rename remote-only file getter

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -313,10 +313,7 @@ class EnteFile {
     return height != 0 && width != 0;
   }
 
-  // returns true if the file isn't available in the user's gallery
-  bool get isRemoteFile {
-    return localID == null && uploadedFileID != null;
-  }
+  bool get isRemoteOnlyFile => localID == null && uploadedFileID != null;
 
   bool get isUploaded {
     return uploadedFileID != null;

--- a/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
+++ b/mobile/apps/photos/lib/module/download/gallery_download_queue_service.dart
@@ -184,7 +184,7 @@ class GalleryDownloadQueueService {
       if (uploadID == null || fileSize == null || fileSize <= 0) {
         continue;
       }
-      final queuedFile = file.isRemoteFile
+      final queuedFile = file.isRemoteOnlyFile
           ? file.copyWith()
           : (file.copyWith()..localID = null);
       _queuedFilesByID[uploadID] = queuedFile;
@@ -476,7 +476,7 @@ class GalleryDownloadQueueService {
       throw DownloadUnavailableError();
     }
     file.fileSize ??= _tasks[fileID]?.totalBytes;
-    final fileToDownload = file.isRemoteFile
+    final fileToDownload = file.isRemoteOnlyFile
         ? file.copyWith()
         : (file.copyWith()..localID = null);
     await downloadToGallery(

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -986,7 +986,7 @@ class MLService {
   bool _shouldDeleteAfterMLProcessing(EnteFile file) {
     return Platform.isIOS &&
         file.fileType != FileType.video &&
-        !file.isRemoteFile;
+        !file.isRemoteOnlyFile;
   }
 
   bool _canRunMLFunction({required String function}) {

--- a/mobile/apps/photos/lib/ui/home/memories/full_screen_memory.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/full_screen_memory.dart
@@ -195,7 +195,7 @@ class _FullScreenMemoryDataUpdaterState
   }
 
   void _preloadThumbnailOwned(EnteFile file) {
-    if (!file.isRemoteFile) {
+    if (!file.isRemoteOnlyFile) {
       preloadThumbnail(file);
       return;
     }

--- a/mobile/apps/photos/lib/ui/home/memories/memory_video_prefetcher.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_video_prefetcher.dart
@@ -58,7 +58,7 @@ class MemoryVideoPrefetcher {
   }
 
   void _enqueue(EnteFile file, bool Function()? stillActive) {
-    if (file.fileType != FileType.video || !file.isRemoteFile) return;
+    if (file.fileType != FileType.video || !file.isRemoteOnlyFile) return;
     final uploadedFileID = file.uploadedFileID;
     if (uploadedFileID == null) return;
     if (_attemptedIDs.contains(uploadedFileID) ||

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -1126,7 +1126,9 @@ class _FileSelectionActionsWidgetState
         continue;
       }
       filesToDownload.add(
-        file.isRemoteFile ? file.copyWith() : (file.copyWith()..localID = null),
+        file.isRemoteOnlyFile
+            ? file.copyWith()
+            : (file.copyWith()..localID = null),
       );
     }
     final skippedFilesCount = skippedFiles.length;

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -652,7 +652,7 @@ class FileAppBarState extends State<FileAppBar> {
       return;
     }
 
-    final fileToDownload = !file.isRemoteFile
+    final fileToDownload = !file.isRemoteOnlyFile
         ? (file.copyWith()..localID = null)
         : file;
     final persistToFilesDB =

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -113,7 +113,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
         }
       }
       // Cancel request only if the widget has been unmounted
-      if (!mounted && widget.file.isRemoteFile && !_hasLoadedThumbnail) {
+      if (!mounted && widget.file.isRemoteOnlyFile && !_hasLoadedThumbnail) {
         removePendingGetThumbnailRequestIfAny(widget.file);
       }
     });
@@ -179,7 +179,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.file.isRemoteFile) {
+    if (widget.file.isRemoteOnlyFile) {
       _loadNetworkImage();
     } else {
       _loadLocalImage(context);

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
@@ -149,7 +149,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
   }
 
   void loadOriginal() {
-    if (widget.file.isRemoteFile) {
+    if (widget.file.isRemoteOnlyFile) {
       _loadNetworkVideo();
       _setFileSizeIfNull();
     } else if (widget.file.isSharedMediaToAppSandbox) {

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -188,7 +188,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   }
 
   void loadOriginal({bool update = false}) async {
-    if (widget.file.isRemoteFile) {
+    if (widget.file.isRemoteOnlyFile) {
       _loadNetworkVideo(update);
       _setFileSizeIfNull();
     } else if (widget.file.isSharedMediaToAppSandbox) {

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -158,7 +158,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
         .on<RetryFailedImageLoadEvent>()
         .listen((_) {
           if (!mounted || _loadedFinalImage) return;
-          if (!_loadedSmallThumbnail && _photo.isRemoteFile) {
+          if (!_loadedSmallThumbnail && _photo.isRemoteOnlyFile) {
             // Evict the stale in-flight thumbnail so the rebuild's
             // getThumbnailFromServer doesn't dedupe against the dead completer.
             removePendingGetThumbnailRequestIfAny(_photo);
@@ -202,7 +202,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
   @override
   Widget build(BuildContext context) {
-    if (_photo.isRemoteFile) {
+    if (_photo.isRemoteOnlyFile) {
       _loadNetworkImage();
     } else {
       _loadLocalImage(context);

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
@@ -234,7 +234,7 @@ class _ZoomableLiveImageNewState extends State<ZoomableLiveImageNew>
   }
 
   Future<File?> _getLivePhotoVideo() async {
-    if (_enteFile.isRemoteFile &&
+    if (_enteFile.isRemoteOnlyFile &&
         !(await isFileCached(_enteFile, liveVideo: true))) {
       showShortToast(context, AppLocalizations.of(context).downloading);
     }
@@ -262,7 +262,7 @@ class _ZoomableLiveImageNewState extends State<ZoomableLiveImageNew>
   }
 
   Future<File?> _getMotionPhotoVideo() async {
-    if (_enteFile.isRemoteFile && !(await isFileCached(_enteFile))) {
+    if (_enteFile.isRemoteOnlyFile && !(await isFileCached(_enteFile))) {
       showShortToast(context, AppLocalizations.of(context).downloading);
     }
 

--- a/mobile/apps/photos/lib/utils/exif_util.dart
+++ b/mobile/apps/photos/lib/utils/exif_util.dart
@@ -49,7 +49,7 @@ Future<Map<String, IfdTag>> getExif(EnteFile file) async {
       throw Exception("Failed to fetch origin file");
     }
     final exif = await readExifAsync(originFile);
-    if (!file.isRemoteFile && Platform.isIOS) {
+    if (!file.isRemoteOnlyFile && Platform.isIOS) {
       await originFile.delete();
     }
     return exif;

--- a/mobile/apps/photos/lib/utils/file_util.dart
+++ b/mobile/apps/photos/lib/utils/file_util.dart
@@ -64,7 +64,7 @@ Future<File?> getFile(
   bool forGalleryDownload = false, // only relevant for live photos
 }) async {
   try {
-    if (file.isRemoteFile) {
+    if (file.isRemoteOnlyFile) {
       return getFileFromServer(
         file,
         liveVideo: liveVideo,
@@ -139,7 +139,7 @@ String getSharedMediaPathFromLocalID(String localID) {
 }
 
 void preloadThumbnail(EnteFile file) {
-  if (file.isRemoteFile) {
+  if (file.isRemoteOnlyFile) {
     getThumbnailFromServer(file);
   } else {
     getThumbnailFromLocal(file);

--- a/mobile/apps/photos/lib/utils/share_util.dart
+++ b/mobile/apps/photos/lib/utils/share_util.dart
@@ -25,11 +25,13 @@ Future<void> share(
   List<EnteFile> files, {
   GlobalKey? shareButtonKey,
 }) async {
-  final remoteFileCount = files.where((element) => element.isRemoteFile).length;
+  final remoteOnlyFileCount = files
+      .where((element) => element.isRemoteOnlyFile)
+      .length;
   final dialog = createProgressDialog(
     context,
     "Preparing...",
-    isDismissible: remoteFileCount > 2,
+    isDismissible: remoteOnlyFileCount > 2,
   );
   await dialog.show();
   try {
@@ -61,7 +63,7 @@ Future<void> share(
       if (path == null) {
         _logger.warning(
           "share missing local path for file $i/${files.length} "
-          "(remote: ${files[i].isRemoteFile})",
+          "(remoteOnly: ${files[i].isRemoteOnlyFile})",
         );
         continue;
       }
@@ -70,7 +72,7 @@ Future<void> share(
     if (resolvedPaths.isEmpty) {
       _logger.severe(
         "share aborted: unable to resolve any files "
-        "(requested: ${files.length}, remote: $remoteFileCount)",
+        "(requested: ${files.length}, remoteOnly: $remoteOnlyFileCount)",
       );
       throw ArgumentError("No files resolved for system share");
     }
@@ -84,7 +86,7 @@ Future<void> share(
   } catch (e, s) {
     _logger.severe(
       "failed to complete system share ${files.length} "
-      "(remote: $remoteFileCount)",
+      "(remoteOnly: $remoteOnlyFileCount)",
       e,
       s,
     );

--- a/mobile/apps/photos/lib/utils/thumbnail_util.dart
+++ b/mobile/apps/photos/lib/utils/thumbnail_util.dart
@@ -36,7 +36,7 @@ class FileDownloadItem {
 }
 
 Future<Uint8List?> getThumbnail(EnteFile file) async {
-  if (file.isRemoteFile) {
+  if (file.isRemoteOnlyFile) {
     return getThumbnailFromServer(file);
   } else {
     return getThumbnailFromLocal(file, size: thumbnailLargeSize);
@@ -45,7 +45,7 @@ Future<Uint8List?> getThumbnail(EnteFile file) async {
 
 Future<({bool acquiredPendingRequestRef, Future<void> pendingRequest})>
 preloadThumbnailWithPendingRequestRef(EnteFile file) async {
-  if (!file.isRemoteFile) {
+  if (!file.isRemoteOnlyFile) {
     unawaited(getThumbnailFromLocal(file));
     return (
       acquiredPendingRequestRef: false,


### PR DESCRIPTION
## Summary
- Rename EnteFile.isRemoteFile to isRemoteOnlyFile to reflect that it checks for remote-only files
- Update Mobile Photos call sites, including the new ML cleanup usage from upstream
- Clarify remote-only naming in share logging/counts
