### PR TITLE
[mobile][photos] Show smaller People groups in Search

### DIFF
--- a/mobile/apps/photos/changes/search-people-preview-fallback.md
+++ b/mobile/apps/photos/changes/search-people-preview-fallback.md
@@ -1,0 +1,1 @@
+- Show smaller detected people groups in Search when no larger groups are available.

--- a/mobile/apps/photos/lib/models/search/search_types.dart
+++ b/mobile/apps/photos/lib/models/search/search_types.dart
@@ -24,6 +24,8 @@ import "package:photos/ui/viewer/location/pick_center_point_widget.dart";
 import "package:photos/utils/dialog_util.dart";
 import "package:photos/utils/share_util.dart";
 
+const _kSearchPreviewFallbackClusterSize = 3;
+
 enum ResultType {
   collection,
   deviceCollection,
@@ -256,6 +258,9 @@ extension SectionTypeExtensions on SectionType {
           minClusterSize: limit == null
               ? kMinimumClusterSizeAllFaces
               : kMinimumClusterSizeSearchResult,
+          fallbackMinClusterSize: limit == null
+              ? null
+              : _kSearchPreviewFallbackClusterSize,
         );
       case SectionType.magic:
         return SearchService.instance.getMagicSectionResults(

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -1074,6 +1074,7 @@ class SearchService {
   Future<List<GenericSearchResult>> getAllFace(
     int? limit, {
     required int minClusterSize,
+    int? fallbackMinClusterSize,
     bool showIgnoredOnly = false,
   }) async {
     try {
@@ -1383,7 +1384,18 @@ class SearchService {
           );
         }
       }
-      if (facesResult.isEmpty) return [];
+      if (facesResult.isEmpty) {
+        if (fallbackMinClusterSize != null &&
+            fallbackMinClusterSize < minClusterSize) {
+          return getAllFace(
+            limit,
+            minClusterSize: fallbackMinClusterSize,
+            showIgnoredOnly: showIgnoredOnly,
+          );
+        } else {
+          return [];
+        }
+      }
       sortPeopleFaces(
         facesResult,
         PeopleSortConfig(


### PR DESCRIPTION
- Fall back to smaller detected people groups when the Search preview has no larger People groups to show.