### PR TITLE
[mobile][photos] Skip duplicate background init after sync setup

### DIFF
--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -81,6 +81,7 @@ const kBGPushTimeout = Duration(seconds: 28);
 const kFGTaskDeathTimeoutInMicroseconds = 5000000;
 bool isProcessBg = true;
 bool _stopHearBeat = false;
+bool _isSyncInitialized = false;
 bool _isRustInitialized = false;
 Future<void>? _rustInitFuture;
 
@@ -310,6 +311,7 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     await LocalSyncService.instance.init(prefs);
     RemoteSyncService.instance.init(prefs);
     await SyncService.instance.init(prefs);
+    _isSyncInitialized = true;
 
     // Misc Services
     await UserService.instance.init();
@@ -487,6 +489,7 @@ Future<void> _init(
 
     _logger.info("SyncService init $tlog");
     await SyncService.instance.init(preferences);
+    _isSyncInitialized = true;
     _logger.info("SyncService init done $tlog");
 
     if (!isBackground && flagService.internalUser) {
@@ -684,7 +687,11 @@ Future<void> _handleBackgroundPush(Object message) async {
         DateTime.now().microsecondsSinceEpoch,
       );
 
-      await _init(true, via: 'firebasePush');
+      if (!_isSyncInitialized) {
+        await _init(true, via: 'firebasePush');
+      } else {
+        _logger.info("Skipping background init; sync already initialized");
+      }
       if (PushService.shouldSync(message)) {
         await _sync('firebaseBgSyncNoActiveProcess');
       }


### PR DESCRIPTION
Prevents Firebase background push from re-running completed Photos app initialization.