### PR TITLE
[desktop] Fix macOS universal build

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -49,3 +49,4 @@ mac:
     category: public.app-category.photography
     hardenedRuntime: true
     mergeASARs: false
+    x64ArchFiles: "**/node_modules/onnxruntime-node/bin/napi-v6/darwin/**"


### PR DESCRIPTION
See commit msg for reason, in brief: the fix in https://github.com/ente/ente/pull/11277 unmasked this issue that had existed since we updated electron-builder 26.0.14 to 26.8.1 and which is now causing builds to fail, e.g. https://github.com/ente/ente/actions/runs/28777576459/job/85325124599