### PR TITLE
[mobile][photos] Fix Magic Cache update lifecycle

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -78,6 +78,9 @@ class FileUploader {
   /// Returns true if any file uploads are currently in progress
   bool get isUploading => _uploadCounter > 0;
 
+  /// Returns true if an upload is queued, running, or waiting in background.
+  bool get hasPendingUploads => _queue.isNotEmpty;
+
   // Maintains the count of files in the current upload session.
   // Upload session is the period between the first entry into the _queue and last entry out of the _queue
   int _totalCountInUploadSession = 0;

--- a/mobile/apps/photos/lib/services/magic_cache_service.dart
+++ b/mobile/apps/photos/lib/services/magic_cache_service.dart
@@ -10,10 +10,13 @@ import "package:logging/logging.dart";
 import "package:path_provider/path_provider.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/offline_files_db.dart";
+import "package:photos/events/backup_updated_event.dart";
 import "package:photos/events/file_uploaded_event.dart";
 import "package:photos/events/magic_cache_updated_event.dart";
+import "package:photos/events/tab_changed_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/l10n/l10n.dart";
+import "package:photos/models/backup/backup_item_status.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/ml/discover/prompt.dart";
@@ -230,6 +233,8 @@ GenericSearchResult? toGenericSearchResult(
 class MagicCacheService {
   static const _lastMagicCacheUpdateTime = "last_magic_cache_update_time";
   static const _kPromptsAssetPath = "assets/discover.json";
+  static const _kSearchTabIndex = 3;
+  static const _kBackgroundUpdateDebounce = Duration(minutes: 5);
 
   /// Delay is for cache update to be done not during app init, during which a
   /// lot of other things are happening.
@@ -243,11 +248,29 @@ class MagicCacheService {
   final Set<String> _pendingUpdateReason = {};
   bool _isUpdateInProgress = false;
   int _cacheGeneration = 0;
+  Timer? _backgroundUpdateTimer;
+  bool _refreshWhenCurrentUpdateCompletes = false;
+  bool _uploadsActive = false;
 
   MagicCacheService(this._prefs) {
     _logger.info("MagicCacheService constructor");
     Bus.instance.on<FileUploadedEvent>().listen((event) {
       queueUpdate("File uploaded");
+      _scheduleBackgroundUpdate();
+    });
+    Bus.instance.on<BackupUpdatedEvent>().listen((event) {
+      _uploadsActive = event.items.values.any(
+        (item) =>
+            item.status == BackupItemStatus.inQueue ||
+            item.status == BackupItemStatus.uploading ||
+            item.status == BackupItemStatus.inBackground,
+      );
+    });
+    Bus.instance.on<TabChangedEvent>().listen((event) {
+      if (event.source == TabChangedEventSource.pageView &&
+          event.selectedIndex == _kSearchTabIndex) {
+        _runPendingUpdateForSearch();
+      }
     });
     Future.delayed(_kCacheUpdateDelay, () {
       _updateCacheIfTheTimeHasCome();
@@ -279,6 +302,24 @@ class MagicCacheService {
     _pendingUpdateReason.add(reason);
   }
 
+  void _scheduleBackgroundUpdate() {
+    _backgroundUpdateTimer?.cancel();
+    _backgroundUpdateTimer = Timer(_kBackgroundUpdateDebounce, () {
+      _backgroundUpdateTimer = null;
+      _updateCache().ignore();
+    });
+  }
+
+  void _runPendingUpdateForSearch() {
+    _backgroundUpdateTimer?.cancel();
+    _backgroundUpdateTimer = null;
+    if (_isUpdateInProgress) {
+      _refreshWhenCurrentUpdateCompletes = true;
+      return;
+    }
+    _updateCache(interactive: true).ignore();
+  }
+
   Future<void> _updateCacheIfTheTimeHasCome() async {
     if (!enableDiscover) {
       return;
@@ -297,7 +338,13 @@ class MagicCacheService {
         "/cache/magic_cache$suffix";
   }
 
-  Future<void> updateCache({bool forced = false}) async {
+  Future<void> updateCache({bool forced = false}) =>
+      _updateCache(forced: forced);
+
+  Future<void> _updateCache({
+    bool forced = false,
+    bool interactive = false,
+  }) async {
     if (!enableDiscover) {
       return;
     }
@@ -305,13 +352,26 @@ class MagicCacheService {
       _pendingUpdateReason.add("Forced update");
     }
     await _updateCacheIfTheTimeHasCome();
-    if (_pendingUpdateReason.isEmpty || _isUpdateInProgress) {
+    if (_uploadsActive && !forced && !interactive) {
+      _scheduleBackgroundUpdate();
+      return;
+    }
+    if (_pendingUpdateReason.isEmpty) {
       _logger.info(
         "No update needed as ${_pendingUpdateReason.toList()} and isUpdateInProgress $_isUpdateInProgress",
       );
       return;
     }
+    if (_isUpdateInProgress) {
+      if (!forced && !interactive) {
+        _scheduleBackgroundUpdate();
+      }
+      _logger.info("Magic cache update is already in progress");
+      return;
+    }
     _logger.info("updating magic cache ${_pendingUpdateReason.toList()}");
+    _backgroundUpdateTimer?.cancel();
+    _backgroundUpdateTimer = null;
     final updateReasons = Set<String>.of(_pendingUpdateReason);
     _pendingUpdateReason.removeAll(updateReasons);
     final updateGeneration = _cacheGeneration;
@@ -349,10 +409,17 @@ class MagicCacheService {
     } catch (e, s) {
       if (updateGeneration == _cacheGeneration) {
         _pendingUpdateReason.addAll(updateReasons);
+        if (!forced) {
+          _scheduleBackgroundUpdate();
+        }
       }
       _logger.info("Error updating magic cache", e, s);
     } finally {
       _isUpdateInProgress = false;
+      if (_refreshWhenCurrentUpdateCompletes) {
+        _refreshWhenCurrentUpdateCompletes = false;
+        _updateCache(interactive: true).ignore();
+      }
     }
   }
 
@@ -409,6 +476,9 @@ class MagicCacheService {
     _cacheGeneration++;
     _magicCacheFuture = null;
     _pendingUpdateReason.clear();
+    _backgroundUpdateTimer?.cancel();
+    _backgroundUpdateTimer = null;
+    _refreshWhenCurrentUpdateCompletes = false;
     await _prefs.remove(_lastMagicCacheUpdateKey);
     await _deleteCacheFile();
   }

--- a/mobile/apps/photos/lib/services/magic_cache_service.dart
+++ b/mobile/apps/photos/lib/services/magic_cache_service.dart
@@ -242,6 +242,7 @@ class MagicCacheService {
   Future<List<Prompt>>? _promptFuture;
   final Set<String> _pendingUpdateReason = {};
   bool _isUpdateInProgress = false;
+  int _cacheGeneration = 0;
 
   MagicCacheService(this._prefs) {
     _logger.info("MagicCacheService constructor");
@@ -304,6 +305,8 @@ class MagicCacheService {
       _pendingUpdateReason.add("Forced update");
     }
     await _updateCacheIfTheTimeHasCome();
+    Set<String>? updateReasons;
+    int? updateGeneration;
     try {
       if (_pendingUpdateReason.isEmpty || _isUpdateInProgress) {
         _logger.info(
@@ -312,6 +315,9 @@ class MagicCacheService {
         return;
       }
       _logger.info("updating magic cache ${_pendingUpdateReason.toList()}");
+      updateReasons = Set<String>.of(_pendingUpdateReason);
+      _pendingUpdateReason.removeAll(updateReasons);
+      updateGeneration = _cacheGeneration;
       _isUpdateInProgress = true;
       final EnteWatch? w = kDebugMode ? EnteWatch("magicCacheWatch") : null;
       w?.start();
@@ -321,22 +327,33 @@ class MagicCacheService {
         magicPromptsData,
       );
       w?.log("resultComputed");
+      if (updateGeneration != _cacheGeneration) {
+        return;
+      }
       _magicCacheFuture = Future.value(magicCaches);
       await writeToJsonFile<List<MagicCache>>(
         await _getCachePath(),
         magicCaches,
         MagicCache.encodeListToJson,
       );
+      if (updateGeneration != _cacheGeneration) {
+        await _deleteCacheFile();
+        return;
+      }
       w?.log("cacheWritten");
       await _resetLastMagicCacheUpdateTime();
+      if (updateGeneration != _cacheGeneration) {
+        return;
+      }
       w?.logAndReset('done');
-      _pendingUpdateReason.clear();
       Bus.instance.fire(MagicCacheUpdatedEvent());
     } catch (e, s) {
+      if (updateReasons != null && updateGeneration == _cacheGeneration) {
+        _pendingUpdateReason.addAll(updateReasons);
+      }
       _logger.info("Error updating magic cache", e, s);
     } finally {
       _isUpdateInProgress = false;
-      Bus.instance.fire(MagicCacheUpdatedEvent());
     }
   }
 
@@ -390,6 +407,13 @@ class MagicCacheService {
   }
 
   Future<void> clearMagicCache() async {
+    _cacheGeneration++;
+    await _deleteCacheFile();
+    _magicCacheFuture = null;
+    _pendingUpdateReason.clear();
+  }
+
+  Future<void> _deleteCacheFile() async {
     final file = File(await _getCachePath());
     if (file.existsSync()) {
       await file.delete();

--- a/mobile/apps/photos/lib/services/magic_cache_service.dart
+++ b/mobile/apps/photos/lib/services/magic_cache_service.dart
@@ -10,13 +10,11 @@ import "package:logging/logging.dart";
 import "package:path_provider/path_provider.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/offline_files_db.dart";
-import "package:photos/events/backup_updated_event.dart";
 import "package:photos/events/file_uploaded_event.dart";
 import "package:photos/events/magic_cache_updated_event.dart";
 import "package:photos/events/tab_changed_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/l10n/l10n.dart";
-import "package:photos/models/backup/backup_item_status.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/ml/discover/prompt.dart";
@@ -24,6 +22,7 @@ import "package:photos/models/search/generic_search_result.dart";
 import "package:photos/models/search/hierarchical/hierarchical_search_filter.dart";
 import "package:photos/models/search/hierarchical/magic_filter.dart";
 import "package:photos/models/search/search_types.dart";
+import "package:photos/module/upload/service/file_uploader.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/semantic_search/semantic_search_service.dart";
 import "package:photos/services/search_service.dart";
@@ -250,21 +249,12 @@ class MagicCacheService {
   int _cacheGeneration = 0;
   Timer? _backgroundUpdateTimer;
   bool _refreshWhenCurrentUpdateCompletes = false;
-  bool _uploadsActive = false;
 
   MagicCacheService(this._prefs) {
     _logger.info("MagicCacheService constructor");
     Bus.instance.on<FileUploadedEvent>().listen((event) {
       queueUpdate("File uploaded");
       _scheduleBackgroundUpdate();
-    });
-    Bus.instance.on<BackupUpdatedEvent>().listen((event) {
-      _uploadsActive = event.items.values.any(
-        (item) =>
-            item.status == BackupItemStatus.inQueue ||
-            item.status == BackupItemStatus.uploading ||
-            item.status == BackupItemStatus.inBackground,
-      );
     });
     Bus.instance.on<TabChangedEvent>().listen((event) {
       if (event.source == TabChangedEventSource.pageView &&
@@ -352,7 +342,7 @@ class MagicCacheService {
       _pendingUpdateReason.add("Forced update");
     }
     await _updateCacheIfTheTimeHasCome();
-    if (_uploadsActive && !forced && !interactive) {
+    if (FileUploader.instance.hasPendingUploads && !forced && !interactive) {
       _scheduleBackgroundUpdate();
       return;
     }

--- a/mobile/apps/photos/lib/services/magic_cache_service.dart
+++ b/mobile/apps/photos/lib/services/magic_cache_service.dart
@@ -305,20 +305,18 @@ class MagicCacheService {
       _pendingUpdateReason.add("Forced update");
     }
     await _updateCacheIfTheTimeHasCome();
-    Set<String>? updateReasons;
-    int? updateGeneration;
+    if (_pendingUpdateReason.isEmpty || _isUpdateInProgress) {
+      _logger.info(
+        "No update needed as ${_pendingUpdateReason.toList()} and isUpdateInProgress $_isUpdateInProgress",
+      );
+      return;
+    }
+    _logger.info("updating magic cache ${_pendingUpdateReason.toList()}");
+    final updateReasons = Set<String>.of(_pendingUpdateReason);
+    _pendingUpdateReason.removeAll(updateReasons);
+    final updateGeneration = _cacheGeneration;
+    _isUpdateInProgress = true;
     try {
-      if (_pendingUpdateReason.isEmpty || _isUpdateInProgress) {
-        _logger.info(
-          "No update needed as ${_pendingUpdateReason.toList()} and isUpdateInProgress $_isUpdateInProgress",
-        );
-        return;
-      }
-      _logger.info("updating magic cache ${_pendingUpdateReason.toList()}");
-      updateReasons = Set<String>.of(_pendingUpdateReason);
-      _pendingUpdateReason.removeAll(updateReasons);
-      updateGeneration = _cacheGeneration;
-      _isUpdateInProgress = true;
       final EnteWatch? w = kDebugMode ? EnteWatch("magicCacheWatch") : null;
       w?.start();
       final magicPromptsData = await getPrompts();
@@ -343,12 +341,13 @@ class MagicCacheService {
       w?.log("cacheWritten");
       await _resetLastMagicCacheUpdateTime();
       if (updateGeneration != _cacheGeneration) {
+        await _prefs.remove(_lastMagicCacheUpdateKey);
         return;
       }
       w?.logAndReset('done');
       Bus.instance.fire(MagicCacheUpdatedEvent());
     } catch (e, s) {
-      if (updateReasons != null && updateGeneration == _cacheGeneration) {
+      if (updateGeneration == _cacheGeneration) {
         _pendingUpdateReason.addAll(updateReasons);
       }
       _logger.info("Error updating magic cache", e, s);
@@ -408,9 +407,10 @@ class MagicCacheService {
 
   Future<void> clearMagicCache() async {
     _cacheGeneration++;
-    await _deleteCacheFile();
     _magicCacheFuture = null;
     _pendingUpdateReason.clear();
+    await _prefs.remove(_lastMagicCacheUpdateKey);
+    await _deleteCacheFile();
   }
 
   Future<void> _deleteCacheFile() async {


### PR DESCRIPTION
- Preserve refresh work queued during an active update and retry failed work without duplicate UI refresh events.
- Keep clear authoritative over memory, disk, freshness, and in-flight computations.
- Debounce expensive Discover refreshes while uploads are active, then refresh after five quiet minutes or immediately when Search is opened.

Validation: Photos formatter and analyzer pass.