### PR TITLE
[mobile][photos] Propagate uploaded public metadata

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -217,6 +217,10 @@ class EnteFile {
     if (uploadedFile.fileSize != null) {
       fileSize = uploadedFile.fileSize;
     }
+    if (uploadedFile.pubMmdEncodedJson != null) {
+      pubMmdEncodedJson = uploadedFile.pubMmdEncodedJson;
+      pubMmdVersion = uploadedFile.pubMmdVersion;
+    }
   }
 
   @override

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -949,6 +949,7 @@ class FileUploader {
         if (preparedPublicMetadata != null) {
           remoteFile
             ..pubMmdEncodedJson = preparedPublicMetadata.encodedJson
+            ..pubMmdVersion = preparedPublicMetadata.version
             ..pubMagicMetadata = preparedPublicMetadata.decodedMetadata;
         }
         if (mediaUploadData.isDeleted) {

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -90,11 +90,13 @@ Map<String, dynamic> _buildPublicMetadata(
 class PreparedPublicMetadata {
   final String encodedJson;
   final PubMagicMetadata decodedMetadata;
+  final int version;
   final MetadataRequest request;
 
   const PreparedPublicMetadata({
     required this.encodedJson,
     required this.decodedMetadata,
+    required this.version,
     required this.request,
   });
 }
@@ -116,11 +118,13 @@ Future<PreparedPublicMetadata> preparePublicMetadata(
     utf8.encode(encodedJson),
     fileKey,
   );
+  final version = file.pubMmdVersion == 0 ? 1 : file.pubMmdVersion;
   return PreparedPublicMetadata(
     encodedJson: encodedJson,
     decodedMetadata: PubMagicMetadata.fromJson(jsonToUpdate),
+    version: version,
     request: MetadataRequest(
-      version: file.pubMmdVersion == 0 ? 1 : file.pubMmdVersion,
+      version: version,
       count: jsonToUpdate.length,
       data: CryptoUtil.bin2base64(encryptedMMd.encryptedData!),
       header: CryptoUtil.bin2base64(encryptedMMd.header!),


### PR DESCRIPTION
- Keep the local public-metadata version aligned with the version stored during file creation.
- Propagate encoded public metadata through the gallery soft refresh so dimensions, panorama, camera, and EXIF-derived date are available without a later reload.

Validation: Photos formatter and analyzer pass.