### PR TITLE
[mobile][photos] Commit file magic updates after remote success

### DIFF
--- a/mobile/apps/photos/lib/services/file_magic_service.dart
+++ b/mobile/apps/photos/lib/services/file_magic_service.dart
@@ -19,9 +19,28 @@ import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/service_locator.dart";
 import 'package:photos/services/sync/remote_sync_service.dart';
 import "package:photos/utils/file_key.dart";
+import "package:synchronized/synchronized.dart";
+
+class _PreparedMagicMetadataUpdate<T> {
+  const _PreparedMagicMetadataUpdate({
+    required this.file,
+    required this.encodedJson,
+    required this.decodedMetadata,
+    required this.nextVersion,
+    required this.request,
+  });
+
+  final EnteFile file;
+  final String encodedJson;
+  final T decodedMetadata;
+  final int nextVersion;
+  final UpdateMagicMetadataRequest request;
+}
 
 class FileMagicService {
   final _logger = Logger("FileMagicService");
+  final _privateMetadataLock = Lock();
+  final _publicMetadataLock = Lock();
   late FilesDB _filesDB;
 
   FileMagicGateway get _gateway => fileMagicGateway;
@@ -61,21 +80,26 @@ class FileMagicService {
     List<EnteFile> files,
     Map<String, dynamic>? newMetadataUpdate, {
     Map<int, Map<String, dynamic>>? metadataUpdateMap,
+  }) {
+    return _publicMetadataLock.synchronized(
+      () => _updatePublicMagicMetadata(
+        files,
+        newMetadataUpdate,
+        metadataUpdateMap: metadataUpdateMap,
+      ),
+    );
+  }
+
+  Future<void> _updatePublicMagicMetadata(
+    List<EnteFile> files,
+    Map<String, dynamic>? newMetadataUpdate, {
+    Map<int, Map<String, dynamic>>? metadataUpdateMap,
   }) async {
-    final metadataList = <UpdateMagicMetadataRequest>[];
+    final updates = <_PreparedMagicMetadataUpdate<PubMagicMetadata>>[];
     final int ownerID = Configuration.instance.getUserID()!;
     try {
       for (final file in files) {
-        if (file.uploadedFileID == null) {
-          throw AssertionError(
-            "operation is only supported on backed up files",
-          );
-        } else if (file.ownerID != ownerID) {
-          throw AssertionError("cannot modify memories not owned by you");
-        }
-        // read the existing magic metadata and apply new updates to existing data
-        // current update is simple replace. This will be enhanced in the future,
-        // as required.
+        _assertCanUpdate(file, ownerID);
         final newUpdates = metadataUpdateMap != null
             ? metadataUpdateMap[file.uploadedFileID]
             : newMetadataUpdate;
@@ -83,40 +107,30 @@ class FileMagicService {
           newUpdates != null && newUpdates.isNotEmpty,
           "can not apply empty updates",
         );
-        final Map<String, dynamic> jsonToUpdate = jsonDecode(
-          file.pubMmdEncodedJson ?? '{}',
-        );
-        newUpdates!.forEach((key, value) {
-          jsonToUpdate[key] = value;
-        });
-
-        // update the local information so that it's reflected on UI
-        file.pubMmdEncodedJson = jsonEncode(jsonToUpdate);
-        file.pubMagicMetadata = PubMagicMetadata.fromJson(jsonToUpdate);
-
-        final fileKey = getFileKey(file);
-        final encryptedMMd = await CryptoUtil.encryptChaCha(
-          utf8.encode(jsonEncode(jsonToUpdate)),
-          fileKey,
-        );
         final int currentVersion = file.pubMmdVersion == 0
             ? 1
             : file.pubMmdVersion;
-        metadataList.add(
-          UpdateMagicMetadataRequest(
-            id: file.uploadedFileID!,
-            magicMetadata: MetadataRequest(
-              version: currentVersion,
-              count: jsonToUpdate.length,
-              data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
-              header: CryptoUtil.bin2base64(encryptedMMd.header!),
-            ),
+        updates.add(
+          await _prepareUpdate(
+            file: file,
+            encodedJson: file.pubMmdEncodedJson,
+            currentVersion: currentVersion,
+            newMetadata: newUpdates!,
+            decode: PubMagicMetadata.fromJson,
           ),
         );
-        file.pubMmdVersion = currentVersion + 1;
       }
 
-      await _gateway.updatePublicMagicMetadata(metadataList);
+      await _gateway.updatePublicMagicMetadata(
+        updates.map((update) => update.request).toList(),
+      );
+      // Remote has accepted these versions; commit the same state locally.
+      for (final update in updates) {
+        update.file
+          ..pubMmdEncodedJson = update.encodedJson
+          ..pubMagicMetadata = update.decodedMetadata
+          ..pubMmdVersion = update.nextVersion;
+      }
       // update the state of the selected file. Same file in other collection
       // should be eventually synced after remote sync has completed
       await _filesDB.insertMultiple(files);
@@ -135,55 +149,45 @@ class FileMagicService {
   Future<void> _updateMagicData(
     List<EnteFile> files,
     Map<String, dynamic> newMetadataUpdate,
+  ) {
+    return _privateMetadataLock.synchronized(
+      () => _updatePrivateMagicMetadata(files, newMetadataUpdate),
+    );
+  }
+
+  Future<void> _updatePrivateMagicMetadata(
+    List<EnteFile> files,
+    Map<String, dynamic> newMetadataUpdate,
   ) async {
     final int ownerID = Configuration.instance.getUserID()!;
     final batchedFiles = files.chunks(batchSize);
     try {
       for (final batch in batchedFiles) {
-        final metadataList = <UpdateMagicMetadataRequest>[];
+        final updates = <_PreparedMagicMetadataUpdate<MagicMetadata>>[];
         for (final file in batch) {
-          if (file.uploadedFileID == null) {
-            throw AssertionError(
-              "operation is only supported on backed up files",
-            );
-          } else if (file.ownerID != ownerID) {
-            throw AssertionError("cannot modify memories not owned by you");
-          }
-          // read the existing magic metadata and apply new updates to existing data
-          // current update is simple replace. This will be enhanced in the future,
-          // as required.
-          final Map<String, dynamic> jsonToUpdate = jsonDecode(
-            file.mMdEncodedJson ?? '{}',
-          );
-          newMetadataUpdate.forEach((key, value) {
-            jsonToUpdate[key] = value;
-          });
-
-          // update the local information so that it's reflected on UI
-          file.mMdEncodedJson = jsonEncode(jsonToUpdate);
-          file.magicMetadata = MagicMetadata.fromJson(jsonToUpdate);
-
-          final fileKey = getFileKey(file);
-          final encryptedMMd = await CryptoUtil.encryptChaCha(
-            utf8.encode(jsonEncode(jsonToUpdate)),
-            fileKey,
-          );
-          metadataList.add(
-            UpdateMagicMetadataRequest(
-              id: file.uploadedFileID!,
-              magicMetadata: MetadataRequest(
-                version: file.mMdVersion,
-                count: jsonToUpdate.length,
-                data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
-                header: CryptoUtil.bin2base64(encryptedMMd.header!),
-              ),
+          _assertCanUpdate(file, ownerID);
+          updates.add(
+            await _prepareUpdate(
+              file: file,
+              encodedJson: file.mMdEncodedJson,
+              currentVersion: file.mMdVersion,
+              newMetadata: newMetadataUpdate,
+              decode: MagicMetadata.fromJson,
             ),
           );
-          file.mMdVersion = file.mMdVersion + 1;
         }
 
-        await _gateway.updateMagicMetadata(metadataList);
-        await _filesDB.insertMultiple(files);
+        await _gateway.updateMagicMetadata(
+          updates.map((update) => update.request).toList(),
+        );
+        // Each batch is committed locally only after its remote transaction.
+        for (final update in updates) {
+          update.file
+            ..mMdEncodedJson = update.encodedJson
+            ..magicMetadata = update.decodedMetadata
+            ..mMdVersion = update.nextVersion;
+        }
+        await _filesDB.insertMultiple(batch);
       }
 
       // update the state of the selected file. Same file in other collection
@@ -198,5 +202,44 @@ class FileMagicService {
       _logger.severe("failed to sync magic metadata", e, s);
       rethrow;
     }
+  }
+
+  void _assertCanUpdate(EnteFile file, int ownerID) {
+    if (file.uploadedFileID == null) {
+      throw AssertionError("operation is only supported on backed up files");
+    } else if (file.ownerID != ownerID) {
+      throw AssertionError("cannot modify memories not owned by you");
+    }
+  }
+
+  Future<_PreparedMagicMetadataUpdate<T>> _prepareUpdate<T>({
+    required EnteFile file,
+    required String? encodedJson,
+    required int currentVersion,
+    required Map<String, dynamic> newMetadata,
+    required T Function(dynamic json) decode,
+  }) async {
+    final Map<String, dynamic> jsonToUpdate = jsonDecode(encodedJson ?? '{}');
+    jsonToUpdate.addAll(newMetadata);
+    final updatedJson = jsonEncode(jsonToUpdate);
+    final encryptedMMd = await CryptoUtil.encryptChaCha(
+      utf8.encode(updatedJson),
+      getFileKey(file),
+    );
+    return _PreparedMagicMetadataUpdate(
+      file: file,
+      encodedJson: updatedJson,
+      decodedMetadata: decode(jsonToUpdate),
+      nextVersion: currentVersion + 1,
+      request: UpdateMagicMetadataRequest(
+        id: file.uploadedFileID!,
+        magicMetadata: MetadataRequest(
+          version: currentVersion,
+          count: jsonToUpdate.length,
+          data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
+          header: CryptoUtil.bin2base64(encryptedMMd.header!),
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
Prepare encrypted File Magic candidates without mutating live files, serialize public and private update transactions, and apply and persist versions only after server acceptance.