### PR TITLE
[mobile][photos] Make upload metadata data flow explicit

### DIFF
--- a/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
@@ -10,14 +10,6 @@ class MediaUploadData {
   final FileHashData hashData;
 
   final DerivedMediaMetadata derivedMetadata;
-  bool? isPanorama;
-
-  int? get height => derivedMetadata.height;
-  int? get width => derivedMetadata.width;
-  String? get cameraMake => derivedMetadata.cameraMake;
-  String? get cameraModel => derivedMetadata.cameraModel;
-  int? get motionPhotoStartIndex => derivedMetadata.motionPhotoStartIndex;
-  Map<String, IfdTag>? get exifData => derivedMetadata.exifData;
 
   MediaUploadData({
     required this.sourceFile,
@@ -25,7 +17,6 @@ class MediaUploadData {
     required this.isDeleted,
     required this.hashData,
     required this.derivedMetadata,
-    this.isPanorama,
   });
 }
 
@@ -57,7 +48,7 @@ class FileHashData {
 
   // zipHash is used to take care of existing live photo uploads from older
   // mobile clients
-  String? zipHash;
+  final String? zipHash;
 
   FileHashData(this.fileHash, {this.zipHash});
 }

--- a/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
@@ -4,10 +4,32 @@ import 'dart:typed_data';
 import 'package:exif_reader/exif_reader.dart';
 
 class MediaUploadData {
-  final File? sourceFile;
+  final File sourceFile;
   final Uint8List? thumbnail;
   final bool isDeleted;
-  final FileHashData? hashData;
+  final FileHashData hashData;
+
+  final DerivedMediaMetadata derivedMetadata;
+  bool? isPanorama;
+
+  int? get height => derivedMetadata.height;
+  int? get width => derivedMetadata.width;
+  String? get cameraMake => derivedMetadata.cameraMake;
+  String? get cameraModel => derivedMetadata.cameraModel;
+  int? get motionPhotoStartIndex => derivedMetadata.motionPhotoStartIndex;
+  Map<String, IfdTag>? get exifData => derivedMetadata.exifData;
+
+  MediaUploadData({
+    required this.sourceFile,
+    required this.thumbnail,
+    required this.isDeleted,
+    required this.hashData,
+    required this.derivedMetadata,
+    this.isPanorama,
+  });
+}
+
+class DerivedMediaMetadata {
   final int? height;
   final int? width;
   final String? cameraMake;
@@ -19,26 +41,19 @@ class MediaUploadData {
 
   final Map<String, IfdTag>? exifData;
 
-  bool? isPanorama;
-
-  MediaUploadData(
-    this.sourceFile,
-    this.thumbnail,
-    this.isDeleted,
-    this.hashData, {
+  const DerivedMediaMetadata({
     this.height,
     this.width,
     this.cameraMake,
     this.cameraModel,
     this.motionPhotoStartIndex,
-    this.isPanorama,
     this.exifData,
   });
 }
 
 class FileHashData {
   // For livePhotos, the fileHash value will be imageHash:videoHash
-  final String? fileHash;
+  final String fileHash;
 
   // zipHash is used to take care of existing live photo uploads from older
   // mobile clients

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -29,7 +29,6 @@ import "package:photos/models/backup/backup_item.dart";
 import "package:photos/models/backup/backup_item_status.dart";
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
-import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/models/user_details.dart";
 import "package:photos/module/download/file.dart";
 import "package:photos/module/metadata/exif.dart";
@@ -819,18 +818,19 @@ class FileUploader {
           contentMd5: thumbnailMd5,
         );
       }
-      final ParsedExifDateTime? exifTime = mediaUploadData.exifData != null
-          ? await tryParseExifDateTime(null, mediaUploadData.exifData)
+      final exifData = mediaUploadData.derivedMetadata.exifData;
+      final ParsedExifDateTime? exifTime = exifData != null
+          ? await tryParseExifDateTime(null, exifData)
           : null;
       file.metadataVersion = EnteFile.kCurrentMetadataVersion;
-      final metadata = await buildUploadMetadata(
+      final preparedMetadata = await prepareUploadMetadata(
         file,
         mediaUploadData,
         exifTime,
       );
 
       final encryptedMetadataResult = await CryptoUtil.encryptChaCha(
-        utf8.encode(jsonEncode(metadata)),
+        utf8.encode(jsonEncode(preparedMetadata.canonicalMetadata)),
         fileAttributes.key,
       );
       final fileDecryptionHeader = CryptoUtil.bin2base64(fileAttributes.header);
@@ -855,10 +855,7 @@ class FileUploader {
         throw LockFreedError();
       }
 
-      final Map<String, dynamic> pubMetadata = _buildPublicMagicData(
-        mediaUploadData,
-        exifTime,
-      );
+      final pubMetadata = preparedMetadata.publicMetadata;
       EnteFile remoteFile;
       if (isUpdatedFile) {
         // Verify that the encrypted file can be decrypted before uploading
@@ -998,40 +995,6 @@ class FileUploader {
         isMultiPartUpload: isMultipartUpload,
       );
     }
-  }
-
-  Map<String, dynamic> _buildPublicMagicData(
-    MediaUploadData mediaUploadData,
-    ParsedExifDateTime? exifTime,
-  ) {
-    final Map<String, dynamic> pubMetadata = {};
-    if ((mediaUploadData.height ?? 0) != 0 &&
-        (mediaUploadData.width ?? 0) != 0) {
-      pubMetadata[heightKey] = mediaUploadData.height;
-      pubMetadata[widthKey] = mediaUploadData.width;
-      pubMetadata[mediaTypeKey] = mediaUploadData.isPanorama == true ? 1 : 0;
-    }
-    if (mediaUploadData.motionPhotoStartIndex != null) {
-      pubMetadata[motionVideoIndexKey] = mediaUploadData.motionPhotoStartIndex;
-    }
-    if (mediaUploadData.thumbnail == null) {
-      pubMetadata[noThumbKey] = true;
-    }
-    if (exifTime != null) {
-      if (exifTime.dateTime != null) {
-        pubMetadata[dateTimeKey] = exifTime.dateTime;
-      }
-      if (exifTime.offsetTime != null) {
-        pubMetadata[offsetTimeKey] = exifTime.offsetTime;
-      }
-    }
-    if ((mediaUploadData.cameraMake ?? '').isNotEmpty) {
-      pubMetadata[cameraMakeKey] = mediaUploadData.cameraMake;
-    }
-    if ((mediaUploadData.cameraModel ?? '').isNotEmpty) {
-      pubMetadata[cameraModelKey] = mediaUploadData.cameraModel;
-    }
-    return pubMetadata;
   }
 
   bool isPutOrMultiPartError(Object e) {

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -585,15 +585,13 @@ class FileUploader {
       rethrow;
     }
 
-    final String? existingMultipartEncFileName =
-        mediaUploadData.hashData?.fileHash != null
-        ? await _uploadLocks.getEncryptedFileName(
-            lockKey,
-            mediaUploadData.hashData!.fileHash!,
-            collectionID,
-          )
-        : null;
-    final sourceLength = await mediaUploadData.sourceFile!.length();
+    final String? existingMultipartEncFileName = await _uploadLocks
+        .getEncryptedFileName(
+          lockKey,
+          mediaUploadData.hashData.fileHash,
+          collectionID,
+        );
+    final sourceLength = await mediaUploadData.sourceFile.length();
     final bool hasExistingMultiPart = existingMultipartEncFileName != null;
     final tempDirectory = Configuration.instance.getTempDirectory();
     final String uniqueID =
@@ -624,7 +622,7 @@ class FileUploader {
       final FileEncryptResult? multiPartFileEncResult = hasExistingMultiPart
           ? await _multiPartUploader.getEncryptionResult(
               lockKey,
-              mediaUploadData.hashData!.fileHash!,
+              mediaUploadData.hashData.fileHash,
               collectionID,
               existingMultipartEncFileName,
             )
@@ -675,7 +673,7 @@ class FileUploader {
         _logger.severe('File exists without multipart entry, deleting file');
         await File(encryptedFilePath).delete();
       }
-      await _checkIfWithinStorageLimit(mediaUploadData.sourceFile!);
+      await _checkIfWithinStorageLimit(mediaUploadData.sourceFile);
       final encryptedFile = File(encryptedFilePath);
 
       // Calculate the number of parts to determine if we need MD5
@@ -691,7 +689,7 @@ class FileUploader {
 
       if (fileAttributes == null) {
         final result = await CryptoUtil.encryptFileWithMD5(
-          mediaUploadData.sourceFile!.path,
+          mediaUploadData.sourceFile.path,
           encryptedFilePath,
           key: key,
           multiPartChunkSizeInBytes: (estimatedCount > 1)
@@ -767,7 +765,7 @@ class FileUploader {
           fileObjectKey = await _multiPartUploader.putExistingMultipartFile(
             encryptedFile,
             lockKey,
-            mediaUploadData.hashData!.fileHash!,
+            mediaUploadData.hashData.fileHash,
             collectionID,
             existingMultipartEncFileName,
           );
@@ -788,7 +786,7 @@ class FileUploader {
           final encFileName = encryptedFile.path.split('/').last;
           await _multiPartUploader.createTableEntry(
             lockKey,
-            mediaUploadData.hashData!.fileHash!,
+            mediaUploadData.hashData.fileHash,
             collectionID,
             fileUploadURLs,
             encFileName,
@@ -1083,7 +1081,7 @@ class FileUploader {
 
     final List<EnteFile> existingUploadedFiles = await FilesDB.instance
         .getUploadedFilesWithHashes(
-          mediaUploadData.hashData!,
+          mediaUploadData.hashData,
           fileToUpload.fileType,
           Configuration.instance.getUserID()!,
         );
@@ -1193,7 +1191,7 @@ class FileUploader {
     required String lockKey,
     bool isMultiPartUpload = false,
   }) async {
-    if (mediaUploadData != null && mediaUploadData.sourceFile != null) {
+    if (mediaUploadData != null) {
       // delete the file from app's internal cache if it was copied to app
       // for upload. On iOS, only remove the file from photo_manager/app cache
       // when upload is either completed or there's a tempFailure
@@ -1201,7 +1199,7 @@ class FileUploader {
       // succeeds.
       if ((Platform.isIOS && (uploadCompleted || uploadHardFailure)) ||
           (uploadCompleted && file.isSharedMediaToAppSandbox)) {
-        await deleteFileSystemEntityIfPresent(mediaUploadData.sourceFile!);
+        await deleteFileSystemEntityIfPresent(mediaUploadData.sourceFile);
       }
     }
     if (File(encryptedFilePath).existsSync()) {

--- a/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
+++ b/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
@@ -154,10 +154,9 @@ class LocalFileUpdateService {
       MediaUploadData uploadData;
       try {
         uploadData = await getUploadData(file);
-        if (uploadData.hashData != null &&
-            file.hash != null &&
-            (file.hash == uploadData.hashData!.fileHash ||
-                file.hash == uploadData.hashData!.zipHash)) {
+        if (file.hash != null &&
+            (file.hash == uploadData.hashData.fileHash ||
+                file.hash == uploadData.hashData.zipHash)) {
           _logger.info("Skip file update as hash matched ${file.tag}");
         } else {
           _logger.info(

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -152,16 +152,18 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
       }
     }
     return MediaUploadData(
-      sourceFile,
-      thumbnailData,
-      isDeleted,
-      FileHashData(fileHash, zipHash: zipHash),
-      height: h,
-      width: w,
-      cameraMake: cameraMake,
-      cameraModel: cameraModel,
-      motionPhotoStartIndex: motionPhotoStartingIndex,
-      exifData: exifData,
+      sourceFile: sourceFile,
+      thumbnail: thumbnailData,
+      isDeleted: isDeleted,
+      hashData: FileHashData(fileHash, zipHash: zipHash),
+      derivedMetadata: DerivedMediaMetadata(
+        height: h,
+        width: w,
+        cameraMake: cameraMake,
+        cameraModel: cameraModel,
+        motionPhotoStartIndex: motionPhotoStartingIndex,
+        exifData: exifData,
+      ),
     );
   } catch (_) {
     if (Platform.isIOS) {
@@ -316,15 +318,17 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(
       }
     }
     return MediaUploadData(
-      sourceFile,
-      thumbnailData,
-      isDeleted,
-      FileHashData(fileHash),
-      height: dimensions?.height,
-      width: dimensions?.width,
-      cameraMake: cameraMake,
-      cameraModel: cameraModel,
-      exifData: exifData,
+      sourceFile: sourceFile,
+      thumbnail: thumbnailData,
+      isDeleted: isDeleted,
+      hashData: FileHashData(fileHash),
+      derivedMetadata: DerivedMediaMetadata(
+        height: dimensions?.height,
+        width: dimensions?.width,
+        cameraMake: cameraMake,
+        cameraModel: cameraModel,
+        exifData: exifData,
+      ),
     );
   } catch (e, s) {
     _logger.warning("failed to generate thumbnail", e, s);

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -20,16 +20,14 @@ Future<Map<String, dynamic>> buildUploadMetadata(
   if (mediaUploadData.exifData != null) {
     mediaUploadData.isPanorama = isPanoramaFromExif(mediaUploadData.exifData);
   }
-  if (mediaUploadData.isPanorama != true &&
-      file.fileType == FileType.image &&
-      mediaUploadData.sourceFile != null) {
+  if (mediaUploadData.isPanorama != true && file.fileType == FileType.image) {
     try {
-      final xmpData = await readXmp(mediaUploadData.sourceFile!);
+      final xmpData = await readXmp(mediaUploadData.sourceFile);
       mediaUploadData.isPanorama = isPanoramaFromXmp(xmpData);
     } catch (_) {}
     mediaUploadData.isPanorama ??= false;
   }
-  file.hash = mediaUploadData.hashData?.fileHash;
+  file.hash = mediaUploadData.hashData.fileHash;
   return file.metadata;
 }
 

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -11,24 +11,80 @@ import "package:photos/module/metadata/local_file.dart";
 import 'package:photos/module/metadata/panorama.dart';
 import "package:photos/module/upload/model/media_upload_data.dart";
 
-Future<Map<String, dynamic>> buildUploadMetadata(
+class PreparedUploadMetadata {
+  final Map<String, dynamic> canonicalMetadata;
+  final Map<String, dynamic> publicMetadata;
+
+  PreparedUploadMetadata({
+    required Map<String, dynamic> canonicalMetadata,
+    required Map<String, dynamic> publicMetadata,
+  }) : canonicalMetadata = Map.unmodifiable(canonicalMetadata),
+       publicMetadata = Map.unmodifiable(publicMetadata);
+}
+
+Future<PreparedUploadMetadata> prepareUploadMetadata(
   EnteFile file,
   MediaUploadData mediaUploadData,
   ParsedExifDateTime? exifTime,
 ) async {
   applyCreationTimeMetadata(file, exifTime);
-  if (mediaUploadData.exifData != null) {
-    mediaUploadData.isPanorama = isPanoramaFromExif(mediaUploadData.exifData);
+  final derivedMetadata = mediaUploadData.derivedMetadata;
+  bool? isPanorama;
+  if (derivedMetadata.exifData != null) {
+    isPanorama = isPanoramaFromExif(derivedMetadata.exifData);
   }
-  if (mediaUploadData.isPanorama != true && file.fileType == FileType.image) {
+  if (isPanorama != true && file.fileType == FileType.image) {
     try {
       final xmpData = await readXmp(mediaUploadData.sourceFile);
-      mediaUploadData.isPanorama = isPanoramaFromXmp(xmpData);
+      isPanorama = isPanoramaFromXmp(xmpData);
     } catch (_) {}
-    mediaUploadData.isPanorama ??= false;
+    isPanorama ??= false;
   }
   file.hash = mediaUploadData.hashData.fileHash;
-  return file.metadata;
+  return PreparedUploadMetadata(
+    canonicalMetadata: file.metadata,
+    publicMetadata: _buildPublicMetadata(
+      derivedMetadata,
+      exifTime,
+      isPanorama: isPanorama == true,
+      hasThumbnail: mediaUploadData.thumbnail != null,
+    ),
+  );
+}
+
+Map<String, dynamic> _buildPublicMetadata(
+  DerivedMediaMetadata derivedMetadata,
+  ParsedExifDateTime? exifTime, {
+  required bool isPanorama,
+  required bool hasThumbnail,
+}) {
+  final Map<String, dynamic> publicMetadata = {};
+  if ((derivedMetadata.height ?? 0) != 0 && (derivedMetadata.width ?? 0) != 0) {
+    publicMetadata[heightKey] = derivedMetadata.height;
+    publicMetadata[widthKey] = derivedMetadata.width;
+    publicMetadata[mediaTypeKey] = isPanorama ? 1 : 0;
+  }
+  if (derivedMetadata.motionPhotoStartIndex != null) {
+    publicMetadata[motionVideoIndexKey] = derivedMetadata.motionPhotoStartIndex;
+  }
+  if (!hasThumbnail) {
+    publicMetadata[noThumbKey] = true;
+  }
+  if (exifTime != null) {
+    if (exifTime.dateTime != null) {
+      publicMetadata[dateTimeKey] = exifTime.dateTime;
+    }
+    if (exifTime.offsetTime != null) {
+      publicMetadata[offsetTimeKey] = exifTime.offsetTime;
+    }
+  }
+  if ((derivedMetadata.cameraMake ?? '').isNotEmpty) {
+    publicMetadata[cameraMakeKey] = derivedMetadata.cameraMake;
+  }
+  if ((derivedMetadata.cameraModel ?? '').isNotEmpty) {
+    publicMetadata[cameraModelKey] = derivedMetadata.cameraModel;
+  }
+  return publicMetadata;
 }
 
 Future<MetadataRequest> buildPublicMetadataRequest(


### PR DESCRIPTION
Make source and hash required upload inputs, group optional derived media fields, and prepare canonical and public metadata together without mutating the upload transport object.