### PR TITLE
[mobile][photos] Focus offline metadata enrichment

### DIFF
--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -1,3 +1,5 @@
+import "dart:io";
+
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart";
@@ -7,6 +9,7 @@ import "package:photos/core/errors.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/location/location.dart";
+import "package:photos/module/metadata/exif.dart";
 
 final _logger = Logger("LocalFileMetadata");
 
@@ -25,6 +28,37 @@ EnteFile fileFromAsset(String deviceFolder, AssetEntity asset) {
     )
     ..fileSubType = asset.subtype
     ..metadataVersion = -1;
+}
+
+/// Applies creation-time precedence without fetching or decoding more media.
+/// Offline import runs this in batches and persists only this derived field.
+void applyCreationTimeMetadata(EnteFile file, ParsedExifDateTime? exifTime) {
+  final hasExifTime = exifTime != null;
+  if (exifTime != null) {
+    file.creationTime = exifTime.time.microsecondsSinceEpoch;
+  }
+
+  // Try to get the timestamp from fileName. In case of iOS, file names are
+  // generic IMG_XXXX, so only parse it on Android devices
+  if (!hasExifTime && Platform.isAndroid && file.title != null) {
+    final timeFromFileName = parseDateTimeFromFileNameV2(file.title!);
+    if (timeFromFileName != null) {
+      // only use timeFromFileName if the existing creationTime and
+      // timeFromFilename belongs to different date.
+      // This is done because many times the fileTimeStamp will only give us
+      // the date, not time value but the photo_manager's creation time will
+      // contain the time.
+      final bool useFileTimeStamp =
+          file.creationTime == null ||
+          !areFromSameDay(
+            file.creationTime!,
+            timeFromFileName.microsecondsSinceEpoch,
+          );
+      if (useFileTimeStamp) {
+        file.creationTime = timeFromFileName.microsecondsSinceEpoch;
+      }
+    }
+  }
 }
 
 int _creationTimeFromAsset(AssetEntity asset) {

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -72,6 +72,10 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     throw InvalidFileError("", InvalidReason.assetDeleted);
   }
   _assertFileType(asset, file);
+  file.fileSubType = asset.subtype;
+  if (file.fileType == FileType.video) {
+    file.duration = asset.duration;
+  }
   if (Platform.isIOS) {
     trackOriginFetchForUploadOrML.put(file.localID!, true);
   }

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -1,14 +1,13 @@
 import "dart:convert";
-import "dart:io";
 import "dart:typed_data";
 
 import "package:ente_crypto/ente_crypto.dart";
-import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:photos/gateways/collections/models/metadata.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/module/metadata/exif.dart";
+import "package:photos/module/metadata/local_file.dart";
 import 'package:photos/module/metadata/panorama.dart';
 import "package:photos/module/upload/model/media_upload_data.dart";
 
@@ -17,18 +16,7 @@ Future<Map<String, dynamic>> buildUploadMetadata(
   MediaUploadData mediaUploadData,
   ParsedExifDateTime? exifTime,
 ) async {
-  final asset = await file.getAsset;
-  // asset can be null for files shared to app
-  if (asset != null) {
-    file.fileSubType = asset.subtype;
-    if (file.fileType == FileType.video) {
-      file.duration = asset.duration;
-    }
-  }
-  final hasExifTime = exifTime != null;
-  if (exifTime != null) {
-    file.creationTime = exifTime.time.microsecondsSinceEpoch;
-  }
+  applyCreationTimeMetadata(file, exifTime);
   if (mediaUploadData.exifData != null) {
     mediaUploadData.isPanorama = isPanoramaFromExif(mediaUploadData.exifData);
   }
@@ -40,28 +28,6 @@ Future<Map<String, dynamic>> buildUploadMetadata(
       mediaUploadData.isPanorama = isPanoramaFromXmp(xmpData);
     } catch (_) {}
     mediaUploadData.isPanorama ??= false;
-  }
-
-  // Try to get the timestamp from fileName. In case of iOS, file names are
-  // generic IMG_XXXX, so only parse it on Android devices
-  if (!hasExifTime && Platform.isAndroid && file.title != null) {
-    final timeFromFileName = parseDateTimeFromFileNameV2(file.title!);
-    if (timeFromFileName != null) {
-      // only use timeFromFileName if the existing creationTime and
-      // timeFromFilename belongs to different date.
-      // This is done because many times the fileTimeStamp will only give us
-      // the date, not time value but the photo_manager's creation time will
-      // contain the time.
-      final bool useFileTimeStamp =
-          file.creationTime == null ||
-          !areFromSameDay(
-            file.creationTime!,
-            timeFromFileName.microsecondsSinceEpoch,
-          );
-      if (useFileTimeStamp) {
-        file.creationTime = timeFromFileName.microsecondsSinceEpoch;
-      }
-    }
   }
   file.hash = mediaUploadData.hashData?.fileHash;
   return file.metadata;

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -11,9 +11,8 @@ import "package:photos/models/file/file.dart";
 import "package:photos/models/location/location.dart";
 import "package:photos/module/download/file.dart";
 import "package:photos/module/metadata/exif.dart";
+import "package:photos/module/metadata/local_file.dart";
 import 'package:photos/module/metadata/location.dart';
-import "package:photos/module/upload/model/media_upload_data.dart";
-import "package:photos/module/upload/upload_metadata.dart";
 import "package:photos/service_locator.dart";
 
 class OfflineImportMetadataService {
@@ -112,14 +111,7 @@ class OfflineImportMetadataService {
 
       await _updateLocationForOfflineFile(file, originFile, exifData);
 
-      final mediaUploadData = MediaUploadData(
-        originFile,
-        null,
-        false,
-        null,
-        exifData: exifData,
-      );
-      await buildUploadMetadata(file, mediaUploadData, exifTime);
+      applyCreationTimeMetadata(file, exifTime);
 
       await _db.updateOfflineImportMetadataForLocalID(
         file.localID!,


### PR DESCRIPTION
Apply only the creation-time policy during offline metadata enrichment, and capture subtype and duration from the upload asset already in scope. This reduces background work and removes a late asset lookup after media transfer.