### PR TITLE
[auth] Add custom icon for Smouter

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -2022,8 +2022,7 @@
       ]
     },
     {
-      "title": "Smouter",
-      "hex": "4F46E5"
+      "title": "Smouter"
     },
     {
       "title": "SMSPool",

--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -2022,6 +2022,10 @@
       ]
     },
     {
+      "title": "Smouter",
+      "hex": "4F46E5"
+    },
+    {
       "title": "SMSPool",
       "slug": "sms_pool_net",
       "altNames": [

--- a/mobile/apps/auth/assets/custom-icons/icons/smouter.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/smouter.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#4f46e5"/>
+  <path d="M21 11 C21 8 11 8 11 12 C11 15 21 17 21 20 C21 24 11 24 11 21" fill="none" stroke="#ffffff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="21" cy="11" r="2.6" fill="#ffffff"/>
+  <circle cx="21" cy="11" r="1.1" fill="#4f46e5"/>
+  <circle cx="11" cy="21" r="2.6" fill="#ffffff"/>
+  <circle cx="11" cy="21" r="1.1" fill="#4f46e5"/>
+</svg>


### PR DESCRIPTION
Adds a custom icon for [Smouter](https://smouter.ai) (an OpenAI-compatible LLM gateway; TOTP 2FA issuer string is `Smouter`), following [adding-icons.md](https://github.com/ente-io/ente/blob/main/mobile/apps/auth/docs/adding-icons.md):

- `icons/smouter.svg` — official brand mark, 498 bytes
- `custom-icons.json` — `{"title": "Smouter", "hex": "4F46E5"}`, inserted alphabetically

I'm the founder of the service, so this is the canonical logo (also served at https://smouter.ai/brand/smouter-logo.svg). Thanks for maintaining the catalog!

🤖 Generated with [Claude Code](https://claude.com/claude-code)