### PR TITLE
[mobile][photos] Cache decoded file magic metadata

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -34,22 +34,38 @@ class EnteFile {
   String? metadataDecryptionHeader;
   int? fileSize;
 
-  String? mMdEncodedJson;
+  String? _mMdEncodedJson;
+  String? get mMdEncodedJson => _mMdEncodedJson;
+
+  set mMdEncodedJson(String? value) {
+    if (_mMdEncodedJson == value) return;
+    _mMdEncodedJson = value;
+    _mmd = null;
+  }
+
   int mMdVersion = 0;
   MagicMetadata? _mmd;
 
   MagicMetadata get magicMetadata =>
-      _mmd ?? MagicMetadata.fromEncodedJson(mMdEncodedJson ?? '{}');
+      _mmd ??= MagicMetadata.fromEncodedJson(mMdEncodedJson ?? '{}');
 
   set magicMetadata(MagicMetadata? val) => _mmd = val;
 
   // public magic metadata is shared if during file/album sharing
-  String? pubMmdEncodedJson;
+  String? _pubMmdEncodedJson;
+  String? get pubMmdEncodedJson => _pubMmdEncodedJson;
+
+  set pubMmdEncodedJson(String? value) {
+    if (_pubMmdEncodedJson == value) return;
+    _pubMmdEncodedJson = value;
+    _pubMmd = null;
+  }
+
   int pubMmdVersion = 0;
   PubMagicMetadata? _pubMmd;
 
   PubMagicMetadata? get pubMagicMetadata =>
-      _pubMmd ?? PubMagicMetadata.fromEncodedJson(pubMmdEncodedJson ?? '{}');
+      _pubMmd ??= PubMagicMetadata.fromEncodedJson(pubMmdEncodedJson ?? '{}');
 
   set pubMagicMetadata(PubMagicMetadata? val) => _pubMmd = val;
 


### PR DESCRIPTION
Memoize decoded private and public file metadata, and invalidate each cache whenever its raw JSON changes. This avoids repeated JSON decoding while preserving fresh sync and update values.

User-facing impact: steady-state UI reads such as names, captions, dimensions, panorama and motion-photo flags, and archive or hidden filtering reuse decoded metadata while the raw JSON is unchanged. Updates invalidate the relevant cache, so subsequent reads still reflect the new values.