### PR TITLE
[mobile][photos] Guard async UI after disposal

### DIFF
--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -134,6 +134,10 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       newFile.generatedID = await FilesDB.instance.insertAndGetId(newFile);
       Bus.instance.fire(LocalPhotosUpdatedEvent([newFile], source: "editSave"));
       unawaited(SyncService.instance.sync());
+      if (!mounted) {
+        await dialog.hide();
+        return;
+      }
       showShortToast(context, AppLocalizations.of(context).editsSaved);
       _logger.info("Original file " + widget.originalFile.toString());
       _logger.info("Saved edits to file " + newFile.toString());
@@ -149,6 +153,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
         selectionIndex = files.length - 1;
       }
       await dialog.hide();
+      if (!mounted) return;
       replacePage(
         context,
         DetailPage(
@@ -160,7 +165,9 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       );
     } catch (e, s) {
       await dialog.hide();
-      showToast(context, AppLocalizations.of(context).oopsCouldNotSaveEdits);
+      if (mounted) {
+        showToast(context, AppLocalizations.of(context).oopsCouldNotSaveEdits);
+      }
       _logger.severe("Failed to save image edits", e, s);
     } finally {
       if (hasStoppedChangeNotify) {

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_selection_actions_widget.dart
@@ -1144,6 +1144,7 @@ class _FileSelectionActionsWidgetState
           addedToQueueCount = enqueueResult.addedCount;
         } catch (e) {
           _logger.warning("Failed to enqueue files for download", e);
+          if (!mounted) return;
           await showGenericErrorDialog(context: context, error: e);
           return;
         }
@@ -1197,6 +1198,7 @@ class _FileSelectionActionsWidgetState
       }
     }
 
+    if (!mounted) return;
     if (skippedFilesCount > 0) {
       String finalMessage;
       if (skippedFilesCount == 1) {

--- a/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
@@ -135,6 +135,7 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
       log("videoCustomProps ${properties.toString()}");
       log("PropData ${properties?.propData.toString()}");
     }
+    if (!mounted) return;
     setState(() {});
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/file_details/file_info_face_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/file_info_face_widget.dart
@@ -258,6 +258,7 @@ class _FileInfoFaceWidgetState extends State<FileInfoFaceWidget> {
             )
             .toList();
       }
+      if (!mounted) return;
       await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (context) => ClusterPage(
@@ -277,6 +278,7 @@ class _FileInfoFaceWidgetState extends State<FileInfoFaceWidget> {
       // assigning a manual new clusterID so that the user can cluster it manually
       final String clusterID = newClusterID();
       await mlDataDB.updateFaceIdToClusterId({widget.face.faceID: clusterID});
+      if (!mounted) return;
       await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (context) =>
@@ -286,6 +288,7 @@ class _FileInfoFaceWidgetState extends State<FileInfoFaceWidget> {
       return;
     }
 
+    if (!mounted) return;
     showShortToast(context, AppLocalizations.of(context).faceNotClusteredYet);
     unawaited(MLService.instance.clusterAllImages(force: true));
     return;
@@ -298,6 +301,7 @@ class _FileInfoFaceWidgetState extends State<FileInfoFaceWidget> {
             faceID: widget.face.faceID,
             clusterID: widget.clusterID,
           );
+      if (!mounted) return;
       await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (context) => SaveOrEditPerson(


### PR DESCRIPTION
- Prevent disposed Photos widgets from navigating, showing UI, or calling setState after async work.
- Fixes PHOTOS-MOBILE-F3K, PHOTOS-MOBILE-G23, PHOTOS-MOBILE-FFY, PHOTOS-MOBILE-FAZ.