### PR TITLE
[mob][photos] Fix iOS cache build up during upload

### DIFF
--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -647,6 +647,8 @@ class FileUploader {
           debugPrint(
             "File success mapped to existing uploaded ${file.toString()}",
           );
+          // treat as completed so _onUploadDone clears the source export
+          uploadCompleted = true;
           // return the mapped file
           return result.item2;
         }
@@ -958,7 +960,8 @@ class FileUploader {
       }
       if ((e is StorageLimitExceededError ||
           e is FileTooLargeForPlanError ||
-          e is NoActiveSubscriptionError)) {
+          e is NoActiveSubscriptionError ||
+          e is InvalidFileError)) {
         // file upload can not be retried in such cases without user intervention
         uploadHardFailure = true;
       }
@@ -1180,7 +1183,7 @@ class FileUploader {
       // succeeds.
       if ((Platform.isIOS && (uploadCompleted || uploadHardFailure)) ||
           (uploadCompleted && file.isSharedMediaToAppSandbox)) {
-        await mediaUploadData.sourceFile?.delete();
+        await deleteFileSystemEntityIfPresent(mediaUploadData.sourceFile!);
       }
     }
     if (File(encryptedFilePath).existsSync()) {

--- a/mobile/apps/photos/lib/utils/file_uploader_util.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader_util.dart
@@ -7,6 +7,8 @@ import 'dart:ui' as ui;
 import "package:archive/archive_io.dart";
 import "package:computer/computer.dart";
 import 'package:ente_crypto/ente_crypto.dart';
+import "package:ente_pure_utils/ente_pure_utils.dart"
+    show deleteFileSystemEntityIfPresent;
 import "package:exif_reader/exif_reader.dart";
 import 'package:logging/logging.dart';
 import 'package:motionphoto/motionphoto.dart';
@@ -158,85 +160,94 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
       InvalidReason.sourceFileMissing,
     );
   }
-  if (parseExif && shouldReadExif(file)) {
-    exifData = await tryExifFromFile(sourceFile);
-    if (exifData != null) {
-      cameraMake = _extractPrintableExifValue(exifData['Image Make']);
-      cameraModel = _extractPrintableExifValue(exifData['Image Model']);
+  try {
+    if (parseExif && shouldReadExif(file)) {
+      exifData = await tryExifFromFile(sourceFile);
+      if (exifData != null) {
+        cameraMake = _extractPrintableExifValue(exifData['Image Make']);
+        cameraModel = _extractPrintableExifValue(exifData['Image Model']);
+      }
     }
-  }
-  // h4ck to fetch location data if missing (thank you Android Q+) lazily only during uploads
-  await _decorateEnteFileData(file, asset, sourceFile, exifData);
-  fileHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
+    // h4ck to fetch location data if missing (thank you Android Q+) lazily only during uploads
+    await _decorateEnteFileData(file, asset, sourceFile, exifData);
+    fileHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
 
-  if (file.fileType == FileType.livePhoto && Platform.isIOS) {
-    final File? videoUrl = await Motionphoto.getLivePhotoFile(file.localID!);
-    if (videoUrl == null || !videoUrl.existsSync()) {
-      final String errMsg =
-          "missing livePhoto url for  ${file.toString()} with subType ${file.fileSubType}";
-      _logger.severe(errMsg);
-      throw InvalidFileError(errMsg, InvalidReason.livePhotoVideoMissing);
+    if (file.fileType == FileType.livePhoto && Platform.isIOS) {
+      final File? videoUrl = await Motionphoto.getLivePhotoFile(file.localID!);
+      if (videoUrl == null || !videoUrl.existsSync()) {
+        final String errMsg =
+            "missing livePhoto url for  ${file.toString()} with subType ${file.fileSubType}";
+        _logger.severe(errMsg);
+        throw InvalidFileError(errMsg, InvalidReason.livePhotoVideoMissing);
+      }
+      final String livePhotoVideoHash = CryptoUtil.bin2base64(
+        await CryptoUtil.getHash(videoUrl),
+      );
+      // imgHash:vidHash
+      fileHash = '$fileHash$kLivePhotoHashSeparator$livePhotoVideoHash';
+      final tempPath = Configuration.instance.getTempDirectory();
+      // .elp -> ente live photo
+      final uniqueId = const Uuid().v4().toString();
+      final livePhotoPath = tempPath + uniqueId + "_${file.generatedID}.elp";
+      _logger.info(
+        "Creating zip for live photo from " + basename(livePhotoPath),
+      );
+      await zip(
+        zipPath: livePhotoPath,
+        imagePath: sourceFile.path,
+        videoPath: videoUrl.path,
+      );
+      // delete the temporary video and image copy (only in IOS)
+      if (Platform.isIOS) {
+        await sourceFile.delete();
+      }
+      // new sourceFile which needs to be uploaded
+      sourceFile = File(livePhotoPath);
+      zipHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
     }
-    final String livePhotoVideoHash = CryptoUtil.bin2base64(
-      await CryptoUtil.getHash(videoUrl),
+
+    thumbnailData = await _getThumbnailForUpload(asset, file);
+    isDeleted = !(await asset.exists);
+    int? h, w;
+    if (asset.width != 0 && asset.height != 0) {
+      w = asset.width;
+      h = asset.height;
+      if (Platform.isAndroid &&
+          file.fileType == FileType.image &&
+          _shouldSwapDimensionsForExifOrientation(exifData)) {
+        final temp = w;
+        w = h;
+        h = temp;
+      }
+    }
+    int? motionPhotoStartingIndex;
+    if (Platform.isAndroid && asset.type == AssetType.image) {
+      try {
+        motionPhotoStartingIndex = await motionVideoIndex({
+          'path': sourceFile.path,
+        });
+      } catch (e) {
+        _logger.severe('error while detecthing motion photo start index', e);
+      }
+    }
+    return MediaUploadData(
+      sourceFile,
+      thumbnailData,
+      isDeleted,
+      FileHashData(fileHash, zipHash: zipHash),
+      height: h,
+      width: w,
+      cameraMake: cameraMake,
+      cameraModel: cameraModel,
+      motionPhotoStartIndex: motionPhotoStartingIndex,
+      exifData: exifData,
     );
-    // imgHash:vidHash
-    fileHash = '$fileHash$kLivePhotoHashSeparator$livePhotoVideoHash';
-    final tempPath = Configuration.instance.getTempDirectory();
-    // .elp -> ente live photo
-    final uniqueId = const Uuid().v4().toString();
-    final livePhotoPath = tempPath + uniqueId + "_${file.generatedID}.elp";
-    _logger.info("Creating zip for live photo from " + basename(livePhotoPath));
-    await zip(
-      zipPath: livePhotoPath,
-      imagePath: sourceFile.path,
-      videoPath: videoUrl.path,
-    );
-    // delete the temporary video and image copy (only in IOS)
+  } catch (_) {
     if (Platform.isIOS) {
-      await sourceFile.delete();
+      await deleteFileSystemEntityIfPresent(sourceFile!);
     }
-    // new sourceFile which needs to be uploaded
-    sourceFile = File(livePhotoPath);
-    zipHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
+    rethrow;
   }
-
-  thumbnailData = await _getThumbnailForUpload(asset, file);
-  isDeleted = !(await asset.exists);
-  int? h, w;
-  if (asset.width != 0 && asset.height != 0) {
-    w = asset.width;
-    h = asset.height;
-    if (Platform.isAndroid &&
-        file.fileType == FileType.image &&
-        _shouldSwapDimensionsForExifOrientation(exifData)) {
-      final temp = w;
-      w = h;
-      h = temp;
-    }
-  }
-  int? motionPhotoStartingIndex;
-  if (Platform.isAndroid && asset.type == AssetType.image) {
-    try {
-      motionPhotoStartingIndex = await motionVideoIndex({
-        'path': sourceFile.path,
-      });
-    } catch (e) {
-      _logger.severe('error while detecthing motion photo start index', e);
-    }
-  }
-  return MediaUploadData(
-    sourceFile,
-    thumbnailData,
-    isDeleted,
-    FileHashData(fileHash, zipHash: zipHash),
-    height: h,
-    width: w,
-    cameraMake: cameraMake,
-    cameraModel: cameraModel,
-    motionPhotoStartIndex: motionPhotoStartingIndex,
-    exifData: exifData,
-  );
 }
 
 bool _shouldSwapDimensionsForExifOrientation(Map<String, IfdTag>? exifData) {


### PR DESCRIPTION
## Summary

Reduce iOS upload cache growth by cleaning temporary upload copies that were missed outside the existing successful-upload cleanup path.

## What changed

- Dedup matches now reuse the existing completion cleanup.
- Too-large files now reuse the hard-failure cleanup.
- Upload-prep failures clean up immediately because `_onUploadDone` is never reached.
- Cleanup now tolerates the file already being deleted elsewhere.

## Why cleanup happens in two places

`_getMediaUploadDataFromAssetFile` handles failures before `MediaUploadData` exists.

`_onUploadDone` handles cases after upload data exists. Successful uploads already used this path; this PR extends it to dedup matches and too-large files.

The cleanup is iOS-only.

## Test plan

- Manually verified on iOS simulator that uploads still work and multipart failure/resume behavior is unchanged.