### PR TITLE
[mobile][photos] Add string response breadcrumbs

### DIFF
--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -11,6 +11,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import "package:photos/core/event_bus.dart";
 import "package:photos/core/network/endpoint_config.dart";
 import 'package:photos/core/network/ente_interceptor.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import "package:shared_preferences/shared_preferences.dart";
 import "package:ua_client_hints/ua_client_hints.dart";
 
@@ -41,6 +42,7 @@ class NetworkClient {
     );
     _enteDio.httpClientAdapter = _newAdaptiveHttpClientAdapter(_connectTimeout);
 
+    _dio.interceptors.add(_StringResponseBreadcrumbInterceptor());
     _setupInterceptors(endpoint);
 
     if (_endpointUpdatedSubscription != null) {
@@ -57,6 +59,7 @@ class NetworkClient {
   void _setupInterceptors(String endpoint) {
     _enteDio.interceptors.clear();
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));
+    _enteDio.interceptors.add(_StringResponseBreadcrumbInterceptor());
   }
 
   BaseOptions _newBaseOptions(
@@ -115,6 +118,51 @@ class NetworkClient {
   Dio get downloadDio => _downloadDio;
 
   Dio get enteDio => _enteDio;
+}
+
+class _StringResponseBreadcrumbInterceptor extends Interceptor {
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    _addBreadcrumb(response);
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final response = err.response;
+    if (response != null) {
+      _addBreadcrumb(response);
+    }
+    handler.next(err);
+  }
+
+  void _addBreadcrumb(Response response) {
+    final responseData = response.data;
+    if (responseData is! String || responseData.isEmpty) {
+      return;
+    }
+
+    final uri = response.requestOptions.uri;
+    unawaited(
+      Sentry.addBreadcrumb(
+        Breadcrumb(
+          category: "http",
+          type: "http",
+          message: "String API response",
+          data: {
+            "method": response.requestOptions.method,
+            "host": uri.host,
+            "status_code": response.statusCode,
+            "content_type": response.headers.value(Headers.contentTypeHeader),
+            "server_header": response.headers.value(HttpHeaders.serverHeader),
+            "cf_ray": response.headers.value("cf-ray"),
+            "cf_cache_status": response.headers.value("cf-cache-status"),
+            "body_length": responseData.length,
+          },
+        ),
+      ),
+    );
+  }
 }
 
 class _HttpSchemeFallbackAdapter implements HttpClientAdapter {


### PR DESCRIPTION
- Add metadata-only breadcrumbs when API responses decode as non-empty strings.
- This helps identify whether malformed responses are coming from redirects, proxies, or edge/self-hosted behavior.