### PR TITLE
[mobile][photos] Commit upload public metadata after creation

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -910,9 +910,9 @@ class FileUploader {
         final keyDecryptionNonce = CryptoUtil.bin2base64(
           encryptedFileKeyData.nonce!,
         );
-        MetadataRequest? pubMetadataRequest;
+        PreparedPublicMetadata? preparedPublicMetadata;
         if (pubMetadata.isNotEmpty) {
-          pubMetadataRequest = await buildPublicMetadataRequest(
+          preparedPublicMetadata = await preparePublicMetadata(
             file,
             pubMetadata,
             fileAttributes.key,
@@ -941,8 +941,13 @@ class FileUploader {
           encThumbSize,
           encryptedMetadata,
           metadataDecryptionHeader,
-          pubMetadata: pubMetadataRequest,
+          pubMetadata: preparedPublicMetadata?.request,
         );
+        if (preparedPublicMetadata != null) {
+          remoteFile
+            ..pubMmdEncodedJson = preparedPublicMetadata.encodedJson
+            ..pubMagicMetadata = preparedPublicMetadata.decodedMetadata;
+        }
         if (mediaUploadData.isDeleted) {
           _logger.info("File found to be deleted");
           remoteFile.localID = null;

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -87,7 +87,19 @@ Map<String, dynamic> _buildPublicMetadata(
   return publicMetadata;
 }
 
-Future<MetadataRequest> buildPublicMetadataRequest(
+class PreparedPublicMetadata {
+  final String encodedJson;
+  final PubMagicMetadata decodedMetadata;
+  final MetadataRequest request;
+
+  const PreparedPublicMetadata({
+    required this.encodedJson,
+    required this.decodedMetadata,
+    required this.request,
+  });
+}
+
+Future<PreparedPublicMetadata> preparePublicMetadata(
   EnteFile file,
   Map<String, dynamic> newData,
   Uint8List fileKey,
@@ -99,17 +111,19 @@ Future<MetadataRequest> buildPublicMetadataRequest(
     jsonToUpdate[key] = value;
   });
 
-  // update the local information so that it's reflected on UI
-  file.pubMmdEncodedJson = jsonEncode(jsonToUpdate);
-  file.pubMagicMetadata = PubMagicMetadata.fromJson(jsonToUpdate);
+  final encodedJson = jsonEncode(jsonToUpdate);
   final encryptedMMd = await CryptoUtil.encryptChaCha(
-    utf8.encode(jsonEncode(jsonToUpdate)),
+    utf8.encode(encodedJson),
     fileKey,
   );
-  return MetadataRequest(
-    version: file.pubMmdVersion == 0 ? 1 : file.pubMmdVersion,
-    count: jsonToUpdate.length,
-    data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
-    header: CryptoUtil.bin2base64(encryptedMMd.header!),
+  return PreparedPublicMetadata(
+    encodedJson: encodedJson,
+    decodedMetadata: PubMagicMetadata.fromJson(jsonToUpdate),
+    request: MetadataRequest(
+      version: file.pubMmdVersion == 0 ? 1 : file.pubMmdVersion,
+      count: jsonToUpdate.length,
+      data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
+      header: CryptoUtil.bin2base64(encryptedMMd.header!),
+    ),
   );
 }


### PR DESCRIPTION
Prepare encrypted public metadata without mutating the live file, then apply the accepted encoded and decoded state only after the file creation request succeeds.