### PR TITLE
[mobile][photos] Guard account recovery dialogs

### DIFF
--- a/mobile/apps/photos/lib/ui/account/login_pwd_verification_page.dart
+++ b/mobile/apps/photos/lib/ui/account/login_pwd_verification_page.dart
@@ -217,7 +217,7 @@ class _LoginPasswordVerificationPageState
           body: AppLocalizations.of(context).recreatePasswordBody,
           firstButtonLabel: AppLocalizations.of(context).useRecoveryKey,
         );
-        if (dialogChoice!.action == ButtonAction.first) {
+        if (dialogChoice?.action == ButtonAction.first && context.mounted) {
           await UserService.instance.sendOtt(
             context,
             email!,
@@ -248,7 +248,7 @@ class _LoginPasswordVerificationPageState
       firstButtonLabel: AppLocalizations.of(context).contactSupport,
       secondButtonLabel: AppLocalizations.of(context).ok,
     );
-    if (dialogChoice!.action == ButtonAction.first) {
+    if (dialogChoice?.action == ButtonAction.first && context.mounted) {
       await sendLogs(
         context,
         AppLocalizations.of(context).contactSupport,

--- a/mobile/apps/photos/lib/ui/account/password_entry_page.dart
+++ b/mobile/apps/photos/lib/ui/account/password_entry_page.dart
@@ -419,6 +419,7 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
     } catch (e) {
       _logger.severe(e);
       await dialog.hide();
+      if (!mounted) return;
       if (e is UnsupportedError) {
         // ignore: unawaited_futures
         showAlertBottomSheet(


### PR DESCRIPTION
- Handle dismissed choice dialogs without force-unwrapping a null result.
- Avoid using account-page contexts after their widgets are disposed.