### PR TITLE
[mobile][photos] Harden review intent EXTRA_STREAM read against ClassCastException

### DIFF
--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/MediaReviewActivity.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/MediaReviewActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.webkit.MimeTypeMap
+import androidx.core.content.IntentCompat
 import java.util.Locale
 
 class MediaReviewActivity : Activity() {
@@ -77,8 +78,7 @@ class MediaReviewActivity : Activity() {
     }
 
     private val Intent.streamUri: Uri?
-        @Suppress("DEPRECATION")
-        get() = getParcelableExtra(Intent.EXTRA_STREAM)
+        get() = IntentCompat.getParcelableExtra(this, Intent.EXTRA_STREAM, Uri::class.java)
 
     private val Intent.reviewUri: Uri?
         get() = data ?: streamUri ?: firstClipDataUri


### PR DESCRIPTION
## Description

`MediaReviewActivity` is exported (`android:exported="true"`, with intent filters for `android.provider.action.REVIEW` and `com.android.camera.action.REVIEW`). When a review intent arrives without a data URI, the activity falls back to reading `Intent.EXTRA_STREAM` via the deprecated untyped `getParcelableExtra(Intent.EXTRA_STREAM)`, whose result Kotlin implicitly casts to `Uri`. A co-installed app can launch the activity with a non-`Uri` Parcelable in `EXTRA_STREAM`, causing an uncaught `ClassCastException` in `onCreate()` that crashes the whole app process (local, single-shot DoS).

### Fix

Replace the untyped read with the type-safe `androidx.core.content.IntentCompat.getParcelableExtra(this, Intent.EXTRA_STREAM, Uri::class.java)`, which returns `null` on a type mismatch instead of throwing. With a `null` stream URI, the existing normalization logic already falls through to the ClipData URI or aborts gracefully.

- Legitimate camera-review intents with a valid `Uri` in `EXTRA_STREAM` resolve exactly as before.
- The change also removes the `@Suppress("DEPRECATION")` annotation, since `IntentCompat` is not deprecated.
- `androidx.core` is already used elsewhere in the app's Kotlin sources (`ContextCompat`, `NotificationCompat`), and the resolved version is well above 1.9.0 where this `IntentCompat` overload was introduced.

This is a low-risk hardening change, tightly scoped to the single unsafe read.

### Testing

Verified by code read-through for syntactic correctness; a full Android Gradle build was **not** run as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
