### PR TITLE
[mobile][photos] Report malformed production API responses

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -16,6 +16,7 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photos/core/error-reporting/tunneled_transport.dart';
 import "package:photos/core/exceptions.dart";
+import "package:photos/core/network/api_response.dart";
 import 'package:photos/models/typedefs.dart';
 import "package:photos/utils/device_info.dart";
 import "package:photos/utils/ram_check_util.dart";
@@ -317,6 +318,10 @@ class SuperLogging {
   }
 
   static bool _shouldSkipSentry(Object error) {
+    final apiResponseError = _apiResponseFormatException(error);
+    if (apiResponseError != null) {
+      return !apiResponseError.shouldReport;
+    }
     if (error is DioException) {
       return true;
     }
@@ -347,15 +352,18 @@ class SuperLogging {
         return;
       }
 
+      final sentryError = _apiResponseFormatException(error) ?? error;
+
       // Determine execution context from prefix
       final executionContext = _getExecutionContext();
 
       if (rec != null) {
         await Sentry.captureException(
-          error,
+          sentryError,
           stackTrace: stack,
           withScope: (scope) {
             scope.setContexts('log_details', {'message': rec.message});
+            _setApiResponseContext(scope, sentryError);
             scope.setTag('logger', rec.loggerName);
             scope.setTag('level', rec.level.name);
             scope.setTag('execution_context', executionContext);
@@ -363,9 +371,10 @@ class SuperLogging {
         );
       } else {
         await Sentry.captureException(
-          error,
+          sentryError,
           stackTrace: stack,
           withScope: (scope) {
+            _setApiResponseContext(scope, sentryError);
             scope.setTag('execution_context', executionContext);
           },
         );
@@ -374,6 +383,26 @@ class SuperLogging {
       $.info('Sending report to sentry failed: $e');
       $.info('Original error: $error');
     }
+  }
+
+  static void _setApiResponseContext(Scope scope, Object error) {
+    final apiResponseError = _apiResponseFormatException(error);
+    if (apiResponseError == null) {
+      return;
+    }
+    scope.setContexts('api_response', apiResponseError.sentryContext);
+    scope.setTag('api_response.path', apiResponseError.path);
+    scope.setTag('api_response.endpoint_kind', apiResponseError.endpointKind);
+  }
+
+  static ApiResponseFormatException? _apiResponseFormatException(Object error) {
+    if (error is ApiResponseFormatException) {
+      return error;
+    }
+    if (error is DioException && error.error is ApiResponseFormatException) {
+      return error.error! as ApiResponseFormatException;
+    }
+    return null;
   }
 
   static void _reportInvalidLoggerUsageInDebug(

--- a/mobile/apps/photos/lib/core/network/api_response.dart
+++ b/mobile/apps/photos/lib/core/network/api_response.dart
@@ -1,0 +1,117 @@
+import "package:dio/dio.dart";
+import "package:photos/core/constants.dart";
+
+class ApiResponseShapeInterceptor extends Interceptor {
+  ApiResponseShapeInterceptor(this._endpoint);
+
+  final String _endpoint;
+
+  static final RegExp _collectionObjectPath = RegExp(
+    r"^/collections(?:/\d+|/v2(?:/diff)?)?$",
+  );
+
+  static const Set<String> _objectPaths = {
+    "/billing/user-plans",
+    "/collection-actions/delete-suggestions",
+    "/collection-actions/pending-remove",
+    "/comments-reactions/updated-at",
+    "/files/data/fetch",
+    "/files/data/preview",
+    "/files/data/preview-upload-url",
+    "/files/data/status-diff",
+    "/memory-share",
+    "/public-collection/files/data/fetch",
+    "/public-collection/files/data/preview",
+    "/user-entity/entity/diff",
+    "/users/details/v2",
+  };
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    final routePath = _objectRoutePath(response.requestOptions.uri.path);
+    if (routePath == null || !_isConfiguredEndpoint(response.requestOptions)) {
+      handler.next(response);
+      return;
+    }
+    final data = response.data;
+    if (data is! String) {
+      handler.next(response);
+      return;
+    }
+    handler.reject(
+      DioException(
+        requestOptions: response.requestOptions,
+        response: response,
+        error: ApiResponseFormatException(response, routePath, data),
+      ),
+    );
+  }
+
+  bool _isConfiguredEndpoint(RequestOptions options) {
+    final endpointUri = Uri.tryParse(_endpoint);
+    return endpointUri != null &&
+        options.uri.scheme == endpointUri.scheme &&
+        options.uri.host == endpointUri.host;
+  }
+
+  static String? _objectRoutePath(String path) {
+    final normalizedPath = path.length > 1 && path.endsWith("/")
+        ? path.substring(0, path.length - 1)
+        : path;
+    if (_objectPaths.contains(normalizedPath)) return normalizedPath;
+    if (!_collectionObjectPath.hasMatch(normalizedPath)) return null;
+    return RegExp(r"^/collections/\d+$").hasMatch(normalizedPath)
+        ? "/collections/:collectionID"
+        : normalizedPath;
+  }
+}
+
+class ApiResponseFormatException implements Exception {
+  ApiResponseFormatException(
+    Response<dynamic> response,
+    this.path,
+    Object? actual,
+  ) : shouldReport =
+          response.requestOptions.uri.host ==
+          Uri.parse(kDefaultProductionEndpoint).host,
+      statusCode = response.statusCode,
+      contentType = response.headers.value("content-type"),
+      requestID =
+          response.headers.value("x-request-id") ??
+          response.requestOptions.headers["x-request-id"]?.toString(),
+      cfRay = response.headers.value("cf-ray"),
+      redirectCount = response.redirects.length,
+      actualType = actual == null ? "null" : actual.runtimeType.toString(),
+      bodyLength = actual is String ? actual.length : null;
+
+  final String path;
+  final bool shouldReport;
+  final String actualType;
+  final int? statusCode;
+  final String? contentType;
+  final String? requestID;
+  final String? cfRay;
+  final int redirectCount;
+  final int? bodyLength;
+
+  String get endpointKind => shouldReport ? "production" : "custom";
+
+  Map<String, dynamic> get sentryContext => {
+    "path": path,
+    "expected": "JSON object",
+    "actual_type": actualType,
+    "endpoint_kind": endpointKind,
+    "redirect_count": redirectCount,
+    if (statusCode != null) "status_code": statusCode,
+    if (contentType != null) "content_type": contentType,
+    if (requestID != null) "x_request_id": requestID,
+    if (cfRay != null) "cf_ray": cfRay,
+    if (bodyLength != null) "body_length": bodyLength,
+  };
+
+  @override
+  String toString() {
+    return "ApiResponseFormatException: expected JSON object at "
+        "$path.response, got $actualType from $endpointKind endpoint";
+  }
+}

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import "package:photos/core/event_bus.dart";
+import "package:photos/core/network/api_response.dart";
 import "package:photos/core/network/endpoint_config.dart";
 import 'package:photos/core/network/ente_interceptor.dart';
 import "package:shared_preferences/shared_preferences.dart";
@@ -55,8 +56,11 @@ class NetworkClient {
   }
 
   void _setupInterceptors(String endpoint) {
+    _dio.interceptors.clear();
+    _dio.interceptors.add(ApiResponseShapeInterceptor(endpoint));
     _enteDio.interceptors.clear();
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));
+    _enteDio.interceptors.add(ApiResponseShapeInterceptor(endpoint));
   }
 
   BaseOptions _newBaseOptions(

--- a/mobile/apps/photos/lib/gateways/billing/billing_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/billing/billing_gateway.dart
@@ -15,7 +15,7 @@ class BillingGateway {
   ///
   /// Returns [BillingPlans] containing all available subscription plans.
   Future<BillingPlans> getUserPlans() async {
-    final response = await _enteDio.get("/billing/user-plans/");
+    final response = await _enteDio.get("/billing/user-plans");
     return BillingPlans.fromMap(response.data);
   }
 

--- a/mobile/apps/photos/lib/gateways/files/file_data_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/files/file_data_gateway.dart
@@ -140,7 +140,7 @@ class FileDataGateway {
   Future<({String encryptedData, String decryptionHeader})>
   fetchSingleFileData({required int fileID, required String type}) async {
     final response = await _enteDio.get(
-      "/files/data/fetch/",
+      "/files/data/fetch",
       queryParameters: {"fileID": fileID, "type": type},
     );
     return (
@@ -167,7 +167,7 @@ class FileDataGateway {
     required Dio nonEnteDio,
   }) async {
     final response = await nonEnteDio.get(
-      "$baseUrl/public-collection/files/data/fetch/",
+      "$baseUrl/public-collection/files/data/fetch",
       queryParameters: {"fileID": fileID, "type": type},
       options: Options(headers: headers),
     );

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -145,7 +145,10 @@ class UserService {
     } on DioException catch (e) {
       await dialog.hide();
       _logger.info(e);
-      final String? enteErrCode = e.response?.data["code"];
+      final responseData = e.response?.data;
+      final String? enteErrCode = responseData is Map
+          ? responseData["code"] as String?
+          : null;
       if (enteErrCode != null && enteErrCode == "USER_ALREADY_REGISTERED") {
         unawaited(
           showAlertBottomSheet(

--- a/mobile/apps/photos/test/core/network/api_response_test.dart
+++ b/mobile/apps/photos/test/core/network/api_response_test.dart
@@ -1,0 +1,111 @@
+import "dart:typed_data";
+
+import "package:dio/dio.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/core/constants.dart";
+import "package:photos/core/network/api_response.dart";
+
+void main() {
+  group(ApiResponseShapeInterceptor, () {
+    test(
+      "rejects non-object production API responses on object routes",
+      () async {
+        final dio = _dio(
+          endpoint: kDefaultProductionEndpoint,
+          body: '"not an object"',
+          contentType: Headers.jsonContentType,
+        );
+
+        final error = await _dioExceptionFor(dio.get("/users/details/v2"));
+
+        expect(error.error, isA<ApiResponseFormatException>());
+        final formatError = error.error! as ApiResponseFormatException;
+        expect(formatError.path, "/users/details/v2");
+        expect(formatError.actualType, "String");
+        expect(formatError.shouldReport, true);
+        expect(formatError.endpointKind, "production");
+        expect(
+          formatError.sentryContext["content_type"],
+          Headers.jsonContentType,
+        );
+        expect(formatError.sentryContext["body_length"], 13);
+      },
+    );
+
+    test(
+      "classifies non-production endpoint response shapes as local",
+      () async {
+        final dio = _dio(
+          endpoint: "https://self-hosted.example.com",
+          body: "<html></html>",
+          contentType: "text/html",
+        );
+
+        final error = await _dioExceptionFor(dio.get("/memory-share"));
+        final formatError = error.error! as ApiResponseFormatException;
+
+        expect(formatError.shouldReport, false);
+        expect(formatError.endpointKind, "custom");
+      },
+    );
+
+    test(
+      "allows non-object responses on routes that do not expect objects",
+      () async {
+        final dio = _dio(
+          endpoint: kDefaultProductionEndpoint,
+          body: '"https://example.com/upload"',
+          contentType: Headers.jsonContentType,
+        );
+
+        final response = await dio.post("/files/upload-url");
+
+        expect(response.data, "https://example.com/upload");
+      },
+    );
+  });
+}
+
+Dio _dio({
+  required String endpoint,
+  required String body,
+  required String contentType,
+}) {
+  return Dio(BaseOptions(baseUrl: endpoint))
+    ..httpClientAdapter = _StaticAdapter(body: body, contentType: contentType)
+    ..interceptors.add(ApiResponseShapeInterceptor(endpoint));
+}
+
+Future<DioException> _dioExceptionFor(Future<Object?> request) async {
+  try {
+    await request;
+  } on DioException catch (e) {
+    return e;
+  }
+  fail("Expected DioException");
+}
+
+class _StaticAdapter implements HttpClientAdapter {
+  _StaticAdapter({required this.body, required this.contentType});
+
+  final String body;
+  final String contentType;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: {
+        Headers.contentTypeHeader: [contentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -119,7 +119,10 @@ class UserService {
     } on DioException catch (e) {
       await dialog.hide();
       _logger.info(e);
-      final String? enteErrCode = e.response?.data["code"];
+      final responseData = e.response?.data;
+      final String? enteErrCode = responseData is Map
+          ? responseData["code"] as String?
+          : null;
       if (enteErrCode != null && enteErrCode == "USER_ALREADY_REGISTERED") {
         unawaited(
           showAlertBottomSheet(


### PR DESCRIPTION
Adds a narrow Photos API response-shape guard for known map-shaped endpoints when Dio returns a top-level String, so production malformed responses report with safe metadata while custom endpoints stay out of Ente Sentry.

Also guards OTT error-code parsing for non-object error bodies and removes trailing slashes from affected calls.

Validation: flutter test test/core/network/api_response_test.dart; dart format --output=none --set-exit-if-changed <touched files>; flutter analyze <touched Photos files>; (cd mobile/packages/accounts && flutter analyze). Full Photos flutter analyze is blocked by existing generated/Rust binding errors.