### PR TITLE
[mobile][photos] Harden malformed auth and API responses

### DIFF
--- a/mobile/apps/photos/lib/gateways/billing/billing_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/billing/billing_gateway.dart
@@ -15,7 +15,7 @@ class BillingGateway {
   ///
   /// Returns [BillingPlans] containing all available subscription plans.
   Future<BillingPlans> getUserPlans() async {
-    final response = await _enteDio.get("/billing/user-plans/");
+    final response = await _enteDio.get("/billing/user-plans");
     return BillingPlans.fromMap(response.data);
   }
 

--- a/mobile/apps/photos/lib/gateways/files/file_data_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/files/file_data_gateway.dart
@@ -140,7 +140,7 @@ class FileDataGateway {
   Future<({String encryptedData, String decryptionHeader})>
   fetchSingleFileData({required int fileID, required String type}) async {
     final response = await _enteDio.get(
-      "/files/data/fetch/",
+      "/files/data/fetch",
       queryParameters: {"fileID": fileID, "type": type},
     );
     return (
@@ -167,7 +167,7 @@ class FileDataGateway {
     required Dio nonEnteDio,
   }) async {
     final response = await nonEnteDio.get(
-      "$baseUrl/public-collection/files/data/fetch/",
+      "$baseUrl/public-collection/files/data/fetch",
       queryParameters: {"fileID": fileID, "type": type},
       options: Options(headers: headers),
     );

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -145,7 +145,10 @@ class UserService {
     } on DioException catch (e) {
       await dialog.hide();
       _logger.info(e);
-      final String? enteErrCode = e.response?.data["code"];
+      final responseData = e.response?.data;
+      final Object? enteErrCode = responseData is Map
+          ? responseData["code"]
+          : null;
       if (enteErrCode != null && enteErrCode == "USER_ALREADY_REGISTERED") {
         unawaited(
           showAlertBottomSheet(

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -119,7 +119,10 @@ class UserService {
     } on DioException catch (e) {
       await dialog.hide();
       _logger.info(e);
-      final String? enteErrCode = e.response?.data["code"];
+      final responseData = e.response?.data;
+      final Object? enteErrCode = responseData is Map
+          ? responseData["code"]
+          : null;
       if (enteErrCode != null && enteErrCode == "USER_ALREADY_REGISTERED") {
         unawaited(
           showAlertBottomSheet(


### PR DESCRIPTION
- Remove slash-suffixed API paths that can hit redirect/plain responses.
- Guard OTT error-code parsing when error bodies are not JSON objects.

Validation: touched-file format, targeted Photos analyze, and accounts analyze passed; full Photos analyze/test blocked locally by ignored generated Rust bindings.