### PR TITLE
[mobile][photos] Add env-based logging filters

### DIFF
--- a/mobile/apps/photos/integration_test/video_editor_test.dart
+++ b/mobile/apps/photos/integration_test/video_editor_test.dart
@@ -174,8 +174,7 @@ void main() {
   final logger = Logger("VideoEditorIntegrationTest");
   Logger.root.level = Level.INFO;
   Logger.root.onRecord.listen((record) {
-    // ignore: avoid_print
-    print('[${record.level.name}] ${record.time}: ${record.message}');
+    stdout.writeln('[${record.level.name}] ${record.time}: ${record.message}');
   });
 
   // TEST CONFIGURATION - Update this list with your files and combinations

--- a/mobile/apps/photos/lib/core/error-reporting/isolate_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/isolate_logging.dart
@@ -57,6 +57,8 @@ class IsolateLogger {
   final Queue<IsolateLogString> fileQueueEntries = Queue();
 
   Future onLogRecordInIsolate(LogRecord rec) async {
+    if (!SuperLogging.shouldLogRecord(rec)) return;
+
     final str = rec.toPrettyString(null, true);
 
     // write to stdout

--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -167,6 +167,11 @@ class SuperLogging {
   /// The logger for SuperLogging
   static final $ = Logger('ente_logging');
 
+  static const _rootLogLevelDefine = String.fromEnvironment('ENTE_LOG_LEVEL');
+  static const _loggerPrefixDefine = String.fromEnvironment(
+    'ENTE_LOGGER_PREFIX',
+  );
+
   /// The current super logging configuration
   static late LogConfig config;
 
@@ -203,7 +208,7 @@ class SuperLogging {
       setupSentry().ignore();
     }
 
-    Logger.root.level = kDebugMode ? Level.ALL : Level.INFO;
+    Logger.root.level = rootLoggerLevel;
     Logger.root.onRecord.listen(onLogRecord);
 
     if (_preferences.getBool("enable_db_logging") ?? kDebugMode) {
@@ -408,7 +413,37 @@ class SuperLogging {
 
   static String _lastExtraLines = '';
 
+  static Level get rootLoggerLevel =>
+      _levelFromName(_rootLogLevelDefine) ??
+      (kDebugMode ? Level.ALL : Level.INFO);
+
+  static String get loggerPrefixFilter => _loggerPrefixDefine.trim();
+
+  static bool shouldLogRecord(LogRecord rec) {
+    final prefix = loggerPrefixFilter;
+    return prefix.isEmpty || rec.loggerName.startsWith(prefix);
+  }
+
+  static Level? _levelFromName(String name) {
+    return switch (name.trim().toUpperCase()) {
+      '' => null,
+      'ALL' => Level.ALL,
+      'SHOUT' => Level.SHOUT,
+      'SEVERE' || 'ERROR' => Level.SEVERE,
+      'WARNING' || 'WARN' => Level.WARNING,
+      'INFO' => Level.INFO,
+      'CONFIG' => Level.CONFIG,
+      'FINE' || 'DEBUG' => Level.FINE,
+      'FINER' => Level.FINER,
+      'FINEST' || 'TRACE' => Level.FINEST,
+      'OFF' => Level.OFF,
+      _ => null,
+    };
+  }
+
   static Future onLogRecord(LogRecord rec) async {
+    if (!shouldLogRecord(rec)) return;
+
     // log misc info if it changed
     String? extraLines = "app version: '$appVersion'\n";
     if (extraLines != _lastExtraLines) {

--- a/mobile/apps/photos/lib/db/common/base.dart
+++ b/mobile/apps/photos/lib/db/common/base.dart
@@ -1,7 +1,8 @@
-import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
 import "package:sqlite_async/sqlite_async.dart";
 
 mixin SqlDbBase {
+  static final Logger _logger = Logger("SqlDbBase");
   static final Map<int, String> _params = <int, String>{};
 
   static String getParams(int count) {
@@ -20,7 +21,7 @@ mixin SqlDbBase {
     final toVersion = migrationScripts.length;
 
     if (currentVersion < toVersion) {
-      debugPrint(
+      _logger.info(
         "$runtimeType migrating database from $currentVersion to $toVersion",
       );
       await database.writeTransaction((tx) async {
@@ -28,7 +29,7 @@ mixin SqlDbBase {
           try {
             await tx.execute(migrationScripts[i - 1]);
           } catch (e) {
-            debugPrint(
+            _logger.warning(
               "$runtimeType Error running migration script index ${i - 1} $e",
             );
             rethrow;

--- a/mobile/apps/photos/lib/db/device_files_db.dart
+++ b/mobile/apps/photos/lib/db/device_files_db.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/db/files_db.dart';
@@ -21,7 +20,7 @@ extension DeviceFiles on FilesDB {
     Map<String, Set<String>> mappingToAdd, {
     ConflictAlgorithm conflictAlgorithm = ConflictAlgorithm.ignore,
   }) async {
-    debugPrint("Inserting missing PathIDToLocalIDMapping");
+    _logger.info("Inserting missing PathIDToLocalIDMapping");
     final parameterSets = <List<Object?>>[];
     int batchCounter = 0;
     for (MapEntry e in mappingToAdd.entries) {
@@ -45,7 +44,7 @@ extension DeviceFiles on FilesDB {
   Future<void> deletePathIDToLocalIDMapping(
     Map<String, Set<String>> mappingsToRemove,
   ) async {
-    debugPrint("removing PathIDToLocalIDMapping");
+    _logger.info("removing PathIDToLocalIDMapping");
     final parameterSets = <List<Object?>>[];
     int batchCounter = 0;
     for (MapEntry e in mappingsToRemove.entries) {
@@ -404,7 +403,7 @@ extension DeviceFiles on FilesDB {
   Future<List<DeviceCollection>> getDeviceCollections({
     bool includeCoverThumbnail = false,
   }) async {
-    debugPrint(
+    _logger.info(
       "Fetching DeviceCollections From DB with thumbnail = "
       "$includeCoverThumbnail",
     );
@@ -466,7 +465,7 @@ extension DeviceFiles on FilesDB {
   }
 
   Future<EnteFile?> getDeviceCollectionThumbnail(String pathID) async {
-    debugPrint("Call fallback method to get potential thumbnail");
+    _logger.info("Call fallback method to get potential thumbnail");
     final db = await sqliteAsyncDB;
     final fileRows = await db.getAll(
       '''SELECT * FROM FILES  f JOIN device_files df on f.local_id = df.id

--- a/mobile/apps/photos/lib/db/entities_db.dart
+++ b/mobile/apps/photos/lib/db/entities_db.dart
@@ -1,15 +1,17 @@
-import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
 import 'package:photos/db/files_db.dart';
 import "package:photos/gateways/entity/models/type.dart";
 import "package:photos/models/local_entity_data.dart";
 import 'package:sqflite/sqlite_api.dart';
 
 extension EntitiesDB on FilesDB {
+  static final Logger _logger = Logger("EntitiesDB");
+
   Future<void> upsertEntities(
     List<LocalEntityData> data, {
     ConflictAlgorithm conflictAlgorithm = ConflictAlgorithm.replace,
   }) async {
-    debugPrint("entitiesDB: upsertEntities ${data.length} entities");
+    _logger.info("entitiesDB: upsertEntities ${data.length} entities");
     final db = await sqliteAsyncDB;
     final parameterSets = <List<Object?>>[];
     int batchCounter = 0;

--- a/mobile/apps/photos/lib/db/file_updation_db.dart
+++ b/mobile/apps/photos/lib/db/file_updation_db.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -66,7 +65,7 @@ class FileUpdationDB {
     final Directory documentsDirectory =
         await getApplicationDocumentsDirectory();
     final String path = join(documentsDirectory.path, _databaseName);
-    debugPrint("DB path " + path);
+    _logger.info("DB path $path");
     return await openDatabaseWithMigration(path, dbConfig);
   }
 

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -426,7 +426,7 @@ class FilesDB with SqlDbBase {
 
   Future<void> deleteDB() async {
     if (kDebugMode) {
-      debugPrint("Deleting files db");
+      _logger.info("Deleting files db");
       final Directory documentsDirectory =
           await getApplicationDocumentsDirectory();
       final String path = join(documentsDirectory.path, _databaseName);

--- a/mobile/apps/photos/lib/db/social_db.dart
+++ b/mobile/apps/photos/lib/db/social_db.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -123,7 +122,7 @@ class SocialDB {
     );
 
     if (rows.isEmpty) {
-      debugPrint('deleteComment: Comment $id does not exist');
+      _logger.info('deleteComment: Comment $id does not exist');
       return null;
     }
 

--- a/mobile/apps/photos/lib/models/collection/collection.dart
+++ b/mobile/apps/photos/lib/models/collection/collection.dart
@@ -1,12 +1,14 @@
 import 'dart:core';
 
-import 'package:flutter/foundation.dart';
+import "package:logging/logging.dart";
 import "package:photos/core/configuration.dart";
 import "package:photos/extensions/user_extension.dart";
 import "package:photos/gateways/collections/models/public_url.dart";
 import "package:photos/models/api/collection/user.dart";
 import "package:photos/models/metadata/collection_magic.dart";
 import "package:photos/models/metadata/common_keys.dart";
+
+final _logger = Logger("Collection");
 
 class Collection {
   final int id;
@@ -347,7 +349,7 @@ CollectionType typeFromString(String type) {
     case "unknown":
       return CollectionType.unknown;
   }
-  debugPrint("unexpected collection type $type");
+  _logger.warning("unexpected collection type $type");
   return CollectionType.unknown;
 }
 

--- a/mobile/apps/photos/lib/models/gallery_type.dart
+++ b/mobile/apps/photos/lib/models/gallery_type.dart
@@ -1,5 +1,7 @@
-import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
 import 'package:photos/models/collection/collection.dart';
+
+final _logger = Logger("GalleryType");
 
 enum GalleryType {
   homepage,
@@ -468,7 +470,7 @@ GalleryType getGalleryType(Collection c, int userID) {
   } else if (c.isHidden()) {
     return GalleryType.hiddenOwnedCollection;
   }
-  debugPrint(
+  _logger.info(
     "Unknown gallery type for collection ${c.id}, falling back to "
     "default",
   );

--- a/mobile/apps/photos/lib/models/metadata/file_magic.dart
+++ b/mobile/apps/photos/lib/models/metadata/file_magic.dart
@@ -1,6 +1,6 @@
 import "dart:convert";
 
-import "package:flutter/cupertino.dart";
+import "package:logging/logging.dart";
 import 'package:photos/models/metadata/common_keys.dart';
 
 const editTimeKey = 'editedTime';
@@ -46,6 +46,8 @@ class MagicMetadata {
 }
 
 class PubMagicMetadata {
+  static final Logger _logger = Logger("PubMagicMetadata");
+
   int? editedTime;
   String? editedName;
   String? caption;
@@ -140,7 +142,7 @@ class PubMagicMetadata {
     if (value == null) return null;
     if (value is int) return value;
     if (value is String) return int.tryParse(value);
-    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
+    _logger.warning("PubMagicMetadata key: $key Unexpected value: $value");
     return null;
   }
 
@@ -148,7 +150,7 @@ class PubMagicMetadata {
     if (value == null) return null;
     if (value is num) return value.toDouble();
     if (value is String) return double.tryParse(value);
-    debugPrint("PubMagicMetadata key: $key Unexpected value: $value");
+    _logger.warning("PubMagicMetadata key: $key Unexpected value: $value");
     return null;
   }
 }

--- a/mobile/apps/photos/lib/models/ml/face/person.dart
+++ b/mobile/apps/photos/lib/models/ml/face/person.dart
@@ -2,6 +2,7 @@
 // On the remote server, the PersonEntity is stored as {Entity} with type person.
 // On the device, this information is stored as [LocalEntityData] with type person.
 import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
 
 const Object _personDataUnchanged = Object();
 
@@ -34,6 +35,8 @@ class ClusterInfo {
 }
 
 class PersonData {
+  static final Logger _logger = Logger("PersonData");
+
   final String name;
 
   /// Used to mark a person to not show in the people section.
@@ -124,7 +127,7 @@ class PersonData {
     for (var cluster in assigned) {
       sb.writeln('Cluster: ${cluster.id} - ${cluster.faces.length}');
     }
-    debugPrint(sb.toString());
+    _logger.info(sb.toString());
   }
 
   // toJson

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -394,7 +394,7 @@ class CollectionsService {
       return Future.value(_coverCache[coverKey]!);
     }
     if (kDebugMode) {
-      debugPrint("getCover for collection ${c.id} ${c.displayName}");
+      _logger.info("getCover for collection ${c.id} ${c.displayName}");
     }
     if (c.hasCover) {
       final coverID = c.pubMagicMetadata.coverID ?? 0;
@@ -963,7 +963,7 @@ class CollectionsService {
       }
     } on DioException catch (e) {
       if (e.response != null) {
-        debugPrint("Error " + e.response!.toString());
+        _logger.warning("Error ${e.response}");
       }
       rethrow;
     } catch (e) {
@@ -1119,7 +1119,7 @@ class CollectionsService {
     if (_cachedKeys.containsKey(collection.id)) {
       return _cachedKeys[collection.id]!;
     }
-    debugPrint(
+    _logger.info(
       "Compute collection decryption key for ${collection.id} source"
       " $source",
     );
@@ -2530,10 +2530,12 @@ class CollectionsService {
   String _decryptCollectionPath(Collection collection) {
     if (collection.decryptedPath != null &&
         collection.decryptedPath!.isNotEmpty) {
-      debugPrint("Using cached decrypted path for collection ${collection.id}");
+      _logger.info(
+        "Using cached decrypted path for collection ${collection.id}",
+      );
       return collection.decryptedPath!;
     } else {
-      debugPrint(
+      _logger.info(
         "Decrypting path for collection ${collection.id} from "
         "encryptedPath",
       );

--- a/mobile/apps/photos/lib/services/entity_service.dart
+++ b/mobile/apps/photos/lib/services/entity_service.dart
@@ -26,7 +26,7 @@ class EntityService {
   late final FilesDB _db = FilesDB.instance;
 
   EntityService(this._prefs, this._gateway) {
-    debugPrint("EntityService constructor");
+    _logger.info("EntityService constructor");
   }
 
   String _getEntityKeyPrefix(EntityType type) {
@@ -80,7 +80,7 @@ class EntityService {
       encryptedData = CryptoUtil.bin2base64(encryptedKeyData.encryptedData!);
       header = CryptoUtil.bin2base64(encryptedKeyData.header!);
     }
-    debugPrint(
+    _logger.info(
       " ${id == null ? 'Adding' : 'Updating'} entity of type: " + type.name,
     );
 

--- a/mobile/apps/photos/lib/services/favorites_service.dart
+++ b/mobile/apps/photos/lib/services/favorites_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:ente_crypto/ente_crypto.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/files_db.dart';
@@ -18,6 +19,8 @@ import 'package:photos/services/sync/remote_sync_service.dart';
 import 'package:photos/ui/actions/collection/collection_sharing_actions.dart';
 
 class FavoritesService {
+  final _logger = Logger("FavoritesService");
+
   late Configuration _config;
 
   late CollectionsService _collectionsService;
@@ -88,7 +91,9 @@ class FavoritesService {
     if (file.collectionID != null &&
         _cachedFavoritesCollectionID != null &&
         file.collectionID == _cachedFavoritesCollectionID) {
-      debugPrint("File ${file.uploadedFileID} is part of favorite collection");
+      _logger.info(
+        "File ${file.uploadedFileID} is part of favorite collection",
+      );
       return true;
     }
     if (checkOnlyAlbum) {

--- a/mobile/apps/photos/lib/services/location_service.dart
+++ b/mobile/apps/photos/lib/services/location_service.dart
@@ -43,7 +43,7 @@ class LocationService {
   List<BaseLocation> baseLocations = [];
 
   LocationService(this.prefs) {
-    debugPrint('LocationService constructor');
+    _logger.info('LocationService constructor');
     Future.delayed(const Duration(seconds: 3), () {
       _loadCities();
     });

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
@@ -2100,7 +2100,7 @@ class ClusterFeedbackService<T> {
     bool onlySortBigSuggestions = true,
   }) async {
     if (suggestions.isEmpty) {
-      debugPrint('No suggestions to sort');
+      _logger.info('No suggestions to sort');
       return;
     }
     if (onlySortBigSuggestions) {
@@ -2110,7 +2110,7 @@ class ClusterFeedbackService<T> {
           )
           .toList();
       if (bigSuggestions.isEmpty) {
-        debugPrint('No big suggestions to sort');
+        _logger.info('No big suggestions to sort');
         return;
       }
     }
@@ -2173,7 +2173,7 @@ class ClusterFeedbackService<T> {
       });
       w?.log('sorted files for cluster $clusterID');
 
-      debugPrint(
+      _logger.info(
         "[${_logger.name}] Sorted suggestions for cluster $clusterID based on distance to person: ${suggestion.filesInCluster.map((e) => fileIdToDistanceMap[e.uploadedFileID]).toList()}",
       );
     }

--- a/mobile/apps/photos/lib/services/machine_learning/ml_indexing_isolate.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_indexing_isolate.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 import "dart:io" show Platform;
 
-import "package:flutter/foundation.dart" show debugPrint, kDebugMode;
+import "package:flutter/foundation.dart" show kDebugMode;
 import "package:logging/logging.dart";
 import "package:photos/service_locator.dart"
     show flagService, isLocalGalleryMode, localSettings;
@@ -121,7 +121,7 @@ class MLIndexingIsolate extends SuperIsolate {
         s,
       );
       if (kDebugMode) {
-        debugPrint(
+        _logger.info(
           "This image with fileID ${instruction.fileKey} has name ${instruction.file.displayName}.",
         );
       }

--- a/mobile/apps/photos/lib/services/remote_assets_service.dart
+++ b/mobile/apps/photos/lib/services/remote_assets_service.dart
@@ -630,7 +630,7 @@ class RemoteAssetsService {
       final boundedReceived = received > total ? total : received;
       _progressController.add((url, boundedReceived, total));
     } else if (kDebugMode) {
-      debugPrint("$url Received: $received, Total: $total");
+      _logger.info("$url Received: $received, Total: $total");
     }
   }
 

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -1083,7 +1083,7 @@ class SearchService {
         if (showIgnoredOnly) {
           return [];
         }
-        debugPrint("getting faces (localGallery)");
+        _logger.info("getting faces (localGallery)");
         final localGalleryMlDb = MLDataDB.localGalleryInstance;
         final Map<int, Set<String>> fileIdToClusterID = await localGalleryMlDb
             .getFileIdToClusterIds();
@@ -1165,7 +1165,7 @@ class SearchService {
         }
         return facesResult;
       }
-      debugPrint("getting faces");
+      _logger.info("getting faces");
       final Map<int, Set<String>> fileIdToClusterID = await mlDataDB
           .getFileIdToClusterIds();
       final Map<String, PersonEntity> personIdToPerson = await PersonService

--- a/mobile/apps/photos/lib/services/storage_bonus_service.dart
+++ b/mobile/apps/photos/lib/services/storage_bonus_service.dart
@@ -1,10 +1,12 @@
 import "package:dio/dio.dart";
-import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
 import "package:photos/gateways/storage_bonus/models/storage_bonus.dart";
 import "package:photos/gateways/storage_bonus/storage_bonus_gateway.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
 class StorageBonusService {
+  final _logger = Logger("StorageBonusService");
+
   final StorageBonusGateway gateway;
   final SharedPreferences prefs;
 
@@ -13,7 +15,7 @@ class StorageBonusService {
 
   StorageBonusService(this.prefs, Dio enteDio)
     : gateway = StorageBonusGateway(enteDio) {
-    debugPrint("StorageBonusService constructor");
+    _logger.info("StorageBonusService constructor");
   }
 
   // returns true if _showStorageBonusTapCount value is less than minTapCountBeforeHidingBanner

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -243,7 +243,7 @@ class LocalSyncService {
         "un-synced files",
       );
     }
-    debugPrint(
+    _logger.info(
       "syncAll: mappingChange : $hasAnyMappingChanged, "
       "unSyncedFiles: $hasUnsyncedFiles",
     );

--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -466,7 +466,7 @@ class RemoteSyncService {
         existingMapping,
       );
       if (commonElements.isNotEmpty) {
-        debugPrint(
+        _logger.info(
           "${commonElements.length} files already existing in "
           "collection $collectionID for ${deviceCollection.name}",
         );
@@ -477,7 +477,7 @@ class RemoteSyncService {
       // new file entries, where we can store mapping for localID and
       // corresponding collection ID
       if (localIDsToSync.isNotEmpty) {
-        debugPrint(
+        _logger.info(
           'Adding new entries for ${localIDsToSync.length} files'
           ' for ${deviceCollection.name}',
         );

--- a/mobile/apps/photos/lib/services/update_service.dart
+++ b/mobile/apps/photos/lib/services/update_service.dart
@@ -28,7 +28,7 @@ class UpdateService {
   UpdateService(SharedPreferences prefs, PackageInfo packageInfo)
     : _prefs = prefs,
       _packageInfo = packageInfo {
-    debugPrint("UpdateService constructor");
+    _logger.info("UpdateService constructor");
   }
 
   Future<bool> shouldShowChangeLog() async {

--- a/mobile/apps/photos/lib/ui/account/passkey_page.dart
+++ b/mobile/apps/photos/lib/ui/account/passkey_page.dart
@@ -196,8 +196,8 @@ class _PasskeyPageState extends State<PasskeyPage> {
               onTap: () async {
                 try {
                   await checkStatus();
-                } catch (e) {
-                  debugPrint('failed to check status $e');
+                } catch (e, s) {
+                  _logger.warning('failed to check status', e, s);
                   showGenericErrorBottomSheet(
                     context: context,
                     error: e,

--- a/mobile/apps/photos/lib/ui/collections/album/horizontal_list.dart
+++ b/mobile/apps/photos/lib/ui/collections/album/horizontal_list.dart
@@ -65,7 +65,7 @@ class _AlbumHorizontalListState extends State<AlbumHorizontalList> {
     final sideOfThumbnail =
         (screenWidth - totalHorizontalPadding - horizontalPadding) /
         albumsCountInRow;
-    debugPrint('$runtimeType widget build');
+    _logger.info('$runtimeType widget build');
     return FutureBuilder<List<Collection>>(
       future: widget.collectionsFuture(),
       builder: (context, snapshot) {

--- a/mobile/apps/photos/lib/ui/common/progress_dialog.dart
+++ b/mobile/apps/photos/lib/ui/common/progress_dialog.dart
@@ -1,8 +1,11 @@
 import "dart:async";
 
 import 'package:flutter/material.dart';
+import "package:logging/logging.dart";
 
 enum ProgressDialogType { normal, download }
+
+final _logger = Logger("ProgressDialog");
 
 String _dialogMessage = "Loading...";
 double _progress = 0.0, _maxProgress = 100.0;
@@ -136,15 +139,14 @@ class ProgressDialog {
           Navigator.of(_dismissingContext!).pop();
         }
         _dialog = null;
-        if (_showLogs) debugPrint('ProgressDialog dismissed');
+        if (_showLogs) _logger.info('ProgressDialog dismissed');
         return Future.value(true);
       } else {
-        if (_showLogs) debugPrint('ProgressDialog already dismissed');
+        if (_showLogs) _logger.info('ProgressDialog already dismissed');
         return Future.value(false);
       }
-    } catch (err) {
-      debugPrint('Seems there is an issue hiding dialog');
-      debugPrint(err.toString());
+    } catch (err, stackTrace) {
+      _logger.warning('Seems there is an issue hiding dialog', err, stackTrace);
       return Future.value(false);
     }
   }
@@ -183,17 +185,16 @@ class ProgressDialog {
         // Delaying the function for 200 milliseconds
         // [Default transitionDuration of DialogRoute]
         await Future.delayed(const Duration(milliseconds: 200));
-        if (_showLogs) debugPrint('ProgressDialog shown');
+        if (_showLogs) _logger.info('ProgressDialog shown');
         return true;
       } else {
-        if (_showLogs) debugPrint("ProgressDialog already shown/showing");
+        if (_showLogs) _logger.info("ProgressDialog already shown/showing");
         return false;
       }
-    } catch (err) {
+    } catch (err, stackTrace) {
       _isShowing = false;
       _dialog = null;
-      debugPrint('Exception while showing the dialog');
-      debugPrint(err.toString());
+      _logger.warning('Exception while showing the dialog', err, stackTrace);
       return false;
     }
   }
@@ -222,7 +223,7 @@ class _BodyState extends State<_Body> {
   @override
   void dispose() {
     _isShowing = false;
-    if (_showLogs) debugPrint('ProgressDialog dismissed by back button');
+    if (_showLogs) _logger.info('ProgressDialog dismissed by back button');
     super.dispose();
   }
 

--- a/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/home/home_bottom_nav_bar.dart
@@ -6,6 +6,7 @@ import 'package:ente_components/theme/spacing.dart';
 import 'package:ente_components/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import "package:logging/logging.dart";
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/tab_changed_event.dart';
 import "package:photos/models/selected_albums.dart";
@@ -34,6 +35,8 @@ class HomeBottomNavigationBar extends StatefulWidget {
 }
 
 class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
+  final _logger = Logger("_HomeBottomNavigationBarState");
+
   static const int _searchTabIndex = 3;
   static const Duration _doubleTapWindow = Duration(milliseconds: 350);
   late StreamSubscription<TabChangedEvent> _tabChangedEventSubscription;
@@ -51,7 +54,7 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
       event,
     ) {
       if (event.source != TabChangedEventSource.tabBar) {
-        debugPrint(
+        _logger.info(
           '${(TabChangedEvent).toString()} index changed  from '
           '$currentTabIndex to ${event.selectedIndex} via ${event.source}',
         );
@@ -92,7 +95,7 @@ class _HomeBottomNavigationBarState extends State<HomeBottomNavigationBar> {
     if (mode == "OnPressed") {
       _handleSearchTabDoubleTap(index);
     }
-    debugPrint("_TabChanged called via method $mode");
+    _logger.info("_TabChanged called via method $mode");
     Bus.instance.fire(TabChangedEvent(index, TabChangedEventSource.tabBar));
   }
 

--- a/mobile/apps/photos/lib/ui/map/map_screen.dart
+++ b/mobile/apps/photos/lib/ui/map/map_screen.dart
@@ -116,7 +116,7 @@ class _MapScreenState extends State<MapScreen> {
         );
 
     if (kDebugMode) {
-      debugPrint(
+      _logger.info(
         "Info for map: center $center, initialZoom ${widget.initialZoom}",
       );
     }

--- a/mobile/apps/photos/lib/ui/settings/pending_sync/path_info_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/settings/pending_sync/path_info_storage_viewer.dart
@@ -114,7 +114,7 @@ class _PathInfoStorageViewerState extends State<PathInfoStorageViewer> {
       onTap: () async {
         if (kDebugMode) {
           await Clipboard.setData(ClipboardData(text: widget.item.path));
-          debugPrint(widget.item.path);
+          _logger.info(widget.item.path);
         }
       },
       onDoubleTap: () async {

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -185,7 +185,7 @@ class _HomeWidgetState extends State<HomeWidget> {
         isOnSearchTabNotifier.value = false;
       }
       if (event.source != TabChangedEventSource.pageView) {
-        debugPrint(
+        _logger.info(
           "TabChange going from $previousTabIndex to ${event.selectedIndex} source: ${event.source}",
         );
         if (_pageController.hasClients) {
@@ -1273,7 +1273,7 @@ class _HomeWidgetState extends State<HomeWidget> {
     if (!mounted) return;
     final String? payload = notificationResponse.payload;
     if (payload != null) {
-      debugPrint('notification payload: $payload');
+      _logger.info('notification payload: $payload');
       final uri = Uri.tryParse(payload);
       if (uri != null &&
           (uri.host.toLowerCase() == "ritual" ||

--- a/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
+++ b/mobile/apps/photos/lib/ui/tabs/nav_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import "package:logging/logging.dart";
 import "package:photos/theme/effects.dart";
 
 class GNav extends StatefulWidget {
@@ -65,6 +66,8 @@ class GNav extends StatefulWidget {
 }
 
 class _GNavState extends State<GNav> {
+  final _logger = Logger("_GNavState");
+
   int? selectedIndex;
   bool clickable = true;
 
@@ -75,7 +78,7 @@ class _GNavState extends State<GNav> {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint(
+    _logger.info(
       '${(_GNavState).toString()} - build with index ${widget.selectedIndex}',
     );
     selectedIndex = widget.selectedIndex;

--- a/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
@@ -131,7 +131,7 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint("$runtimeType building");
+    _logger.info("$runtimeType building");
 
     return Scaffold(
       body: CustomScrollView(

--- a/mobile/apps/photos/lib/ui/tools/debug/path_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/path_storage_viewer.dart
@@ -121,7 +121,7 @@ class _PathStorageViewerState extends State<PathStorageViewer> {
       onTap: () async {
         if (kDebugMode) {
           await Clipboard.setData(ClipboardData(text: widget.item.path));
-          debugPrint(widget.item.path);
+          _logger.info(widget.item.path);
         }
       },
       onDoubleTap: () async {

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -70,7 +70,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     );
     await dialog.show();
 
-    debugPrint("Image saved with size: ${bytes.length} bytes");
+    _logger.info("Image saved with size: ${bytes.length} bytes");
     final DateTime start = DateTime.now();
     bool hasStoppedChangeNotify = false;
 

--- a/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
@@ -284,7 +284,7 @@ class _AlbumSelectionActionWidgetState
         nonEmptyCollection,
       );
       if (result == false) {
-        debugPrint("Failed to delete collection");
+        _logger.warning("Failed to delete collection");
       }
     }
     if (hasFavorites) {

--- a/mobile/apps/photos/lib/ui/viewer/actions/delete_empty_albums.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/delete_empty_albums.dart
@@ -1,5 +1,6 @@
 import "package:ente_components/ente_components.dart";
 import 'package:flutter/material.dart';
+import "package:logging/logging.dart";
 import 'package:photos/core/event_bus.dart';
 import "package:photos/db/files_db.dart";
 import 'package:photos/events/collection_updated_event.dart';
@@ -23,6 +24,8 @@ class DeleteEmptyAlbums extends StatefulWidget {
 }
 
 class _DeleteEmptyAlbumsState extends State<DeleteEmptyAlbums> {
+  final _logger = Logger("_DeleteEmptyAlbumsState");
+
   final ValueNotifier<String> _deleteProgress = ValueNotifier("");
   bool _isCancelled = false;
 
@@ -133,7 +136,7 @@ class _DeleteEmptyAlbumsState extends State<DeleteEmptyAlbums> {
       }
     }
     if (failedCount > 0) {
-      debugPrint("Delete ops failed for $failedCount collections");
+      _logger.warning("Delete ops failed for $failedCount collections");
     }
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "package:ente_components/ente_components.dart" as components;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import "package:logging/logging.dart";
 import "package:photos/generated/l10n.dart";
 import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/gallery_type.dart';
@@ -45,6 +46,8 @@ class FileSelectionOverlayBar extends StatefulWidget {
 
 class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar>
     with BoundaryReporter {
+  final _logger = Logger("_FileSelectionOverlayBarState");
+
   final ValueNotifier<bool> _hasSelectedFilesNotifier = ValueNotifier(false);
   late GalleryType _galleryType;
   SearchFilterDataProvider? _searchFilterDataProvider;
@@ -106,7 +109,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar>
 
   @override
   Widget build(BuildContext context) {
-    debugPrint(
+    _logger.info(
       '$runtimeType building with ${widget.selectedFiles.files.length}',
     );
 

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -419,7 +419,7 @@ class _BodyState extends State<_Body> {
       onPageChanged: (index) {
         if (_selectedIndexNotifier.value == index) {
           if (kDebugMode) {
-            debugPrint("onPageChanged called with same index $index");
+            _logger.info("onPageChanged called with same index $index");
           }
           // always notify listeners when the index is the same because
           // the total number of files might have changed

--- a/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_bottom_bar.dart
@@ -491,9 +491,13 @@ class FileBottomBarState extends State<FileBottomBar> {
               fileID: fileID,
             );
           }
-        } catch (e) {
+        } catch (e, s) {
           failedCount++;
-          debugPrint("Failed to unlike from ${collection.displayName}: $e");
+          _logger.warning(
+            "Failed to unlike from ${collection.displayName}",
+            e,
+            s,
+          );
         }
       }
 
@@ -503,9 +507,9 @@ class FileBottomBarState extends State<FileBottomBar> {
         safeRefresh();
         showShortToast(context, "Failed to unlike photo");
       }
-    } catch (e) {
+    } catch (e, s) {
       // Rollback on error (e.g., fetching collections failed)
-      debugPrint("Failed to unlike from all collections: $e");
+      _logger.warning("Failed to unlike from all collections", e, s);
       if (mounted) {
         _hasLiked = previousState;
         safeRefresh();

--- a/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
@@ -77,7 +77,7 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
 
   @override
   void initState() {
-    debugPrint('file_details_sheet initState');
+    _logger.info('file_details_sheet initState');
     _currentUserID = Configuration.instance.getUserIDV2();
     hasLocationData.value = widget.file.hasLocation;
     _isImage =
@@ -412,7 +412,7 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
       final double roundedMegaPixels = (megaPixels * 10).round() / 10.0;
       _exifData['megaPixels'] = roundedMegaPixels..toStringAsFixed(1);
     } else {
-      debugPrint("No image width/height");
+      _logger.info("No image width/height");
     }
     if (exif["Image Make"] != null && exif["Image Model"] != null) {
       _exifData["takenOnDevice"] =

--- a/mobile/apps/photos/lib/ui/viewer/file/ocr/display_image_helper.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/ocr/display_image_helper.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import "package:logging/logging.dart";
 
 /// Internal helper that asks the native side to produce a Flutter-friendly
 /// image path for formats (e.g. HEIC) that some decoders can't render.
 class DisplayImageHelper {
   DisplayImageHelper._();
 
+  static final Logger _logger = Logger("DisplayImageHelper");
   static const MethodChannel _channel = MethodChannel('mobile_ocr');
   static final Map<String, String> _cache = <String, String>{};
   static final Map<String, Future<String>> _inFlight =
@@ -39,8 +41,7 @@ class DisplayImageHelper {
       _cache[imagePath] = result;
       return result;
     } catch (error, stack) {
-      debugPrint('Failed to normalize image $imagePath: $error');
-      debugPrintStack(stackTrace: stack);
+      _logger.warning('Failed to normalize image $imagePath', error, stack);
       return imagePath;
     } finally {
       final _ = _inFlight.remove(imagePath);

--- a/mobile/apps/photos/lib/ui/viewer/file/ocr/text_detector_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/ocr/text_detector_widget.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import "package:logging/logging.dart";
 import 'package:mobile_ocr/mobile_ocr_plugin.dart';
 import 'package:mobile_ocr/models/text_block.dart';
 import 'package:photos/ui/viewer/file/ocr/display_image_helper.dart';
@@ -205,6 +206,8 @@ class TextDetectorWidget extends StatefulWidget {
 }
 
 class _TextDetectorWidgetState extends State<TextDetectorWidget> {
+  final _logger = Logger("_TextDetectorWidgetState");
+
   final MobileOcr _ocr = MobileOcr();
   final TextOverlayController _textOverlayController = TextOverlayController();
   List<TextBlock>? _detectedTextBlocks;
@@ -295,8 +298,12 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
       if (widget.autoDetect || widget.initialInteractionPosition != null) {
         unawaited(_detectText());
       }
-    } catch (error) {
-      debugPrint('Failed to prepare image $requestedPath: $error');
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Failed to prepare image $requestedPath',
+        error,
+        stackTrace,
+      );
       if (!mounted || widget.imagePath != requestedPath) {
         return;
       }
@@ -353,7 +360,7 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
           } else {
             _errorMessage = widget.strings.modelsPrepareFailed;
           }
-          debugPrint('Model preparation error: $error');
+          _logger.warning('Model preparation error', error);
         })
         .whenComplete(() {
           _modelPreparation = null;
@@ -420,8 +427,8 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
           _textOverlayController.selectTextAtPosition(pendingPos);
         }
       }
-    } catch (e) {
-      debugPrint('Error detecting text: $e');
+    } catch (e, stackTrace) {
+      _logger.warning('Error detecting text', e, stackTrace);
       if (mounted && widget.imagePath == requestedPath) {
         setState(() {
           // Show user-friendly message based on error type

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -1055,7 +1055,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
       if (result == true) {
         Navigator.of(context).pop();
       } else {
-        debugPrint("No pop");
+        _logger.info("No pop");
       }
     }
   }

--- a/mobile/apps/photos/lib/ui/viewer/people/person_cluster_suggestion.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/person_cluster_suggestion.dart
@@ -374,7 +374,7 @@ class _PersonClustersState extends State<PersonReviewClusterSuggestion> {
 
   // Method to fetch cluster suggestions
   void _fetchClusterSuggestions() {
-    debugPrint("Fetching suggestions for ${widget.person.data.name}");
+    _logger.info("Fetching suggestions for ${widget.person.data.name}");
     futureClusterSuggestions = ClusterFeedbackService.instance
         .getSuggestionForPerson(widget.person);
   }
@@ -539,7 +539,9 @@ class _PersonClustersState extends State<PersonReviewClusterSuggestion> {
         );
         compCount += computeHere;
         if (compCount >= maxPrecomputations) {
-          debugPrint('Prefetching $compCount face thumbnails for suggestions');
+          _logger.info(
+            'Prefetching $compCount face thumbnails for suggestions',
+          );
           break outerLoop;
         }
       }

--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -74,7 +74,7 @@ class SearchWidgetState extends State<SearchWidget> {
     _tabDoubleTapEvent = Bus.instance.on<TabDoubleTapEvent>().listen((
       event,
     ) async {
-      debugPrint("Firing now ${event.selectedIndex}");
+      _logger.info("Firing now ${event.selectedIndex}");
       if (mounted && event.selectedIndex == 3) {
         focusNode.requestFocus();
       }

--- a/mobile/apps/photos/lib/utils/face/face_thumbnail_cache.dart
+++ b/mobile/apps/photos/lib/utils/face/face_thumbnail_cache.dart
@@ -289,7 +289,7 @@ Future<Uint8List?> precomputeClusterFaceCrop(
     );
     w?.log('getCoverFaceForPerson');
     if (face == null) {
-      debugPrint(
+      _logger.info(
         "No cover face for cluster $clusterID and recentFile ${file.uploadedFileID}",
       );
       return null;

--- a/mobile/apps/photos/lib/utils/file_download_util.dart
+++ b/mobile/apps/photos/lib/utils/file_download_util.dart
@@ -442,7 +442,7 @@ Future<void> _saveLivePhotoOnDroid(
   File video,
   EnteFile enteFile,
 ) async {
-  debugPrint("Downloading LivePhoto on Droid");
+  _logger.info("Downloading LivePhoto on Droid");
   final imageTitle = _getGallerySaveTitle(enteFile, image.path);
   AssetEntity? savedAsset =
       await (PhotoManager.editor.saveImageWithPath(

--- a/mobile/apps/photos/lib/utils/file_uploader.dart
+++ b/mobile/apps/photos/lib/utils/file_uploader.dart
@@ -196,7 +196,7 @@ class FileUploader {
       _totalCountInUploadSession--;
       return item.completer.future;
     }
-    debugPrint(
+    _logger.info(
       "Wait on another upload on same local ID to finish before "
       "adding it to new collection",
     );
@@ -644,7 +644,7 @@ class FileUploader {
         );
         final isMappedToExistingUpload = result.item1;
         if (isMappedToExistingUpload) {
-          debugPrint(
+          _logger.info(
             "File success mapped to existing uploaded ${file.toString()}",
           );
           // treat as completed so _onUploadDone clears the source export

--- a/mobile/apps/photos/lib/utils/file_util.dart
+++ b/mobile/apps/photos/lib/utils/file_util.dart
@@ -342,7 +342,7 @@ Future<_LivePhoto?> _downloadLivePhoto(
         if (imageFileCache != null && videoFileCache != null) {
           return _LivePhoto(imageFileCache, videoFileCache);
         } else {
-          debugPrint(
+          _logger.warning(
             "Warning: ${file.tag} either image ${imageFileCache == null} or video ${videoFileCache == null} is missing from remoteLive",
           );
           return null;

--- a/mobile/apps/photos/lib/utils/isolate/super_isolate.dart
+++ b/mobile/apps/photos/lib/utils/isolate/super_isolate.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:isolate';
 
 import "package:dart_ui_isolate/dart_ui_isolate.dart";
-import "package:flutter/foundation.dart" show kDebugMode;
 import "package:flutter/services.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/error-reporting/isolate_logging.dart";
+import "package:photos/core/error-reporting/super_logging.dart";
 import "package:photos/models/base/id.dart";
 import "package:photos/utils/isolate/isolate_operations.dart";
 import "package:synchronized/synchronized.dart";
@@ -72,7 +72,7 @@ abstract class SuperIsolate {
     final SendPort mainSendPort = args[0] as SendPort;
     final RootIsolateToken? rootToken = args[1] as RootIsolateToken?;
 
-    Logger.root.level = kDebugMode ? Level.ALL : Level.INFO;
+    Logger.root.level = SuperLogging.rootLoggerLevel;
     final IsolateLogger isolateLogger = IsolateLogger();
     Logger.root.onRecord.listen(isolateLogger.onLogRecordInIsolate);
     final receivePort = ReceivePort();

--- a/mobile/apps/photos/plugins/ente_cast/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_cast/lib/src/service.dart
@@ -1,13 +1,14 @@
 import "dart:async";
-import "dart:developer" as dev;
 import "dart:io";
 
 import "package:cast/cast.dart";
 import "package:ente_cast/src/model.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
+import "package:logging/logging.dart";
 
 class CastService {
+  final _logger = Logger("CastService");
   final String _appId = "F5BCEC64";
   final String _pairRequestNamespace = "urn:x-cast:pair-request";
 
@@ -39,30 +40,27 @@ class CastService {
 
     session.messageStream.listen((message) {
       if (message["type"] == "RECEIVER_STATUS") {
-        dev.log(
-          "got RECEIVER_STATUS, Send request to pair",
-          name: "CastService",
-        );
+        _logger.info("got RECEIVER_STATUS, Send request to pair");
         session.sendMessage(_pairRequestNamespace, {
           "collectionID": collectionID,
         });
       } else if (onMessage != null && message.containsKey("code")) {
         onMessage({CastMessageType.pairCode: message});
       } else if (kDebugMode) {
-        print("receive message: $message");
+        _logger.info("receive message: $message");
       }
     });
 
     session.stateStream.listen((state) {
       if (state == CastSessionState.connected) {
-        debugPrint("Send request to pair");
+        _logger.info("Send request to pair");
         session.sendMessage(_pairRequestNamespace, {});
       } else if (state == CastSessionState.closed) {
-        dev.log("Session closed", name: "CastService");
+        _logger.info("Session closed");
       }
     });
 
-    debugPrint("Send request to launch");
+    _logger.info("Send request to launch");
     session.sendMessage(CastSession.kNamespaceReceiver, {
       "type": "LAUNCH",
       "appId": _appId,
@@ -76,7 +74,7 @@ class CastService {
 
     final sessions = CastSessionManager().sessions;
     for (final session in sessions) {
-      debugPrint("send close message for ${session.sessionId}");
+      _logger.info("send close message for ${session.sessionId}");
       unawaited(
         Future(() {
           session.sendMessage(CastSession.kNamespaceConnection, {
@@ -85,11 +83,11 @@ class CastService {
         }).timeout(
           const Duration(seconds: 5),
           onTimeout: () {
-            debugPrint("sendMessage timed out after 5 seconds");
+            _logger.warning("sendMessage timed out after 5 seconds");
           },
         ),
       );
-      debugPrint("close session ${session.sessionId}");
+      _logger.info("close session ${session.sessionId}");
       unawaited(session.close());
     }
     CastSessionManager().sessions.clear();

--- a/mobile/apps/photos/plugins/ente_cast/pubspec.yaml
+++ b/mobile/apps/photos/plugins/ente_cast/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   dio: 5.9.2
   flutter:
     sdk: flutter
+  logging: 1.3.0
 
 dev_dependencies:
   flutter_lints: 6.0.0

--- a/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
+++ b/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
@@ -8,7 +8,6 @@ import "package:crypto/crypto.dart";
 import "package:ente_crypto/src/models/derived_key_result.dart";
 import "package:ente_crypto/src/models/encryption_result.dart";
 import "package:ente_crypto/src/models/errors.dart";
-import "package:flutter/foundation.dart";
 import "package:flutter_sodium/flutter_sodium.dart";
 import "package:logging/logging.dart";
 
@@ -409,7 +408,7 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
     final partsInfo = multiPartChunkSizeInBytes != null
         ? " Parts: ${partMd5s.length}"
         : "";
-    debugPrint(
+    logger.info(
       "FileEncryption: Time: ${encryptionTimeSeconds}s "
       "Total encrypted: $totalEncryptedBytes bytes$partsInfo",
     );

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -2,16 +2,18 @@
 
 import "dart:async";
 import "dart:convert";
-import "dart:developer";
 import "dart:io";
 
 import "package:dio/dio.dart";
 import "package:flutter/foundation.dart";
+import "package:logging/logging.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
 import "model.dart";
 
 class FlagService {
+  final _logger = Logger("FlagService");
+
   static const int _commentsFlag = 1 << 1;
   static const int _videoStreamingFlag = 1 << 3;
   static const int _castSessionsV2Flag = 1 << 5;
@@ -39,8 +41,8 @@ class FlagService {
         jsonDecode(_prefs.getString("remote_flags") ?? "{}"),
       );
       return _flags!;
-    } catch (e) {
-      debugPrint("Failed to get feature flags $e");
+    } catch (e, s) {
+      _logger.warning("Failed to get feature flags", e, s);
       return RemoteFlags.defaultValue;
     }
   }
@@ -130,8 +132,8 @@ class FlagService {
   Future<void> tryRefreshFlags() async {
     try {
       await _fetch();
-    } catch (e) {
-      debugPrint("Failed to refresh flags: $e");
+    } catch (e, s) {
+      _logger.warning("Failed to refresh flags", e, s);
     }
   }
 
@@ -157,7 +159,7 @@ class FlagService {
   Completer<void>? _fetchCompleter;
   Future<void> _fetch() async {
     if (!_prefs.containsKey("token")) {
-      log("token not found, skip", name: "FlagService");
+      _logger.info("token not found, skip");
       return;
     }
     if (_fetchCompleter != null) {
@@ -166,13 +168,13 @@ class FlagService {
     }
     _fetchCompleter = Completer<void>();
     try {
-      log("fetching feature flags", name: "FlagService");
+      _logger.info("fetching feature flags");
       final response = await _enteDio.get("/remote-store/feature-flags");
       final remoteFlags = RemoteFlags.fromMap(response.data);
       await _prefs.setString("remote_flags", remoteFlags.toJson());
       _flags = remoteFlags;
-    } catch (e) {
-      debugPrint("Failed to sync feature flags $e");
+    } catch (e, s) {
+      _logger.warning("Failed to sync feature flags", e, s);
     } finally {
       _fetchCompleter?.complete();
       _fetchCompleter = null;
@@ -188,8 +190,8 @@ class FlagService {
       if (response.statusCode != HttpStatus.ok) {
         throw Exception("Unexpected state");
       }
-    } catch (e) {
-      debugPrint("Failed to set flag for $key $e");
+    } catch (e, s) {
+      _logger.warning("Failed to set flag for $key", e, s);
       rethrow;
     }
   }

--- a/mobile/apps/photos/plugins/ente_feature_flag/pubspec.yaml
+++ b/mobile/apps/photos/plugins/ente_feature_flag/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   dio: 5.9.2
   flutter:
     sdk: flutter
+  logging: 1.3.0
   shared_preferences: 2.5.3
 
 dev_dependencies:

--- a/mobile/apps/photos/rust_builder/cargokit/build_tool/lib/src/build_tool.dart
+++ b/mobile/apps/photos/rust_builder/cargokit/build_tool/lib/src/build_tool.dart
@@ -81,6 +81,8 @@ class BuildCMakeCommand extends BuildCommand {
 }
 
 class GenKeyCommand extends Command {
+  final _logger = Logger("GenKeyCommand");
+
   @override
   final name = 'gen-key';
 
@@ -92,8 +94,8 @@ class GenKeyCommand extends Command {
     final kp = generateKey();
     final private = HEX.encode(kp.privateKey.bytes);
     final public = HEX.encode(kp.publicKey.bytes);
-    print("Private Key: $private");
-    print("Public Key: $public");
+    _logger.info("Private Key: $private");
+    _logger.info("Public Key: $public");
   }
 }
 


### PR DESCRIPTION
## Summary

Adds two Dart defines for the mobile photos app logging setup:

- `ENTE_LOG_LEVEL` controls the root logger level while keeping the existing defaults when unset or invalid.
- `ENTE_LOGGER_PREFIX` filters log records by logger name prefix when provided.

The same level and prefix filter are also used for isolate logging so foreground and isolate logs follow the same gates.

## Validation

- `fvm flutter analyze lib/core/error-reporting/super_logging.dart lib/core/error-reporting/isolate_logging.dart lib/utils/isolate/super_isolate.dart`
- `git diff --check`