### PR TITLE
[web][contacts] Bind warm-up retries to session generation

### DIFF
--- a/web/packages/contacts/index.test.ts
+++ b/web/packages/contacts/index.test.ts
@@ -92,7 +92,7 @@ const setupContactsModule = async (options: SetupOptions = {}) => {
         return typeof value === "number" ? value : undefined;
     });
 
-    const savedAuthToken = vi.fn(() => "auth-token-secret");
+    const savedAuthToken = vi.fn((): string | undefined => "auth-token-secret");
     const apiOrigin = vi.fn(() => "https://api.example");
     const info = vi.fn();
     const warn = vi.fn();
@@ -186,6 +186,8 @@ const setupContactsModule = async (options: SetupOptions = {}) => {
     return {
         contacts,
         setKV,
+        savedAuthToken,
+        update_auth_token,
         get_diff,
         get_profile_picture,
         legacy_get_info,
@@ -354,6 +356,45 @@ describe("retry after warm-up failure", () => {
         expect(get_diff).toHaveBeenCalledTimes(4);
         await vi.advanceTimersByTimeAsync(300_000);
         expect(get_diff).toHaveBeenCalledTimes(4);
+    });
+
+    test("stale retry does not update a newer generation context token", async () => {
+        vi.useFakeTimers();
+        const { contacts, savedAuthToken, update_auth_token, get_diff } =
+            await setupContactsModule();
+        savedAuthToken
+            .mockReturnValueOnce("old-token")
+            .mockReturnValueOnce(undefined)
+            .mockReturnValue("new-token");
+        get_diff.mockReset();
+        get_diff
+            .mockRejectedValueOnce(new Error("transient"))
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([]);
+
+        const staleReady = contacts.ensureContactsReady({
+            userID: 101,
+            masterKeyB64: "old-master-key",
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(get_diff).toHaveBeenCalledTimes(1);
+
+        await contacts.ensureContactsReady({
+            userID: 101,
+            masterKeyB64: "clearing-master-key",
+        });
+        expect(get_diff).toHaveBeenCalledTimes(1);
+
+        await contacts.ensureContactsReady({
+            userID: 101,
+            masterKeyB64: "new-master-key",
+        });
+        expect(get_diff).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(10_001);
+        await expect(staleReady).resolves.toBeUndefined();
+        expect(update_auth_token).not.toHaveBeenCalled();
+        expect(get_diff).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/web/packages/contacts/index.ts
+++ b/web/packages/contacts/index.ts
@@ -100,6 +100,13 @@ interface ContactsReadyInput {
     masterKeyB64: string;
 }
 
+type ContactsSessionInput = ContactsReadyInput & {
+    sessionKey: string;
+    baseURL: string;
+    authToken: string;
+    generation: number;
+};
+
 type RootKeySource = "cache" | "unresolved";
 
 interface OpenedContactsCtx {
@@ -338,7 +345,13 @@ const loadLocalSessionState = async (sessionKey: string) => {
     }
 
     emitSnapshot(true);
+    return generation;
 };
+
+const ensureSessionLoaded = async (sessionKey: string) =>
+    state.currentSessionKey === sessionKey
+        ? state.sessionGeneration
+        : loadLocalSessionState(sessionKey);
 
 const ensureContactsCtxOpen = async ({
     sessionKey,
@@ -346,13 +359,13 @@ const ensureContactsCtxOpen = async ({
     authToken,
     userID,
     masterKeyB64,
-}: ContactsReadyInput & {
-    sessionKey: string;
-    baseURL: string;
-    authToken: string;
-}) => {
+    generation,
+}: ContactsSessionInput) => {
+    if (!isCurrentSession(sessionKey, generation)) {
+        return;
+    }
+
     let ctx = state.ctx;
-    const generation = state.sessionGeneration;
 
     if (!ctx) {
         const cachedWrappedRootContactKey =
@@ -402,22 +415,19 @@ const syncContacts = async ({
     authToken,
     userID,
     masterKeyB64,
-}: ContactsReadyInput & {
-    sessionKey: string;
-    baseURL: string;
-    authToken: string;
-}) => {
+    generation,
+}: ContactsSessionInput) => {
     const ctx = await ensureContactsCtxOpen({
         sessionKey,
         baseURL,
         authToken,
         userID,
         masterKeyB64,
+        generation,
     });
     if (!ctx) {
         return;
     }
-    const generation = state.sessionGeneration;
 
     let sinceTime = (await savedContactsSinceTime(sessionKey)) ?? 0;
     let didChange = false;
@@ -483,8 +493,9 @@ export const ensureContactsReady = async ({
     const baseURL = await apiOrigin();
     const sessionKey = buildSessionKey(baseURL, userID);
 
-    if (state.currentSessionKey !== sessionKey) {
-        await loadLocalSessionState(sessionKey);
+    const generation = await ensureSessionLoaded(sessionKey);
+    if (generation === undefined) {
+        return;
     }
 
     if (state.readyPromise) {
@@ -499,6 +510,7 @@ export const ensureContactsReady = async ({
                 authToken,
                 userID,
                 masterKeyB64,
+                generation,
             }),
         { retryProfile: "background" },
     ).finally(() => {
@@ -524,8 +536,9 @@ const ensureCurrentLegacyCtx = async () => {
     const user = ensureLocalUser();
     const baseURL = await apiOrigin();
     const sessionKey = buildSessionKey(baseURL, user.id);
-    if (state.currentSessionKey !== sessionKey) {
-        await loadLocalSessionState(sessionKey);
+    const generation = await ensureSessionLoaded(sessionKey);
+    if (generation === undefined) {
+        throw new Error("Contacts context not available");
     }
     const ctx = await ensureContactsCtxOpen({
         sessionKey,
@@ -533,6 +546,7 @@ const ensureCurrentLegacyCtx = async () => {
         authToken,
         userID: user.id,
         masterKeyB64,
+        generation,
     });
     if (!ctx) {
         throw new Error("Contacts context not available");


### PR DESCRIPTION
Fix contacts warm-up retries so stale attempts cannot reuse credentials after a session change.

Adds a regression test for same-user token changes.