### PR TITLE
[mob][photos] Keep ML working files cached when indexing is paused or fails

### DIFF
--- a/mobile/apps/photos/changes/ml-cleanup-retry.md
+++ b/mobile/apps/photos/changes/ml-cleanup-retry.md
@@ -1,0 +1,1 @@
+- Avoid re-downloading photos when machine learning indexing is interrupted.

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -751,6 +751,9 @@ class MLService {
 
     final mlDataDB = _dbForMode(instruction.mode);
     String? pathToDeleteAfterMLProcessing;
+    // True once result or skip-marker rows are stored, meaning the file
+    // won't be retried and its cached download/export can be dropped.
+    bool indexedOrSkipped = false;
     try {
       final String filePath = await getImagePathForML(instruction.file);
       if (_shouldDeleteAfterMLProcessing(instruction.file)) {
@@ -905,6 +908,7 @@ class MLService {
         }
       }
       _logger.info("ML result for fileID ${result.fileId} stored remote+local");
+      indexedOrSkipped = true;
       return actuallyRanML;
     } catch (e, s) {
       final String format = instruction.file.displayName.split('.').last;
@@ -951,6 +955,7 @@ class MLService {
         _logger.info(
           "Stored empty ML result markers for fileID ${instruction.fileKey}: ${storedMarkers.join(', ')}",
         );
+        indexedOrSkipped = true;
         return true;
       }
       _logger.severe(
@@ -965,18 +970,20 @@ class MLService {
       }
       return false;
     } finally {
-      if (pathToDeleteAfterMLProcessing != null) {
-        try {
-          await File(pathToDeleteAfterMLProcessing).delete();
-        } catch (e, s) {
-          _logger.warning(
-            "Failed to delete origin file exported for ML at $pathToDeleteAfterMLProcessing",
-            e,
-            s,
-          );
+      if (indexedOrSkipped) {
+        if (pathToDeleteAfterMLProcessing != null) {
+          try {
+            await File(pathToDeleteAfterMLProcessing).delete();
+          } catch (e, s) {
+            _logger.warning(
+              "Failed to delete origin file exported for ML at $pathToDeleteAfterMLProcessing",
+              e,
+              s,
+            );
+          }
         }
+        await _evictRemoteCacheAfterMLProcessing(instruction.file);
       }
-      await _evictRemoteCacheAfterMLProcessing(instruction.file);
     }
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #11310. `processImage` cleaned up its working files (remote-download cache entry, iOS origin export) in a `finally`, so cleanup also ran when indexing did not complete because of MLController pause or a transient failure. Those files are retried on the next pass, which re-downloaded the original for remote files or re-exported it from PhotoKit for local files.

Cleanup now runs only on terminal outcomes: a stored result or a permanent skip marker. Non-terminal exits keep the cached download/export so the retry is free. 

