### PR TITLE
[mobile][photos] Skip undecodable person entities to avoid startup crash-loop

### DIFF
--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/person/person_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/person/person_service.dart
@@ -126,6 +126,12 @@ class PersonService {
       param: {"entity": entities},
       taskName: "decode_person_entities",
     );
+    if (persons.length != entities.length) {
+      logger.severe(
+        "Skipped ${entities.length - persons.length} of ${entities.length} "
+        "person entities that could not be decoded",
+      );
+    }
     _emailToPartialPersonDataMapCache.clear();
     for (PersonEntity person in persons) {
       if (person.data.email != null && person.data.email!.isNotEmpty) {
@@ -141,11 +147,24 @@ class PersonService {
 
   static List<PersonEntity> _decodePersonEntities(Map<String, dynamic> param) {
     final entities = param["entity"] as List<LocalEntityData>;
-    return entities
-        .map(
-          (e) => PersonEntity(e.id, PersonData.fromJson(json.decode(e.data))),
-        )
-        .toList();
+    final persons = <PersonEntity>[];
+    for (final e in entities) {
+      try {
+        persons.add(
+          PersonEntity(e.id, PersonData.fromJson(json.decode(e.data))),
+        );
+      } catch (err, stackTrace) {
+        // Skip the undecodable entity so a single corrupt person entity
+        // cannot abort the entire decode (which is awaited during app
+        // startup, before runApp).
+        Logger("PersonService").severe(
+          "Failed to decode person entity ${e.id}, skipping it",
+          err,
+          stackTrace,
+        );
+      }
+    }
+    return persons;
   }
 
   Future<PersonEntity?> getPerson(String id) {


### PR DESCRIPTION
## Problem

During foreground startup, `_init` in `mobile/apps/photos/lib/main.dart` awaits `PersonService.instance.refreshPersonCache()` before initialization completes, and `_init` rethrows any error. The cache warm ends up in `_decodePersonEntities`, which decoded every cgroup (person) entity with `PersonData.fromJson(json.decode(e.data))` and no per-entity error handling.

As a result, a single semantically-corrupt person entity (e.g. valid JSON that is missing a `String` `name`, making the `as String` cast in `PersonData.fromJson` throw a `TypeError`) aborts the entire decode, which bubbles unguarded through `_init` and produces a **permanent splash-screen crash-loop**. Reinstalling does not help, because the corrupt entity re-syncs from remote.

## Fix

Localized skip-and-log in `PersonService`:

- `_decodePersonEntities` now wraps the per-entity decode in a try/catch: an undecodable entity is logged (with error and stack trace) and skipped, instead of aborting the whole decode.
- Since `_decodePersonEntities` runs in a `Computer` worker isolate (where log listeners may not be attached), `_fetchAndCachePersons` additionally logs on the main isolate when the decoded count differs from the entity count, so skipped entities are always visible in logs.

## Why this is low risk

- Startup does not functionally require the person cache; skipping a corrupt entity only means that one person is absent from people features until the entity is fixed.
- The normal path is behavior-preserving: all valid entities decode exactly as before, in the same order.
- The fix is applied at the narrowest possible point (the per-entity decode) rather than swallowing errors at the `_init` call site, which would hide unrelated startup failures.

Verified with `dart format` (no changes) and `dart analyze` on the modified file (no issues found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
