### PR TITLE
[mobile][photos] Clean up Live Photo artifacts

### DIFF
--- a/mobile/apps/photos/lib/module/live_photo/download.dart
+++ b/mobile/apps/photos/lib/module/live_photo/download.dart
@@ -62,7 +62,7 @@ Future<LivePhotoFiles?> downloadLivePhotoFiles(
 }
 
 Future<File> _cacheImagePart(EnteFile file, LivePhotoArchivePart part) async {
-  final fileExtension = _fileExtension(part.fileName);
+  var fileExtension = _fileExtension(part.fileName);
   File imageFile = part.file;
   if (fileExtension == 'unknown' ||
       (Platform.isAndroid && fileExtension == 'heic')) {
@@ -75,6 +75,7 @@ Future<File> _cacheImagePart(EnteFile file, LivePhotoArchivePart part) async {
       throw Exception('Failed to compress file');
     }
     imageFile = File(compressResult.path);
+    fileExtension = 'jpg';
   }
   return DefaultCacheManager().putFileStream(
     file.downloadUrl,

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -1162,10 +1162,15 @@ class FileUploader {
     if (mediaUploadData != null) {
       // delete the file from app's internal cache if it was copied to app
       // for upload. On iOS, only remove the file from photo_manager/app cache
-      // when upload is either completed or there's a tempFailure
+      // when upload is either completed or cannot be retried automatically.
       // Shared Media should only be cleared when the upload
       // succeeds.
-      if ((Platform.isIOS && (uploadCompleted || uploadHardFailure)) ||
+      // A Live Photo source is an app-created archive, and each retry rebuilds
+      // it, so it must be removed after every attempt.
+      if ((Platform.isIOS &&
+              (file.fileType == FileType.livePhoto ||
+                  uploadCompleted ||
+                  uploadHardFailure)) ||
           (uploadCompleted && file.isSharedMediaToAppSandbox)) {
         await deleteFileSystemEntityIfPresent(mediaUploadData.sourceFile);
       }


### PR DESCRIPTION
- Remove per-attempt iOS Live Photo archives even after retryable failures, preventing temporary storage growth.
- Store converted HEIC or unknown image parts with a JPEG cache suffix.

Validation: Photos formatter and analyzer pass.