### PR TITLE
[mobile] Gate account deletion on summary

### DIFF
--- a/mobile/packages/account_deletion/lib/src/ui/delete_account_page.dart
+++ b/mobile/packages/account_deletion/lib/src/ui/delete_account_page.dart
@@ -42,7 +42,10 @@ class _DeleteAccountPageState extends State<DeleteAccountPage> {
     final colors = context.componentColors;
     final isConfirmationStep = _step == _DeleteAccountStep.confirmation;
     final isActionEnabled = isConfirmationStep
-        ? _confirmationAccepted && !_summaryLoading && !_isDeleting
+        ? _confirmationAccepted &&
+              (_summary != null || _summaryUnsupported) &&
+              !_summaryLoading &&
+              !_isDeleting
         : _selectedReason != null && !_isDeleting;
 
     return Scaffold(


### PR DESCRIPTION
Blocks final account deletion until the impact summary loads, except for the explicit unsupported-summary case.