### PR TITLE
[mobile] Route to landing after account deletion

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
+++ b/mobile/apps/auth/lib/ui/settings/account_section_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ente_account_deletion/account_deletion.dart';
 import 'package:ente_accounts/pages/change_email_dialog.dart';
 import 'package:ente_accounts/pages/password_entry_page.dart';
@@ -131,14 +133,20 @@ class AccountSectionWidget extends StatelessWidget {
           if (!context.mounted || !hasAuthenticated) {
             return;
           }
-          // ignore: unawaited_futures
-          Navigator.of(context).push(
+          final deleted = await Navigator.of(context).push<bool>(
             MaterialPageRoute(
               builder: (BuildContext context) {
                 return const DeleteAccountPage();
               },
             ),
           );
+          if (deleted == true && context.mounted) {
+            unawaited(
+              Navigator.of(
+                context,
+              ).pushNamedAndRemoveUntil('/', (route) => false),
+            );
+          }
         },
       ),
       sectionOptionSpacing,

--- a/mobile/apps/locker/lib/ui/settings/pages/account_settings_page.dart
+++ b/mobile/apps/locker/lib/ui/settings/pages/account_settings_page.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:ente_account_deletion/account_deletion.dart";
 import "package:ente_accounts/pages/change_email_dialog.dart";
 import "package:ente_accounts/pages/password_entry_page.dart";
@@ -128,13 +130,17 @@ class AccountSettingsPage extends StatelessWidget {
     if (!context.mounted || !hasAuthenticated) {
       return;
     }
-    // ignore: unawaited_futures
-    Navigator.of(context).push(
+    final deleted = await Navigator.of(context).push<bool>(
       MaterialPageRoute(
         builder: (BuildContext context) {
           return const DeleteAccountPage();
         },
       ),
     );
+    if (deleted == true && context.mounted) {
+      unawaited(
+        Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false),
+      );
+    }
   }
 }

--- a/mobile/apps/photos/lib/ui/settings/account/account_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/account/account_settings_page.dart
@@ -190,14 +190,15 @@ class AccountSettingsPage extends StatelessWidget {
     if (!context.mounted || !hasAuthenticated) {
       return;
     }
-    unawaited(
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (BuildContext context) {
-            return const DeleteAccountPage();
-          },
-        ),
+    final deleted = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (BuildContext context) {
+          return const DeleteAccountPage();
+        },
       ),
     );
+    if (deleted == true && context.mounted) {
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    }
   }
 }

--- a/mobile/packages/account_deletion/lib/src/ui/delete_account_page.dart
+++ b/mobile/packages/account_deletion/lib/src/ui/delete_account_page.dart
@@ -162,7 +162,7 @@ class _DeleteAccountPageState extends State<DeleteAccountPage> {
       if (!mounted) {
         return;
       }
-      Navigator.of(context).popUntil((route) => route.isFirst);
+      Navigator.of(context).pop(true);
     } catch (e, s) {
       _logger.severe('Failed to delete account', e, s);
       if (!mounted) {


### PR DESCRIPTION
Fix Auth/Locker landing on the stale home screen after account deletion — the shared `DeleteAccountPage` now returns success to its caller (`pop(true)`) and each app navigates to its own landing page, instead of hard-coding `popUntil` (which only worked for Photos').