### PR TITLE
[mobile][photos] Add persistent video mute control

### DIFF
--- a/mobile/apps/photos/lib/events/video_mute_changed_event.dart
+++ b/mobile/apps/photos/lib/events/video_mute_changed_event.dart
@@ -1,0 +1,7 @@
+import "package:photos/events/event.dart";
+
+class VideoMuteChangedEvent extends Event {
+  final bool isMuted;
+
+  VideoMuteChangedEvent(this.isMuted);
+}

--- a/mobile/apps/photos/lib/settings/local_settings.dart
+++ b/mobile/apps/photos/lib/settings/local_settings.dart
@@ -72,6 +72,7 @@ class LocalSettings {
       "ls.birthday_notifications_enabled";
   static const kRateUsPromptThreshold = 2;
   static const shouldLoopVideoKey = "video.should_loop";
+  static const isMutedKey = "video.is_muted";
   static const onGuestViewKey = "on_guest_view";
   static const _hasConfiguredLinksInAppPermissionKey =
       "has_configured_links_in_app_permission";
@@ -462,6 +463,14 @@ class LocalSettings {
 
   bool shouldLoopVideo() {
     return _prefs.getBool(shouldLoopVideoKey) ?? true;
+  }
+
+  Future<void> setIsMuted(bool value) async {
+    await _prefs.setBool(isMutedKey, value);
+  }
+
+  bool isMuted() {
+    return _prefs.getBool(isMutedKey) ?? false;
   }
 
   Future<void> setOnGuestView(bool value) {

--- a/mobile/apps/photos/lib/ui/viewer/file/video_control/mute_button.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_control/mute_button.dart
@@ -55,9 +55,9 @@ class _VideoMuteButtonState extends State<VideoMuteButton> {
           size: 20,
         ),
       ),
-      onPressed: () {
+      onPressed: () async {
         final newValue = !_isMuted;
-        localSettings.setIsMuted(newValue);
+        await localSettings.setIsMuted(newValue);
         Bus.instance.fire(VideoMuteChangedEvent(newValue));
       },
     );

--- a/mobile/apps/photos/lib/ui/viewer/file/video_control/mute_button.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_control/mute_button.dart
@@ -1,0 +1,65 @@
+import "dart:async";
+
+import "package:flutter/material.dart";
+import "package:hugeicons/hugeicons.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/video_mute_changed_event.dart";
+import "package:photos/service_locator.dart";
+
+class VideoMuteButton extends StatefulWidget {
+  const VideoMuteButton({super.key});
+
+  @override
+  State<VideoMuteButton> createState() => _VideoMuteButtonState();
+}
+
+class _VideoMuteButtonState extends State<VideoMuteButton> {
+  late bool _isMuted;
+  StreamSubscription<VideoMuteChangedEvent>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _isMuted = localSettings.isMuted();
+    _subscription = Bus.instance.on<VideoMuteChangedEvent>().listen((event) {
+      if (mounted) {
+        setState(() {
+          _isMuted = event.isMuted;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 250),
+        transitionBuilder: (Widget child, Animation<double> animation) {
+          return ScaleTransition(scale: animation, child: child);
+        },
+        switchInCurve: Curves.easeInOutQuart,
+        switchOutCurve: Curves.easeInOutQuart,
+        child: HugeIcon(
+          key: ValueKey(_isMuted),
+          icon: _isMuted
+              ? HugeIcons.strokeRoundedVolumeOff
+              : HugeIcons.strokeRoundedVolumeHigh,
+          color: Colors.white,
+          size: 20,
+        ),
+      ),
+      onPressed: () {
+        final newValue = !_isMuted;
+        localSettings.setIsMuted(newValue);
+        Bus.instance.fire(VideoMuteChangedEvent(newValue));
+      },
+    );
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
@@ -12,6 +12,7 @@ import "package:photos/events/guest_view_event.dart";
 import "package:photos/events/pause_video_event.dart";
 import "package:photos/events/resume_video_event.dart";
 import "package:photos/events/stream_switched_event.dart";
+import "package:photos/events/video_mute_changed_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
@@ -67,6 +68,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
   bool _isAppInFG = true;
   late StreamSubscription<PauseVideoEvent> pauseVideoSubscription;
   late StreamSubscription<ResumeVideoEvent> resumeVideoSubscription;
+  late final StreamSubscription<VideoMuteChangedEvent> _muteSubscription;
   bool isGuestView = false;
   late final StreamSubscription<GuestViewEvent> _guestViewEventSubscription;
   bool _isGuestView = false;
@@ -98,6 +100,11 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
       event,
     ) {
       player.play();
+    });
+    _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
+      event,
+    ) {
+      player.setVolume(event.isMuted ? 0.0 : 100.0);
     });
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
@@ -193,6 +200,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
     _guestViewEventSubscription.cancel();
     pauseVideoSubscription.cancel();
     resumeVideoSubscription.cancel();
+    _muteSubscription.cancel();
     removeDownloadCallback(widget.file);
     _progressNotifier.dispose();
     WidgetsBinding.instance.removeObserver(this);
@@ -347,6 +355,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
           );
           controller = VideoController(player);
         }
+        player.setVolume(localSettings.isMuted() ? 0.0 : 100.0);
         player.open(Media(url), play: _isAppInFG);
       });
       int duration = controller!.player.state.duration.inSeconds;

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
@@ -68,7 +68,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
   bool _isAppInFG = true;
   late StreamSubscription<PauseVideoEvent> pauseVideoSubscription;
   late StreamSubscription<ResumeVideoEvent> resumeVideoSubscription;
-  late final StreamSubscription<VideoMuteChangedEvent> _muteSubscription;
+  StreamSubscription<VideoMuteChangedEvent>? _muteSubscription;
   bool isGuestView = false;
   late final StreamSubscription<GuestViewEvent> _guestViewEventSubscription;
   bool _isGuestView = false;
@@ -101,11 +101,13 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
     ) {
       player.play();
     });
-    _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
-      event,
-    ) {
-      player.setVolume(event.isMuted ? 0.0 : 100.0);
-    });
+    if (!widget.isFromMemories) {
+      _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
+        event,
+      ) {
+        player.setVolume(event.isMuted ? 0.0 : 100.0);
+      });
+    }
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
     ) {
@@ -200,7 +202,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
     _guestViewEventSubscription.cancel();
     pauseVideoSubscription.cancel();
     resumeVideoSubscription.cancel();
-    _muteSubscription.cancel();
+    _muteSubscription?.cancel();
     removeDownloadCallback(widget.file);
     _progressNotifier.dispose();
     WidgetsBinding.instance.removeObserver(this);
@@ -355,7 +357,9 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
           );
           controller = VideoController(player);
         }
-        player.setVolume(localSettings.isMuted() ? 0.0 : 100.0);
+        if (!widget.isFromMemories) {
+          player.setVolume(localSettings.isMuted() ? 0.0 : 100.0);
+        }
         player.open(Media(url), play: _isAppInFG);
       });
       int duration = controller!.player.state.duration.inSeconds;

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -9,6 +9,7 @@ import "package:photos/theme/colors.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/actions/file/file_actions.dart";
 import "package:photos/ui/common/loading_widget.dart";
+import "package:photos/ui/viewer/file/video_control/mute_button.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 
@@ -365,6 +366,8 @@ class SeekBarAndDuration extends StatelessWidget {
                     ),
                     style: textStyle,
                   ),
+                  const SizedBox(width: 8),
+                  const VideoMuteButton(),
                 ],
               ),
             ),

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -76,7 +76,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   final _progressNotifier = ValueNotifier<double?>(null);
   late StreamSubscription<PauseVideoEvent> pauseVideoSubscription;
   late StreamSubscription<ResumeVideoEvent> resumeVideoSubscription;
-  late final StreamSubscription<VideoMuteChangedEvent> _muteSubscription;
+  StreamSubscription<VideoMuteChangedEvent>? _muteSubscription;
   bool _isGuestView = false;
   late final StreamSubscription<GuestViewEvent> _guestViewEventSubscription;
   NativeVideoPlayerController? _controller;
@@ -120,13 +120,15 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     ) {
       _controller?.play();
     });
-    _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
-      event,
-    ) async {
-      final controller = _controller;
-      if (controller == null) return;
-      await controller.setVolume(event.isMuted ? 0.0 : 1.0);
-    });
+    if (!widget.isFromMemories) {
+      _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
+        event,
+      ) async {
+        final controller = _controller;
+        if (controller == null) return;
+        await controller.setVolume(event.isMuted ? 0.0 : 1.0);
+      });
+    }
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
     ) {
@@ -181,7 +183,9 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
       type: VideoSourceType.file,
     );
     await _controller?.loadVideo(videoSource);
-    await _controller?.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
+    if (!widget.isFromMemories) {
+      await _controller?.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
+    }
     await _controller?.play();
 
     Bus.instance.fire(SeekbarTriggeredEvent(position: 0));
@@ -271,7 +275,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     _guestViewEventSubscription.cancel();
     pauseVideoSubscription.cancel();
     resumeVideoSubscription.cancel();
-    _muteSubscription.cancel();
+    _muteSubscription?.cancel();
     removeDownloadCallback(widget.file);
     _progressNotifier.dispose();
     WidgetsBinding.instance.removeObserver(this);
@@ -611,7 +615,9 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
 
   Future<void> _onPlaybackReady() async {
     if (_isPlaybackReady.value) return;
-    await _controller!.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
+    if (!widget.isFromMemories) {
+      await _controller!.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
+    }
     await _controller!.play();
     final durationInSeconds = durationToSeconds(duration) ?? 10;
     widget.onFinalFileLoad?.call(memoryDuration: durationInSeconds);

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -122,8 +122,10 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     });
     _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
       event,
-    ) {
-      _controller?.setVolume(event.isMuted ? 0.0 : 1.0);
+    ) async {
+      final controller = _controller;
+      if (controller == null) return;
+      await controller.setVolume(event.isMuted ? 0.0 : 1.0);
     });
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -14,6 +14,7 @@ import "package:photos/events/resume_video_event.dart";
 import "package:photos/events/seekbar_triggered_event.dart";
 import "package:photos/events/stream_switched_event.dart";
 import "package:photos/events/use_media_kit_for_video.dart";
+import "package:photos/events/video_mute_changed_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
@@ -33,6 +34,7 @@ import "package:photos/ui/notification/toast.dart";
 import "package:photos/ui/viewer/file/native_video_player_controls/play_pause_button.dart";
 import "package:photos/ui/viewer/file/native_video_player_controls/seek_bar.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
+import "package:photos/ui/viewer/file/video_control/mute_button.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -74,6 +76,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   final _progressNotifier = ValueNotifier<double?>(null);
   late StreamSubscription<PauseVideoEvent> pauseVideoSubscription;
   late StreamSubscription<ResumeVideoEvent> resumeVideoSubscription;
+  late final StreamSubscription<VideoMuteChangedEvent> _muteSubscription;
   bool _isGuestView = false;
   late final StreamSubscription<GuestViewEvent> _guestViewEventSubscription;
   NativeVideoPlayerController? _controller;
@@ -116,6 +119,11 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
       event,
     ) {
       _controller?.play();
+    });
+    _muteSubscription = Bus.instance.on<VideoMuteChangedEvent>().listen((
+      event,
+    ) {
+      _controller?.setVolume(event.isMuted ? 0.0 : 1.0);
     });
     _guestViewEventSubscription = Bus.instance.on<GuestViewEvent>().listen((
       event,
@@ -171,6 +179,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
       type: VideoSourceType.file,
     );
     await _controller?.loadVideo(videoSource);
+    await _controller?.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
     await _controller?.play();
 
     Bus.instance.fire(SeekbarTriggeredEvent(position: 0));
@@ -260,6 +269,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     _guestViewEventSubscription.cancel();
     pauseVideoSubscription.cancel();
     resumeVideoSubscription.cancel();
+    _muteSubscription.cancel();
     removeDownloadCallback(widget.file);
     _progressNotifier.dispose();
     WidgetsBinding.instance.removeObserver(this);
@@ -599,10 +609,10 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
 
   Future<void> _onPlaybackReady() async {
     if (_isPlaybackReady.value) return;
+    await _controller!.setVolume(localSettings.isMuted() ? 0.0 : 1.0);
     await _controller!.play();
     final durationInSeconds = durationToSeconds(duration) ?? 10;
     widget.onFinalFileLoad?.call(memoryDuration: durationInSeconds);
-    unawaited(_controller!.setVolume(1));
     _isPlaybackReady.value = true;
   }
 
@@ -942,6 +952,8 @@ class _SeekBarAndDuration extends StatelessWidget {
                             ),
                           ),
                           Text(duration ?? "0:00", style: textStyle),
+                          const SizedBox(width: 8),
+                          const VideoMuteButton(),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Description

Adds a persistent mute button to the video player. Mute state is saved across app restarts and syncs instantly to all preloaded videos via the event bus. Works on both the native and MediaKit players.

Volume is now set before playback begins in-order to fix the bug where the native player would briefly play audio on startup even when muted.

**Before:**

<img width="720" height="108" alt="image" src="https://github.com/user-attachments/assets/b5d77b36-639f-4353-b430-c1e2e17ce777" />

**After:**

<img width="1320" height="547" alt="image" src="https://github.com/user-attachments/assets/93db1b9e-4ce7-4b94-b176-b63e8d753467" />


## Tests

Tested and verified on devices Realme C67 5G and Realme Pad 2.