### PR TITLE
[mobile][photos] Remove legacy Live Photo ZIP hashes

### DIFF
--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -15,7 +15,6 @@ import 'package:photos/models/file_load_result.dart';
 import 'package:photos/models/freeable_space_info.dart';
 import 'package:photos/models/location/location.dart';
 import "package:photos/models/metadata/common_keys.dart";
-import 'package:photos/module/upload/model/media_upload_data.dart';
 import "package:photos/services/filter/db_filters.dart";
 import 'package:sqlite_async/sqlite_async.dart';
 
@@ -1339,21 +1338,17 @@ class FilesDB with SqlDbBase {
     return Map.fromIterable(matchedFiles, key: (e) => e.hash);
   }
 
-  Future<List<EnteFile>> getUploadedFilesWithHashes(
-    FileHashData hashData,
+  Future<List<EnteFile>> getUploadedFilesWithHash(
+    String hash,
     FileType fileType,
     int ownerID,
   ) async {
-    String inParam = "'${hashData.fileHash}'";
-    if (fileType == FileType.livePhoto && hashData.zipHash != null) {
-      inParam += ",'${hashData.zipHash}'";
-    }
     final db = await instance.sqliteAsyncDB;
     final rows = await db.getAll(
       'SELECT * FROM $filesTable WHERE ($columnUploadedFileID != NULL OR '
       '$columnUploadedFileID != -1) AND $columnOwnerID = ? AND '
-      '$columnFileType = ? AND $columnHash IN ($inParam)',
-      [ownerID, getInt(fileType)],
+      '$columnFileType = ? AND $columnHash = ?',
+      [ownerID, getInt(fileType), hash],
     );
     return convertToFiles(rows);
   }

--- a/mobile/apps/photos/lib/module/live_photo/upload.dart
+++ b/mobile/apps/photos/lib/module/live_photo/upload.dart
@@ -13,13 +13,7 @@ import 'package:photos/models/file/file.dart';
 import 'package:photos/module/live_photo/archive.dart';
 import 'package:uuid/uuid.dart';
 
-typedef LivePhotoUploadData = ({
-  File sourceFile,
-  String fileHash,
-  String zipHash,
-});
-
-typedef LivePhotoHashData = ({String fileHash, String? zipHash});
+typedef LivePhotoUploadData = ({File sourceFile, String fileHash});
 
 typedef _LivePhotoVideoData = ({File file, String fileHash});
 
@@ -43,47 +37,15 @@ Future<LivePhotoUploadData> prepareLivePhotoForUpload(
     // photo_manager can return the same iOS temp copy to concurrent upload or
     // hash-check paths, where cleanup may have already run.
     await deleteFileSystemEntityIfPresent(imageFile);
-    final zipHash = CryptoUtil.bin2base64(
-      await CryptoUtil.getHash(archiveFile),
-    );
-    return (
-      sourceFile: archiveFile,
-      fileHash: videoData.fileHash,
-      zipHash: zipHash,
-    );
+    return (sourceFile: archiveFile, fileHash: videoData.fileHash);
   } catch (_) {
     await deleteFileSystemEntityIfPresent(archiveFile);
     rethrow;
   }
 }
 
-/// Computes the modern component hash first and creates the legacy ZIP only
-/// when it is still needed to compare an older stored hash.
-Future<LivePhotoHashData> getLivePhotoHashDataForComparison(
-  EnteFile file,
-  File imageFile,
-  String imageHash,
-) async {
-  final videoData = await _getLivePhotoVideoData(file, imageHash);
-  final storedHash = file.hash;
-  if (storedHash == null ||
-      storedHash == videoData.fileHash ||
-      storedHash.contains(kLivePhotoHashSeparator)) {
-    return (fileHash: videoData.fileHash, zipHash: null);
-  }
-  final archiveFile = await _createLivePhotoArchiveFile(
-    file,
-    imageFile,
-    videoData.file,
-  );
-  try {
-    return (
-      fileHash: videoData.fileHash,
-      zipHash: CryptoUtil.bin2base64(await CryptoUtil.getHash(archiveFile)),
-    );
-  } finally {
-    await deleteFileSystemEntityIfPresent(archiveFile);
-  }
+Future<String> getLivePhotoFileHash(EnteFile file, String imageHash) async {
+  return (await _getLivePhotoVideoData(file, imageHash)).fileHash;
 }
 
 Future<_LivePhotoVideoData> _getLivePhotoVideoData(

--- a/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/model/media_upload_data.dart
@@ -7,7 +7,7 @@ class MediaUploadData {
   final File sourceFile;
   final Uint8List? thumbnail;
   final bool isDeleted;
-  final FileHashData hashData;
+  final String fileHash;
 
   final DerivedMediaMetadata derivedMetadata;
 
@@ -15,7 +15,7 @@ class MediaUploadData {
     required this.sourceFile,
     required this.thumbnail,
     required this.isDeleted,
-    required this.hashData,
+    required this.fileHash,
     required this.derivedMetadata,
   });
 }
@@ -40,15 +40,4 @@ class DerivedMediaMetadata {
     this.motionPhotoStartIndex,
     this.exifData,
   });
-}
-
-class FileHashData {
-  // For livePhotos, the fileHash value will be imageHash:videoHash
-  final String fileHash;
-
-  // zipHash is used to take care of existing live photo uploads from older
-  // mobile clients
-  final String? zipHash;
-
-  FileHashData(this.fileHash, {this.zipHash});
 }

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -411,11 +411,7 @@ class FileUploader {
     }
 
     final String? existingMultipartEncFileName = await _uploadLocks
-        .getEncryptedFileName(
-          lockKey,
-          mediaUploadData.hashData.fileHash,
-          collectionID,
-        );
+        .getEncryptedFileName(lockKey, mediaUploadData.fileHash, collectionID);
     final sourceLength = await mediaUploadData.sourceFile.length();
     final bool hasExistingMultiPart = existingMultipartEncFileName != null;
     final tempDirectory = Configuration.instance.getTempDirectory();
@@ -447,7 +443,7 @@ class FileUploader {
       final FileEncryptResult? multiPartFileEncResult = hasExistingMultiPart
           ? await _multiPartUploader.getEncryptionResult(
               lockKey,
-              mediaUploadData.hashData.fileHash,
+              mediaUploadData.fileHash,
               collectionID,
               existingMultipartEncFileName,
             )
@@ -590,7 +586,7 @@ class FileUploader {
           fileObjectKey = await _multiPartUploader.putExistingMultipartFile(
             encryptedFile,
             lockKey,
-            mediaUploadData.hashData.fileHash,
+            mediaUploadData.fileHash,
             collectionID,
             existingMultipartEncFileName,
           );
@@ -611,7 +607,7 @@ class FileUploader {
           final encFileName = encryptedFile.path.split('/').last;
           await _multiPartUploader.createTableEntry(
             lockKey,
-            mediaUploadData.hashData.fileHash,
+            mediaUploadData.fileHash,
             collectionID,
             fileUploadURLs,
             encFileName,
@@ -875,8 +871,8 @@ class FileUploader {
     final bool isSandBoxFile = fileToUpload.isSharedMediaToAppSandbox;
 
     final List<EnteFile> existingUploadedFiles = await FilesDB.instance
-        .getUploadedFilesWithHashes(
-          mediaUploadData.hashData,
+        .getUploadedFilesWithHash(
+          mediaUploadData.fileHash,
           fileToUpload.fileType,
           Configuration.instance.getUserID()!,
         );

--- a/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
+++ b/mobile/apps/photos/lib/module/upload/service/local_file_update_service.dart
@@ -148,10 +148,8 @@ class LocalFileUpdateService {
         continue;
       }
       try {
-        final contentIdentity = await getFileContentIdentity(file);
-        if (file.hash != null &&
-            (file.hash == contentIdentity.fileHash ||
-                file.hash == contentIdentity.zipHash)) {
+        final contentHash = await getFileContentIdentity(file);
+        if (file.hash != null && file.hash == contentHash) {
           _logger.info("Skip file update as hash matched ${file.tag}");
         } else {
           _logger.info(

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -41,8 +41,8 @@ Future<MediaUploadData> getUploadDataFromEnteFile(EnteFile file) async {
   }
 }
 
-/// Computes only the hashes needed to decide whether a local file changed.
-Future<FileHashData> getFileContentIdentity(EnteFile file) async {
+/// Computes the content hash used to decide whether a local file changed.
+Future<String> getFileContentIdentity(EnteFile file) async {
   if (file.isSharedMediaToAppSandbox) {
     final sourceFile = File(getSharedMediaFilePath(file));
     if (!sourceFile.existsSync()) {
@@ -51,9 +51,7 @@ Future<FileHashData> getFileContentIdentity(EnteFile file) async {
         InvalidReason.sourceFileMissing,
       );
     }
-    return FileHashData(
-      CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile)),
-    );
+    return CryptoUtil.bin2base64(await CryptoUtil.getHash(sourceFile));
   }
 
   final asset = await _getAsset(file);
@@ -63,14 +61,9 @@ Future<FileHashData> getFileContentIdentity(EnteFile file) async {
       await CryptoUtil.getHash(sourceFile),
     );
     if (file.fileType == FileType.livePhoto && Platform.isIOS) {
-      final livePhoto = await getLivePhotoHashDataForComparison(
-        file,
-        sourceFile,
-        sourceHash,
-      );
-      return FileHashData(livePhoto.fileHash, zipHash: livePhoto.zipHash);
+      return getLivePhotoFileHash(file, sourceHash);
     }
-    return FileHashData(sourceHash);
+    return sourceHash;
   } finally {
     if (Platform.isIOS) {
       await deleteFileSystemEntityIfPresent(sourceFile);
@@ -82,7 +75,6 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(EnteFile file) async {
   File? sourceFile;
   Uint8List? thumbnailData;
   bool isDeleted;
-  String? zipHash;
   String fileHash;
   Map<String, IfdTag>? exifData;
   String? cameraMake;
@@ -114,7 +106,6 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(EnteFile file) async {
       );
       sourceFile = livePhoto.sourceFile;
       fileHash = livePhoto.fileHash;
-      zipHash = livePhoto.zipHash;
     }
 
     thumbnailData = await _getThumbnailForUpload(asset, file);
@@ -144,7 +135,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAssetFile(EnteFile file) async {
       sourceFile: sourceFile,
       thumbnail: thumbnailData,
       isDeleted: isDeleted,
-      hashData: FileHashData(fileHash, zipHash: zipHash),
+      fileHash: fileHash,
       derivedMetadata: DerivedMediaMetadata(
         height: h,
         width: w,
@@ -356,7 +347,7 @@ Future<MediaUploadData> _getMediaUploadDataFromAppCache(EnteFile file) async {
     sourceFile: sourceFile,
     thumbnail: thumbnailData,
     isDeleted: isDeleted,
-    hashData: FileHashData(fileHash),
+    fileHash: fileHash,
     derivedMetadata: DerivedMediaMetadata(
       height: dimensions?.height,
       width: dimensions?.width,

--- a/mobile/apps/photos/lib/module/upload/upload_metadata.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_metadata.dart
@@ -40,7 +40,7 @@ Future<PreparedUploadMetadata> prepareUploadMetadata(
     } catch (_) {}
     isPanorama ??= false;
   }
-  file.hash = mediaUploadData.hashData.fileHash;
+  file.hash = mediaUploadData.fileHash;
   return PreparedUploadMetadata(
     canonicalMetadata: file.metadata,
     publicMetadata: _buildPublicMetadata(


### PR DESCRIPTION
## What changed

- use `imageHash:videoHash` as the only Live Photo content identity
- remove legacy ZIP hash generation, comparison, and database lookup
- simplify upload data to carry a single file hash
- avoid rebuilding a Live Photo archive during changed-file checks

## Why

The legacy ZIP hash is not a stable content identity. ZIP output includes archive metadata such as source-file modification times and modes, so rebuilding an archive can produce a different hash even when the image and video content is unchanged. This makes the compatibility fallback unreliable across reinstalls and regenerated temporary files while adding extra I/O and complexity.

## Impact

New and existing modern Live Photos continue to use the component identity (`imageHash:videoHash`). Files whose encrypted metadata contains only the pre-2022 ZIP hash will no longer use that unreliable fallback during upload reuse or changed-file detection.

## Checks

- `flutter test test/module/live_photo/archive_test.dart`
- targeted `dart analyze` for the changed files that do not require generated Rust bindings
- `git diff --check`
