### PR TITLE
[mobile][photos] Separate content identity from upload preparation

### DIFF
--- a/mobile/apps/photos/lib/module/live_photo/upload.dart
+++ b/mobile/apps/photos/lib/module/live_photo/upload.dart
@@ -19,6 +19,10 @@ typedef LivePhotoUploadData = ({
   String zipHash,
 });
 
+typedef LivePhotoHashData = ({String fileHash, String? zipHash});
+
+typedef _LivePhotoVideoData = ({File file, String fileHash});
+
 final _logger = Logger('LivePhotoUpload');
 
 /// Uploads may prepare several files concurrently. Keep this per-file pipeline
@@ -27,6 +31,63 @@ final _logger = Logger('LivePhotoUpload');
 Future<LivePhotoUploadData> prepareLivePhotoForUpload(
   EnteFile file,
   File imageFile,
+  String imageHash,
+) async {
+  final videoData = await _getLivePhotoVideoData(file, imageHash);
+  final archiveFile = await _createLivePhotoArchiveFile(
+    file,
+    imageFile,
+    videoData.file,
+  );
+  try {
+    // photo_manager can return the same iOS temp copy to concurrent upload or
+    // hash-check paths, where cleanup may have already run.
+    await deleteFileSystemEntityIfPresent(imageFile);
+    final zipHash = CryptoUtil.bin2base64(
+      await CryptoUtil.getHash(archiveFile),
+    );
+    return (
+      sourceFile: archiveFile,
+      fileHash: videoData.fileHash,
+      zipHash: zipHash,
+    );
+  } catch (_) {
+    await deleteFileSystemEntityIfPresent(archiveFile);
+    rethrow;
+  }
+}
+
+/// Computes the modern component hash first and creates the legacy ZIP only
+/// when it is still needed to compare an older stored hash.
+Future<LivePhotoHashData> getLivePhotoHashDataForComparison(
+  EnteFile file,
+  File imageFile,
+  String imageHash,
+) async {
+  final videoData = await _getLivePhotoVideoData(file, imageHash);
+  final storedHash = file.hash;
+  if (storedHash == null ||
+      storedHash == videoData.fileHash ||
+      storedHash.contains(kLivePhotoHashSeparator)) {
+    return (fileHash: videoData.fileHash, zipHash: null);
+  }
+  final archiveFile = await _createLivePhotoArchiveFile(
+    file,
+    imageFile,
+    videoData.file,
+  );
+  try {
+    return (
+      fileHash: videoData.fileHash,
+      zipHash: CryptoUtil.bin2base64(await CryptoUtil.getHash(archiveFile)),
+    );
+  } finally {
+    await deleteFileSystemEntityIfPresent(archiveFile);
+  }
+}
+
+Future<_LivePhotoVideoData> _getLivePhotoVideoData(
+  EnteFile file,
   String imageHash,
 ) async {
   final videoFile = await Motionphoto.getLivePhotoFile(file.localID!);
@@ -39,6 +100,14 @@ Future<LivePhotoUploadData> prepareLivePhotoForUpload(
 
   final videoHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(videoFile));
   final fileHash = '$imageHash$kLivePhotoHashSeparator$videoHash';
+  return (file: videoFile, fileHash: fileHash);
+}
+
+Future<File> _createLivePhotoArchiveFile(
+  EnteFile file,
+  File imageFile,
+  File videoFile,
+) async {
   final archivePath =
       '${Configuration.instance.getTempDirectory()}${const Uuid().v4()}_${file.generatedID}.elp';
   final archiveFile = File(archivePath);
@@ -50,13 +119,7 @@ Future<LivePhotoUploadData> prepareLivePhotoForUpload(
       imagePath: imageFile.path,
       videoPath: videoFile.path,
     );
-    // photo_manager can return the same iOS temp copy to concurrent upload or
-    // hash-check paths, where cleanup may have already run.
-    await deleteFileSystemEntityIfPresent(imageFile);
-    final zipHash = CryptoUtil.bin2base64(
-      await CryptoUtil.getHash(archiveFile),
-    );
-    return (sourceFile: archiveFile, fileHash: fileHash, zipHash: zipHash);
+    return archiveFile;
   } catch (_) {
     await deleteFileSystemEntityIfPresent(archiveFile);
     rethrow;

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -571,7 +571,7 @@ class FileUploader {
 
     MediaUploadData? mediaUploadData;
     try {
-      mediaUploadData = await getUploadDataFromEnteFile(file, parseExif: true);
+      mediaUploadData = await getUploadDataFromEnteFile(file);
     } catch (e) {
       // This additional try catch block is added because for resumable upload,
       // we need to compute the hash before the next step. Previously, this

--- a/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
+++ b/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
@@ -1,8 +1,5 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:ente_pure_utils/ente_pure_utils.dart'
-    show deleteFileSystemEntityIfPresent;
 import 'package:logging/logging.dart';
 import "package:photos/core/configuration.dart";
 import 'package:photos/core/errors.dart';
@@ -11,7 +8,6 @@ import 'package:photos/db/files_db.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import 'package:photos/module/download/file.dart';
-import 'package:photos/module/upload/model/media_upload_data.dart';
 import "package:photos/module/upload/upload_data.dart";
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -151,12 +147,11 @@ class LocalFileUpdateService {
         processedIDs.add(file.localID!);
         continue;
       }
-      MediaUploadData uploadData;
       try {
-        uploadData = await getUploadData(file);
+        final contentIdentity = await getFileContentIdentity(file);
         if (file.hash != null &&
-            (file.hash == uploadData.hashData.fileHash ||
-                file.hash == uploadData.hashData.zipHash)) {
+            (file.hash == contentIdentity.fileHash ||
+                file.hash == contentIdentity.zipHash)) {
           _logger.info("Skip file update as hash matched ${file.tag}");
         } else {
           _logger.info(
@@ -205,26 +200,5 @@ class LocalFileUpdateService {
       processedIDs.toList(),
       FileUpdationDB.modificationTimeUpdated,
     );
-  }
-
-  Future<MediaUploadData> getUploadData(EnteFile file) async {
-    final mediaUploadData = await getUploadDataFromEnteFile(file);
-    // delete the file from app's internal cache if it was copied to app
-    // for upload. Shared Media should only be cleared when the upload
-    // succeeds.
-    await _deleteCopiedIOSUploadFile(mediaUploadData.sourceFile);
-    return mediaUploadData;
-  }
-
-  Future<void> _deleteCopiedIOSUploadFile(File? sourceFile) async {
-    if (!Platform.isIOS || sourceFile == null) {
-      return;
-    }
-    final deleted = await deleteFileSystemEntityIfPresent(sourceFile);
-    if (!deleted) {
-      _logger.info(
-        "Copied upload temp file already missing: ${sourceFile.path}",
-      );
-    }
   }
 }

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -33,14 +33,11 @@ import 'package:video_thumbnail/video_thumbnail.dart';
 final _logger = Logger("UploadData");
 
 /// Builds the source, thumbnail, hashes, and embedded metadata for an upload.
-Future<MediaUploadData> getUploadDataFromEnteFile(
-  EnteFile file, {
-  bool parseExif = false,
-}) async {
+Future<MediaUploadData> getUploadDataFromEnteFile(EnteFile file) async {
   if (file.isSharedMediaToAppSandbox) {
-    return await _getMediaUploadDataFromAppCache(file, parseExif);
+    return await _getMediaUploadDataFromAppCache(file);
   } else {
-    return await _getMediaUploadDataFromAssetFile(file, parseExif);
+    return await _getMediaUploadDataFromAssetFile(file);
   }
 }
 
@@ -81,10 +78,7 @@ Future<FileHashData> getFileContentIdentity(EnteFile file) async {
   }
 }
 
-Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
-  EnteFile file,
-  bool parseExif,
-) async {
+Future<MediaUploadData> _getMediaUploadDataFromAssetFile(EnteFile file) async {
   File? sourceFile;
   Uint8List? thumbnailData;
   bool isDeleted;
@@ -101,7 +95,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   }
   sourceFile = await _getOriginFile(asset, file);
   try {
-    if (parseExif && shouldReadExif(file)) {
+    if (shouldReadExif(file)) {
       exifData = await tryExifFromFile(sourceFile);
       if (exifData != null) {
         cameraMake = extractPrintableExifValue(exifData['Image Make']);
@@ -308,10 +302,7 @@ Future<void> _decorateEnteFileData(
   }
 }
 
-Future<MediaUploadData> _getMediaUploadDataFromAppCache(
-  EnteFile file,
-  bool parseExif,
-) async {
+Future<MediaUploadData> _getMediaUploadDataFromAppCache(EnteFile file) async {
   File sourceFile;
   Uint8List? thumbnailData;
   Map<String, IfdTag>? exifData;
@@ -327,56 +318,58 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(
       InvalidReason.sourceFileMissing,
     );
   }
-  try {
-    thumbnailData = await getThumbnailFromInAppCacheFile(file);
-    final fileHash = CryptoUtil.bin2base64(
-      await CryptoUtil.getHash(sourceFile),
-    );
-    ({int width, int height})? dimensions;
-    if (file.fileType == FileType.image) {
-      dimensions = await getImageDimensions(imagePath: localPath);
-      exifData = await tryExifFromFile(sourceFile);
-      if (exifData != null) {
-        cameraMake = extractPrintableExifValue(exifData['Image Make']);
-        cameraModel = extractPrintableExifValue(exifData['Image Model']);
-        if (!file.hasLocation) {
-          final exifLocation = locationFromExif(exifData);
-          if (Location.isValidLocation(exifLocation)) {
-            file.location = exifLocation;
-          }
+  thumbnailData = await _getAppCacheThumbnailForUpload(file);
+  final fileHash = CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
+  ({int width, int height})? dimensions;
+  if (file.fileType == FileType.image) {
+    dimensions = await getImageDimensions(imagePath: localPath);
+    exifData = await tryExifFromFile(sourceFile);
+    if (exifData != null) {
+      cameraMake = extractPrintableExifValue(exifData['Image Make']);
+      cameraModel = extractPrintableExifValue(exifData['Image Model']);
+      if (!file.hasLocation) {
+        final exifLocation = locationFromExif(exifData);
+        if (Location.isValidLocation(exifLocation)) {
+          file.location = exifLocation;
         }
       }
-    } else if (thumbnailData != null) {
-      // the thumbnail null check is to ensure that we are able to generate thum
-      // for video, we need to use the thumbnail data with any max width/height
-      final thumbnailFilePath = await VideoThumbnail.thumbnailFile(
-        video: localPath,
-        imageFormat: ImageFormat.JPEG,
-        thumbnailPath: (await getTemporaryDirectory()).path,
-        quality: 10,
-      );
-      dimensions = await getImageDimensions(imagePath: thumbnailFilePath);
     }
-
-    if (!file.hasLocation && file.isVideo && Platform.isAndroid) {
-      final FFProbeProps? props = await getVideoProps(sourceFile);
-      if (props?.location != null) {
-        file.location = props!.location;
-      }
-    }
-    return MediaUploadData(
-      sourceFile: sourceFile,
-      thumbnail: thumbnailData,
-      isDeleted: isDeleted,
-      hashData: FileHashData(fileHash),
-      derivedMetadata: DerivedMediaMetadata(
-        height: dimensions?.height,
-        width: dimensions?.width,
-        cameraMake: cameraMake,
-        cameraModel: cameraModel,
-        exifData: exifData,
-      ),
+  } else if (thumbnailData != null) {
+    // The thumbnail null check ensures that video thumbnail generation worked.
+    // Use it without a max dimension to obtain the video's aspect ratio.
+    final thumbnailFilePath = await VideoThumbnail.thumbnailFile(
+      video: localPath,
+      imageFormat: ImageFormat.JPEG,
+      thumbnailPath: (await getTemporaryDirectory()).path,
+      quality: 10,
     );
+    dimensions = await getImageDimensions(imagePath: thumbnailFilePath);
+  }
+
+  if (!file.hasLocation && file.isVideo && Platform.isAndroid) {
+    final FFProbeProps? props = await getVideoProps(sourceFile);
+    if (props?.location != null) {
+      file.location = props!.location;
+    }
+  }
+  return MediaUploadData(
+    sourceFile: sourceFile,
+    thumbnail: thumbnailData,
+    isDeleted: isDeleted,
+    hashData: FileHashData(fileHash),
+    derivedMetadata: DerivedMediaMetadata(
+      height: dimensions?.height,
+      width: dimensions?.width,
+      cameraMake: cameraMake,
+      cameraModel: cameraModel,
+      exifData: exifData,
+    ),
+  );
+}
+
+Future<Uint8List?> _getAppCacheThumbnailForUpload(EnteFile file) async {
+  try {
+    return await getThumbnailFromInAppCacheFile(file);
   } catch (e, s) {
     _logger.warning("failed to generate thumbnail", e, s);
     throw InvalidFileError(

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -44,6 +44,43 @@ Future<MediaUploadData> getUploadDataFromEnteFile(
   }
 }
 
+/// Computes only the hashes needed to decide whether a local file changed.
+Future<FileHashData> getFileContentIdentity(EnteFile file) async {
+  if (file.isSharedMediaToAppSandbox) {
+    final sourceFile = File(getSharedMediaFilePath(file));
+    if (!sourceFile.existsSync()) {
+      throw InvalidFileError(
+        "source missing in sandbox",
+        InvalidReason.sourceFileMissing,
+      );
+    }
+    return FileHashData(
+      CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile)),
+    );
+  }
+
+  final asset = await _getAsset(file);
+  final sourceFile = await _getOriginFile(asset, file);
+  try {
+    final sourceHash = CryptoUtil.bin2base64(
+      await CryptoUtil.getHash(sourceFile),
+    );
+    if (file.fileType == FileType.livePhoto && Platform.isIOS) {
+      final livePhoto = await getLivePhotoHashDataForComparison(
+        file,
+        sourceFile,
+        sourceHash,
+      );
+      return FileHashData(livePhoto.fileHash, zipHash: livePhoto.zipHash);
+    }
+    return FileHashData(sourceHash);
+  } finally {
+    if (Platform.isIOS) {
+      await deleteFileSystemEntityIfPresent(sourceFile);
+    }
+  }
+}
+
 Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   EnteFile file,
   bool parseExif,
@@ -57,54 +94,12 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
   String? cameraMake;
   String? cameraModel;
 
-  // The timeouts are to safeguard against https://github.com/CaiJingLong/flutter_photo_manager/issues/467
-  final asset = await file.getAsset
-      .timeout(const Duration(seconds: 3))
-      .catchError((e) async {
-        if (e is TimeoutException) {
-          _logger.info("Asset fetch timed out for " + file.toString());
-          return await file.getAsset;
-        } else {
-          throw e;
-        }
-      });
-  if (asset == null) {
-    throw InvalidFileError("", InvalidReason.assetDeleted);
-  }
-  _assertFileType(asset, file);
+  final asset = await _getAsset(file);
   file.fileSubType = asset.subtype;
   if (file.fileType == FileType.video) {
     file.duration = asset.duration;
   }
-  if (Platform.isIOS) {
-    trackOriginFetchForUploadOrML.put(file.localID!, true);
-  }
-  try {
-    sourceFile = await asset.originFile
-        .timeout(const Duration(seconds: 15))
-        .catchError((e) async {
-          if (e is TimeoutException) {
-            _logger.info("Origin file fetch timed out for " + file.tag);
-            return await asset.originFile;
-          } else {
-            throw e;
-          }
-        });
-  } catch (e) {
-    if (isPHPhotosNetworkError(e)) {
-      throw InvalidFileError(
-        phPhotosResourceUnavailableReason,
-        InvalidReason.photosResourceUnavailable,
-      );
-    }
-    rethrow;
-  }
-  if (sourceFile == null || !sourceFile.existsSync()) {
-    throw InvalidFileError(
-      "id: ${file.localID}",
-      InvalidReason.sourceFileMissing,
-    );
-  }
+  sourceFile = await _getOriginFile(asset, file);
   try {
     if (parseExif && shouldReadExif(file)) {
       exifData = await tryExifFromFile(sourceFile);
@@ -171,6 +166,58 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(
     }
     rethrow;
   }
+}
+
+Future<AssetEntity> _getAsset(EnteFile file) async {
+  // The timeout safeguards against
+  // https://github.com/CaiJingLong/flutter_photo_manager/issues/467.
+  final asset = await file.getAsset
+      .timeout(const Duration(seconds: 3))
+      .catchError((e) async {
+        if (e is TimeoutException) {
+          _logger.info("Asset fetch timed out for " + file.toString());
+          return await file.getAsset;
+        }
+        throw e;
+      });
+  if (asset == null) {
+    throw InvalidFileError("", InvalidReason.assetDeleted);
+  }
+  _assertFileType(asset, file);
+  return asset;
+}
+
+Future<File> _getOriginFile(AssetEntity asset, EnteFile file) async {
+  if (Platform.isIOS) {
+    trackOriginFetchForUploadOrML.put(file.localID!, true);
+  }
+  File? sourceFile;
+  try {
+    sourceFile = await asset.originFile
+        .timeout(const Duration(seconds: 15))
+        .catchError((e) async {
+          if (e is TimeoutException) {
+            _logger.info("Origin file fetch timed out for " + file.tag);
+            return await asset.originFile;
+          }
+          throw e;
+        });
+  } catch (e) {
+    if (isPHPhotosNetworkError(e)) {
+      throw InvalidFileError(
+        phPhotosResourceUnavailableReason,
+        InvalidReason.photosResourceUnavailable,
+      );
+    }
+    rethrow;
+  }
+  if (sourceFile == null || !sourceFile.existsSync()) {
+    throw InvalidFileError(
+      "id: ${file.localID}",
+      InvalidReason.sourceFileMissing,
+    );
+  }
+  return sourceFile;
 }
 
 Future<Uint8List?> _getThumbnailForUpload(


### PR DESCRIPTION
Give changed-file checks a hash-only path that skips thumbnails and metadata probing, while preserving modern and legacy Live Photo hash matching. Also limit app-cache thumbnail error translation to the thumbnail operation.