### PR TITLE
[server] Reuse emergency recovery status update path

### DIFF
--- a/server/pkg/controller/emergency/recovery.go
+++ b/server/pkg/controller/emergency/recovery.go
@@ -67,13 +67,13 @@ func (c *Controller) ChangePassword(ctx *gin.Context, userID int64, request ente
 		return nil, stacktrace.Propagate(err, "")
 	}
 
-	hasUpdate, err := c.Repo.UpdateRecoveryStatusForID(ctx, sessionID, ente.RecoveryStatusRecovered)
+	hasUpdate, err := c.Repo.UpdateRecoveryStatusForSession(ctx, sessionID, contact.UserID, contact.EmergencyContactID, ente.RecoveryStatusRecovered)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to update recovery status")
 	}
 	if !hasUpdate {
 		log.WithField("userID", userID).WithField("req", request).
-			Warn("no row updated while rejecting recovery")
+			Warn("no row updated while marking recovery complete")
 	} else {
 		go c.sendRecoveryNotification(ctx, contact.UserID, contact.EmergencyContactID, ente.RecoveryStatusRecovered, nil)
 	}

--- a/server/pkg/controller/emergency/recovery_contact.go
+++ b/server/pkg/controller/emergency/recovery_contact.go
@@ -2,6 +2,7 @@ package emergency
 
 import (
 	"github.com/ente/museum/ente"
+	emergencyRepo "github.com/ente/museum/pkg/repo/emergency"
 	"github.com/ente/stacktrace"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -45,12 +46,19 @@ func (c *Controller) RejectRecovery(ctx *gin.Context,
 	if req.UserID != userID {
 		return stacktrace.Propagate(ente.ErrPermissionDenied, "only account owner can reject recovery")
 	}
-	hasUpdate, err := c.Repo.UpdateRecoveryStatusForID(ctx, req.ID, ente.RecoveryStatusRejected)
+	session, err := c.getRecoverySessionMatchingRequest(ctx, req)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if session.UserID != userID {
+		return stacktrace.Propagate(ente.ErrPermissionDenied, "only account owner can reject recovery")
+	}
+	hasUpdate, err := c.Repo.UpdateRecoveryStatusForSession(ctx, session.ID, session.UserID, session.EmergencyContactID, ente.RecoveryStatusRejected)
 	if !hasUpdate {
 		log.WithField("userID", userID).WithField("req", req).
 			Warn("no row updated while rejecting recovery")
 	} else {
-		go c.sendRecoveryNotification(ctx, req.UserID, req.EmergencyContactID, ente.RecoveryStatusRejected, nil)
+		go c.sendRecoveryNotification(ctx, session.UserID, session.EmergencyContactID, ente.RecoveryStatusRejected, nil)
 	}
 	if err != nil {
 		return stacktrace.Propagate(err, "")
@@ -64,17 +72,14 @@ func (c *Controller) ApproveRecovery(ctx *gin.Context,
 	if req.EmergencyContactID == req.UserID {
 		return stacktrace.Propagate(ente.NewBadRequestWithMessage("contact and user can not be same"), "")
 	}
-	session, err := c.Repo.GetRecoverRowByID(ctx, req.ID)
+	session, err := c.getRecoverySessionMatchingRequest(ctx, req)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
-	}
-	if session.UserID != req.UserID || session.EmergencyContactID != req.EmergencyContactID {
-		return stacktrace.Propagate(ente.ErrPermissionDenied, "recovery session does not match request")
 	}
 	if session.UserID != userID {
 		return stacktrace.Propagate(ente.ErrPermissionDenied, "only account owner can approve recovery")
 	}
-	hasUpdate, err := c.Repo.ApproveRecoveryForSession(ctx, session.ID, session.UserID, session.EmergencyContactID)
+	hasUpdate, err := c.Repo.UpdateRecoveryStatusForSession(ctx, session.ID, session.UserID, session.EmergencyContactID, ente.RecoveryStatusReady)
 	if !hasUpdate {
 		log.WithField("userID", userID).WithField("req", req).
 			Warn("no row updated while approving recovery")
@@ -96,7 +101,14 @@ func (c *Controller) StopRecovery(ctx *gin.Context,
 	if req.EmergencyContactID != userID {
 		return stacktrace.Propagate(ente.ErrPermissionDenied, "only the emergency contact can stop recovery")
 	}
-	hasUpdate, err := c.Repo.UpdateRecoveryStatusForID(ctx, req.ID, ente.RecoveryStatusStopped)
+	session, err := c.getRecoverySessionMatchingRequest(ctx, req)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if session.EmergencyContactID != userID {
+		return stacktrace.Propagate(ente.ErrPermissionDenied, "only the emergency contact can stop recovery")
+	}
+	hasUpdate, err := c.Repo.UpdateRecoveryStatusForSession(ctx, session.ID, session.UserID, session.EmergencyContactID, ente.RecoveryStatusStopped)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -104,7 +116,18 @@ func (c *Controller) StopRecovery(ctx *gin.Context,
 		log.WithField("userID", userID).WithField("req", req).
 			Warn("no row updated while stopping recovery")
 	} else {
-		go c.sendRecoveryNotification(ctx, req.UserID, req.EmergencyContactID, ente.RecoveryStatusStopped, nil)
+		go c.sendRecoveryNotification(ctx, session.UserID, session.EmergencyContactID, ente.RecoveryStatusStopped, nil)
 	}
 	return stacktrace.Propagate(err, "")
+}
+
+func (c *Controller) getRecoverySessionMatchingRequest(ctx *gin.Context, req ente.RecoveryIdentifier) (*emergencyRepo.RecoverRow, error) {
+	session, err := c.Repo.GetRecoverRowByID(ctx, req.ID)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	if session.UserID != req.UserID || session.EmergencyContactID != req.EmergencyContactID {
+		return nil, stacktrace.Propagate(ente.ErrPermissionDenied, "recovery session does not match request")
+	}
+	return session, nil
 }

--- a/server/pkg/controller/emergency/recovery_contact_test.go
+++ b/server/pkg/controller/emergency/recovery_contact_test.go
@@ -44,6 +44,76 @@ func TestApproveRecoveryRejectsSpoofedSessionPartiesBeforeUpdate(t *testing.T) {
 	}
 }
 
+func TestRejectRecoveryRejectsSpoofedSessionPartiesBeforeUpdate(t *testing.T) {
+	ctx, db, ctrl := setupEmergencyRecoveryControllerTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "legacy-owner@ente.com",
+		CreationTime: 1,
+	})
+	contactID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "trusted-contact@ente.com",
+		CreationTime: 1,
+	})
+	attackerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       3,
+		Email:        "attacker@ente.com",
+		CreationTime: 1,
+	})
+	sessionID := mustInsertEmergencyRecoverySession(t, db, ownerID, contactID, ente.RecoveryStatusWaiting)
+
+	err := ctrl.RejectRecovery(ctx, attackerID, ente.RecoveryIdentifier{
+		ID:                 sessionID,
+		UserID:             attackerID,
+		EmergencyContactID: contactID,
+	})
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("RejectRecovery() error = %v, want permission denied", err)
+	}
+
+	status := mustGetEmergencyRecoveryStatus(t, db, sessionID)
+	if status != ente.RecoveryStatusWaiting {
+		t.Fatalf("recovery status = %s, want %s", status, ente.RecoveryStatusWaiting)
+	}
+}
+
+func TestStopRecoveryRejectsSpoofedSessionPartiesBeforeUpdate(t *testing.T) {
+	ctx, db, ctrl := setupEmergencyRecoveryControllerTest(t)
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "legacy-owner@ente.com",
+		CreationTime: 1,
+	})
+	contactID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "trusted-contact@ente.com",
+		CreationTime: 1,
+	})
+	attackerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       3,
+		Email:        "attacker@ente.com",
+		CreationTime: 1,
+	})
+	sessionID := mustInsertEmergencyRecoverySession(t, db, ownerID, contactID, ente.RecoveryStatusWaiting)
+
+	err := ctrl.StopRecovery(ctx, attackerID, ente.RecoveryIdentifier{
+		ID:                 sessionID,
+		UserID:             ownerID,
+		EmergencyContactID: attackerID,
+	})
+	if !errors.Is(err, ente.ErrPermissionDenied) {
+		t.Fatalf("StopRecovery() error = %v, want permission denied", err)
+	}
+
+	status := mustGetEmergencyRecoveryStatus(t, db, sessionID)
+	if status != ente.RecoveryStatusWaiting {
+		t.Fatalf("recovery status = %s, want %s", status, ente.RecoveryStatusWaiting)
+	}
+}
+
 func setupEmergencyRecoveryControllerTest(t *testing.T) (*gin.Context, *sql.DB, *Controller) {
 	t.Helper()
 

--- a/server/pkg/repo/emergency/recovery.go
+++ b/server/pkg/repo/emergency/recovery.go
@@ -135,9 +135,17 @@ func (repo *Repository) UpdateRecoveryStatusForID(ctx context.Context, sessionID
 	return rows > 0, nil
 }
 
-func (repo *Repository) ApproveRecoveryForSession(ctx context.Context, sessionID uuid.UUID, userID, emergencyContactID int64) (bool, error) {
-	result, err := repo.DB.ExecContext(ctx, `UPDATE emergency_recovery SET status=$1, wait_till=$2 WHERE id=$3 and user_id=$4 and emergency_contact_id=$5 and status = ANY($6)`,
-		ente.RecoveryStatusReady, time.Microseconds(), sessionID, userID, emergencyContactID, pq.Array(validPreviousStatus(ente.RecoveryStatusReady)))
+func (repo *Repository) UpdateRecoveryStatusForSession(ctx context.Context, sessionID uuid.UUID, userID, emergencyContactID int64, status ente.RecoveryStatus) (bool, error) {
+	validPrevStatus := validPreviousStatus(status)
+	var result sql.Result
+	var err error
+	if status == ente.RecoveryStatusReady {
+		result, err = repo.DB.ExecContext(ctx, `UPDATE emergency_recovery SET status=$1, wait_till=$2 WHERE id=$3 and user_id=$4 and emergency_contact_id=$5 and status = ANY($6)`,
+			status, time.Microseconds(), sessionID, userID, emergencyContactID, pq.Array(validPrevStatus))
+	} else {
+		result, err = repo.DB.ExecContext(ctx, `UPDATE emergency_recovery SET status=$1 WHERE id=$2 and user_id=$3 and emergency_contact_id=$4 and status = ANY($5)`,
+			status, sessionID, userID, emergencyContactID, pq.Array(validPrevStatus))
+	}
 	if err != nil {
 		return false, stacktrace.Propagate(err, "")
 	}


### PR DESCRIPTION
- Route emergency recovery status changes through a shared session-aware update helper.
- Apply the same path across approve, reject, stop, and recovered transitions.
- Add regression coverage for spoofed reject/stop recovery requests.



Thank you @inthenightsky for reporting this.