### PR TITLE
[mob][photos] Pin flutter_cache_manager to delete fix

### DIFF
--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -30,6 +30,7 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Redesigned the Search tab with improved spacing, previews, empty states, and keyboard handling.
 - Improved Albums with Shared/Received filters, refreshed empty states, and better add-to-album flows.
 - Fixed a bug in bulk file downloads and improved backup album selection.
+- Fixed cached remote images and videos not being deleted from device storage during automatic cache cleanup when cache limits are reached.
 - Added skipped backup file reasons, such as “Deleted from Ente”.
 - Preserved draft comments when closing and reopening the photo comment panel.
 - Polished app lock, login/signup, gallery, trash, and warning screens.

--- a/docs/docs/photos/changelog.md
+++ b/docs/docs/photos/changelog.md
@@ -30,7 +30,6 @@ A short summary list of changes to the Ente Photos mobile and desktop apps. For 
 - Redesigned the Search tab with improved spacing, previews, empty states, and keyboard handling.
 - Improved Albums with Shared/Received filters, refreshed empty states, and better add-to-album flows.
 - Fixed a bug in bulk file downloads and improved backup album selection.
-- Fixed cached remote images and videos not being deleted from device storage during automatic cache cleanup when cache limits are reached.
 - Added skipped backup file reasons, such as “Deleted from Ente”.
 - Preserved draft comments when closing and reopening the photo comment panel.
 - Polished app lock, login/signup, gallery, trash, and warning screens.

--- a/mobile/apps/photos/changes/fix-cache-cleanup-deletion.md
+++ b/mobile/apps/photos/changes/fix-cache-cleanup-deletion.md
@@ -1,0 +1,1 @@
+- Fixed cached remote images and videos not being deleted from device storage during automatic cache cleanup.

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -109,7 +109,11 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_animate: 4.5.2
-  flutter_cache_manager: 3.4.1
+  flutter_cache_manager:
+    git:
+      url: https://github.com/Baseflow/flutter_cache_manager.git
+      ref: 54904e499a06d0364a2b3f4ca9789e5f829f1879
+      path: flutter_cache_manager
   flutter_displaymode: 0.6.0
   flutter_easyloading: 3.0.5
   flutter_email_sender: 7.0.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -884,12 +884,13 @@ packages:
     source: hosted
     version: "4.5.2"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_cache_manager
+      ref: "54904e499a06d0364a2b3f4ca9789e5f829f1879"
+      resolved-ref: "54904e499a06d0364a2b3f4ca9789e5f829f1879"
+      url: "https://github.com/Baseflow/flutter_cache_manager.git"
+    source: git
     version: "3.4.1"
   flutter_context_menu:
     dependency: transitive

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -50,6 +50,8 @@ dev_dependencies:
   melos: 7.8.1
 
 dependency_overrides:
+  # cached_network_image still resolves the hosted package; this override
+  # moves all flutter_cache_manager uses to the upstream delete fix.
   flutter_cache_manager:
     git:
       url: https://github.com/Baseflow/flutter_cache_manager.git

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -50,8 +50,8 @@ dev_dependencies:
   melos: 7.8.1
 
 dependency_overrides:
-  # cached_network_image still resolves the hosted package; this override
-  # moves all flutter_cache_manager uses to the upstream delete fix.
+  # Hosted 3.4.1 drops DB rows but fails to delete cache files; use the
+  # upstream delete fix until a fixed release ships.
   flutter_cache_manager:
     git:
       url: https://github.com/Baseflow/flutter_cache_manager.git

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -50,6 +50,11 @@ dev_dependencies:
   melos: 7.8.1
 
 dependency_overrides:
+  flutter_cache_manager:
+    git:
+      url: https://github.com/Baseflow/flutter_cache_manager.git
+      ref: 54904e499a06d0364a2b3f4ca9789e5f829f1879
+      path: flutter_cache_manager
   motion_sensors:
     git:
       url: https://github.com/deckerst/aves_panorama_motion_sensors.git


### PR DESCRIPTION
## Summary

Pins `flutter_cache_manager` to upstream commit `54904e499a06d0364a2b3f4ca9789e5f829f1879`, which contains the cache-file deletion fix missing from the latest hosted `3.4.1` release.

## Why

`flutter_cache_manager` 3.4.1 removes sqlite rows during capacity eviction, stale eviction, `removeFile()`, and `emptyCache()`, but its delete path resolves a bare relative filename against the process CWD via `io.File(relativePath)`. That means the DB rows disappear while the cached files remain on disk, so caches can keep growing past their configured cap. The field symptom we investigated was `libCachedImageData` holding 1,823 files / 7.00 GB against the 200-object default cap.

Upstream provenance:

- Baseflow/flutter_cache_manager issues: https://github.com/Baseflow/flutter_cache_manager/issues/472 and https://github.com/Baseflow/flutter_cache_manager/issues/490
- Upstream fix PR: https://github.com/Baseflow/flutter_cache_manager/pull/469
- Pinned ref: `54904e499a06d0364a2b3f4ca9789e5f829f1879`

Security/blast-radius review:

- The consumed package delta versus the hosted 3.4.1 release is the upstream delete fix plus its test.
- No new dependencies, network calls, native code, or CI changes are introduced by the consumed package change.
- The override is workspace-wide by mechanism, but grep found only `mobile/apps/photos/pubspec.yaml` declares `cached_network_image` / `flutter_cache_manager`.

Known limitation: this fixes future deletions. Files already orphaned during the buggy era have no DB rows and are intentionally left. Only way to clear them is manually clearing caches. 

## Test Plan

- `flutter pub get`
- `flutter pub get --enforce-lockfile`
- `flutter analyze apps/photos`
- Verified pinned `cache_store.dart` uses `fileSystem.createFile(cacheObject.relativePath)` and no longer uses `io.File(cacheObject.relativePath)` for deletion.