### PR TITLE
[mobile] Publish backup queue deltas

### DIFF
--- a/mobile/apps/photos/lib/events/backup_updated_event.dart
+++ b/mobile/apps/photos/lib/events/backup_updated_event.dart
@@ -1,8 +1,12 @@
 import "package:photos/events/event.dart";
 import "package:photos/models/backup/backup_item.dart";
+import "package:photos/models/backup/backup_items_change.dart";
 
 class BackupUpdatedEvent extends Event {
-  final Map<String, BackupItem> items;
+  BackupUpdatedEvent(this.change);
 
-  BackupUpdatedEvent(this.items);
+  final BackupItemsChange change;
+
+  Map<String, BackupItem> get upserts => change.upserts;
+  Set<String> get removedLocalIDs => change.removedLocalIDs;
 }

--- a/mobile/apps/photos/lib/models/backup/backup_items_change.dart
+++ b/mobile/apps/photos/lib/models/backup/backup_items_change.dart
@@ -1,0 +1,12 @@
+import "package:photos/models/backup/backup_item.dart";
+
+class BackupItemsChange {
+  BackupItemsChange({
+    Map<String, BackupItem> upserts = const {},
+    Set<String> removedLocalIDs = const {},
+  }) : upserts = Map.unmodifiable(upserts),
+       removedLocalIDs = Set.unmodifiable(removedLocalIDs);
+
+  final Map<String, BackupItem> upserts;
+  final Set<String> removedLocalIDs;
+}

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -63,7 +63,7 @@ class FileUploader {
   final _dio = NetworkClient.instance.getDio();
   FileUploadGateway get _gateway => fileUploadGateway;
   final _queue = UploadQueue(
-    (items) => Bus.instance.fire(BackupUpdatedEvent(items)),
+    (change) => Bus.instance.fire(BackupUpdatedEvent(change)),
   );
   final _uploadLocks = UploadLocksDB.instance;
   final _uploadArtifactLifecycle = UploadArtifactLifecycle(

--- a/mobile/apps/photos/lib/module/upload/service/upload_queue.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_queue.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:collection/collection.dart';
 import 'package:photos/models/backup/backup_item.dart';
 import 'package:photos/models/backup/backup_item_status.dart';
+import 'package:photos/models/backup/backup_items_change.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 
-typedef BackupItemsChanged = void Function(Map<String, BackupItem> items);
+typedef BackupItemsChanged = void Function(BackupItemsChange change);
 
 class UploadQueue {
   UploadQueue(this._onBackupItemsChanged);
@@ -16,12 +18,13 @@ class UploadQueue {
   final _backupItems = <String, BackupItem>{};
   final _backupOwners = <String, Object>{};
 
-  Map<String, BackupItem> _backupItemsSnapshot = const {};
+  Map<String, BackupItem>? _backupItemsSnapshot;
   int _activeUploads = 0;
   int _activeVideoUploads = 0;
   int _sessionUploadCount = 0;
 
-  Map<String, BackupItem> get backupItems => _backupItemsSnapshot;
+  Map<String, BackupItem> get backupItems => _backupItemsSnapshot ??=
+      UnmodifiableMapView(LinkedHashMap.of(_backupItems));
   bool get hasPendingUploads => _items.isNotEmpty;
   bool get isUploading => _activeUploads > 0;
   int get sessionUploadCount => _sessionUploadCount;
@@ -48,7 +51,7 @@ class UploadQueue {
       completer: completer,
     );
     _backupOwners[localID] = item;
-    _notifyBackupItemsChanged();
+    _notifyBackupItemsChanged(upserts: {localID: _backupItems[localID]!});
     return UploadQueueRequest.added(item);
   }
 
@@ -131,7 +134,7 @@ class UploadQueue {
     item.completer.complete(uploadedFile);
     _backupItems.remove(localID);
     _backupOwners.remove(localID);
-    _notifyBackupItemsChanged();
+    _notifyBackupItemsChanged(removedLocalIDs: {localID});
   }
 
   Future<EnteFile> moveToBackground(UploadQueueItem item) {
@@ -170,7 +173,7 @@ class UploadQueue {
       _setBackupStatus(localID, owner, BackupItemStatus.uploaded);
     } else if (_backupItems.remove(localID) != null) {
       _backupOwners.remove(localID);
-      _notifyBackupItemsChanged();
+      _notifyBackupItemsChanged(removedLocalIDs: {localID});
     }
   }
 
@@ -191,16 +194,20 @@ class UploadQueue {
     if (localIDs.isEmpty) {
       return;
     }
+    final upserts = <String, BackupItem>{};
     for (final localID in localIDs) {
       _items.remove(localID)?.completer.completeError(reason);
-      _setBackupStatusWithoutNotification(
+      final updatedItem = _setBackupStatusWithoutNotification(
         localID,
         _backupOwners[localID]!,
         BackupItemStatus.retry,
         error: reason,
       );
+      if (updatedItem != null) {
+        upserts[localID] = updatedItem;
+      }
     }
-    _notifyBackupItemsChanged();
+    _notifyBackupItemsChanged(upserts: upserts);
   }
 
   void _setBackupStatus(
@@ -209,8 +216,15 @@ class UploadQueue {
     BackupItemStatus status, {
     Object? error,
   }) {
-    _setBackupStatusWithoutNotification(localID, owner, status, error: error);
-    _notifyBackupItemsChanged();
+    final updatedItem = _setBackupStatusWithoutNotification(
+      localID,
+      owner,
+      status,
+      error: error,
+    );
+    if (updatedItem != null) {
+      _notifyBackupItemsChanged(upserts: {localID: updatedItem});
+    }
   }
 
   void _setBackupStatusIfOwned(
@@ -225,24 +239,31 @@ class UploadQueue {
     _setBackupStatus(localID, owner, status, error: error);
   }
 
-  void _setBackupStatusWithoutNotification(
+  BackupItem? _setBackupStatusWithoutNotification(
     String localID,
     Object owner,
     BackupItemStatus status, {
     Object? error,
   }) {
     if (!identical(_backupOwners[localID], owner)) {
-      return;
+      return null;
     }
-    _backupItems[localID] = _backupItems[localID]!.copyWith(
+    final updatedItem = _backupItems[localID]!.copyWith(
       status: status,
       error: error,
     );
+    _backupItems[localID] = updatedItem;
+    return updatedItem;
   }
 
-  void _notifyBackupItemsChanged() {
-    _backupItemsSnapshot = Map.unmodifiable(_backupItems);
-    _onBackupItemsChanged(_backupItemsSnapshot);
+  void _notifyBackupItemsChanged({
+    Map<String, BackupItem> upserts = const {},
+    Set<String> removedLocalIDs = const {},
+  }) {
+    _backupItemsSnapshot = null;
+    _onBackupItemsChanged(
+      BackupItemsChange(upserts: upserts, removedLocalIDs: removedLocalIDs),
+    );
   }
 }
 

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import "dart:async";
+import "dart:collection";
 
 import "package:collection/collection.dart";
 import "package:ente_components/ente_components.dart";
@@ -24,7 +25,7 @@ class BackupStatusScreen extends StatefulWidget {
 }
 
 class _BackupStatusScreenState extends State<BackupStatusScreen> {
-  Map<String, BackupItem> items = FileUploader.instance.allBackups;
+  final LinkedHashMap<String, BackupItem> _items = LinkedHashMap();
   List<BackupItem>? result;
   StreamSubscription? _fileUploadedSubscription;
   StreamSubscription? _backupUpdatedSubscription;
@@ -33,6 +34,7 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
   void initState() {
     super.initState();
 
+    _items.addAll(FileUploader.instance.allBackups);
     checkBackupUpdatedEvent();
     getAllFiles();
   }
@@ -73,7 +75,10 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
     _backupUpdatedSubscription = Bus.instance.on<BackupUpdatedEvent>().listen((
       event,
     ) {
-      items = event.items;
+      for (final localID in event.removedLocalIDs) {
+        _items.remove(localID);
+      }
+      _items.addAll(event.upserts);
       safeSetState();
     });
   }
@@ -93,7 +98,7 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final List<BackupItem> items = this.items.values.toList().sorted(
+    final List<BackupItem> items = _items.values.toList().sorted(
       (a, b) => a.status.index.compareTo(b.status.index),
     );
 

--- a/mobile/apps/photos/test/module/upload/service/upload_queue_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_queue_test.dart
@@ -1,14 +1,17 @@
+import 'dart:collection';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:photos/models/backup/backup_item.dart';
 import 'package:photos/models/backup/backup_item_status.dart';
+import 'package:photos/models/backup/backup_items_change.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import 'package:photos/module/upload/service/upload_queue.dart';
 
 void main() {
   test('shares requests and preserves session count semantics', () {
-    final snapshots = <Map<String, BackupItem>>[];
-    final queue = UploadQueue(snapshots.add);
+    final changes = <BackupItemsChange>[];
+    final queue = UploadQueue(changes.add);
     final file = _file('local-1');
 
     final added = queue.add(file, 10);
@@ -21,9 +24,16 @@ void main() {
     expect(identical(added.item, sameCollection.item), isTrue);
     expect(identical(added.item, otherCollection.item), isTrue);
     expect(queue.sessionUploadCount, 2);
-    expect(snapshots, hasLength(1));
+    expect(changes, hasLength(1));
+    expect(changes.single.upserts.keys, ['local-1']);
+    expect(changes.single.removedLocalIDs, isEmpty);
     expect(
-      () => snapshots.single['other'] = snapshots.single.values.single,
+      () => changes.single.upserts['other'] =
+          changes.single.upserts.values.single,
+      throwsUnsupportedError,
+    );
+    expect(
+      () => changes.single.removedLocalIDs.add('other'),
       throwsUnsupportedError,
     );
   });
@@ -47,8 +57,8 @@ void main() {
   });
 
   test('cancels pending items with one backup notification', () async {
-    final snapshots = <Map<String, BackupItem>>[];
-    final queue = UploadQueue(snapshots.add);
+    final changes = <BackupItemsChange>[];
+    final queue = UploadQueue(changes.add);
     final active = queue.add(_file('active'), 1).item;
     final firstPending = queue.add(_file('pending-1'), 1).item;
     final secondPending = queue.add(_file('pending-2'), 1).item;
@@ -62,12 +72,14 @@ void main() {
       secondPending.completer.future,
       throwsA(error),
     );
-    final notificationsBeforeRemoval = snapshots.length;
+    final notificationsBeforeRemoval = changes.length;
 
     final removed = queue.removeWhere((_) => true, error);
 
     expect(removed, 2);
-    expect(snapshots.length, notificationsBeforeRemoval + 1);
+    expect(changes.length, notificationsBeforeRemoval + 1);
+    expect(changes.last.upserts.keys, ['pending-1', 'pending-2']);
+    expect(changes.last.removedLocalIDs, isEmpty);
     expect(queue.hasPendingUploads, isTrue);
     expect(queue.backupItems['active']!.status, BackupItemStatus.uploading);
     expect(queue.backupItems['pending-1']!.status, BackupItemStatus.retry);
@@ -104,6 +116,102 @@ void main() {
     expect(await secondItem.completer.future, same(uploadedFile));
     expect(queue.backupItems, isEmpty);
   });
+
+  test('emits removals without rebuilding full backup snapshots', () async {
+    final changes = <BackupItemsChange>[];
+    final queue = UploadQueue(changes.add);
+    final item = queue.add(_file('local-1'), 1).item;
+    final snapshotBeforeRemoval = queue.backupItems;
+    expect(_start(queue), same(item));
+
+    final uploadedFile = _file('uploaded');
+    queue.complete(item, uploadedFile);
+    queue.finishAttempt(item);
+
+    expect(changes.last.upserts, isEmpty);
+    expect(changes.last.removedLocalIDs, {'local-1'});
+    expect(snapshotBeforeRemoval.keys, ['local-1']);
+    expect(queue.backupItems, isEmpty);
+    expect(await item.completer.future, same(uploadedFile));
+  });
+
+  test('preserves insertion order in lazy immutable snapshots', () {
+    final queue = UploadQueue((_) {});
+    queue.add(_file('first'), 1);
+    queue.add(_file('second'), 1);
+
+    final snapshot = queue.backupItems;
+
+    expect(snapshot.keys, ['first', 'second']);
+    expect(identical(queue.backupItems, snapshot), isTrue);
+    expect(() => snapshot.remove('first'), throwsUnsupportedError);
+
+    queue.add(_file('third'), 1);
+    expect(snapshot.keys, ['first', 'second']);
+    expect(queue.backupItems.keys, ['first', 'second', 'third']);
+    expect(identical(queue.backupItems, snapshot), isFalse);
+  });
+
+  test('deltas reconstruct the authoritative ordered snapshot', () async {
+    final reducedItems = LinkedHashMap<String, BackupItem>();
+    late final UploadQueue queue;
+    queue = UploadQueue((change) {
+      for (final localID in change.removedLocalIDs) {
+        reducedItems.remove(localID);
+      }
+      reducedItems.addAll(change.upserts);
+      expect(reducedItems.keys, queue.backupItems.keys);
+      expect(reducedItems, queue.backupItems);
+    });
+
+    final active = queue.add(_file('active'), 1).item;
+    final firstPending = queue.add(_file('pending-1'), 1).item;
+    final secondPending = queue.add(_file('pending-2'), 1).item;
+    expect(_start(queue), same(active));
+
+    final error = _QueueError();
+    final firstResult = expectLater(
+      firstPending.completer.future,
+      throwsA(error),
+    );
+    final secondResult = expectLater(
+      secondPending.completer.future,
+      throwsA(error),
+    );
+    queue.removeWhere((file) => file.localID != 'active', error);
+
+    final uploadedFile = _file('uploaded');
+    queue.complete(active, uploadedFile);
+    queue.finishAttempt(active);
+
+    await firstResult;
+    await secondResult;
+    expect(await active.completer.future, same(uploadedFile));
+    expect(reducedItems.keys, ['pending-1', 'pending-2']);
+    expect(reducedItems, queue.backupItems);
+  });
+
+  for (final itemCount in [1000, 10000]) {
+    test('$itemCount additions emit linear aggregate delta work', () {
+      var notificationCount = 0;
+      var upsertCount = 0;
+      var removalCount = 0;
+      final queue = UploadQueue((change) {
+        notificationCount++;
+        upsertCount += change.upserts.length;
+        removalCount += change.removedLocalIDs.length;
+      });
+
+      for (var index = 0; index < itemCount; index++) {
+        queue.add(_file('local-$index'), 1);
+      }
+
+      expect(notificationCount, itemCount);
+      expect(upsertCount, itemCount);
+      expect(removalCount, 0);
+      expect(queue.backupItems, hasLength(itemCount));
+    });
+  }
 }
 
 UploadQueueItem? _start(UploadQueue queue) {


### PR DESCRIPTION
## Summary

- publish immutable backup queue deltas (`upserts` and `removedLocalIDs`) instead of copying the full backup map for every mutation
- build the full immutable insertion-ordered backup snapshot lazily when `allBackups` is read
- keep the backup status screen's own insertion-ordered map and apply each delta
- cover immutability, ordering, batched cancellation, removals, reducer equivalence, and 1,000/10,000-item linear notification workloads

## Behavior and performance

Successful entries are still removed, retry entries are retained, batch cancellation still produces one notification, and stale owners cannot publish transitions. The event path now copies only the changed entries/IDs; it performs no disk, hash, encryption, database, or network work. A full map copy occurs only on the first `allBackups` read after a queue mutation.

Touched/new production files are 1,853 lines before and 1,895 after (+42, +2.3%). `file_uploader.dart` remains 1,411 lines. The increase is the immutable delta type, lazy snapshot cache/invalidation, and ordered UI reducer.

## Validation

- Flutter 3.38.10 dependency resolution with lockfile enforcement
- Rust FRB generation using `~/code/ente/rust-target`
- formatting and diff whitespace checks
- focused upload queue tests: 9 passed
- full Photos tests: 216 passed
- full Photos analysis: no issues found

Profile-mode device smoke tests were not run because this workspace has no attached Android/iOS device or simulator. This PR changes only the in-memory queue notification representation and its backup-screen consumer.
