### PR TITLE
[mobile] Extract upload transport

### DIFF
--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -34,7 +34,6 @@ import 'package:photos/events/user_logged_out_event.dart';
 import 'package:photos/gateways/users/models/key_attributes.dart';
 import 'package:photos/gateways/users/models/key_gen_result.dart';
 import 'package:photos/gateways/users/models/private_key_attributes.dart';
-import 'package:photos/module/upload/service/file_uploader.dart';
 import 'package:photos/module/upload/upload_artifact.dart';
 import 'package:photos/service_locator.dart';
 import 'package:photos/services/collections_service.dart';
@@ -287,7 +286,6 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
 
     if (!autoLogout) {
       // Following services won't be initialized if it's the case of autoLogout
-      FileUploader.instance.clearCachedUploadURLs();
       CollectionsService.instance.clearCache();
       FavoritesService.instance.clearCache();
       SearchService.instance.clearCache();

--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -114,22 +114,6 @@ class MultiPartError implements Exception {
   String toString() => "MultiPartError: $message";
 }
 
-class DuplicateUploadURLError extends Error {
-  final DateTime firstUsedAt;
-  final DateTime duplicateUsedAt;
-
-  DuplicateUploadURLError({
-    required this.firstUsedAt,
-    required this.duplicateUsedAt,
-  });
-
-  @override
-  String toString() =>
-      "DuplicateUploadURLError: Upload URL was reused. "
-      "First used at: $firstUsedAt, Duplicate attempt at: $duplicateUsedAt. "
-      "This indicates a race condition in parallel uploads.";
-}
-
 class EncSizeMismatchError implements Exception {
   final String message;
   EncSizeMismatchError(this.message);

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -211,10 +211,6 @@ class FileUploader {
     _queue.clear(reason);
   }
 
-  void clearCachedUploadURLs() {
-    _uploadTransport?.clearCachedUploadURLs();
-  }
-
   /// Validates that the user can upload before starting expensive encryption.
   /// Throws on 402 (no subscription) or 426 (storage exceeded).
   Future<void> validateUploadEligibility() async {

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -135,7 +135,6 @@ class FileUploader {
       clearQueue: clearQueue,
     );
     _multiPartUploader = MultiPartUploader(
-      _dio, // legacy parameter, not used by MultiPartUploader
       _dio,
       UploadLocksDB.instance,
       flagService,

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -8,7 +8,6 @@ import 'package:ente_crypto/ente_crypto.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
-import "package:path/path.dart";
 import "package:permission_handler/permission_handler.dart";
 import 'package:photos/core/configuration.dart';
 import "package:photos/core/constants.dart";
@@ -21,7 +20,6 @@ import "package:photos/events/backup_updated_event.dart";
 import "package:photos/events/file_uploaded_event.dart";
 import 'package:photos/events/files_updated_event.dart';
 import 'package:photos/events/local_photos_updated_event.dart';
-import "package:photos/gateways/collections/models/metadata.dart";
 import "package:photos/gateways/files/file_upload_gateway.dart";
 import "package:photos/main.dart" show isProcessBg, kLastBGTaskHeartBeatTime;
 import "package:photos/models/backup/backup_item.dart";
@@ -30,10 +28,10 @@ import 'package:photos/models/file/file_type.dart';
 import "package:photos/models/user_details.dart";
 import "package:photos/module/metadata/exif.dart";
 import 'package:photos/module/upload/model/media_upload_data.dart';
-import 'package:photos/module/upload/model/upload_url.dart';
 import "package:photos/module/upload/service/multipart.dart";
 import 'package:photos/module/upload/service/upload_artifact_lifecycle.dart';
 import 'package:photos/module/upload/service/upload_queue.dart';
+import 'package:photos/module/upload/service/upload_transport.dart';
 import "package:photos/module/upload/upload_data.dart";
 import "package:photos/module/upload/upload_metadata.dart";
 import "package:photos/service_locator.dart";
@@ -52,7 +50,6 @@ import "package:uuid/uuid.dart";
 class FileUploader {
   static const kMaximumConcurrentUploads = 4;
   static const kMaximumConcurrentVideoUploads = 2;
-  static const kMaximumUploadAttempts = 4;
   static const kMaxFileSize10Gib = 10737418240;
   static const kBlockedUploadsPollFrequency = Duration(seconds: 2);
   static const kFileUploadTimeout = Duration(minutes: 50);
@@ -72,9 +69,6 @@ class FileUploader {
   );
   final kSafeBufferForLockExpiry = const Duration(hours: 4).inMicroseconds;
   final kBGTaskDeathTimeout = const Duration(seconds: 5).inMicroseconds;
-  // Track used upload URLs to detect race conditions
-  final Map<String, DateTime> _usedUploadURLs = {};
-
   Map<String, BackupItem> get allBackups => _queue.backupItems;
 
   /// Returns true if any file uploads are currently in progress
@@ -87,6 +81,7 @@ class FileUploader {
   bool _hasStartedBackgroundUploadPolling = false;
 
   late MultiPartUploader _multiPartUploader;
+  UploadTransport? _uploadTransport;
   StreamSubscription<LocalPhotosUpdatedEvent>? _localPhotosUpdatedSubscription;
 
   FileUploader._privateConstructor();
@@ -129,6 +124,16 @@ class FileUploader {
         _pollBackgroundUploadStatus();
       }
     }
+    _uploadTransport ??= UploadTransport(
+      _dio,
+      _gateway,
+      shouldUseUploadProxy: () =>
+          !flagService.disableCFWorker &&
+          (localSettings.cfUploadProxyEnabled ??
+              flagService.cloudflareUploadWorker) &&
+          endpointConfig.isProduction,
+      clearQueue: clearQueue,
+    );
     _multiPartUploader = MultiPartUploader(
       _dio, // legacy parameter, not used by MultiPartUploader
       _dio,
@@ -208,7 +213,7 @@ class FileUploader {
   }
 
   void clearCachedUploadURLs() {
-    _usedUploadURLs.clear();
+    _uploadTransport?.clearCachedUploadURLs();
   }
 
   /// Validates that the user can upload before starting expensive encryption.
@@ -558,26 +563,18 @@ class FileUploader {
       late String thumbnailObjectKey;
 
       if (count <= 1) {
-        fileMd5 ??= await computeMd5(encryptedFilePath);
-        final thumbnailUploadURL = await _getUploadURL(
-          contentLength: encThumbSize,
-          contentMd5: thumbnailMd5,
+        final singlePartFileMd5 = fileMd5 ??= await computeMd5(
+          encryptedFilePath,
         );
-        thumbnailObjectKey = await _putFile(
-          thumbnailUploadURL,
+        thumbnailObjectKey = await _uploadTransport!.uploadSinglePart(
           encryptedThumbnailFile,
           encThumbSize,
           contentMd5: thumbnailMd5,
         );
-        final fileUploadURL = await _getUploadURL(
-          contentLength: encFileSize,
-          contentMd5: fileMd5,
-        );
-        fileObjectKey = await _putFile(
-          fileUploadURL,
+        fileObjectKey = await _uploadTransport!.uploadSinglePart(
           encryptedFile,
           encFileSize,
-          contentMd5: fileMd5,
+          contentMd5: singlePartFileMd5,
         );
       } else {
         isMultipartUpload = true;
@@ -631,12 +628,7 @@ class FileUploader {
         // re-uploading the thumbnail in case of failure.
         // In regular upload, always upload the thumbnail first to keep existing behaviour
         //
-        final thumbnailUploadURL = await _getUploadURL(
-          contentLength: encThumbSize,
-          contentMd5: thumbnailMd5,
-        );
-        thumbnailObjectKey = await _putFile(
-          thumbnailUploadURL,
+        thumbnailObjectKey = await _uploadTransport!.uploadSinglePart(
           encryptedThumbnailFile,
           encThumbSize,
           contentMd5: thumbnailMd5,
@@ -680,6 +672,16 @@ class FileUploader {
       }
 
       final pubMetadata = preparedMetadata.publicMetadata;
+      final commitData = UploadCommitData(
+        fileObjectKey: fileObjectKey,
+        fileDecryptionHeader: fileDecryptionHeader,
+        fileSize: encFileSize,
+        thumbnailObjectKey: thumbnailObjectKey,
+        thumbnailDecryptionHeader: thumbnailDecryptionHeader,
+        thumbnailSize: encThumbSize,
+        encryptedMetadata: encryptedMetadata,
+        metadataDecryptionHeader: metadataDecryptionHeader,
+      );
       EnteFile remoteFile;
       if (isUpdatedFile) {
         // Verify that the encrypted file can be decrypted before uploading
@@ -692,20 +694,13 @@ class FileUploader {
           CollectionsService.instance.getCollectionKey(collectionID),
           chunkLimit: 1, // Verify at least first chunk
         );
-        remoteFile = await _updateFile(
-          file,
-          fileObjectKey,
-          fileDecryptionHeader,
-          encFileSize,
-          thumbnailObjectKey,
-          thumbnailDecryptionHeader,
-          encThumbSize,
-          encryptedMetadata,
-          metadataDecryptionHeader,
+        remoteFile = await _uploadTransport!.updateFile(
+          file: file,
+          data: commitData,
         );
         // Update across all collections
         await FilesDB.instance.updateUploadedFileAcrossCollections(remoteFile);
-        // _updateFile does not carry public magic metadata, so derived values
+        // The update response does not carry public magic metadata, so derived values
         // (width/height, mediaType, exif, camera) that change when the file is
         // edited would stay stale. Refresh them here. updatePublicMagicMetadata
         // merges into the existing pub mmd, preserving user-editable keys
@@ -751,21 +746,13 @@ class FileUploader {
           chunkLimit: 1, // Verify at least first chunk
         );
 
-        remoteFile = await _uploadFile(
-          file,
-          collectionID,
-          encryptedKey,
-          keyDecryptionNonce,
-          fileAttributes,
-          fileObjectKey,
-          fileDecryptionHeader,
-          encFileSize,
-          thumbnailObjectKey,
-          thumbnailDecryptionHeader,
-          encThumbSize,
-          encryptedMetadata,
-          metadataDecryptionHeader,
-          pubMetadata: preparedPublicMetadata?.request,
+        remoteFile = await _uploadTransport!.createFile(
+          file: file,
+          collectionID: collectionID,
+          encryptedKey: encryptedKey,
+          keyDecryptionNonce: keyDecryptionNonce,
+          data: commitData,
+          pubMagicMetadata: preparedPublicMetadata?.request.toJson(),
         );
         if (preparedPublicMetadata != null) {
           remoteFile
@@ -1087,288 +1074,6 @@ class FileUploader {
       }
     } catch (e, s) {
       _logger.severe("Failed to handle invalid file error", e, s);
-    }
-  }
-
-  Future<EnteFile> _uploadFile(
-    EnteFile file,
-    int collectionID,
-    String encryptedKey,
-    String keyDecryptionNonce,
-    FileEncryptResult fileAttributes,
-    String fileObjectKey,
-    String fileDecryptionHeader,
-    int fileSize,
-    String thumbnailObjectKey,
-    String thumbnailDecryptionHeader,
-    int thumbnailSize,
-    String encryptedMetadata,
-    String metadataDecryptionHeader, {
-    MetadataRequest? pubMetadata,
-    int attempt = 1,
-  }) async {
-    try {
-      final data = await _gateway.createFile(
-        collectionID: collectionID,
-        encryptedKey: encryptedKey,
-        keyDecryptionNonce: keyDecryptionNonce,
-        fileObjectKey: fileObjectKey,
-        fileDecryptionHeader: fileDecryptionHeader,
-        fileSize: fileSize,
-        thumbnailObjectKey: thumbnailObjectKey,
-        thumbnailDecryptionHeader: thumbnailDecryptionHeader,
-        thumbnailSize: thumbnailSize,
-        encryptedMetadata: encryptedMetadata,
-        metadataDecryptionHeader: metadataDecryptionHeader,
-        pubMagicMetadata: pubMetadata?.toJson(),
-      );
-      file.uploadedFileID = data["id"];
-      file.collectionID = collectionID;
-      file.updationTime = data["updationTime"];
-      file.ownerID = data["ownerID"];
-      file.encryptedKey = encryptedKey;
-      file.keyDecryptionNonce = keyDecryptionNonce;
-      file.fileDecryptionHeader = fileDecryptionHeader;
-      file.thumbnailDecryptionHeader = thumbnailDecryptionHeader;
-      file.metadataDecryptionHeader = metadataDecryptionHeader;
-      return file;
-    } on DioException catch (e) {
-      final int statusCode = e.response?.statusCode ?? -1;
-      if (statusCode == 413) {
-        throw FileTooLargeForPlanError();
-      } else if (statusCode == 426) {
-        _onStorageLimitExceeded();
-      } else if (attempt < kMaximumUploadAttempts && statusCode == -1) {
-        // retry when DioException contains no response/status code
-        _logger.info(
-          "Upload file (${file.tag}) failed, will retry in 3 seconds",
-        );
-        await Future.delayed(const Duration(seconds: 3));
-        return _uploadFile(
-          file,
-          collectionID,
-          encryptedKey,
-          keyDecryptionNonce,
-          fileAttributes,
-          fileObjectKey,
-          fileDecryptionHeader,
-          fileSize,
-          thumbnailObjectKey,
-          thumbnailDecryptionHeader,
-          thumbnailSize,
-          encryptedMetadata,
-          metadataDecryptionHeader,
-          attempt: attempt + 1,
-          pubMetadata: pubMetadata,
-        );
-      } else {
-        _logger.severe("Failed to upload file ${file.tag}", e);
-      }
-      rethrow;
-    }
-  }
-
-  Future<EnteFile> _updateFile(
-    EnteFile file,
-    String fileObjectKey,
-    String fileDecryptionHeader,
-    int fileSize,
-    String thumbnailObjectKey,
-    String thumbnailDecryptionHeader,
-    int thumbnailSize,
-    String encryptedMetadata,
-    String metadataDecryptionHeader, {
-    int attempt = 1,
-  }) async {
-    try {
-      final data = await _gateway.updateFile(
-        fileID: file.uploadedFileID!,
-        fileObjectKey: fileObjectKey,
-        fileDecryptionHeader: fileDecryptionHeader,
-        fileSize: fileSize,
-        thumbnailObjectKey: thumbnailObjectKey,
-        thumbnailDecryptionHeader: thumbnailDecryptionHeader,
-        thumbnailSize: thumbnailSize,
-        encryptedMetadata: encryptedMetadata,
-        metadataDecryptionHeader: metadataDecryptionHeader,
-      );
-      file.uploadedFileID = data["id"];
-      file.updationTime = data["updationTime"];
-      file.fileDecryptionHeader = fileDecryptionHeader;
-      file.thumbnailDecryptionHeader = thumbnailDecryptionHeader;
-      file.metadataDecryptionHeader = metadataDecryptionHeader;
-      return file;
-    } on DioException catch (e) {
-      final int statusCode = e.response?.statusCode ?? -1;
-      if (statusCode == 426) {
-        _onStorageLimitExceeded();
-      } else if (attempt < kMaximumUploadAttempts && statusCode == -1) {
-        _logger.info(
-          "Update file (${file.tag}) failed, will retry in 3 seconds",
-        );
-        await Future.delayed(const Duration(seconds: 3));
-        return _updateFile(
-          file,
-          fileObjectKey,
-          fileDecryptionHeader,
-          fileSize,
-          thumbnailObjectKey,
-          thumbnailDecryptionHeader,
-          thumbnailSize,
-          encryptedMetadata,
-          metadataDecryptionHeader,
-          attempt: attempt + 1,
-        );
-      } else {
-        _logger.severe("Failed to update file ${file.tag}", e);
-      }
-      rethrow;
-    }
-  }
-
-  Future<UploadURL> _getUploadURL({
-    required int contentLength,
-    required String contentMd5,
-  }) async {
-    final uploadURL = await _requestChecksumProtectedUploadURL(
-      contentLength: contentLength,
-      contentMd5: contentMd5,
-    );
-    return _registerUploadURLUsage(uploadURL);
-  }
-
-  Future<UploadURL> _requestChecksumProtectedUploadURL({
-    required int contentLength,
-    required String contentMd5,
-  }) async {
-    if (contentMd5.isEmpty) {
-      throw StateError("Missing MD5 for checksum-protected upload URL");
-    }
-    try {
-      return await _gateway.getUploadUrl(
-        contentLength: contentLength,
-        contentMd5: contentMd5,
-      );
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 402) {
-        final error = NoActiveSubscriptionError();
-        clearQueue(error);
-        throw error;
-      } else if (e.response?.statusCode == 426) {
-        final error = StorageLimitExceededError();
-        clearQueue(error);
-        throw error;
-      }
-      rethrow;
-    }
-  }
-
-  UploadURL _registerUploadURLUsage(UploadURL uploadURL) {
-    // Atomic check-and-set to prevent race conditions in parallel uploads
-    final now = DateTime.now();
-    final existingTimestamp = _usedUploadURLs.putIfAbsent(
-      uploadURL.url,
-      () => now,
-    );
-
-    if (existingTimestamp != now) {
-      throw DuplicateUploadURLError(
-        firstUsedAt: existingTimestamp,
-        duplicateUsedAt: now,
-      );
-    }
-    // Clean up old entries to prevent memory growth (only when > 5000 entries)
-    if (_usedUploadURLs.length > 5000) {
-      final oneHourAgo = now.subtract(const Duration(hours: 1));
-      _usedUploadURLs.removeWhere((key, value) => value.isBefore(oneHourAgo));
-      _logger.info(
-        "Cleaned up used upload URLs, remaining: ${_usedUploadURLs.length}",
-      );
-    }
-
-    return uploadURL;
-  }
-
-  bool get _shouldUseCFUploadProxy =>
-      !flagService.disableCFWorker &&
-      (localSettings.cfUploadProxyEnabled ??
-          flagService.cloudflareUploadWorker) &&
-      endpointConfig.isProduction;
-
-  void _onStorageLimitExceeded() {
-    clearQueue(StorageLimitExceededError());
-    throw StorageLimitExceededError();
-  }
-
-  Future<String> _putFile(
-    UploadURL uploadURL,
-    File file,
-    int fileSize, {
-    required String contentMd5,
-    int attempt = 1,
-  }) async {
-    if (contentMd5.isEmpty) {
-      throw StateError("Missing MD5 for checksum-protected upload");
-    }
-    final startTime = DateTime.now().millisecondsSinceEpoch;
-    final fileName = basename(file.path);
-    int bytesSent = 0;
-    try {
-      final useUploadProxy = _shouldUseCFUploadProxy;
-      final Map<String, dynamic> headers = {
-        Headers.contentLengthHeader: fileSize,
-      };
-      if (useUploadProxy) {
-        headers["UPLOAD-URL"] = uploadURL.url;
-      }
-      headers[useUploadProxy ? 'CONTENT-MD5' : 'Content-MD5'] = contentMd5;
-
-      await _dio.put(
-        useUploadProxy ? "$kUploadProxyEndpoint/file-upload" : uploadURL.url,
-        data: file.openRead(),
-        options: Options(headers: headers),
-        onSendProgress: (sent, total) {
-          bytesSent = sent;
-        },
-      );
-      _logger.info(
-        "Uploaded object $fileName of size: ${formatBytes(fileSize)} at speed: ${(fileSize / (DateTime.now().millisecondsSinceEpoch - startTime)).toStringAsFixed(2)} KB/s",
-      );
-
-      return uploadURL.objectKey;
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 400 &&
-              e.response?.data.toString().contains('BadDigest') == true ||
-          e.response?.data.toString().contains('InvalidDigest') == true) {
-        final String recomputedMd5 = await computeMd5(file.path);
-        throw BadMD5DigestError(
-          "Failed ${e.response?.data}, sent: $contentMd5, computed: $recomputedMd5",
-        );
-      } else if (e.message?.startsWith("HttpException: Content size") ??
-          false) {
-        rethrow;
-      } else if (attempt < kMaximumUploadAttempts) {
-        _logger.info(
-          "Upload failed for $fileName after sending ${formatBytes(bytesSent)} of ${formatBytes(fileSize)}, retrying attempt ${attempt + 1}",
-        );
-        final newUploadURL = await _getUploadURL(
-          contentLength: fileSize,
-          contentMd5: contentMd5,
-        );
-        return _putFile(
-          newUploadURL,
-          file,
-          fileSize,
-          contentMd5: contentMd5,
-          attempt: attempt + 1,
-        );
-      } else {
-        _logger.info(
-          "Failed to upload file ${basename(file.path)} after $attempt attempts",
-          e,
-        );
-        rethrow;
-      }
     }
   }
 

--- a/mobile/apps/photos/lib/module/upload/service/multipart.dart
+++ b/mobile/apps/photos/lib/module/upload/service/multipart.dart
@@ -22,12 +22,7 @@ class MultiPartUploader {
   late final Logger _logger = Logger("MultiPartUploader");
   FileUploadGateway get _gateway => fileUploadGateway;
 
-  MultiPartUploader(
-    Dio _, // unused, kept for backwards compatibility
-    this._s3Dio,
-    this._db,
-    this._featureFlagService,
-  );
+  MultiPartUploader(this._s3Dio, this._db, this._featureFlagService);
 
   Future<FileEncryptResult> getEncryptionResult(
     String localId,

--- a/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
@@ -14,7 +14,6 @@ import "package:photos/module/upload/model/upload_url.dart";
 
 typedef UploadDelay = Future<void> Function(Duration duration);
 typedef UploadClock = DateTime Function();
-typedef Md5Computer = Future<String> Function(String path);
 
 class UploadCommitData {
   const UploadCommitData({
@@ -46,12 +45,10 @@ class UploadTransport {
     required void Function(Error) clearQueue,
     UploadDelay? delay,
     UploadClock? clock,
-    Md5Computer? recomputeMd5,
   }) : _shouldUseUploadProxy = shouldUseUploadProxy,
        _clearQueue = clearQueue,
        _delay = delay ?? Future<void>.delayed,
-       _clock = clock ?? DateTime.now,
-       _recomputeMd5 = recomputeMd5 ?? ((path) => computeMd5(path));
+       _clock = clock ?? DateTime.now;
 
   static const maximumAttempts = 4;
   static const apiRetryDelay = Duration(seconds: 3);
@@ -66,7 +63,6 @@ class UploadTransport {
   final void Function(Error) _clearQueue;
   final UploadDelay _delay;
   final UploadClock _clock;
-  final Md5Computer _recomputeMd5;
   final Map<String, DateTime> _usedUploadURLs = {};
   DateTime? _nextUploadURLCleanupAt;
   int _uploadURLCleanupEntryChecks = 0;
@@ -225,7 +221,7 @@ class UploadTransport {
       if (error.response?.statusCode == 400 &&
               error.response?.data.toString().contains("BadDigest") == true ||
           error.response?.data.toString().contains("InvalidDigest") == true) {
-        final recomputedMd5 = await _recomputeMd5(file.path);
+        final recomputedMd5 = await computeMd5(file.path);
         throw BadMD5DigestError(
           "Failed ${error.response?.data}, sent: $contentMd5, "
           "computed: $recomputedMd5",

--- a/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
@@ -3,6 +3,7 @@ import "dart:io";
 
 import "package:dio/dio.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
+import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart";
 import "package:photos/core/constants.dart";
@@ -54,6 +55,9 @@ class UploadTransport {
 
   static const maximumAttempts = 4;
   static const apiRetryDelay = Duration(seconds: 3);
+  static const _maximumRecentUploadURLs = 5000;
+  static const _uploadURLRetention = Duration(hours: 1);
+  static const _uploadURLCleanupInterval = Duration(minutes: 5);
 
   final _logger = Logger("UploadTransport");
   final Dio _dio;
@@ -64,8 +68,17 @@ class UploadTransport {
   final UploadClock _clock;
   final Md5Computer _recomputeMd5;
   final Map<String, DateTime> _usedUploadURLs = {};
+  DateTime? _nextUploadURLCleanupAt;
+  int _uploadURLCleanupEntryChecks = 0;
 
-  void clearCachedUploadURLs() => _usedUploadURLs.clear();
+  @visibleForTesting
+  int get uploadURLCleanupEntryChecks => _uploadURLCleanupEntryChecks;
+
+  void clearCachedUploadURLs() {
+    _usedUploadURLs.clear();
+    _nextUploadURLCleanupAt = null;
+    _uploadURLCleanupEntryChecks = 0;
+  }
 
   Future<String> uploadSinglePart(
     File file,
@@ -136,24 +149,42 @@ class UploadTransport {
 
   UploadURL _registerUploadURLUsage(UploadURL uploadURL) {
     final now = _clock();
-    final existingTimestamp = _usedUploadURLs.putIfAbsent(
-      uploadURL.url,
-      () => now,
-    );
-    if (existingTimestamp != now) {
+    final existingTimestamp = _usedUploadURLs[uploadURL.url];
+    if (existingTimestamp != null) {
       throw DuplicateUploadURLError(
         firstUsedAt: existingTimestamp,
         duplicateUsedAt: now,
       );
     }
-    if (_usedUploadURLs.length > 5000) {
-      final oneHourAgo = now.subtract(const Duration(hours: 1));
-      _usedUploadURLs.removeWhere((key, value) => value.isBefore(oneHourAgo));
+
+    _usedUploadURLs[uploadURL.url] = now;
+    _cleanUsedUploadURLsIfDue(now);
+    return uploadURL;
+  }
+
+  void _cleanUsedUploadURLsIfDue(DateTime now) {
+    if (_usedUploadURLs.length <= _maximumRecentUploadURLs ||
+        (_nextUploadURLCleanupAt?.isAfter(now) ?? false)) {
+      return;
+    }
+
+    final oldestRetainedAt = now.subtract(_uploadURLRetention);
+    var removedCount = 0;
+    _usedUploadURLs.removeWhere((key, usedAt) {
+      _uploadURLCleanupEntryChecks++;
+      final shouldRemove = usedAt.isBefore(oldestRetainedAt);
+      if (shouldRemove) {
+        removedCount++;
+      }
+      return shouldRemove;
+    });
+    _nextUploadURLCleanupAt = now.add(_uploadURLCleanupInterval);
+    if (removedCount > 0) {
       _logger.info(
-        "Cleaned up used upload URLs, remaining: ${_usedUploadURLs.length}",
+        "Removed $removedCount expired upload URLs, "
+        "remaining: ${_usedUploadURLs.length}",
       );
     }
-    return uploadURL;
   }
 
   Future<String> _putFile(

--- a/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
@@ -1,0 +1,335 @@
+import "dart:async";
+import "dart:io";
+
+import "package:dio/dio.dart";
+import "package:ente_pure_utils/ente_pure_utils.dart";
+import "package:logging/logging.dart";
+import "package:path/path.dart";
+import "package:photos/core/constants.dart";
+import "package:photos/core/errors.dart";
+import "package:photos/gateways/files/file_upload_gateway.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/module/upload/model/upload_url.dart";
+
+typedef UploadDelay = Future<void> Function(Duration duration);
+typedef UploadClock = DateTime Function();
+typedef Md5Computer = Future<String> Function(String path);
+
+class UploadCommitData {
+  const UploadCommitData({
+    required this.fileObjectKey,
+    required this.fileDecryptionHeader,
+    required this.fileSize,
+    required this.thumbnailObjectKey,
+    required this.thumbnailDecryptionHeader,
+    required this.thumbnailSize,
+    required this.encryptedMetadata,
+    required this.metadataDecryptionHeader,
+  });
+
+  final String fileObjectKey;
+  final String fileDecryptionHeader;
+  final int fileSize;
+  final String thumbnailObjectKey;
+  final String thumbnailDecryptionHeader;
+  final int thumbnailSize;
+  final String encryptedMetadata;
+  final String metadataDecryptionHeader;
+}
+
+class UploadTransport {
+  UploadTransport(
+    this._dio,
+    this._gateway, {
+    required bool Function() shouldUseUploadProxy,
+    required void Function(Error) clearQueue,
+    UploadDelay? delay,
+    UploadClock? clock,
+    Md5Computer? recomputeMd5,
+  }) : _shouldUseUploadProxy = shouldUseUploadProxy,
+       _clearQueue = clearQueue,
+       _delay = delay ?? Future<void>.delayed,
+       _clock = clock ?? DateTime.now,
+       _recomputeMd5 = recomputeMd5 ?? ((path) => computeMd5(path));
+
+  static const maximumAttempts = 4;
+  static const apiRetryDelay = Duration(seconds: 3);
+
+  final _logger = Logger("UploadTransport");
+  final Dio _dio;
+  final FileUploadGateway _gateway;
+  final bool Function() _shouldUseUploadProxy;
+  final void Function(Error) _clearQueue;
+  final UploadDelay _delay;
+  final UploadClock _clock;
+  final Md5Computer _recomputeMd5;
+  final Map<String, DateTime> _usedUploadURLs = {};
+
+  void clearCachedUploadURLs() => _usedUploadURLs.clear();
+
+  Future<String> uploadSinglePart(
+    File file,
+    int fileSize, {
+    required String contentMd5,
+  }) async {
+    final uploadURL = await _getUploadURL(
+      contentLength: fileSize,
+      contentMd5: contentMd5,
+    );
+    return _putFile(
+      uploadURL,
+      file,
+      fileSize,
+      contentMd5: contentMd5,
+      attempt: 1,
+    );
+  }
+
+  Future<UploadURL> _getUploadURL({
+    required int contentLength,
+    required String contentMd5,
+  }) async {
+    if (contentMd5.isEmpty) {
+      throw StateError("Missing MD5 for checksum-protected upload URL");
+    }
+    try {
+      final uploadURL = await _gateway.getUploadUrl(
+        contentLength: contentLength,
+        contentMd5: contentMd5,
+      );
+      return _registerUploadURLUsage(uploadURL);
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 402) {
+        final subscriptionError = NoActiveSubscriptionError();
+        _clearQueue(subscriptionError);
+        throw subscriptionError;
+      } else if (error.response?.statusCode == 426) {
+        final storageError = StorageLimitExceededError();
+        _clearQueue(storageError);
+        throw storageError;
+      }
+      rethrow;
+    }
+  }
+
+  Future<EnteFile> createFile({
+    required EnteFile file,
+    required int collectionID,
+    required String encryptedKey,
+    required String keyDecryptionNonce,
+    required UploadCommitData data,
+    Map<String, dynamic>? pubMagicMetadata,
+  }) => _createFile(
+    file: file,
+    collectionID: collectionID,
+    encryptedKey: encryptedKey,
+    keyDecryptionNonce: keyDecryptionNonce,
+    data: data,
+    pubMagicMetadata: pubMagicMetadata,
+    attempt: 1,
+  );
+
+  Future<EnteFile> updateFile({
+    required EnteFile file,
+    required UploadCommitData data,
+  }) => _updateFile(file: file, data: data, attempt: 1);
+
+  UploadURL _registerUploadURLUsage(UploadURL uploadURL) {
+    final now = _clock();
+    final existingTimestamp = _usedUploadURLs.putIfAbsent(
+      uploadURL.url,
+      () => now,
+    );
+    if (existingTimestamp != now) {
+      throw DuplicateUploadURLError(
+        firstUsedAt: existingTimestamp,
+        duplicateUsedAt: now,
+      );
+    }
+    if (_usedUploadURLs.length > 5000) {
+      final oneHourAgo = now.subtract(const Duration(hours: 1));
+      _usedUploadURLs.removeWhere((key, value) => value.isBefore(oneHourAgo));
+      _logger.info(
+        "Cleaned up used upload URLs, remaining: ${_usedUploadURLs.length}",
+      );
+    }
+    return uploadURL;
+  }
+
+  Future<String> _putFile(
+    UploadURL uploadURL,
+    File file,
+    int fileSize, {
+    required String contentMd5,
+    required int attempt,
+  }) async {
+    if (contentMd5.isEmpty) {
+      throw StateError("Missing MD5 for checksum-protected upload");
+    }
+    final startTime = _clock().millisecondsSinceEpoch;
+    final fileName = basename(file.path);
+    var bytesSent = 0;
+    try {
+      final useUploadProxy = _shouldUseUploadProxy();
+      final headers = <String, dynamic>{Headers.contentLengthHeader: fileSize};
+      if (useUploadProxy) {
+        headers["UPLOAD-URL"] = uploadURL.url;
+      }
+      headers[useUploadProxy ? "CONTENT-MD5" : "Content-MD5"] = contentMd5;
+
+      await _dio.put(
+        useUploadProxy ? "$kUploadProxyEndpoint/file-upload" : uploadURL.url,
+        data: file.openRead(),
+        options: Options(headers: headers),
+        onSendProgress: (sent, total) {
+          bytesSent = sent;
+        },
+      );
+      _logger.info(
+        "Uploaded object $fileName of size: ${formatBytes(fileSize)} at speed: "
+        "${(fileSize / (_clock().millisecondsSinceEpoch - startTime)).toStringAsFixed(2)} KB/s",
+      );
+      return uploadURL.objectKey;
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 400 &&
+              error.response?.data.toString().contains("BadDigest") == true ||
+          error.response?.data.toString().contains("InvalidDigest") == true) {
+        final recomputedMd5 = await _recomputeMd5(file.path);
+        throw BadMD5DigestError(
+          "Failed ${error.response?.data}, sent: $contentMd5, "
+          "computed: $recomputedMd5",
+        );
+      } else if (error.message?.startsWith("HttpException: Content size") ??
+          false) {
+        rethrow;
+      } else if (attempt < maximumAttempts) {
+        _logger.info(
+          "Upload failed for $fileName after sending ${formatBytes(bytesSent)} "
+          "of ${formatBytes(fileSize)}, retrying attempt ${attempt + 1}",
+        );
+        final newUploadURL = await _getUploadURL(
+          contentLength: fileSize,
+          contentMd5: contentMd5,
+        );
+        return _putFile(
+          newUploadURL,
+          file,
+          fileSize,
+          contentMd5: contentMd5,
+          attempt: attempt + 1,
+        );
+      }
+      _logger.info(
+        "Failed to upload file $fileName after $attempt attempts",
+        error,
+      );
+      rethrow;
+    }
+  }
+
+  Future<EnteFile> _createFile({
+    required EnteFile file,
+    required int collectionID,
+    required String encryptedKey,
+    required String keyDecryptionNonce,
+    required UploadCommitData data,
+    required Map<String, dynamic>? pubMagicMetadata,
+    required int attempt,
+  }) async {
+    try {
+      final response = await _gateway.createFile(
+        collectionID: collectionID,
+        encryptedKey: encryptedKey,
+        keyDecryptionNonce: keyDecryptionNonce,
+        fileObjectKey: data.fileObjectKey,
+        fileDecryptionHeader: data.fileDecryptionHeader,
+        fileSize: data.fileSize,
+        thumbnailObjectKey: data.thumbnailObjectKey,
+        thumbnailDecryptionHeader: data.thumbnailDecryptionHeader,
+        thumbnailSize: data.thumbnailSize,
+        encryptedMetadata: data.encryptedMetadata,
+        metadataDecryptionHeader: data.metadataDecryptionHeader,
+        pubMagicMetadata: pubMagicMetadata == null
+            ? null
+            : Map<String, dynamic>.of(pubMagicMetadata),
+      );
+      file.uploadedFileID = response["id"];
+      file.collectionID = collectionID;
+      file.updationTime = response["updationTime"];
+      file.ownerID = response["ownerID"];
+      file.encryptedKey = encryptedKey;
+      file.keyDecryptionNonce = keyDecryptionNonce;
+      file.fileDecryptionHeader = data.fileDecryptionHeader;
+      file.thumbnailDecryptionHeader = data.thumbnailDecryptionHeader;
+      file.metadataDecryptionHeader = data.metadataDecryptionHeader;
+      return file;
+    } on DioException catch (error) {
+      final statusCode = error.response?.statusCode ?? -1;
+      if (statusCode == 413) {
+        throw FileTooLargeForPlanError();
+      } else if (statusCode == 426) {
+        _throwStorageLimitExceeded();
+      } else if (attempt < maximumAttempts && statusCode == -1) {
+        _logger.info(
+          "Upload file (${file.tag}) failed, will retry in 3 seconds",
+        );
+        await _delay(apiRetryDelay);
+        return _createFile(
+          file: file,
+          collectionID: collectionID,
+          encryptedKey: encryptedKey,
+          keyDecryptionNonce: keyDecryptionNonce,
+          data: data,
+          pubMagicMetadata: pubMagicMetadata,
+          attempt: attempt + 1,
+        );
+      }
+      _logger.severe("Failed to upload file ${file.tag}", error);
+      rethrow;
+    }
+  }
+
+  Future<EnteFile> _updateFile({
+    required EnteFile file,
+    required UploadCommitData data,
+    required int attempt,
+  }) async {
+    try {
+      final response = await _gateway.updateFile(
+        fileID: file.uploadedFileID!,
+        fileObjectKey: data.fileObjectKey,
+        fileDecryptionHeader: data.fileDecryptionHeader,
+        fileSize: data.fileSize,
+        thumbnailObjectKey: data.thumbnailObjectKey,
+        thumbnailDecryptionHeader: data.thumbnailDecryptionHeader,
+        thumbnailSize: data.thumbnailSize,
+        encryptedMetadata: data.encryptedMetadata,
+        metadataDecryptionHeader: data.metadataDecryptionHeader,
+      );
+      file.uploadedFileID = response["id"];
+      file.updationTime = response["updationTime"];
+      file.fileDecryptionHeader = data.fileDecryptionHeader;
+      file.thumbnailDecryptionHeader = data.thumbnailDecryptionHeader;
+      file.metadataDecryptionHeader = data.metadataDecryptionHeader;
+      return file;
+    } on DioException catch (error) {
+      final statusCode = error.response?.statusCode ?? -1;
+      if (statusCode == 426) {
+        _throwStorageLimitExceeded();
+      } else if (attempt < maximumAttempts && statusCode == -1) {
+        _logger.info(
+          "Update file (${file.tag}) failed, will retry in 3 seconds",
+        );
+        await _delay(apiRetryDelay);
+        return _updateFile(file: file, data: data, attempt: attempt + 1);
+      }
+      _logger.severe("Failed to update file ${file.tag}", error);
+      rethrow;
+    }
+  }
+
+  Never _throwStorageLimitExceeded() {
+    _clearQueue(StorageLimitExceededError());
+    throw StorageLimitExceededError();
+  }
+}

--- a/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_transport.dart
@@ -3,7 +3,6 @@ import "dart:io";
 
 import "package:dio/dio.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
-import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart";
 import "package:photos/core/constants.dart";
@@ -13,7 +12,6 @@ import "package:photos/models/file/file.dart";
 import "package:photos/module/upload/model/upload_url.dart";
 
 typedef UploadDelay = Future<void> Function(Duration duration);
-typedef UploadClock = DateTime Function();
 
 class UploadCommitData {
   const UploadCommitData({
@@ -44,17 +42,12 @@ class UploadTransport {
     required bool Function() shouldUseUploadProxy,
     required void Function(Error) clearQueue,
     UploadDelay? delay,
-    UploadClock? clock,
   }) : _shouldUseUploadProxy = shouldUseUploadProxy,
        _clearQueue = clearQueue,
-       _delay = delay ?? Future<void>.delayed,
-       _clock = clock ?? DateTime.now;
+       _delay = delay ?? Future<void>.delayed;
 
   static const maximumAttempts = 4;
   static const apiRetryDelay = Duration(seconds: 3);
-  static const _maximumRecentUploadURLs = 5000;
-  static const _uploadURLRetention = Duration(hours: 1);
-  static const _uploadURLCleanupInterval = Duration(minutes: 5);
 
   final _logger = Logger("UploadTransport");
   final Dio _dio;
@@ -62,19 +55,6 @@ class UploadTransport {
   final bool Function() _shouldUseUploadProxy;
   final void Function(Error) _clearQueue;
   final UploadDelay _delay;
-  final UploadClock _clock;
-  final Map<String, DateTime> _usedUploadURLs = {};
-  DateTime? _nextUploadURLCleanupAt;
-  int _uploadURLCleanupEntryChecks = 0;
-
-  @visibleForTesting
-  int get uploadURLCleanupEntryChecks => _uploadURLCleanupEntryChecks;
-
-  void clearCachedUploadURLs() {
-    _usedUploadURLs.clear();
-    _nextUploadURLCleanupAt = null;
-    _uploadURLCleanupEntryChecks = 0;
-  }
 
   Future<String> uploadSinglePart(
     File file,
@@ -106,7 +86,7 @@ class UploadTransport {
         contentLength: contentLength,
         contentMd5: contentMd5,
       );
-      return _registerUploadURLUsage(uploadURL);
+      return uploadURL;
     } on DioException catch (error) {
       if (error.response?.statusCode == 402) {
         final subscriptionError = NoActiveSubscriptionError();
@@ -143,46 +123,6 @@ class UploadTransport {
     required UploadCommitData data,
   }) => _updateFile(file: file, data: data, attempt: 1);
 
-  UploadURL _registerUploadURLUsage(UploadURL uploadURL) {
-    final now = _clock();
-    final existingTimestamp = _usedUploadURLs[uploadURL.url];
-    if (existingTimestamp != null) {
-      throw DuplicateUploadURLError(
-        firstUsedAt: existingTimestamp,
-        duplicateUsedAt: now,
-      );
-    }
-
-    _usedUploadURLs[uploadURL.url] = now;
-    _cleanUsedUploadURLsIfDue(now);
-    return uploadURL;
-  }
-
-  void _cleanUsedUploadURLsIfDue(DateTime now) {
-    if (_usedUploadURLs.length <= _maximumRecentUploadURLs ||
-        (_nextUploadURLCleanupAt?.isAfter(now) ?? false)) {
-      return;
-    }
-
-    final oldestRetainedAt = now.subtract(_uploadURLRetention);
-    var removedCount = 0;
-    _usedUploadURLs.removeWhere((key, usedAt) {
-      _uploadURLCleanupEntryChecks++;
-      final shouldRemove = usedAt.isBefore(oldestRetainedAt);
-      if (shouldRemove) {
-        removedCount++;
-      }
-      return shouldRemove;
-    });
-    _nextUploadURLCleanupAt = now.add(_uploadURLCleanupInterval);
-    if (removedCount > 0) {
-      _logger.info(
-        "Removed $removedCount expired upload URLs, "
-        "remaining: ${_usedUploadURLs.length}",
-      );
-    }
-  }
-
   Future<String> _putFile(
     UploadURL uploadURL,
     File file,
@@ -193,7 +133,7 @@ class UploadTransport {
     if (contentMd5.isEmpty) {
       throw StateError("Missing MD5 for checksum-protected upload");
     }
-    final startTime = _clock().millisecondsSinceEpoch;
+    final startTime = DateTime.now().millisecondsSinceEpoch;
     final fileName = basename(file.path);
     var bytesSent = 0;
     try {
@@ -214,7 +154,7 @@ class UploadTransport {
       );
       _logger.info(
         "Uploaded object $fileName of size: ${formatBytes(fileSize)} at speed: "
-        "${(fileSize / (_clock().millisecondsSinceEpoch - startTime)).toStringAsFixed(2)} KB/s",
+        "${(fileSize / (DateTime.now().millisecondsSinceEpoch - startTime)).toStringAsFixed(2)} KB/s",
       );
       return uploadURL.objectKey;
     } on DioException catch (error) {

--- a/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
@@ -1,0 +1,733 @@
+import "dart:collection";
+import "dart:io";
+
+import "package:dio/dio.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/core/constants.dart";
+import "package:photos/core/errors.dart";
+import "package:photos/gateways/files/file_upload_gateway.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/module/upload/model/upload_url.dart";
+import "package:photos/module/upload/service/upload_transport.dart";
+
+void main() {
+  late Directory tempDir;
+  late File file;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp("upload_transport_test_");
+    file = File("${tempDir.path}/payload")..writeAsBytesSync([1, 2, 3, 4]);
+  });
+
+  tearDownAll(() => tempDir.delete(recursive: true));
+
+  test("requires MD5 before URL or object requests", () async {
+    final fixture = _Fixture();
+
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: ""),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(fixture.gateway.uploadURLRequests, isEmpty);
+    expect(fixture.dio.putPaths, isEmpty);
+  });
+
+  test("registers URL use and rejects a duplicate", () async {
+    final fixture = _Fixture();
+    fixture.gateway.uploadURLs.addAll([
+      UploadURL("same-url", "first"),
+      UploadURL("same-url", "second"),
+    ]);
+
+    final first = await fixture.transport.uploadSinglePart(
+      file,
+      4,
+      contentMd5: "md5",
+    );
+
+    expect(first, "first");
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      throwsA(isA<DuplicateUploadURLError>()),
+    );
+    fixture.transport.clearCachedUploadURLs();
+    fixture.gateway.uploadURLs.add(UploadURL("same-url", "third"));
+    expect(
+      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      "third",
+    );
+  });
+
+  test("maps upload URL 402 and 426 responses and clears the queue", () async {
+    for (final statusCode in [402, 426]) {
+      final fixture = _Fixture();
+      fixture.gateway.uploadURLFailures.add(_dioError(statusCode: statusCode));
+
+      await expectLater(
+        fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+        throwsA(
+          statusCode == 402
+              ? isA<NoActiveSubscriptionError>()
+              : isA<StorageLimitExceededError>(),
+        ),
+      );
+
+      expect(fixture.clearedErrors, hasLength(1));
+    }
+  });
+
+  test("leaves other upload URL response failures unchanged", () async {
+    final fixture = _Fixture();
+    final error = _dioError(statusCode: 413);
+    fixture.gateway.uploadURLFailures.add(error);
+
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      throwsA(same(error)),
+    );
+
+    expect(fixture.clearedErrors, isEmpty);
+    expect(fixture.dio.putPaths, isEmpty);
+  });
+
+  test("streams direct and proxy PUTs with their existing headers", () async {
+    final fixture = _Fixture();
+    fixture.gateway.uploadURLs.addAll([
+      UploadURL("direct-url", "direct-key"),
+      UploadURL("proxy-url", "proxy-key"),
+    ]);
+
+    expect(
+      await fixture.transport.uploadSinglePart(
+        file,
+        4,
+        contentMd5: "direct-md5",
+      ),
+      "direct-key",
+    );
+    fixture.useProxy = true;
+    expect(
+      await fixture.transport.uploadSinglePart(
+        file,
+        4,
+        contentMd5: "proxy-md5",
+      ),
+      "proxy-key",
+    );
+
+    expect(fixture.dio.putPaths, [
+      "direct-url",
+      "$kUploadProxyEndpoint/file-upload",
+    ]);
+    expect(fixture.dio.payloads, [
+      [1, 2, 3, 4],
+      [1, 2, 3, 4],
+    ]);
+    expect(fixture.dio.headers[0], {
+      Headers.contentLengthHeader: 4,
+      "Content-MD5": "direct-md5",
+    });
+    expect(fixture.dio.headers[1], {
+      Headers.contentLengthHeader: 4,
+      "UPLOAD-URL": "proxy-url",
+      "CONTENT-MD5": "proxy-md5",
+    });
+  });
+
+  test("PUT retries four times with a fresh signed URL", () async {
+    final fixture = _Fixture();
+    fixture.gateway.uploadURLs.addAll([
+      UploadURL("url-1", "key-1"),
+      UploadURL("url-2", "key-2"),
+      UploadURL("url-3", "key-3"),
+      UploadURL("url-4", "key-4"),
+    ]);
+    fixture.dio.putFailures.addAll([_dioError(), _dioError(), _dioError()]);
+    final objectKey = await fixture.transport.uploadSinglePart(
+      file,
+      4,
+      contentMd5: "md5",
+    );
+
+    expect(objectKey, "key-4");
+    expect(fixture.dio.putPaths, ["url-1", "url-2", "url-3", "url-4"]);
+    expect(fixture.gateway.uploadURLRequests, hasLength(4));
+    expect(fixture.dio.payloads, everyElement([1, 2, 3, 4]));
+  });
+
+  test("PUT stops after four failures", () async {
+    final fixture = _Fixture();
+    fixture.gateway.uploadURLs.addAll(
+      List.generate(
+        4,
+        (index) => UploadURL("url-${index + 1}", "key-${index + 1}"),
+      ),
+    );
+    final finalError = _dioError(statusCode: 500);
+    fixture.dio.putFailures.addAll([
+      _dioError(statusCode: 500),
+      _dioError(statusCode: 500),
+      _dioError(statusCode: 500),
+      finalError,
+    ]);
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      throwsA(same(finalError)),
+    );
+
+    expect(fixture.dio.putPaths, hasLength(4));
+    expect(fixture.gateway.uploadURLRequests, hasLength(4));
+  });
+
+  test("PUT retries response failures without clearing the queue", () async {
+    for (final statusCode in [402, 413, 426]) {
+      final fixture = _Fixture();
+      fixture.gateway.uploadURLs.addAll([
+        UploadURL("url-$statusCode-1", "key-$statusCode-1"),
+        UploadURL("url-$statusCode-2", "key-$statusCode-2"),
+      ]);
+      fixture.dio.putFailures.add(_dioError(statusCode: statusCode));
+
+      expect(
+        await fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+        "key-$statusCode-2",
+      );
+      expect(fixture.gateway.uploadURLRequests, hasLength(2));
+      expect(fixture.clearedErrors, isEmpty);
+    }
+  });
+
+  test("maps a fatal upload URL failure during PUT retry", () async {
+    for (final statusCode in [402, 426]) {
+      final fixture = _Fixture();
+      final retryURLFailure = _dioError(statusCode: statusCode);
+      fixture.gateway.uploadURLs.add(UploadURL("initial", "initial-key"));
+      fixture.dio
+        ..putFailures.add(_dioError(statusCode: 500))
+        ..onPutFailure = () {
+          fixture.gateway.uploadURLFailures.add(retryURLFailure);
+        };
+
+      await expectLater(
+        fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+        throwsA(
+          statusCode == 402
+              ? isA<NoActiveSubscriptionError>()
+              : isA<StorageLimitExceededError>(),
+        ),
+      );
+
+      expect(fixture.gateway.uploadURLRequests, hasLength(2));
+      expect(fixture.clearedErrors, hasLength(1));
+    }
+  });
+
+  test("PUT reports digest errors without retrying", () async {
+    final fixture = _Fixture(recomputedMd5: "recomputed");
+    fixture.gateway.uploadURLs.add(UploadURL("url", "key"));
+    fixture.dio.putFailures.add(_dioError(statusCode: 400, data: "BadDigest"));
+
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "sent"),
+      throwsA(
+        isA<BadMD5DigestError>().having(
+          (error) => error.message,
+          "message",
+          contains("sent: sent, computed: recomputed"),
+        ),
+      ),
+    );
+
+    expect(fixture.dio.putPaths, hasLength(1));
+    expect(fixture.recomputedPaths, [file.path]);
+    expect(fixture.gateway.uploadURLRequests, hasLength(1));
+  });
+
+  test("PUT does not retry content-size transport failures", () async {
+    final fixture = _Fixture();
+    fixture.gateway.uploadURLs.add(UploadURL("url", "key"));
+    final error = _dioError(message: "HttpException: Content size mismatch");
+    fixture.dio.putFailures.add(error);
+
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      throwsA(same(error)),
+    );
+
+    expect(fixture.dio.putPaths, hasLength(1));
+    expect(fixture.gateway.uploadURLRequests, hasLength(1));
+  });
+
+  test("create sends commit data and applies the response", () async {
+    final fixture = _Fixture();
+    fixture.gateway.createResults.add({
+      "id": 11,
+      "updationTime": 12,
+      "ownerID": 13,
+    });
+    final enteFile = EnteFile()..localID = "local";
+
+    final result = await fixture.transport.createFile(
+      file: enteFile,
+      collectionID: 14,
+      encryptedKey: "encrypted-key",
+      keyDecryptionNonce: "key-nonce",
+      data: _commitData,
+      pubMagicMetadata: {"version": 1},
+    );
+
+    expect(result, same(enteFile));
+    expect(enteFile.uploadedFileID, 11);
+    expect(enteFile.collectionID, 14);
+    expect(enteFile.updationTime, 12);
+    expect(enteFile.ownerID, 13);
+    expect(enteFile.encryptedKey, "encrypted-key");
+    expect(enteFile.keyDecryptionNonce, "key-nonce");
+    expect(enteFile.fileDecryptionHeader, "file-header");
+    expect(enteFile.thumbnailDecryptionHeader, "thumb-header");
+    expect(enteFile.metadataDecryptionHeader, "metadata-header");
+    expect(fixture.gateway.createRequests.single, _expectedCreateRequest);
+  });
+
+  test(
+    "create retries no-response failures four times with 3s delays",
+    () async {
+      final fixture = _Fixture();
+      fixture.gateway.createResults.addAll([
+        _dioError(),
+        _dioError(),
+        _dioError(),
+        {"id": 1, "updationTime": 2, "ownerID": 3},
+      ]);
+
+      await fixture.transport.createFile(
+        file: EnteFile()..localID = "local",
+        collectionID: 1,
+        encryptedKey: "key",
+        keyDecryptionNonce: "nonce",
+        data: _commitData,
+      );
+
+      expect(fixture.gateway.createRequests, hasLength(4));
+      expect(
+        fixture.gateway.createRequests,
+        everyElement(_expectedCreateRequestWithoutPublicMetadata),
+      );
+      expect(fixture.delays, [
+        UploadTransport.apiRetryDelay,
+        UploadTransport.apiRetryDelay,
+        UploadTransport.apiRetryDelay,
+      ]);
+    },
+  );
+
+  test("create copies public metadata for every retry", () async {
+    final fixture = _Fixture();
+    fixture.gateway
+      ..clearReceivedPublicMetadata = true
+      ..createResults.addAll([
+        _dioError(),
+        {"id": 1, "updationTime": 2, "ownerID": 3},
+      ]);
+    final publicMetadata = <String, dynamic>{"version": 1};
+
+    await fixture.transport.createFile(
+      file: EnteFile()..localID = "local",
+      collectionID: 14,
+      encryptedKey: "encrypted-key",
+      keyDecryptionNonce: "key-nonce",
+      data: _commitData,
+      pubMagicMetadata: publicMetadata,
+    );
+
+    expect(
+      fixture.gateway.createRequests,
+      everyElement(_expectedCreateRequest),
+    );
+    expect(publicMetadata, {"version": 1});
+  });
+
+  test("create maps 413 and create/update clear on 426", () async {
+    final tooLarge = _Fixture()
+      ..gateway.createResults.add(_dioError(statusCode: 413));
+    await expectLater(
+      tooLarge.transport.createFile(
+        file: EnteFile()..localID = "local",
+        collectionID: 1,
+        encryptedKey: "key",
+        keyDecryptionNonce: "nonce",
+        data: _commitData,
+      ),
+      throwsA(isA<FileTooLargeForPlanError>()),
+    );
+
+    final createStorage = _Fixture()
+      ..gateway.createResults.add(_dioError(statusCode: 426));
+    await expectLater(
+      createStorage.transport.createFile(
+        file: EnteFile()..localID = "local",
+        collectionID: 1,
+        encryptedKey: "key",
+        keyDecryptionNonce: "nonce",
+        data: _commitData,
+      ),
+      throwsA(isA<StorageLimitExceededError>()),
+    );
+    expect(
+      createStorage.clearedErrors.single,
+      isA<StorageLimitExceededError>(),
+    );
+
+    final updateStorage = _Fixture()
+      ..gateway.updateResults.add(_dioError(statusCode: 426));
+    await expectLater(
+      updateStorage.transport.updateFile(
+        file: EnteFile()
+          ..localID = "local"
+          ..uploadedFileID = 1,
+        data: _commitData,
+      ),
+      throwsA(isA<StorageLimitExceededError>()),
+    );
+    expect(
+      updateStorage.clearedErrors.single,
+      isA<StorageLimitExceededError>(),
+    );
+  });
+
+  test("create does not retry a server response failure", () async {
+    final fixture = _Fixture();
+    final error = _dioError(statusCode: 500);
+    fixture.gateway.createResults.add(error);
+
+    await expectLater(
+      fixture.transport.createFile(
+        file: EnteFile()..localID = "local",
+        collectionID: 1,
+        encryptedKey: "key",
+        keyDecryptionNonce: "nonce",
+        data: _commitData,
+      ),
+      throwsA(same(error)),
+    );
+
+    expect(fixture.gateway.createRequests, hasLength(1));
+    expect(fixture.delays, isEmpty);
+  });
+
+  test("create leaves 402 response failures unchanged", () async {
+    final fixture = _Fixture();
+    final error = _dioError(statusCode: 402);
+    fixture.gateway.createResults.add(error);
+
+    await expectLater(
+      fixture.transport.createFile(
+        file: EnteFile()..localID = "local",
+        collectionID: 1,
+        encryptedKey: "key",
+        keyDecryptionNonce: "nonce",
+        data: _commitData,
+      ),
+      throwsA(same(error)),
+    );
+
+    expect(fixture.gateway.createRequests, hasLength(1));
+    expect(fixture.clearedErrors, isEmpty);
+  });
+
+  test("update retries and applies only update response fields", () async {
+    final fixture = _Fixture();
+    fixture.gateway.updateResults.addAll([
+      _dioError(),
+      _dioError(),
+      _dioError(),
+      {"id": 20, "updationTime": 21},
+    ]);
+    final enteFile = EnteFile()
+      ..localID = "local"
+      ..uploadedFileID = 10
+      ..ownerID = 30
+      ..collectionID = 31
+      ..encryptedKey = "existing-key"
+      ..keyDecryptionNonce = "existing-nonce";
+
+    final result = await fixture.transport.updateFile(
+      file: enteFile,
+      data: _commitData,
+    );
+
+    expect(result, same(enteFile));
+    expect(enteFile.uploadedFileID, 20);
+    expect(enteFile.updationTime, 21);
+    expect(enteFile.ownerID, 30);
+    expect(enteFile.collectionID, 31);
+    expect(enteFile.encryptedKey, "existing-key");
+    expect(enteFile.keyDecryptionNonce, "existing-nonce");
+    expect(enteFile.fileDecryptionHeader, "file-header");
+    expect(enteFile.thumbnailDecryptionHeader, "thumb-header");
+    expect(enteFile.metadataDecryptionHeader, "metadata-header");
+    expect(fixture.gateway.updateRequests, hasLength(4));
+    expect(
+      fixture.gateway.updateRequests,
+      everyElement(_expectedUpdateRequest),
+    );
+    expect(fixture.delays, [
+      UploadTransport.apiRetryDelay,
+      UploadTransport.apiRetryDelay,
+      UploadTransport.apiRetryDelay,
+    ]);
+  });
+
+  test("update leaves response failures unchanged", () async {
+    for (final statusCode in [402, 413, 500]) {
+      final fixture = _Fixture();
+      final error = _dioError(statusCode: statusCode);
+      fixture.gateway.updateResults.add(error);
+
+      await expectLater(
+        fixture.transport.updateFile(
+          file: EnteFile()
+            ..localID = "local"
+            ..uploadedFileID = 1,
+          data: _commitData,
+        ),
+        throwsA(same(error)),
+      );
+
+      expect(fixture.gateway.updateRequests, hasLength(1));
+      expect(fixture.delays, isEmpty);
+      expect(fixture.clearedErrors, isEmpty);
+    }
+  });
+}
+
+const _commitData = UploadCommitData(
+  fileObjectKey: "file-key",
+  fileDecryptionHeader: "file-header",
+  fileSize: 100,
+  thumbnailObjectKey: "thumb-key",
+  thumbnailDecryptionHeader: "thumb-header",
+  thumbnailSize: 10,
+  encryptedMetadata: "metadata",
+  metadataDecryptionHeader: "metadata-header",
+);
+
+const _expectedCreateRequest = <String, dynamic>{
+  "collectionID": 14,
+  "encryptedKey": "encrypted-key",
+  "keyDecryptionNonce": "key-nonce",
+  "fileObjectKey": "file-key",
+  "fileDecryptionHeader": "file-header",
+  "fileSize": 100,
+  "thumbnailObjectKey": "thumb-key",
+  "thumbnailDecryptionHeader": "thumb-header",
+  "thumbnailSize": 10,
+  "encryptedMetadata": "metadata",
+  "metadataDecryptionHeader": "metadata-header",
+  "pubMagicMetadata": <String, dynamic>{"version": 1},
+};
+
+const _expectedCreateRequestWithoutPublicMetadata = <String, dynamic>{
+  "collectionID": 1,
+  "encryptedKey": "key",
+  "keyDecryptionNonce": "nonce",
+  "fileObjectKey": "file-key",
+  "fileDecryptionHeader": "file-header",
+  "fileSize": 100,
+  "thumbnailObjectKey": "thumb-key",
+  "thumbnailDecryptionHeader": "thumb-header",
+  "thumbnailSize": 10,
+  "encryptedMetadata": "metadata",
+  "metadataDecryptionHeader": "metadata-header",
+  "pubMagicMetadata": null,
+};
+
+const _expectedUpdateRequest = <String, dynamic>{
+  "fileID": 10,
+  "fileObjectKey": "file-key",
+  "fileDecryptionHeader": "file-header",
+  "fileSize": 100,
+  "thumbnailObjectKey": "thumb-key",
+  "thumbnailDecryptionHeader": "thumb-header",
+  "thumbnailSize": 10,
+  "encryptedMetadata": "metadata",
+  "metadataDecryptionHeader": "metadata-header",
+};
+
+class _Fixture {
+  _Fixture({String recomputedMd5 = "recomputed"}) {
+    transport = UploadTransport(
+      dio,
+      gateway,
+      shouldUseUploadProxy: () => useProxy,
+      clearQueue: clearedErrors.add,
+      delay: (duration) async => delays.add(duration),
+      clock: clock.call,
+      recomputeMd5: (path) async {
+        recomputedPaths.add(path);
+        return recomputedMd5;
+      },
+    );
+  }
+
+  final dio = _FakeDio();
+  final gateway = _FakeGateway();
+  final clock = _Clock();
+  final clearedErrors = <Error>[];
+  final delays = <Duration>[];
+  final recomputedPaths = <String>[];
+  bool useProxy = false;
+  late final UploadTransport transport;
+}
+
+class _Clock {
+  DateTime _value = DateTime.utc(2026);
+
+  DateTime call() {
+    _value = _value.add(const Duration(milliseconds: 1));
+    return _value;
+  }
+}
+
+class _FakeDio extends Fake implements Dio {
+  final putFailures = Queue<DioException>();
+  final putPaths = <String>[];
+  final payloads = <List<int>>[];
+  final headers = <Map<String, dynamic>>[];
+  void Function()? onPutFailure;
+
+  @override
+  Future<Response<T>> put<T>(
+    String path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    putPaths.add(path);
+    headers.add(Map<String, dynamic>.from(options?.headers ?? const {}));
+    final payload = await (data! as Stream<List<int>>).fold<List<int>>(
+      [],
+      (bytes, chunk) => bytes..addAll(chunk),
+    );
+    payloads.add(payload);
+    onSendProgress?.call(payload.length, payload.length);
+    if (putFailures.isNotEmpty) {
+      final error = putFailures.removeFirst();
+      onPutFailure?.call();
+      throw error;
+    }
+    return Response<T>(requestOptions: RequestOptions(path: path));
+  }
+}
+
+class _FakeGateway extends Fake implements FileUploadGateway {
+  final uploadURLs = Queue<UploadURL>();
+  final uploadURLFailures = Queue<DioException>();
+  final uploadURLRequests = <({int contentLength, String contentMd5})>[];
+  final createResults = Queue<Object>();
+  final createRequests = <Map<String, dynamic>>[];
+  final updateResults = Queue<Object>();
+  final updateRequests = <Map<String, dynamic>>[];
+  bool clearReceivedPublicMetadata = false;
+
+  @override
+  Future<UploadURL> getUploadUrl({
+    required int contentLength,
+    required String contentMd5,
+  }) async {
+    uploadURLRequests.add((
+      contentLength: contentLength,
+      contentMd5: contentMd5,
+    ));
+    if (uploadURLFailures.isNotEmpty) {
+      throw uploadURLFailures.removeFirst();
+    }
+    return uploadURLs.removeFirst();
+  }
+
+  @override
+  Future<Map<String, dynamic>> createFile({
+    required int collectionID,
+    required String encryptedKey,
+    required String keyDecryptionNonce,
+    required String fileObjectKey,
+    required String fileDecryptionHeader,
+    required int fileSize,
+    required String thumbnailObjectKey,
+    required String thumbnailDecryptionHeader,
+    required int thumbnailSize,
+    required String encryptedMetadata,
+    required String metadataDecryptionHeader,
+    Map<String, dynamic>? pubMagicMetadata,
+  }) async {
+    createRequests.add({
+      "collectionID": collectionID,
+      "encryptedKey": encryptedKey,
+      "keyDecryptionNonce": keyDecryptionNonce,
+      "fileObjectKey": fileObjectKey,
+      "fileDecryptionHeader": fileDecryptionHeader,
+      "fileSize": fileSize,
+      "thumbnailObjectKey": thumbnailObjectKey,
+      "thumbnailDecryptionHeader": thumbnailDecryptionHeader,
+      "thumbnailSize": thumbnailSize,
+      "encryptedMetadata": encryptedMetadata,
+      "metadataDecryptionHeader": metadataDecryptionHeader,
+      "pubMagicMetadata": pubMagicMetadata == null
+          ? null
+          : Map<String, dynamic>.of(pubMagicMetadata),
+    });
+    if (clearReceivedPublicMetadata) {
+      pubMagicMetadata?.clear();
+    }
+    final result = createResults.removeFirst();
+    if (result is DioException) throw result;
+    return result as Map<String, dynamic>;
+  }
+
+  @override
+  Future<Map<String, dynamic>> updateFile({
+    required int fileID,
+    required String fileObjectKey,
+    required String fileDecryptionHeader,
+    required int fileSize,
+    required String thumbnailObjectKey,
+    required String thumbnailDecryptionHeader,
+    required int thumbnailSize,
+    required String encryptedMetadata,
+    required String metadataDecryptionHeader,
+  }) async {
+    updateRequests.add({
+      "fileID": fileID,
+      "fileObjectKey": fileObjectKey,
+      "fileDecryptionHeader": fileDecryptionHeader,
+      "fileSize": fileSize,
+      "thumbnailObjectKey": thumbnailObjectKey,
+      "thumbnailDecryptionHeader": thumbnailDecryptionHeader,
+      "thumbnailSize": thumbnailSize,
+      "encryptedMetadata": encryptedMetadata,
+      "metadataDecryptionHeader": metadataDecryptionHeader,
+    });
+    final result = updateResults.removeFirst();
+    if (result is DioException) throw result;
+    return result as Map<String, dynamic>;
+  }
+}
+
+DioException _dioError({int? statusCode, Object? data, String? message}) {
+  final request = RequestOptions(path: "test");
+  return DioException(
+    requestOptions: request,
+    response: statusCode == null
+        ? null
+        : Response<dynamic>(
+            requestOptions: request,
+            statusCode: statusCode,
+            data: data,
+          ),
+    message: message,
+  );
+}

--- a/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
@@ -34,88 +34,6 @@ void main() {
     expect(fixture.dio.putPaths, isEmpty);
   });
 
-  test("registers URL use and rejects a duplicate", () async {
-    final fixture = _Fixture();
-    fixture.gateway.uploadURLs.addAll([
-      UploadURL("same-url", "first"),
-      UploadURL("same-url", "second"),
-    ]);
-
-    final first = await fixture.transport.uploadSinglePart(
-      file,
-      4,
-      contentMd5: "md5",
-    );
-
-    expect(first, "first");
-    await expectLater(
-      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
-      throwsA(isA<DuplicateUploadURLError>()),
-    );
-    fixture.transport.clearCachedUploadURLs();
-    fixture.gateway.uploadURLs.add(UploadURL("same-url", "third"));
-    expect(
-      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
-      "third",
-    );
-  });
-
-  test("rejects duplicate URLs with identical timestamps", () async {
-    final clock = _FixedRegistrationClock();
-    final fixture = _Fixture(uploadClock: clock.call);
-    fixture.gateway.uploadURLs.addAll([
-      UploadURL("same-url", "first"),
-      UploadURL("same-url", "second"),
-    ]);
-
-    expect(
-      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
-      "first",
-    );
-    await expectLater(
-      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
-      throwsA(isA<DuplicateUploadURLError>()),
-    );
-  });
-
-  test("10000 URLs keep cleanup work linear and expire old entries", () async {
-    final clock = _FixedRegistrationClock();
-    final fixture = _Fixture(uploadClock: clock.call);
-    fixture.gateway.uploadURLs.addAll(
-      List.generate(10000, (index) => UploadURL("url-$index", "key-$index")),
-    );
-
-    String? lastObjectKey;
-    for (var index = 0; index < 10000; index++) {
-      lastObjectKey = await fixture.transport.uploadSinglePart(
-        file,
-        4,
-        contentMd5: "md5-$index",
-      );
-    }
-
-    expect(lastObjectKey, "key-9999");
-    expect(fixture.transport.uploadURLCleanupEntryChecks, 5001);
-
-    clock.advance(const Duration(hours: 1, seconds: 1));
-    fixture.gateway.uploadURLs.addAll([
-      UploadURL("cleanup-trigger", "trigger-key"),
-      UploadURL("url-0", "reused-key"),
-    ]);
-    expect(
-      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "trigger"),
-      "trigger-key",
-    );
-    expect(
-      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "reused"),
-      "reused-key",
-    );
-
-    expect(fixture.transport.uploadURLCleanupEntryChecks, 15002);
-    expect(fixture.gateway.uploadURLRequests, hasLength(10002));
-    expect(fixture.dio.putPaths, hasLength(10002));
-  });
-
   test("maps upload URL 402 and 426 responses and clears the queue", () async {
     for (final statusCode in [402, 426]) {
       final fixture = _Fixture();
@@ -613,47 +531,22 @@ const _expectedUpdateRequest = <String, dynamic>{
 };
 
 class _Fixture {
-  _Fixture({UploadClock? uploadClock}) {
+  _Fixture() {
     transport = UploadTransport(
       dio,
       gateway,
       shouldUseUploadProxy: () => useProxy,
       clearQueue: clearedErrors.add,
       delay: (duration) async => delays.add(duration),
-      clock: uploadClock ?? clock.call,
     );
   }
 
   final dio = _FakeDio();
   final gateway = _FakeGateway();
-  final clock = _Clock();
   final clearedErrors = <Error>[];
   final delays = <Duration>[];
   bool useProxy = false;
   late final UploadTransport transport;
-}
-
-class _Clock {
-  DateTime _value = DateTime.utc(2026);
-
-  DateTime call() {
-    _value = _value.add(const Duration(milliseconds: 1));
-    return _value;
-  }
-}
-
-class _FixedRegistrationClock {
-  var _value = DateTime.utc(2026);
-  var _calls = 0;
-
-  void advance(Duration duration) {
-    _value = _value.add(duration);
-  }
-
-  DateTime call() {
-    final phase = _calls++ % 3;
-    return phase == 2 ? _value.add(const Duration(milliseconds: 1)) : _value;
-  }
 }
 
 class _FakeDio extends Fake implements Dio {

--- a/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
@@ -2,6 +2,7 @@ import "dart:collection";
 import "dart:io";
 
 import "package:dio/dio.dart";
+import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/core/errors.dart";
@@ -280,9 +281,10 @@ void main() {
   });
 
   test("PUT reports digest errors without retrying", () async {
-    final fixture = _Fixture(recomputedMd5: "recomputed");
+    final fixture = _Fixture();
     fixture.gateway.uploadURLs.add(UploadURL("url", "key"));
     fixture.dio.putFailures.add(_dioError(statusCode: 400, data: "BadDigest"));
+    final expectedMd5 = await computeMd5(file.path);
 
     await expectLater(
       fixture.transport.uploadSinglePart(file, 4, contentMd5: "sent"),
@@ -290,13 +292,12 @@ void main() {
         isA<BadMD5DigestError>().having(
           (error) => error.message,
           "message",
-          contains("sent: sent, computed: recomputed"),
+          contains("sent: sent, computed: $expectedMd5"),
         ),
       ),
     );
 
     expect(fixture.dio.putPaths, hasLength(1));
-    expect(fixture.recomputedPaths, [file.path]);
     expect(fixture.gateway.uploadURLRequests, hasLength(1));
   });
 
@@ -612,7 +613,7 @@ const _expectedUpdateRequest = <String, dynamic>{
 };
 
 class _Fixture {
-  _Fixture({String recomputedMd5 = "recomputed", UploadClock? uploadClock}) {
+  _Fixture({UploadClock? uploadClock}) {
     transport = UploadTransport(
       dio,
       gateway,
@@ -620,10 +621,6 @@ class _Fixture {
       clearQueue: clearedErrors.add,
       delay: (duration) async => delays.add(duration),
       clock: uploadClock ?? clock.call,
-      recomputeMd5: (path) async {
-        recomputedPaths.add(path);
-        return recomputedMd5;
-      },
     );
   }
 
@@ -632,7 +629,6 @@ class _Fixture {
   final clock = _Clock();
   final clearedErrors = <Error>[];
   final delays = <Duration>[];
-  final recomputedPaths = <String>[];
   bool useProxy = false;
   late final UploadTransport transport;
 }

--- a/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_transport_test.dart
@@ -59,6 +59,62 @@ void main() {
     );
   });
 
+  test("rejects duplicate URLs with identical timestamps", () async {
+    final clock = _FixedRegistrationClock();
+    final fixture = _Fixture(uploadClock: clock.call);
+    fixture.gateway.uploadURLs.addAll([
+      UploadURL("same-url", "first"),
+      UploadURL("same-url", "second"),
+    ]);
+
+    expect(
+      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      "first",
+    );
+    await expectLater(
+      fixture.transport.uploadSinglePart(file, 4, contentMd5: "md5"),
+      throwsA(isA<DuplicateUploadURLError>()),
+    );
+  });
+
+  test("10000 URLs keep cleanup work linear and expire old entries", () async {
+    final clock = _FixedRegistrationClock();
+    final fixture = _Fixture(uploadClock: clock.call);
+    fixture.gateway.uploadURLs.addAll(
+      List.generate(10000, (index) => UploadURL("url-$index", "key-$index")),
+    );
+
+    String? lastObjectKey;
+    for (var index = 0; index < 10000; index++) {
+      lastObjectKey = await fixture.transport.uploadSinglePart(
+        file,
+        4,
+        contentMd5: "md5-$index",
+      );
+    }
+
+    expect(lastObjectKey, "key-9999");
+    expect(fixture.transport.uploadURLCleanupEntryChecks, 5001);
+
+    clock.advance(const Duration(hours: 1, seconds: 1));
+    fixture.gateway.uploadURLs.addAll([
+      UploadURL("cleanup-trigger", "trigger-key"),
+      UploadURL("url-0", "reused-key"),
+    ]);
+    expect(
+      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "trigger"),
+      "trigger-key",
+    );
+    expect(
+      await fixture.transport.uploadSinglePart(file, 4, contentMd5: "reused"),
+      "reused-key",
+    );
+
+    expect(fixture.transport.uploadURLCleanupEntryChecks, 15002);
+    expect(fixture.gateway.uploadURLRequests, hasLength(10002));
+    expect(fixture.dio.putPaths, hasLength(10002));
+  });
+
   test("maps upload URL 402 and 426 responses and clears the queue", () async {
     for (final statusCode in [402, 426]) {
       final fixture = _Fixture();
@@ -556,14 +612,14 @@ const _expectedUpdateRequest = <String, dynamic>{
 };
 
 class _Fixture {
-  _Fixture({String recomputedMd5 = "recomputed"}) {
+  _Fixture({String recomputedMd5 = "recomputed", UploadClock? uploadClock}) {
     transport = UploadTransport(
       dio,
       gateway,
       shouldUseUploadProxy: () => useProxy,
       clearQueue: clearedErrors.add,
       delay: (duration) async => delays.add(duration),
-      clock: clock.call,
+      clock: uploadClock ?? clock.call,
       recomputeMd5: (path) async {
         recomputedPaths.add(path);
         return recomputedMd5;
@@ -587,6 +643,20 @@ class _Clock {
   DateTime call() {
     _value = _value.add(const Duration(milliseconds: 1));
     return _value;
+  }
+}
+
+class _FixedRegistrationClock {
+  var _value = DateTime.utc(2026);
+  var _calls = 0;
+
+  void advance(Duration duration) {
+    _value = _value.add(duration);
+  }
+
+  DateTime call() {
+    final phase = _calls++ % 3;
+    return phase == 2 ? _value.add(const Duration(milliseconds: 1)) : _value;
   }
 }
 


### PR DESCRIPTION
## Summary

- Extract signed-URL acquisition, streamed single-part PUTs, create/update commits, proxy headers, and retry policy into `UploadTransport`.
- Keep queue orchestration, multipart handling, persistence, and events in `FileUploader`.
- Remove the obsolete client upload-URL usage cache and the unused multipart `Dio` argument.

## Rationale

Upload V2 requests one checksum-bound URL at a time. The server creates a fresh UUID object key, enforces temporary and committed object-key uniqueness, and signs the expected content length and MD5, so retaining full signed URLs on the client no longer provides a meaningful correctness boundary.

## Tests

Add transport coverage for streaming, direct/proxy headers, fresh-URL retries, error mappings, MD5 diagnostics, and exact create/update requests and responses.
