### PR TITLE
[mobile][photos] Handle missing video stream metadata

### DIFF
--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -49,6 +49,7 @@ import "package:photos/utils/network_util.dart";
 const _maxRetryCount = 3;
 const _maxFfmpegOutputLines = 24;
 const _maxFfmpegOutputChars = 4000;
+const _missingVideoStreamError = "No video stream found in FFprobe metadata";
 
 class VideoPreviewService {
   final _logger = Logger("VideoPreviewService");
@@ -499,11 +500,10 @@ class VideoPreviewService {
         props?.propData?["streams"] ?? [],
       ).firstWhereOrNull((e) => e["type"] == "video");
       if (videoData == null) {
-        _logger.warning(
-          "No video stream found in FFprobe metadata for "
-          "fileID=${enteFile.uploadedFileID}; skipping preview creation",
-        );
-        removeFile = true;
+        error =
+            "$_missingVideoStreamError for ${enteFile.displayName} "
+            "(fileID=${enteFile.uploadedFileID})";
+        _logger.warning("$error; skipping preview creation");
         return;
       }
 
@@ -789,6 +789,9 @@ class VideoPreviewService {
         "Network error detected, marking file as failed instead of retrying",
       );
       shouldRetry = false;
+    } else if (error is String && error.startsWith(_missingVideoStreamError)) {
+      shouldRetry = false;
+      uploadLocksDB.removeFromStreamQueue(enteFile.uploadedFileID!).ignore();
     }
 
     if (!_items.containsKey(enteFile.uploadedFileID!)) return;

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -495,22 +495,26 @@ class VideoPreviewService {
       props ??= await getVideoPropsAsync(file);
       final fileSize = enteFile.fileSize ?? file.lengthSync();
 
-      final videoData = _getVideoStream(props);
+      final videoData = List.from(
+        props?.propData?["streams"] ?? [],
+      ).firstWhereOrNull((e) => e["type"] == "video");
       if (videoData == null) {
         _logger.warning(
           "No video stream found in FFprobe metadata for "
-          "fileID=${enteFile.uploadedFileID}; trying ffmpeg with defaults",
+          "fileID=${enteFile.uploadedFileID}; skipping preview creation",
         );
+        removeFile = true;
+        return;
       }
 
-      final codec = videoData?["codec_name"]?.toString().toLowerCase();
+      final codec = videoData["codec_name"]?.toString().toLowerCase();
       final isH264 = codec?.contains("h264") ?? false;
 
-      final bitrate = videoData != null && props?.duration?.inSeconds != null
+      final bitrate = props?.duration?.inSeconds != null
           ? (fileSize * 8) / props!.duration!.inSeconds
           : null;
 
-      final colorTransfer = videoData?["color_transfer"]
+      final colorTransfer = videoData["color_transfer"]
           ?.toString()
           .toLowerCase();
       final isHDR =
@@ -1222,11 +1226,10 @@ class VideoPreviewService {
         file = await getFile(enteFile, isOrigin: true);
         if (file != null) {
           props = await getVideoPropsAsync(file);
-          final videoData = _getVideoStream(props);
-          if (videoData == null) {
-            return (props, skipFile, file);
-          }
-          final codec = videoData["codec_name"]?.toString().toLowerCase();
+          final videoData = List.from(
+            props?.propData?["streams"] ?? [],
+          ).firstWhereOrNull((e) => e["type"] == "video");
+          final codec = videoData?["codec_name"]?.toString().toLowerCase();
           skipFile = codec?.contains("h264") ?? false;
 
           if (skipFile) {
@@ -1245,13 +1248,6 @@ class VideoPreviewService {
       _logger.warning("Failed to check props", e, sT);
     }
     return (props, skipFile, file);
-  }
-
-  Map<dynamic, dynamic>? _getVideoStream(FFProbeProps? props) {
-    final streams = props?.propData?["streams"];
-    return streams is Iterable
-        ? streams.whereType<Map>().firstWhereOrNull((e) => e["type"] == "video")
-        : null;
   }
 
   // generate stream for all files after cutoff date

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -50,6 +50,15 @@ const _maxRetryCount = 3;
 const _maxFfmpegOutputLines = 24;
 const _maxFfmpegOutputChars = 4000;
 
+class _VideoPreviewUnsupportedError implements Exception {
+  const _VideoPreviewUnsupportedError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 class VideoPreviewService {
   final _logger = Logger("VideoPreviewService");
   final LinkedHashMap<int, PreviewItem> _items = LinkedHashMap();
@@ -495,9 +504,25 @@ class VideoPreviewService {
       props ??= await getVideoPropsAsync(file);
       final fileSize = enteFile.fileSize ?? file.lengthSync();
 
-      final videoData = List.from(
-        props?.propData?["streams"] ?? [],
-      ).firstWhereOrNull((e) => e["type"] == "video");
+      final videoData = _getVideoStream(props);
+      if (videoData == null) {
+        final streams = props?.propData?["streams"];
+        final streamTypes = streams is Iterable
+            ? streams.whereType<Map>().map((stream) => stream["type"]).toList()
+            : null;
+        final streamCount = streams is Iterable ? streams.length : null;
+        error = _VideoPreviewUnsupportedError(
+          "No video stream found in FFprobe metadata for "
+          "fileID=${enteFile.uploadedFileID}, "
+          "hasProps=${props != null}, "
+          "streamCount=$streamCount, "
+          "streamTypes=$streamTypes, "
+          "size=${enteFile.fileSize}, "
+          "duration=${enteFile.duration}",
+        );
+        _logger.warning(error.toString());
+        return;
+      }
 
       final codec = videoData["codec_name"]?.toString().toLowerCase();
       final isH264 = codec?.contains("h264") ?? false;
@@ -779,6 +804,11 @@ class VideoPreviewService {
     if (_isNetworkError(error)) {
       _logger.fine(
         "Network error detected, marking file as failed instead of retrying",
+      );
+      shouldRetry = false;
+    } else if (error is _VideoPreviewUnsupportedError) {
+      _logger.fine(
+        "Non-retryable video preview error detected, marking file as failed",
       );
       shouldRetry = false;
     }
@@ -1218,9 +1248,10 @@ class VideoPreviewService {
         file = await getFile(enteFile, isOrigin: true);
         if (file != null) {
           props = await getVideoPropsAsync(file);
-          final videoData = List.from(
-            props?.propData?["streams"] ?? [],
-          ).firstWhereOrNull((e) => e["type"] == "video");
+          final videoData = _getVideoStream(props);
+          if (videoData == null) {
+            return (props, skipFile, file);
+          }
           final codec = videoData["codec_name"]?.toString().toLowerCase();
           skipFile = codec?.contains("h264") ?? false;
 
@@ -1240,6 +1271,13 @@ class VideoPreviewService {
       _logger.warning("Failed to check props", e, sT);
     }
     return (props, skipFile, file);
+  }
+
+  Map<dynamic, dynamic>? _getVideoStream(FFProbeProps? props) {
+    final streams = props?.propData?["streams"];
+    return streams is Iterable
+        ? streams.whereType<Map>().firstWhereOrNull((e) => e["type"] == "video")
+        : null;
   }
 
   // generate stream for all files after cutoff date

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -506,32 +506,20 @@ class VideoPreviewService {
 
       final videoData = _getVideoStream(props);
       if (videoData == null) {
-        final streams = props?.propData?["streams"];
-        final streamTypes = streams is Iterable
-            ? streams.whereType<Map>().map((stream) => stream["type"]).toList()
-            : null;
-        final streamCount = streams is Iterable ? streams.length : null;
-        error = _VideoPreviewUnsupportedError(
-          "No video stream found in FFprobe metadata for "
-          "fileID=${enteFile.uploadedFileID}, "
-          "hasProps=${props != null}, "
-          "streamCount=$streamCount, "
-          "streamTypes=$streamTypes, "
-          "size=${enteFile.fileSize}, "
-          "duration=${enteFile.duration}",
+        _logger.warning(
+          "${_missingVideoStreamMetadataMessage(enteFile, props)}; "
+          "trying ffmpeg with defaults",
         );
-        _logger.warning(error.toString());
-        return;
       }
 
-      final codec = videoData["codec_name"]?.toString().toLowerCase();
+      final codec = videoData?["codec_name"]?.toString().toLowerCase();
       final isH264 = codec?.contains("h264") ?? false;
 
-      final bitrate = props?.duration?.inSeconds != null
+      final bitrate = videoData != null && props?.duration?.inSeconds != null
           ? (fileSize * 8) / props!.duration!.inSeconds
           : null;
 
-      final colorTransfer = videoData["color_transfer"]
+      final colorTransfer = videoData?["color_transfer"]
           ?.toString()
           .toLowerCase();
       final isHDR =
@@ -647,10 +635,6 @@ class VideoPreviewService {
 
           final playlistFile = File("$prefix/output.m3u8");
           final previewFile = File("$prefix/output.ts");
-          final result = await _uploadPreviewVideo(enteFile, previewFile);
-
-          objectId = result.$1;
-          objectSize = result.$2;
 
           // Fetch resolution of generated stream by decrypting a single frame
           final playlistFrameResult = await ffmpegService
@@ -681,28 +665,45 @@ class VideoPreviewService {
             _logger.warning("Failed to fetch resolution of stream", err, sT);
           }
 
-          await _reportVideoPreview(
-            enteFile,
-            playlistFile,
-            objectId: objectId,
-            objectSize: objectSize,
-            width: width,
-            height: height,
-          );
+          if (videoData == null && (width == null || height == null)) {
+            error = _VideoPreviewUnsupportedError(
+              "${_missingVideoStreamMetadataMessage(enteFile, props)}; "
+              "ffmpeg did not produce a video frame",
+            );
+            _logger.warning(error.toString());
+          } else {
+            final result = await _uploadPreviewVideo(enteFile, previewFile);
 
-          _logger.info("Video preview uploaded for $enteFile");
+            objectId = result.$1;
+            objectSize = result.$2;
+
+            await _reportVideoPreview(
+              enteFile,
+              playlistFile,
+              objectId: objectId,
+              objectSize: objectSize,
+              width: width,
+              height: height,
+            );
+
+            _logger.info("Video preview uploaded for $enteFile");
+          }
         } catch (err, sT) {
           error = "Failed to upload video preview\nError: $err";
           _logger.shout("Something went wrong with preview upload", err, sT);
         }
       } else {
         final output = playlistGenResult["output"] as String?;
+        final outputSummary = _summarizeFfmpegOutput(output);
         _logger.warning(
           "FFmpeg command failed with return code $playlistGenReturnCode\n"
-          "${_summarizeFfmpegOutput(output)}",
+          "$outputSummary",
         );
-        error =
+        final errorMessage =
             "Failed to generate video preview (return code $playlistGenReturnCode)";
+        error = _hasNoVideoStreamFfmpegOutput(output)
+            ? _VideoPreviewUnsupportedError("$errorMessage\n$outputSummary")
+            : errorMessage;
       }
 
       if (error == null) {
@@ -1509,4 +1510,32 @@ String _summarizeFfmpegOutput(String? output) {
   return wasTruncated
       ? "FFmpeg output (truncated):\n$summary"
       : "FFmpeg output:\n$summary";
+}
+
+String _missingVideoStreamMetadataMessage(
+  EnteFile enteFile,
+  FFProbeProps? props,
+) {
+  final streams = props?.propData?["streams"];
+  final streamTypes = streams is Iterable
+      ? streams.whereType<Map>().map((stream) => stream["type"]).toList()
+      : null;
+  final streamCount = streams is Iterable ? streams.length : null;
+  return "No video stream found in FFprobe metadata for "
+      "fileID=${enteFile.uploadedFileID}, "
+      "hasProps=${props != null}, "
+      "streamCount=$streamCount, "
+      "streamTypes=$streamTypes, "
+      "size=${enteFile.fileSize}, "
+      "duration=${enteFile.duration}";
+}
+
+bool _hasNoVideoStreamFfmpegOutput(String? output) {
+  final normalizedOutput = output?.toLowerCase();
+  if (normalizedOutput == null) return false;
+  return normalizedOutput.contains("does not contain any stream") ||
+      normalizedOutput.contains("matches no streams") ||
+      normalizedOutput.contains(
+        "cannot find a matching stream for unlabeled input pad",
+      );
 }

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -50,15 +50,6 @@ const _maxRetryCount = 3;
 const _maxFfmpegOutputLines = 24;
 const _maxFfmpegOutputChars = 4000;
 
-class _VideoPreviewUnsupportedError implements Exception {
-  const _VideoPreviewUnsupportedError(this.message);
-
-  final String message;
-
-  @override
-  String toString() => message;
-}
-
 class VideoPreviewService {
   final _logger = Logger("VideoPreviewService");
   final LinkedHashMap<int, PreviewItem> _items = LinkedHashMap();
@@ -507,8 +498,8 @@ class VideoPreviewService {
       final videoData = _getVideoStream(props);
       if (videoData == null) {
         _logger.warning(
-          "${_missingVideoStreamMetadataMessage(enteFile, props)}; "
-          "trying ffmpeg with defaults",
+          "No video stream found in FFprobe metadata for "
+          "fileID=${enteFile.uploadedFileID}; trying ffmpeg with defaults",
         );
       }
 
@@ -635,6 +626,10 @@ class VideoPreviewService {
 
           final playlistFile = File("$prefix/output.m3u8");
           final previewFile = File("$prefix/output.ts");
+          final result = await _uploadPreviewVideo(enteFile, previewFile);
+
+          objectId = result.$1;
+          objectSize = result.$2;
 
           // Fetch resolution of generated stream by decrypting a single frame
           final playlistFrameResult = await ffmpegService
@@ -665,45 +660,28 @@ class VideoPreviewService {
             _logger.warning("Failed to fetch resolution of stream", err, sT);
           }
 
-          if (videoData == null && (width == null || height == null)) {
-            error = _VideoPreviewUnsupportedError(
-              "${_missingVideoStreamMetadataMessage(enteFile, props)}; "
-              "ffmpeg did not produce a video frame",
-            );
-            _logger.warning(error.toString());
-          } else {
-            final result = await _uploadPreviewVideo(enteFile, previewFile);
+          await _reportVideoPreview(
+            enteFile,
+            playlistFile,
+            objectId: objectId,
+            objectSize: objectSize,
+            width: width,
+            height: height,
+          );
 
-            objectId = result.$1;
-            objectSize = result.$2;
-
-            await _reportVideoPreview(
-              enteFile,
-              playlistFile,
-              objectId: objectId,
-              objectSize: objectSize,
-              width: width,
-              height: height,
-            );
-
-            _logger.info("Video preview uploaded for $enteFile");
-          }
+          _logger.info("Video preview uploaded for $enteFile");
         } catch (err, sT) {
           error = "Failed to upload video preview\nError: $err";
           _logger.shout("Something went wrong with preview upload", err, sT);
         }
       } else {
         final output = playlistGenResult["output"] as String?;
-        final outputSummary = _summarizeFfmpegOutput(output);
         _logger.warning(
           "FFmpeg command failed with return code $playlistGenReturnCode\n"
-          "$outputSummary",
+          "${_summarizeFfmpegOutput(output)}",
         );
-        final errorMessage =
+        error =
             "Failed to generate video preview (return code $playlistGenReturnCode)";
-        error = _hasNoVideoStreamFfmpegOutput(output)
-            ? _VideoPreviewUnsupportedError("$errorMessage\n$outputSummary")
-            : errorMessage;
       }
 
       if (error == null) {
@@ -805,11 +783,6 @@ class VideoPreviewService {
     if (_isNetworkError(error)) {
       _logger.fine(
         "Network error detected, marking file as failed instead of retrying",
-      );
-      shouldRetry = false;
-    } else if (error is _VideoPreviewUnsupportedError) {
-      _logger.fine(
-        "Non-retryable video preview error detected, marking file as failed",
       );
       shouldRetry = false;
     }
@@ -1510,32 +1483,4 @@ String _summarizeFfmpegOutput(String? output) {
   return wasTruncated
       ? "FFmpeg output (truncated):\n$summary"
       : "FFmpeg output:\n$summary";
-}
-
-String _missingVideoStreamMetadataMessage(
-  EnteFile enteFile,
-  FFProbeProps? props,
-) {
-  final streams = props?.propData?["streams"];
-  final streamTypes = streams is Iterable
-      ? streams.whereType<Map>().map((stream) => stream["type"]).toList()
-      : null;
-  final streamCount = streams is Iterable ? streams.length : null;
-  return "No video stream found in FFprobe metadata for "
-      "fileID=${enteFile.uploadedFileID}, "
-      "hasProps=${props != null}, "
-      "streamCount=$streamCount, "
-      "streamTypes=$streamTypes, "
-      "size=${enteFile.fileSize}, "
-      "duration=${enteFile.duration}";
-}
-
-bool _hasNoVideoStreamFfmpegOutput(String? output) {
-  final normalizedOutput = output?.toLowerCase();
-  if (normalizedOutput == null) return false;
-  return normalizedOutput.contains("does not contain any stream") ||
-      normalizedOutput.contains("matches no streams") ||
-      normalizedOutput.contains(
-        "cannot find a matching stream for unlabeled input pad",
-      );
 }

--- a/mobile/apps/photos/lib/services/video_preview_service.dart
+++ b/mobile/apps/photos/lib/services/video_preview_service.dart
@@ -496,8 +496,16 @@ class VideoPreviewService {
       props ??= await getVideoPropsAsync(file);
       final fileSize = enteFile.fileSize ?? file.lengthSync();
 
+      if (props == null) {
+        error =
+            "Failed to read FFprobe metadata for ${enteFile.displayName} "
+            "(fileID=${enteFile.uploadedFileID})";
+        _logger.warning(error);
+        return;
+      }
+
       final videoData = List.from(
-        props?.propData?["streams"] ?? [],
+        props.propData?["streams"] ?? [],
       ).firstWhereOrNull((e) => e["type"] == "video");
       if (videoData == null) {
         error =
@@ -510,8 +518,8 @@ class VideoPreviewService {
       final codec = videoData["codec_name"]?.toString().toLowerCase();
       final isH264 = codec?.contains("h264") ?? false;
 
-      final bitrate = props?.duration?.inSeconds != null
-          ? (fileSize * 8) / props!.duration!.inSeconds
+      final bitrate = props.duration?.inSeconds != null
+          ? (fileSize * 8) / props.duration!.inSeconds
           : null;
 
       final colorTransfer = videoData["color_transfer"]
@@ -546,7 +554,7 @@ class VideoPreviewService {
           !(isH264 && bitrate != null && bitrate <= 4000 * 1000);
       final rescaleVideo = !(bitrate != null && bitrate <= 2000 * 1000);
       final needsTonemap = isHDR;
-      final applyFPS = (double.tryParse(props?.fps ?? "") ?? 100) > 30;
+      final applyFPS = (double.tryParse(props.fps ?? "") ?? 100) > 30;
 
       String filters = "";
 


### PR DESCRIPTION
- Skip preview creation when FFprobe metadata has no video stream.
- Persist the local stream failure so confirmed missing streams are not retried automatically.
- Keep FFprobe metadata-read failures on the existing retry path.
- Keep the small-H.264 pre-check null-safe.