### PR TITLE
[server] Bump Go toolchain to 1.26.5

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -2,7 +2,7 @@ module github.com/ente/museum
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/TwiN/go-away v1.6.13


### PR DESCRIPTION
Fix for https://pkg.go.dev/vuln/GO-2026-5856