### PR TITLE
[mobile] Fix upload queue state tracking

### DIFF
--- a/mobile/apps/photos/lib/models/backup/backup_item.dart
+++ b/mobile/apps/photos/lib/models/backup/backup_item.dart
@@ -1,36 +1,38 @@
-import "dart:async";
-
 import "package:photos/models/backup/backup_item_status.dart";
 import "package:photos/models/file/file.dart";
 
+class _PreserveError {
+  const _PreserveError();
+}
+
 class BackupItem {
+  static const _preserveError = _PreserveError();
+
   final BackupItemStatus status;
   final EnteFile file;
   final int collectionID;
-  final Completer<EnteFile>? completer;
   final Object? error;
 
   BackupItem({
     required this.status,
     required this.file,
     required this.collectionID,
-    required this.completer,
-    this.error,
-  });
+    Object? error,
+  }) : error = status == BackupItemStatus.retry ? error : null;
 
   BackupItem copyWith({
     BackupItemStatus? status,
     EnteFile? file,
     int? collectionID,
-    Completer<EnteFile>? completer,
-    Object? error,
+    Object? error = _preserveError,
   }) {
+    final nextStatus = status ?? this.status;
+    final nextError = identical(error, _preserveError) ? this.error : error;
     return BackupItem(
-      status: status ?? this.status,
+      status: nextStatus,
       file: file ?? this.file,
       collectionID: collectionID ?? this.collectionID,
-      completer: completer ?? this.completer,
-      error: error ?? this.error,
+      error: nextStatus == BackupItemStatus.retry ? nextError : null,
     );
   }
 
@@ -46,7 +48,6 @@ class BackupItem {
     return other.status == status &&
         other.file == file &&
         other.collectionID == collectionID &&
-        other.completer == completer &&
         other.error == error;
   }
 
@@ -55,6 +56,6 @@ class BackupItem {
     return status.hashCode ^
         file.hashCode ^
         collectionID.hashCode ^
-        completer.hashCode;
+        error.hashCode;
   }
 }

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -148,15 +148,11 @@ class FileUploader {
         .listen((event) {
           if (event.type == EventType.deletedFromDevice ||
               event.type == EventType.deletedFromEverywhere) {
+            final deletedGeneratedIDs = event.updatedFiles
+                .map((file) => file.generatedID)
+                .toSet();
             removeFromQueueWhere(
-              (file) {
-                for (final updatedFile in event.updatedFiles) {
-                  if (file.generatedID == updatedFile.generatedID) {
-                    return true;
-                  }
-                }
-                return false;
-              },
+              (file) => deletedGeneratedIDs.contains(file.generatedID),
               InvalidFileError(
                 "File already deleted",
                 InvalidReason.assetDeletedEvent,

--- a/mobile/apps/photos/lib/module/upload/service/upload_queue.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_queue.dart
@@ -48,7 +48,6 @@ class UploadQueue {
       status: BackupItemStatus.inQueue,
       file: file,
       collectionID: collectionID,
-      completer: completer,
     );
     _backupOwners[localID] = item;
     _notifyBackupItemsChanged(upserts: {localID: _backupItems[localID]!});
@@ -75,6 +74,7 @@ class UploadQueue {
         .toList();
     _removePendingUploads(pendingUploadIDs, reason);
     _sessionUploadCount -= pendingUploadIDs.length;
+    _resetSessionUploadCountIfEmpty();
     return pendingUploadIDs.length;
   }
 
@@ -131,6 +131,7 @@ class UploadQueue {
       return;
     }
     _items.remove(localID);
+    _resetSessionUploadCountIfEmpty();
     item.completer.complete(uploadedFile);
     _backupItems.remove(localID);
     _backupOwners.remove(localID);
@@ -153,6 +154,7 @@ class UploadQueue {
       return;
     }
     _items.remove(localID);
+    _resetSessionUploadCountIfEmpty();
     item.completer.completeError(error);
     _setBackupStatus(localID, item, BackupItemStatus.retry, error: error);
   }
@@ -264,6 +266,12 @@ class UploadQueue {
     _onBackupItemsChanged(
       BackupItemsChange(upserts: upserts, removedLocalIDs: removedLocalIDs),
     );
+  }
+
+  void _resetSessionUploadCountIfEmpty() {
+    if (_items.isEmpty) {
+      _sessionUploadCount = 0;
+    }
   }
 }
 

--- a/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/backup/backup_status_screen.dart
@@ -47,7 +47,6 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
             status: BackupItemStatus.uploaded,
             file: e,
             collectionID: e.collectionID ?? 0,
-            completer: null,
           );
         })
         .sorted(
@@ -63,7 +62,6 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
           status: BackupItemStatus.uploaded,
           file: event.file,
           collectionID: event.file.collectionID ?? 0,
-          completer: null,
         ),
       );
       safeSetState();
@@ -122,9 +120,16 @@ class _BackupStatusScreenState extends State<BackupStatusScreen> {
               padding: const EdgeInsets.symmetric(horizontal: Spacing.lg),
               sliver: SliverList.builder(
                 itemBuilder: (context, index) {
+                  final file = allItems[index].file;
                   return BackupItemCard(
                     item: allItems[index],
-                    key: ValueKey(allItems[index].file.uploadedFileID),
+                    key: ValueKey(
+                      file.uploadedFileID != null
+                          ? ("uploaded", file.uploadedFileID)
+                          : file.localID != null
+                          ? ("local", file.localID)
+                          : ("generated", file.generatedID),
+                    ),
                   );
                 },
                 itemCount: allItems.length,

--- a/mobile/apps/photos/test/models/backup/backup_item_test.dart
+++ b/mobile/apps/photos/test/models/backup/backup_item_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photos/models/backup/backup_item.dart';
+import 'package:photos/models/backup/backup_item_status.dart';
+import 'package:photos/models/file/file.dart';
+
+void main() {
+  test('copyWith can explicitly clear a retry error', () {
+    final error = StateError('retry');
+    final retryItem = BackupItem(
+      status: BackupItemStatus.retry,
+      file: EnteFile(),
+      collectionID: 1,
+      error: error,
+    );
+
+    expect(retryItem.copyWith().error, same(error));
+    expect(retryItem.copyWith(error: null).error, isNull);
+
+    const replacementError = Object();
+    expect(
+      retryItem.copyWith(error: replacementError).error,
+      same(replacementError),
+    );
+  });
+
+  test('non-retry statuses cannot retain an error', () {
+    final retryItem = BackupItem(
+      status: BackupItemStatus.retry,
+      file: EnteFile(),
+      collectionID: 1,
+      error: StateError('retry'),
+    );
+
+    final uploadingItem = retryItem.copyWith(
+      status: BackupItemStatus.uploading,
+    );
+
+    expect(uploadingItem.error, isNull);
+  });
+
+  test('normalizes an error on a non-retry item', () {
+    final item = BackupItem(
+      status: BackupItemStatus.uploading,
+      file: EnteFile(),
+      collectionID: 1,
+      error: StateError('unexpected'),
+    );
+
+    expect(item.error, isNull);
+  });
+}

--- a/mobile/apps/photos/test/module/upload/service/upload_queue_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_queue_test.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:photos/models/backup/backup_item.dart';
 import 'package:photos/models/backup/backup_item_status.dart';
@@ -9,21 +7,25 @@ import 'package:photos/models/file/file_type.dart';
 import 'package:photos/module/upload/service/upload_queue.dart';
 
 void main() {
-  test('shares requests and preserves session count semantics', () {
+  test('same-collection requests share one item and future', () {
     final changes = <BackupItemsChange>[];
     final queue = UploadQueue(changes.add);
     final file = _file('local-1');
 
     final added = queue.add(file, 10);
     final sameCollection = queue.add(file, 10);
-    final otherCollection = queue.add(file, 20);
 
     expect(added.disposition, UploadQueueDisposition.added);
     expect(sameCollection.disposition, UploadQueueDisposition.sameCollection);
-    expect(otherCollection.disposition, UploadQueueDisposition.otherCollection);
     expect(identical(added.item, sameCollection.item), isTrue);
-    expect(identical(added.item, otherCollection.item), isTrue);
-    expect(queue.sessionUploadCount, 2);
+    expect(
+      identical(
+        added.item.completer.future,
+        sameCollection.item.completer.future,
+      ),
+      isTrue,
+    );
+    expect(queue.sessionUploadCount, 1);
     expect(changes, hasLength(1));
     expect(changes.single.upserts.keys, ['local-1']);
     expect(changes.single.removedLocalIDs, isEmpty);
@@ -38,22 +40,65 @@ void main() {
     );
   });
 
-  test('selects FIFO work within total and video limits', () {
+  test('different-collection requests wait on the same queued item', () {
+    final queue = UploadQueue((_) {});
+    final file = _file('local-1');
+
+    final added = queue.add(file, 10);
+    final otherCollection = queue.add(file, 20);
+
+    expect(otherCollection.disposition, UploadQueueDisposition.otherCollection);
+    expect(otherCollection.item, same(added.item));
+    expect(
+      identical(
+        added.item.completer.future,
+        otherCollection.item.completer.future,
+      ),
+      isTrue,
+    );
+    expect(queue.sessionUploadCount, 2);
+  });
+
+  test('selects non-video work in FIFO order', () {
+    final queue = UploadQueue((_) {});
+    final first = queue.add(_file('first'), 1).item;
+    final second = queue.add(_file('second'), 1).item;
+    final third = queue.add(_file('third'), 1).item;
+
+    expect(_start(queue), same(first));
+    expect(_start(queue), same(second));
+    expect(_start(queue), same(third));
+  });
+
+  test('enforces total and video limits while allowing image bypass', () {
     final queue = UploadQueue((_) {});
     final firstVideo = queue.add(_file('video-1', FileType.video), 1).item;
     final secondVideo = queue.add(_file('video-2', FileType.video), 1).item;
     final thirdVideo = queue.add(_file('video-3', FileType.video), 1).item;
-    final image = queue.add(_file('image-1'), 1).item;
+    final firstImage = queue.add(_file('image-1'), 1).item;
+    final secondImage = queue.add(_file('image-2'), 1).item;
+    final thirdImage = queue.add(_file('image-3'), 1).item;
 
     expect(_start(queue), same(firstVideo));
     expect(_start(queue), same(secondVideo));
-    expect(_start(queue), same(image));
+    expect(_start(queue), same(firstImage));
+    expect(_start(queue), same(secondImage));
     expect(_start(queue), isNull);
 
     queue.finishAttempt(firstVideo);
     expect(_start(queue), same(thirdVideo));
+    expect(_start(queue), isNull);
+
+    queue.finishAttempt(firstImage);
+    expect(_start(queue), same(thirdImage));
     expect(queue.isUploading, isTrue);
     expect(queue.backupItems['video-3']!.status, BackupItemStatus.uploading);
+
+    queue.finishAttempt(secondVideo);
+    queue.finishAttempt(secondImage);
+    queue.finishAttempt(thirdVideo);
+    queue.finishAttempt(thirdImage);
+    expect(queue.isUploading, isFalse);
   });
 
   test('cancels pending items with one backup notification', () async {
@@ -153,7 +198,7 @@ void main() {
   });
 
   test('deltas reconstruct the authoritative ordered snapshot', () async {
-    final reducedItems = LinkedHashMap<String, BackupItem>();
+    final reducedItems = <String, BackupItem>{};
     late final UploadQueue queue;
     queue = UploadQueue((change) {
       for (final localID in change.removedLocalIDs) {
@@ -212,6 +257,91 @@ void main() {
       expect(queue.backupItems, hasLength(itemCount));
     });
   }
+
+  test('terminal completion resolves once and resets the session', () async {
+    final queue = UploadQueue((_) {});
+    final item = queue.add(_file('local-1'), 1).item;
+    expect(_start(queue), same(item));
+    var completionCount = 0;
+    final result = item.completer.future.then((file) {
+      completionCount++;
+      return file;
+    });
+    final uploadedFile = _file('uploaded');
+
+    queue.complete(item, uploadedFile);
+    queue.complete(item, _file('duplicate'));
+    queue.finishAttempt(item);
+
+    expect(await result, same(uploadedFile));
+    expect(completionCount, 1);
+    expect(queue.sessionUploadCount, 0);
+    expect(queue.hasPendingUploads, isFalse);
+    expect(queue.isUploading, isFalse);
+  });
+
+  test('background completion resets the session', () async {
+    final queue = UploadQueue((_) {});
+    final item = queue.add(_file('local-1'), 1).item;
+    expect(_start(queue), same(item));
+    final result = queue.moveToBackground(item);
+    queue.finishAttempt(item);
+
+    final uploadedFile = _file('uploaded');
+    queue.complete(item, uploadedFile);
+
+    expect(await result, same(uploadedFile));
+    expect(queue.backgroundItems, isEmpty);
+    expect(queue.sessionUploadCount, 0);
+  });
+
+  test('terminal failure resets the session and keeps retry details', () async {
+    final queue = UploadQueue((_) {});
+    final item = queue.add(_file('local-1'), 1).item;
+    expect(_start(queue), same(item));
+    final error = _QueueError();
+    final result = expectLater(item.completer.future, throwsA(same(error)));
+
+    queue.fail(item, error);
+    queue.finishAttempt(item);
+
+    expect(queue.sessionUploadCount, 0);
+    expect(queue.hasPendingUploads, isFalse);
+    expect(queue.isUploading, isFalse);
+    expect(queue.backupItems['local-1']!.status, BackupItemStatus.retry);
+    expect(queue.backupItems['local-1']!.error, same(error));
+    await result;
+  });
+
+  test('removing the final item clears deferred session intents', () async {
+    final queue = UploadQueue((_) {});
+    final item = queue.add(_file('local-1'), 1).item;
+    queue.add(item.file, 2);
+    final error = _QueueError();
+    final result = expectLater(item.completer.future, throwsA(same(error)));
+
+    expect(queue.removeWhere((_) => true, error), 1);
+
+    expect(queue.sessionUploadCount, 0);
+    expect(queue.hasPendingUploads, isFalse);
+    await result;
+  });
+
+  test('moving retry back to uploading clears its error', () async {
+    final queue = UploadQueue((_) {});
+    final item = queue.add(_file('local-1'), 1).item;
+    expect(_start(queue), same(item));
+    final error = _QueueError();
+    final result = expectLater(item.completer.future, throwsA(same(error)));
+    queue.fail(item, error);
+    queue.finishAttempt(item);
+    await result;
+
+    queue.markBackupUploading(item, 'local-1');
+
+    expect(queue.backupItems['local-1']!.status, BackupItemStatus.uploading);
+    expect(queue.backupItems['local-1']!.error, isNull);
+  });
 }
 
 UploadQueueItem? _start(UploadQueue queue) {


### PR DESCRIPTION
## Summary

- Reset the session upload count when the final queued item exits through completion, failure, background completion, or cancellation.
- Make backup retry errors clearable, prevent errors on non-retry states, and remove the unused `BackupItem` completer.
- Give backup cards stable identities and replace nested deleted-file matching with a generated-ID set lookup.

## Why

This fixes stale session counts and retry errors, avoids duplicate null widget keys, and reduces deleted-file matching from nested scans to linear set membership.

## Test plan

- `flutter test test/models/backup/backup_item_test.dart test/module/upload/service/upload_queue_test.dart`
- `flutter test`
- `flutter analyze`
