### PR TITLE
[rust] Update heic decoder with additional hardening

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3558,7 +3558,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "heic_decoder"
 version = "0.1.0"
-source = "git+https://github.com/ente/heic-decoder.git?rev=019b2fd8ee6af99579f26e424a6a0b9016a73fdc#019b2fd8ee6af99579f26e424a6a0b9016a73fdc"
+source = "git+https://github.com/ente/heic-decoder.git?rev=37ceaee761e17c0253daeadd85dc0c1904fb894b#37ceaee761e17c0253daeadd85dc0c1904fb894b"
 dependencies = [
  "archmage",
  "brotli",

--- a/rust/crates/image/Cargo.toml
+++ b/rust/crates/image/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 fast_image_resize = { version = "5.5.0", features = ["image"] }
 image = { version = "0.25.5", default-features = true }
 kamadak-exif = "0.6.1"
-ente_heic = { package = "heic_decoder", git = "https://github.com/ente/heic-decoder.git", rev = "019b2fd8ee6af99579f26e424a6a0b9016a73fdc", features = [
+ente_heic = { package = "heic_decoder", git = "https://github.com/ente/heic-decoder.git", rev = "37ceaee761e17c0253daeadd85dc0c1904fb894b", features = [
     "image-integration",
 ] }
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

Updates the `ente-image` Rust crate's `heic_decoder` git dependency from `019b2fd8ee6af99579f26e424a6a0b9016a73fdc` to `37ceaee761e17c0253daeadd85dc0c1904fb894b`, the current `main` head of `ente/heic-decoder`.

## Impact

Keeps HEIC decoding in `ente-image` aligned with the latest decoder repository changes.

## Validation

- `cargo test -p ente-image`