### PR TITLE
[mobile][photos] Reject stale detail page selections

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -159,8 +159,9 @@ class _BodyState extends State<_Body> {
     super.initState();
     _files = widget.config.files;
 
-    _selectedIndexNotifier.value = widget.config.selectedIndex;
-    _pageController = PageController(initialPage: _selectedIndexNotifier.value);
+    final selectedIndex = _initialSelectedIndex();
+    _selectedIndexNotifier.value = selectedIndex ?? -1;
+    _pageController = PageController(initialPage: selectedIndex ?? 0);
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
     ) {
@@ -177,8 +178,13 @@ class _BodyState extends State<_Body> {
     // Update shared collection state after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _updateSharedCollectionState(_files![_selectedIndexNotifier.value]);
-      _evaluateQrIfEligible(_files![_selectedIndexNotifier.value]);
+      final selectedFile = _selectedFile;
+      if (selectedFile == null) {
+        Navigator.maybePop(context).ignore();
+        return;
+      }
+      _updateSharedCollectionState(selectedFile);
+      _evaluateQrIfEligible(selectedFile);
       widget.config.onPageReady?.call(context);
     });
   }
@@ -200,15 +206,19 @@ class _BodyState extends State<_Body> {
 
   @override
   Widget build(BuildContext context) {
-    try {
-      _files![_selectedIndexNotifier.value];
-    } catch (e) {
-      _logger.severe(e);
-      Navigator.pop(context);
+    final selectedFile = _selectedFile;
+    if (selectedFile == null) {
+      _logger.warning("Closing detail page without a selected file");
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          Navigator.maybePop(context).ignore();
+        }
+      });
+      return const Scaffold(backgroundColor: Colors.black);
     }
     _logger.info(
       "Opening " +
-          _files![_selectedIndexNotifier.value].toString() +
+          selectedFile.toString() +
           ". " +
           (_selectedIndexNotifier.value + 1).toString() +
           " / " +
@@ -419,6 +429,10 @@ class _BodyState extends State<_Body> {
         );
       },
       onPageChanged: (index) {
+        final file = _fileAt(index);
+        if (file == null) {
+          return;
+        }
         if (_selectedIndexNotifier.value == index) {
           if (kDebugMode) {
             debugPrint("onPageChanged called with same index $index");
@@ -431,8 +445,8 @@ class _BodyState extends State<_Body> {
           _selectedIndexNotifier.value = index;
         }
         Bus.instance.fire(GuestViewEvent(isGuestView, swipeLocked));
-        _updateSharedCollectionState(_files![index]);
-        _evaluateQrIfEligible(_files![index]);
+        _updateSharedCollectionState(file);
+        _evaluateQrIfEligible(file);
       },
       physics: _shouldDisableScroll || swipeLocked
           ? const NeverScrollableScrollPhysics()
@@ -594,8 +608,30 @@ class _BodyState extends State<_Body> {
 
     // Guard: Only update if still showing the same file
     // (user may have swiped to a different file while awaiting)
-    if (_files![_selectedIndexNotifier.value].uploadedFileID == fileID) {
+    if (_selectedFile?.uploadedFileID == fileID) {
       notifier.value = isShared;
     }
+  }
+
+  int? _initialSelectedIndex() {
+    final files = _files;
+    if (files == null || files.isEmpty) {
+      return null;
+    }
+    final selectedIndex = widget.config.selectedIndex;
+    if (selectedIndex < 0 || selectedIndex >= files.length) {
+      return null;
+    }
+    return selectedIndex;
+  }
+
+  EnteFile? get _selectedFile => _fileAt(_selectedIndexNotifier.value);
+
+  EnteFile? _fileAt(int index) {
+    final files = _files;
+    if (files == null || index < 0 || index >= files.length) {
+      return null;
+    }
+    return files[index];
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -159,9 +159,12 @@ class _BodyState extends State<_Body> {
     super.initState();
     _files = widget.config.files;
 
-    final selectedIndex = _initialSelectedIndex();
-    _selectedIndexNotifier.value = selectedIndex ?? -1;
-    _pageController = PageController(initialPage: selectedIndex ?? 0);
+    final configuredIndex = widget.config.selectedIndex;
+    final selectedIndex = _fileAt(configuredIndex) == null
+        ? -1
+        : configuredIndex;
+    _selectedIndexNotifier.value = selectedIndex;
+    _pageController = PageController(initialPage: max(0, selectedIndex));
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
     ) {
@@ -611,18 +614,6 @@ class _BodyState extends State<_Body> {
     if (_selectedFile?.uploadedFileID == fileID) {
       notifier.value = isShared;
     }
-  }
-
-  int? _initialSelectedIndex() {
-    final files = _files;
-    if (files == null || files.isEmpty) {
-      return null;
-    }
-    final selectedIndex = widget.config.selectedIndex;
-    if (selectedIndex < 0 || selectedIndex >= files.length) {
-      return null;
-    }
-    return selectedIndex;
   }
 
   EnteFile? get _selectedFile => _fileAt(_selectedIndexNotifier.value);

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
+import "package:logging/logging.dart";
 import "package:media_extension/media_extension.dart";
 import "package:media_extension/media_extension_action_types.dart";
 import "package:photos/core/constants.dart";
@@ -47,6 +48,7 @@ class GalleryFileWidget extends StatefulWidget {
 
 class _GalleryFileWidgetState extends State<GalleryFileWidget> {
   static const borderRadius = BorderRadius.all(Radius.circular(1));
+  static final _logger = Logger("GalleryFileWidget");
   late bool _isFileSelected;
   int? _currentPointerId;
   bool _isPointerInside = false;
@@ -289,6 +291,9 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
     final selectedIndex = galleryFiles.indexOf(file);
     // A refresh can make the tapped tile stale.
     if (selectedIndex < 0) {
+      _logger.warning(
+        "Not opening viewer; tapped item is no longer in the gallery",
+      );
       return;
     }
     // Device folders (local-only contexts) should keep files visible

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -286,6 +286,10 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
 
   void _routeToDetailPage(EnteFile file, BuildContext context) {
     final galleryFiles = GalleryFilesState.of(context).galleryFiles;
+    final selectedIndex = galleryFiles.indexOf(file);
+    if (selectedIndex < 0) {
+      return;
+    }
     // Device folders (local-only contexts) should keep files visible
     // even after deleting from Ente (remote) since they still exist locally
     final galleryType = GalleryContextState.of(context)?.galleryType;
@@ -293,7 +297,7 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
     final page = DetailPage(
       DetailPageConfiguration(
         galleryFiles,
-        galleryFiles.indexOf(file),
+        selectedIndex,
         widget.tag,
         isLocalOnlyContext: isLocalOnlyContext,
         galleryType: galleryType,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -287,6 +287,7 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
   void _routeToDetailPage(EnteFile file, BuildContext context) {
     final galleryFiles = GalleryFilesState.of(context).galleryFiles;
     final selectedIndex = galleryFiles.indexOf(file);
+    // A refresh can make the tapped tile stale.
     if (selectedIndex < 0) {
       return;
     }


### PR DESCRIPTION
Fixes PHOTOS-MOBILE-F0V.
Fixes PHOTOS-MOBILE-F0T.

Before: A stale selection could open a broken black viewer and emit repeated errors.
After: Stale selections are ignored, or the viewer closes cleanly if already opening.