### PR TITLE
[mobile] Extract existing upload resolver

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
+++ b/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
@@ -1,0 +1,176 @@
+import "package:collection/collection.dart";
+import "package:logging/logging.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/db/files_db.dart";
+import "package:photos/events/files_updated_event.dart";
+import "package:photos/events/local_photos_updated_event.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/models/file/file_type.dart";
+import "package:photos/services/collections_service.dart";
+
+typedef FindUploadedFiles =
+    Future<List<EnteFile>> Function(
+      String hash,
+      FileType fileType,
+      int ownerID,
+    );
+typedef DeleteGeneratedFile = Future<void> Function(int generatedID);
+typedef UpdateUploadedFileLocalID =
+    Future<void> Function(int uploadedFileID, String localID);
+typedef LinkExistingUpload =
+    Future<EnteFile> Function(
+      int collectionID, {
+      required EnteFile localFileToUpload,
+      required EnteFile existingUploadedFile,
+    });
+typedef EmitLocalPhotosUpdated = void Function(LocalPhotosUpdatedEvent event);
+
+/// Resolves a pending upload to an already-uploaded file with the same hash.
+///
+/// Resolution priority and side effects intentionally match the legacy upload
+/// flow: same local file in the target collection, missing local ID, same local
+/// file in another collection, then no mapping.
+class ExistingUploadResolver {
+  ExistingUploadResolver({
+    required FindUploadedFiles findUploadedFiles,
+    required DeleteGeneratedFile deleteGeneratedFile,
+    required UpdateUploadedFileLocalID updateUploadedFileLocalID,
+    required LinkExistingUpload linkExistingUpload,
+    required EmitLocalPhotosUpdated emitLocalPhotosUpdated,
+  }) : _findUploadedFiles = findUploadedFiles,
+       _deleteGeneratedFile = deleteGeneratedFile,
+       _updateUploadedFileLocalID = updateUploadedFileLocalID,
+       _linkExistingUpload = linkExistingUpload,
+       _emitLocalPhotosUpdated = emitLocalPhotosUpdated;
+
+  factory ExistingUploadResolver.forApp() => ExistingUploadResolver(
+    findUploadedFiles: (hash, fileType, ownerID) =>
+        FilesDB.instance.getUploadedFilesWithHash(hash, fileType, ownerID),
+    deleteGeneratedFile: (generatedID) =>
+        FilesDB.instance.deleteByGeneratedID(generatedID),
+    updateUploadedFileLocalID: (uploadedFileID, localID) =>
+        FilesDB.instance.updateLocalIDForUploaded(uploadedFileID, localID),
+    linkExistingUpload:
+        (
+          collectionID, {
+          required localFileToUpload,
+          required existingUploadedFile,
+        }) => CollectionsService.instance
+            .linkLocalFileToExistingUploadedFileInAnotherCollection(
+              collectionID,
+              localFileToUpload: localFileToUpload,
+              existingUploadedFile: existingUploadedFile,
+            ),
+    emitLocalPhotosUpdated: (event) => Bus.instance.fire(event),
+  );
+
+  final _logger = Logger("ExistingUploadResolver");
+  final FindUploadedFiles _findUploadedFiles;
+  final DeleteGeneratedFile _deleteGeneratedFile;
+  final UpdateUploadedFileLocalID _updateUploadedFileLocalID;
+  final LinkExistingUpload _linkExistingUpload;
+  final EmitLocalPhotosUpdated _emitLocalPhotosUpdated;
+
+  /// Returns the mapped file, or `null` when the caller should upload it.
+  Future<EnteFile?> resolve({
+    required String fileHash,
+    required EnteFile fileToUpload,
+    required int targetCollectionID,
+    required int ownerID,
+  }) async {
+    if (fileToUpload.uploadedFileID != null) {
+      // This should never happen. Avoid mapping an already-uploaded row because
+      // the branches below can delete or relink the pending local entry.
+      _logger.severe("Critical: file is already uploaded, skipped mapping");
+      return null;
+    }
+
+    final existingUploadedFiles = await _findUploadedFiles(
+      fileHash,
+      fileToUpload.fileType,
+      ownerID,
+    );
+    if (existingUploadedFiles.isEmpty) {
+      return null;
+    }
+
+    final isSandboxFile = fileToUpload.isSharedMediaToAppSandbox;
+
+    // Case a: the same local file is already in the target collection.
+    final sameLocalSameCollection = existingUploadedFiles.firstWhereOrNull(
+      (file) =>
+          file.collectionID == targetCollectionID &&
+          (file.localID == fileToUpload.localID || isSandboxFile),
+    );
+    if (sameLocalSameCollection != null) {
+      _logger.info(
+        "sameLocalSameCollection: toUpload ${fileToUpload.tag} "
+        "existing: ${sameLocalSameCollection.tag} $isSandboxFile",
+      );
+      if (fileToUpload.generatedID != null) {
+        await _deleteGeneratedFile(fileToUpload.generatedID!);
+      }
+      _emitDeletedEvent(fileToUpload, "sameLocalSameCollection");
+      return sameLocalSameCollection;
+    }
+
+    // Case b: reuse an uploaded file whose local ID is not known yet.
+    final fileMissingLocal = existingUploadedFiles.firstWhereOrNull(
+      (file) => file.localID == null,
+    );
+    if (fileMissingLocal != null) {
+      _logger.info(
+        "fileMissingLocal: \n toUpload ${fileToUpload.tag} "
+        "\n existing: ${fileMissingLocal.tag}",
+      );
+      fileMissingLocal.localID = fileToUpload.localID;
+      await _updateUploadedFileLocalID(
+        fileMissingLocal.uploadedFileID!,
+        fileToUpload.localID!,
+      );
+      if (fileToUpload.generatedID != null) {
+        await _deleteGeneratedFile(fileToUpload.generatedID!);
+      }
+      _emitDeletedEvent(fileToUpload, "fileMissingLocal");
+      return fileMissingLocal;
+    }
+
+    // Case c: link the same local file from another collection.
+    final fileInDifferentCollection = existingUploadedFiles.firstWhereOrNull(
+      (file) =>
+          file.collectionID != targetCollectionID &&
+          (file.localID == fileToUpload.localID || isSandboxFile),
+    );
+    if (fileInDifferentCollection != null) {
+      _logger.info(
+        "fileExistsButDifferentCollection: toUpload ${fileToUpload.tag} "
+        "existing: ${fileInDifferentCollection.tag} $isSandboxFile",
+      );
+      return _linkExistingUpload(
+        targetCollectionID,
+        localFileToUpload: fileToUpload,
+        existingUploadedFile: fileInDifferentCollection,
+      );
+    }
+
+    // Case d: the hash belongs to a different local file, so upload this one.
+    final matchLocalIDs = existingUploadedFiles
+        .where((file) => file.localID != null)
+        .map((file) => file.localID!)
+        .toSet();
+    _logger.info(
+      "Found hashMatch but probably with diff localIDs $matchLocalIDs",
+    );
+    return null;
+  }
+
+  void _emitDeletedEvent(EnteFile file, String source) {
+    _emitLocalPhotosUpdated(
+      LocalPhotosUpdatedEvent(
+        [file],
+        type: EventType.deletedFromEverywhere,
+        source: source,
+      ),
+    );
+  }
+}

--- a/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
+++ b/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
@@ -1,6 +1,5 @@
 import "package:collection/collection.dart";
 import "package:logging/logging.dart";
-import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/events/files_updated_event.dart";
@@ -15,7 +14,6 @@ typedef FindUploadedFiles =
       FileType fileType,
       int ownerID,
     );
-typedef GetOwnerID = int Function();
 typedef DeleteGeneratedFile = Future<void> Function(int generatedID);
 typedef UpdateUploadedFileLocalID =
     Future<void> Function(int uploadedFileID, String localID);
@@ -35,13 +33,11 @@ typedef EmitLocalPhotosUpdated = void Function(LocalPhotosUpdatedEvent event);
 class ExistingUploadResolver {
   ExistingUploadResolver({
     required FindUploadedFiles findUploadedFiles,
-    required GetOwnerID getOwnerID,
     required DeleteGeneratedFile deleteGeneratedFile,
     required UpdateUploadedFileLocalID updateUploadedFileLocalID,
     required LinkExistingUpload linkExistingUpload,
     required EmitLocalPhotosUpdated emitLocalPhotosUpdated,
   }) : _findUploadedFiles = findUploadedFiles,
-       _getOwnerID = getOwnerID,
        _deleteGeneratedFile = deleteGeneratedFile,
        _updateUploadedFileLocalID = updateUploadedFileLocalID,
        _linkExistingUpload = linkExistingUpload,
@@ -50,7 +46,6 @@ class ExistingUploadResolver {
   factory ExistingUploadResolver.forApp() => ExistingUploadResolver(
     findUploadedFiles: (hash, fileType, ownerID) =>
         FilesDB.instance.getUploadedFilesWithHash(hash, fileType, ownerID),
-    getOwnerID: () => Configuration.instance.getUserID()!,
     deleteGeneratedFile: (generatedID) =>
         FilesDB.instance.deleteByGeneratedID(generatedID),
     updateUploadedFileLocalID: (uploadedFileID, localID) =>
@@ -71,7 +66,6 @@ class ExistingUploadResolver {
 
   final _logger = Logger("ExistingUploadResolver");
   final FindUploadedFiles _findUploadedFiles;
-  final GetOwnerID _getOwnerID;
   final DeleteGeneratedFile _deleteGeneratedFile;
   final UpdateUploadedFileLocalID _updateUploadedFileLocalID;
   final LinkExistingUpload _linkExistingUpload;
@@ -82,6 +76,7 @@ class ExistingUploadResolver {
     required String fileHash,
     required EnteFile fileToUpload,
     required int targetCollectionID,
+    required int? ownerID,
   }) async {
     if (fileToUpload.uploadedFileID != null) {
       // This should never happen. Avoid mapping an already-uploaded row because
@@ -89,12 +84,15 @@ class ExistingUploadResolver {
       _logger.severe("Critical: file is already uploaded, skipped mapping");
       return null;
     }
+    if (ownerID == null) {
+      return null;
+    }
 
     final isSandboxFile = fileToUpload.isSharedMediaToAppSandbox;
     final existingUploadedFiles = await _findUploadedFiles(
       fileHash,
       fileToUpload.fileType,
-      _getOwnerID(),
+      ownerID,
     );
     if (existingUploadedFiles.isEmpty) {
       return null;
@@ -127,7 +125,6 @@ class ExistingUploadResolver {
         "fileMissingLocal: \n toUpload ${fileToUpload.tag} "
         "\n existing: ${fileMissingLocal.tag}",
       );
-      fileMissingLocal.localID = fileToUpload.localID;
       await _updateUploadedFileLocalID(
         fileMissingLocal.uploadedFileID!,
         fileToUpload.localID!,
@@ -136,6 +133,7 @@ class ExistingUploadResolver {
         await _deleteGeneratedFile(fileToUpload.generatedID!);
       }
       _emitDeletedEvent(fileToUpload, "fileMissingLocal");
+      fileMissingLocal.localID = fileToUpload.localID;
       return fileMissingLocal;
     }
 

--- a/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
+++ b/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
@@ -1,5 +1,6 @@
 import "package:collection/collection.dart";
 import "package:logging/logging.dart";
+import "package:photos/core/configuration.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/events/files_updated_event.dart";
@@ -14,6 +15,7 @@ typedef FindUploadedFiles =
       FileType fileType,
       int ownerID,
     );
+typedef GetOwnerID = int Function();
 typedef DeleteGeneratedFile = Future<void> Function(int generatedID);
 typedef UpdateUploadedFileLocalID =
     Future<void> Function(int uploadedFileID, String localID);
@@ -33,11 +35,13 @@ typedef EmitLocalPhotosUpdated = void Function(LocalPhotosUpdatedEvent event);
 class ExistingUploadResolver {
   ExistingUploadResolver({
     required FindUploadedFiles findUploadedFiles,
+    required GetOwnerID getOwnerID,
     required DeleteGeneratedFile deleteGeneratedFile,
     required UpdateUploadedFileLocalID updateUploadedFileLocalID,
     required LinkExistingUpload linkExistingUpload,
     required EmitLocalPhotosUpdated emitLocalPhotosUpdated,
   }) : _findUploadedFiles = findUploadedFiles,
+       _getOwnerID = getOwnerID,
        _deleteGeneratedFile = deleteGeneratedFile,
        _updateUploadedFileLocalID = updateUploadedFileLocalID,
        _linkExistingUpload = linkExistingUpload,
@@ -46,6 +50,7 @@ class ExistingUploadResolver {
   factory ExistingUploadResolver.forApp() => ExistingUploadResolver(
     findUploadedFiles: (hash, fileType, ownerID) =>
         FilesDB.instance.getUploadedFilesWithHash(hash, fileType, ownerID),
+    getOwnerID: () => Configuration.instance.getUserID()!,
     deleteGeneratedFile: (generatedID) =>
         FilesDB.instance.deleteByGeneratedID(generatedID),
     updateUploadedFileLocalID: (uploadedFileID, localID) =>
@@ -66,6 +71,7 @@ class ExistingUploadResolver {
 
   final _logger = Logger("ExistingUploadResolver");
   final FindUploadedFiles _findUploadedFiles;
+  final GetOwnerID _getOwnerID;
   final DeleteGeneratedFile _deleteGeneratedFile;
   final UpdateUploadedFileLocalID _updateUploadedFileLocalID;
   final LinkExistingUpload _linkExistingUpload;
@@ -76,7 +82,6 @@ class ExistingUploadResolver {
     required String fileHash,
     required EnteFile fileToUpload,
     required int targetCollectionID,
-    required int ownerID,
   }) async {
     if (fileToUpload.uploadedFileID != null) {
       // This should never happen. Avoid mapping an already-uploaded row because
@@ -85,16 +90,15 @@ class ExistingUploadResolver {
       return null;
     }
 
+    final isSandboxFile = fileToUpload.isSharedMediaToAppSandbox;
     final existingUploadedFiles = await _findUploadedFiles(
       fileHash,
       fileToUpload.fileType,
-      ownerID,
+      _getOwnerID(),
     );
     if (existingUploadedFiles.isEmpty) {
       return null;
     }
-
-    final isSandboxFile = fileToUpload.isSharedMediaToAppSandbox;
 
     // Case a: the same local file is already in the target collection.
     final sameLocalSameCollection = existingUploadedFiles.firstWhereOrNull(

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -458,6 +458,7 @@ class FileUploader {
           fileHash: mediaUploadData.fileHash,
           fileToUpload: file,
           targetCollectionID: collectionID,
+          ownerID: Configuration.instance.getUserID(),
         );
         if (mappedFile != null) {
           debugPrint(

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import "package:dio/dio.dart";
 import 'package:ente_crypto/ente_crypto.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
@@ -28,6 +27,7 @@ import 'package:photos/models/file/file_type.dart';
 import "package:photos/models/user_details.dart";
 import "package:photos/module/metadata/exif.dart";
 import 'package:photos/module/upload/model/media_upload_data.dart';
+import "package:photos/module/upload/service/existing_upload_resolver.dart";
 import "package:photos/module/upload/service/multipart.dart";
 import 'package:photos/module/upload/service/upload_artifact_lifecycle.dart';
 import 'package:photos/module/upload/service/upload_queue.dart';
@@ -43,7 +43,6 @@ import 'package:photos/services/sync/sync_service.dart';
 import "package:photos/utils/file_key.dart";
 import "package:photos/utils/network_util.dart";
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:tuple/tuple.dart';
 import "package:uuid/uuid.dart";
 
 /// Coordinates encryption, transfer, persistence, and retries for file uploads.
@@ -67,6 +66,7 @@ class FileUploader {
     UploadLocksDB.instance,
     FilesDB.instance,
   );
+  final _existingUploadResolver = ExistingUploadResolver.forApp();
   final kSafeBufferForLockExpiry = const Duration(hours: 4).inMicroseconds;
   final kBGTaskDeathTimeout = const Duration(seconds: 5).inMicroseconds;
   Map<String, BackupItem> get allBackups => _queue.backupItems;
@@ -454,23 +454,18 @@ class FileUploader {
         key = getFileKey(file);
       } else {
         key = multiPartFileEncResult?.key;
-        // check if the file is already uploaded and can be mapped to existing
-        // uploaded file. If map is found, it also returns the corresponding
-        // mapped or update file entry.
-        final result = await _mapToExistingUploadWithSameHash(
-          mediaUploadData,
-          file,
-          collectionID,
+        final mappedFile = await _existingUploadResolver.resolve(
+          fileHash: mediaUploadData.fileHash,
+          fileToUpload: file,
+          targetCollectionID: collectionID,
         );
-        final isMappedToExistingUpload = result.item1;
-        if (isMappedToExistingUpload) {
+        if (mappedFile != null) {
           debugPrint(
             "File success mapped to existing uploaded ${file.toString()}",
           );
           // treat as completed so _onUploadDone clears the source export
           uploadCompleted = true;
-          // return the mapped file
-          return result.item2;
+          return mappedFile;
         }
       }
 
@@ -820,140 +815,6 @@ class FileUploader {
           e.requestOptions.path.contains("/files/update");
     }
     return false;
-  }
-
-  /*
-  _mapToExistingUpload links the fileToUpload with the existing uploaded
-  files. if the link is successful, it returns true otherwise false.
-  When false, we should go ahead and re-upload or update the file.
-  It performs following checks:
-    a) Target file with same localID and destination collection exists. Delete the
-     fileToUpload entry. If target file is sandbox file, then we skip localID match
-     check.
-    b) Uploaded file in any collection but with missing localID.
-     Update the localID for uploadedFile and delete the fileToUpload entry
-    c) A uploaded file exist with same localID but in a different collection.
-    Add a symlink in the destination collection and update the fileToUpload.
-    If target file is sandbox file, then we skip localID match
-     check.
-    d) File already exists but different localID. Re-upload
-    In case the existing files already have local identifier, which is
-    different from the {fileToUpload}, then most probably device has
-    duplicate files.
-  */
-  Future<Tuple2<bool, EnteFile>> _mapToExistingUploadWithSameHash(
-    MediaUploadData mediaUploadData,
-    EnteFile fileToUpload,
-    int toCollectionID,
-  ) async {
-    if (fileToUpload.uploadedFileID != null) {
-      // ideally this should never happen, but because the code below this case
-      // can do unexpected mapping, we are adding this additional check
-      _logger.severe('Critical: file is already uploaded, skipped mapping');
-      return Tuple2(false, fileToUpload);
-    }
-    final bool isSandBoxFile = fileToUpload.isSharedMediaToAppSandbox;
-
-    final List<EnteFile> existingUploadedFiles = await FilesDB.instance
-        .getUploadedFilesWithHash(
-          mediaUploadData.fileHash,
-          fileToUpload.fileType,
-          Configuration.instance.getUserID()!,
-        );
-    if (existingUploadedFiles.isEmpty) {
-      // continueUploading this file
-      return Tuple2(false, fileToUpload);
-    }
-
-    // case a
-    final EnteFile? sameLocalSameCollection = existingUploadedFiles
-        .firstWhereOrNull(
-          (e) =>
-              e.collectionID == toCollectionID &&
-              (e.localID == fileToUpload.localID || isSandBoxFile),
-        );
-    if (sameLocalSameCollection != null) {
-      _logger.info(
-        "sameLocalSameCollection: toUpload  ${fileToUpload.tag} "
-        "existing: ${sameLocalSameCollection.tag} $isSandBoxFile",
-      );
-      // should delete the fileToUploadEntry
-      if (fileToUpload.generatedID != null) {
-        await FilesDB.instance.deleteByGeneratedID(fileToUpload.generatedID!);
-      }
-
-      Bus.instance.fire(
-        LocalPhotosUpdatedEvent(
-          [fileToUpload],
-          type: EventType.deletedFromEverywhere,
-          source: "sameLocalSameCollection", //
-        ),
-      );
-      return Tuple2(true, sameLocalSameCollection);
-    }
-
-    // case b
-    final EnteFile? fileMissingLocal = existingUploadedFiles.firstWhereOrNull(
-      (e) => e.localID == null,
-    );
-    if (fileMissingLocal != null) {
-      // update the local id of the existing file and delete the fileToUpload
-      // entry
-      _logger.info(
-        "fileMissingLocal: \n toUpload  ${fileToUpload.tag} "
-        "\n existing: ${fileMissingLocal.tag}",
-      );
-      fileMissingLocal.localID = fileToUpload.localID;
-      // set localID for the given uploadedID across collections
-      await FilesDB.instance.updateLocalIDForUploaded(
-        fileMissingLocal.uploadedFileID!,
-        fileToUpload.localID!,
-      );
-      // For files selected from device, during collaborative upload, we don't
-      // insert entries in the FilesDB. So, we don't need to delete the entry
-      if (fileToUpload.generatedID != null) {
-        await FilesDB.instance.deleteByGeneratedID(fileToUpload.generatedID!);
-      }
-      Bus.instance.fire(
-        LocalPhotosUpdatedEvent(
-          [fileToUpload],
-          source: "fileMissingLocal",
-          type: EventType.deletedFromEverywhere, //
-        ),
-      );
-      return Tuple2(true, fileMissingLocal);
-    }
-
-    // case c
-    final EnteFile? fileExistsButDifferentCollection = existingUploadedFiles
-        .firstWhereOrNull(
-          (e) =>
-              e.collectionID != toCollectionID &&
-              (e.localID == fileToUpload.localID || isSandBoxFile),
-        );
-    if (fileExistsButDifferentCollection != null) {
-      _logger.info(
-        "fileExistsButDifferentCollection: toUpload  ${fileToUpload.tag} "
-        "existing: ${fileExistsButDifferentCollection.tag} $isSandBoxFile",
-      );
-      final linkedFile = await CollectionsService.instance
-          .linkLocalFileToExistingUploadedFileInAnotherCollection(
-            toCollectionID,
-            localFileToUpload: fileToUpload,
-            existingUploadedFile: fileExistsButDifferentCollection,
-          );
-      return Tuple2(true, linkedFile);
-    }
-    final Set<String> matchLocalIDs = existingUploadedFiles
-        .where((e) => e.localID != null)
-        .map((e) => e.localID!)
-        .toSet();
-    _logger.info(
-      "Found hashMatch but probably with diff localIDs "
-      "$matchLocalIDs",
-    );
-    // case d
-    return Tuple2(false, fileToUpload);
   }
 
   Future<void> _onUploadDone(

--- a/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
@@ -13,6 +13,7 @@ void main() {
 
     expect(await fixture.resolve(pending), isNull);
     expect(fixture.calls, isEmpty);
+    expect(fixture.ownerIDCalls, 0);
   });
 
   test("no hash matches continues uploading", () async {
@@ -20,6 +21,18 @@ void main() {
 
     expect(await fixture.resolve(_file(localID: "local")), isNull);
     expect(fixture.calls, ["find:hash:${FileType.image.index}:10"]);
+    expect(fixture.ownerIDCalls, 1);
+  });
+
+  test("hash lookup failure propagates without side effects", () async {
+    final fixture = _Fixture()..findError = _Error();
+
+    await expectLater(
+      fixture.resolve(_file(localID: "local")),
+      throwsA(isA<_Error>()),
+    );
+    expect(fixture.calls, ["find:hash:${FileType.image.index}:10"]);
+    expect(fixture.events, isEmpty);
   });
 
   test("case a deletes pending row before emitting deletion", () async {
@@ -187,6 +200,26 @@ void main() {
     expect(fixture.events, isEmpty);
   });
 
+  test("event failure propagates after case a deletion", () async {
+    final existing = _file(
+      localID: "local",
+      uploadedFileID: 11,
+      collectionID: 20,
+    );
+    final fixture = _Fixture(existingFiles: [existing])..emitError = _Error();
+
+    await expectLater(
+      fixture.resolve(_file(localID: "local", generatedID: 7)),
+      throwsA(isA<_Error>()),
+    );
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "delete:7",
+      "event:deletedFromEverywhere:sameLocalSameCollection",
+    ]);
+    expect(fixture.events, hasLength(1));
+  });
+
   test("update failure prevents case b deletion and event", () async {
     final existing = _file(uploadedFileID: 12, collectionID: 30);
     final fixture = _Fixture(existingFiles: [existing])..updateError = _Error();
@@ -252,7 +285,12 @@ class _Fixture {
     resolver = ExistingUploadResolver(
       findUploadedFiles: (hash, fileType, ownerID) async {
         calls.add("find:$hash:${fileType.index}:$ownerID");
+        if (findError != null) throw findError!;
         return this.existingFiles;
+      },
+      getOwnerID: () {
+        ownerIDCalls++;
+        return ownerID;
       },
       deleteGeneratedFile: (generatedID) async {
         calls.add("delete:$generatedID");
@@ -280,6 +318,7 @@ class _Fixture {
       emitLocalPhotosUpdated: (event) {
         calls.add("event:${event.type.name}:${event.source}");
         events.add(event);
+        if (emitError != null) throw emitError!;
       },
     );
   }
@@ -296,14 +335,16 @@ class _Fixture {
   EnteFile? linkedLocalFile;
   EnteFile? linkedExistingFile;
   Object? deleteError;
+  Object? findError;
+  Object? emitError;
   Object? updateError;
   Object? linkError;
+  var ownerIDCalls = 0;
 
   Future<EnteFile?> resolve(EnteFile pending) => resolver.resolve(
     fileHash: fileHash,
     fileToUpload: pending,
     targetCollectionID: targetCollectionID,
-    ownerID: ownerID,
   );
 }
 

--- a/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
@@ -1,0 +1,310 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/core/constants.dart";
+import "package:photos/events/files_updated_event.dart";
+import "package:photos/events/local_photos_updated_event.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/models/file/file_type.dart";
+import "package:photos/module/upload/service/existing_upload_resolver.dart";
+
+void main() {
+  test("already-uploaded input skips lookup and mapping", () async {
+    final fixture = _Fixture();
+    final pending = _file(localID: "local", uploadedFileID: 1);
+
+    expect(await fixture.resolve(pending), isNull);
+    expect(fixture.calls, isEmpty);
+  });
+
+  test("no hash matches continues uploading", () async {
+    final fixture = _Fixture();
+
+    expect(await fixture.resolve(_file(localID: "local")), isNull);
+    expect(fixture.calls, ["find:hash:${FileType.image.index}:10"]);
+  });
+
+  test("case a deletes pending row before emitting deletion", () async {
+    final existing = _file(
+      localID: "local",
+      uploadedFileID: 11,
+      collectionID: 20,
+    );
+    final fixture = _Fixture(existingFiles: [existing]);
+    final pending = _file(localID: "local", generatedID: 7);
+
+    expect(await fixture.resolve(pending), same(existing));
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "delete:7",
+      "event:deletedFromEverywhere:sameLocalSameCollection",
+    ]);
+    _expectDeletionEvent(
+      fixture.events.single,
+      pending,
+      "sameLocalSameCollection",
+    );
+  });
+
+  test(
+    "case a emits deletion without deleting an absent pending row",
+    () async {
+      final existing = _file(
+        localID: "local",
+        uploadedFileID: 11,
+        collectionID: 20,
+      );
+      final fixture = _Fixture(existingFiles: [existing]);
+      final pending = _file(localID: "local");
+
+      expect(await fixture.resolve(pending), same(existing));
+      expect(fixture.calls, [
+        "find:hash:${FileType.image.index}:10",
+        "event:deletedFromEverywhere:sameLocalSameCollection",
+      ]);
+    },
+  );
+
+  test("case b updates local ID, deletes pending row, then emits", () async {
+    final existing = _file(uploadedFileID: 12, collectionID: 30);
+    final fixture = _Fixture(existingFiles: [existing]);
+    final pending = _file(localID: "local", generatedID: 8);
+
+    expect(await fixture.resolve(pending), same(existing));
+    expect(existing.localID, "local");
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "update:12:local",
+      "delete:8",
+      "event:deletedFromEverywhere:fileMissingLocal",
+    ]);
+    _expectDeletionEvent(fixture.events.single, pending, "fileMissingLocal");
+  });
+
+  test("case c links matching local file from another collection", () async {
+    final existing = _file(
+      localID: "local",
+      uploadedFileID: 13,
+      collectionID: 30,
+    );
+    final linked = _file(
+      localID: "local",
+      uploadedFileID: 13,
+      collectionID: 20,
+    );
+    final fixture = _Fixture(existingFiles: [existing], linkedFile: linked);
+    final pending = _file(localID: "local", generatedID: 9);
+
+    expect(await fixture.resolve(pending), same(linked));
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "link:20:local:13",
+    ]);
+    expect(fixture.linkedLocalFile, same(pending));
+    expect(fixture.linkedExistingFile, same(existing));
+    expect(fixture.events, isEmpty);
+  });
+
+  test("case d leaves a different local file untouched", () async {
+    final existing = _file(
+      localID: "other",
+      uploadedFileID: 14,
+      collectionID: 30,
+    );
+    final fixture = _Fixture(existingFiles: [existing]);
+
+    expect(await fixture.resolve(_file(localID: "local")), isNull);
+    expect(fixture.calls, ["find:hash:${FileType.image.index}:10"]);
+    expect(fixture.events, isEmpty);
+  });
+
+  test("case priority remains a then b then c", () async {
+    final caseC = _file(localID: "local", uploadedFileID: 13, collectionID: 30);
+    final caseB = _file(uploadedFileID: 12, collectionID: 30);
+    final caseA = _file(localID: "local", uploadedFileID: 11, collectionID: 20);
+    final fixture = _Fixture(existingFiles: [caseC, caseB, caseA]);
+
+    expect(await fixture.resolve(_file(localID: "local")), same(caseA));
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "event:deletedFromEverywhere:sameLocalSameCollection",
+    ]);
+  });
+
+  test("case b remains preferred over case c", () async {
+    final caseC = _file(localID: "local", uploadedFileID: 13, collectionID: 30);
+    final caseB = _file(uploadedFileID: 12, collectionID: 30);
+    final fixture = _Fixture(existingFiles: [caseC, caseB]);
+
+    expect(await fixture.resolve(_file(localID: "local")), same(caseB));
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "update:12:local",
+      "event:deletedFromEverywhere:fileMissingLocal",
+    ]);
+  });
+
+  test("sandbox file ignores local ID for same-collection mapping", () async {
+    final existing = _file(
+      localID: "different",
+      uploadedFileID: 11,
+      collectionID: 20,
+    );
+    final fixture = _Fixture(existingFiles: [existing]);
+
+    expect(
+      await fixture.resolve(_file(localID: "${sharedMediaIdentifier}pending")),
+      same(existing),
+    );
+  });
+
+  test("sandbox file ignores local ID for cross-collection mapping", () async {
+    final existing = _file(
+      localID: "different",
+      uploadedFileID: 13,
+      collectionID: 30,
+    );
+    final linked = _file(uploadedFileID: 13, collectionID: 20);
+    final fixture = _Fixture(existingFiles: [existing], linkedFile: linked);
+
+    expect(
+      await fixture.resolve(_file(localID: "${sharedMediaIdentifier}pending")),
+      same(linked),
+    );
+  });
+
+  test("delete failure prevents case a event", () async {
+    final existing = _file(
+      localID: "local",
+      uploadedFileID: 11,
+      collectionID: 20,
+    );
+    final fixture = _Fixture(existingFiles: [existing])..deleteError = _Error();
+
+    await expectLater(
+      fixture.resolve(_file(localID: "local", generatedID: 7)),
+      throwsA(isA<_Error>()),
+    );
+    expect(fixture.calls, ["find:hash:${FileType.image.index}:10", "delete:7"]);
+    expect(fixture.events, isEmpty);
+  });
+
+  test("update failure prevents case b deletion and event", () async {
+    final existing = _file(uploadedFileID: 12, collectionID: 30);
+    final fixture = _Fixture(existingFiles: [existing])..updateError = _Error();
+
+    await expectLater(
+      fixture.resolve(_file(localID: "local", generatedID: 8)),
+      throwsA(isA<_Error>()),
+    );
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "update:12:local",
+    ]);
+    expect(fixture.events, isEmpty);
+  });
+
+  test("link failure propagates without resolver event", () async {
+    final existing = _file(
+      localID: "local",
+      uploadedFileID: 13,
+      collectionID: 30,
+    );
+    final fixture = _Fixture(existingFiles: [existing])..linkError = _Error();
+
+    await expectLater(
+      fixture.resolve(_file(localID: "local")),
+      throwsA(isA<_Error>()),
+    );
+    expect(fixture.calls, [
+      "find:hash:${FileType.image.index}:10",
+      "link:20:local:13",
+    ]);
+    expect(fixture.events, isEmpty);
+  });
+}
+
+void _expectDeletionEvent(
+  LocalPhotosUpdatedEvent event,
+  EnteFile pending,
+  String source,
+) {
+  expect(event.updatedFiles, [same(pending)]);
+  expect(event.type, EventType.deletedFromEverywhere);
+  expect(event.source, source);
+}
+
+EnteFile _file({
+  String? localID,
+  int? generatedID,
+  int? uploadedFileID,
+  int? collectionID,
+  FileType fileType = FileType.image,
+}) => EnteFile()
+  ..localID = localID
+  ..generatedID = generatedID
+  ..uploadedFileID = uploadedFileID
+  ..collectionID = collectionID
+  ..fileType = fileType;
+
+class _Fixture {
+  _Fixture({List<EnteFile>? existingFiles, EnteFile? linkedFile})
+    : existingFiles = existingFiles ?? [],
+      linkedFile = linkedFile ?? _file(uploadedFileID: 99, collectionID: 20) {
+    resolver = ExistingUploadResolver(
+      findUploadedFiles: (hash, fileType, ownerID) async {
+        calls.add("find:$hash:${fileType.index}:$ownerID");
+        return this.existingFiles;
+      },
+      deleteGeneratedFile: (generatedID) async {
+        calls.add("delete:$generatedID");
+        if (deleteError != null) throw deleteError!;
+      },
+      updateUploadedFileLocalID: (uploadedFileID, localID) async {
+        calls.add("update:$uploadedFileID:$localID");
+        if (updateError != null) throw updateError!;
+      },
+      linkExistingUpload:
+          (
+            collectionID, {
+            required localFileToUpload,
+            required existingUploadedFile,
+          }) async {
+            calls.add(
+              "link:$collectionID:${localFileToUpload.localID}:"
+              "${existingUploadedFile.uploadedFileID}",
+            );
+            linkedLocalFile = localFileToUpload;
+            linkedExistingFile = existingUploadedFile;
+            if (linkError != null) throw linkError!;
+            return this.linkedFile;
+          },
+      emitLocalPhotosUpdated: (event) {
+        calls.add("event:${event.type.name}:${event.source}");
+        events.add(event);
+      },
+    );
+  }
+
+  static const fileHash = "hash";
+  static const ownerID = 10;
+  static const targetCollectionID = 20;
+
+  final List<EnteFile> existingFiles;
+  final EnteFile linkedFile;
+  final calls = <String>[];
+  final events = <LocalPhotosUpdatedEvent>[];
+  late final ExistingUploadResolver resolver;
+  EnteFile? linkedLocalFile;
+  EnteFile? linkedExistingFile;
+  Object? deleteError;
+  Object? updateError;
+  Object? linkError;
+
+  Future<EnteFile?> resolve(EnteFile pending) => resolver.resolve(
+    fileHash: fileHash,
+    fileToUpload: pending,
+    targetCollectionID: targetCollectionID,
+    ownerID: ownerID,
+  );
+}
+
+class _Error extends Error {}

--- a/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/existing_upload_resolver_test.dart
@@ -13,7 +13,16 @@ void main() {
 
     expect(await fixture.resolve(pending), isNull);
     expect(fixture.calls, isEmpty);
-    expect(fixture.ownerIDCalls, 0);
+  });
+
+  test("missing owner skips lookup and mapping", () async {
+    final fixture = _Fixture();
+
+    expect(
+      await fixture.resolve(_file(localID: "local"), ownerID: null),
+      isNull,
+    );
+    expect(fixture.calls, isEmpty);
   });
 
   test("no hash matches continues uploading", () async {
@@ -21,7 +30,6 @@ void main() {
 
     expect(await fixture.resolve(_file(localID: "local")), isNull);
     expect(fixture.calls, ["find:hash:${FileType.image.index}:10"]);
-    expect(fixture.ownerIDCalls, 1);
   });
 
   test("hash lookup failure propagates without side effects", () async {
@@ -232,6 +240,7 @@ void main() {
       "find:hash:${FileType.image.index}:10",
       "update:12:local",
     ]);
+    expect(existing.localID, isNull);
     expect(fixture.events, isEmpty);
   });
 
@@ -288,10 +297,6 @@ class _Fixture {
         if (findError != null) throw findError!;
         return this.existingFiles;
       },
-      getOwnerID: () {
-        ownerIDCalls++;
-        return ownerID;
-      },
       deleteGeneratedFile: (generatedID) async {
         calls.add("delete:$generatedID");
         if (deleteError != null) throw deleteError!;
@@ -324,7 +329,7 @@ class _Fixture {
   }
 
   static const fileHash = "hash";
-  static const ownerID = 10;
+  static const defaultOwnerID = 10;
   static const targetCollectionID = 20;
 
   final List<EnteFile> existingFiles;
@@ -339,12 +344,14 @@ class _Fixture {
   Object? emitError;
   Object? updateError;
   Object? linkError;
-  var ownerIDCalls = 0;
-
-  Future<EnteFile?> resolve(EnteFile pending) => resolver.resolve(
+  Future<EnteFile?> resolve(
+    EnteFile pending, {
+    int? ownerID = defaultOwnerID,
+  }) => resolver.resolve(
     fileHash: fileHash,
     fileToUpload: pending,
     targetCollectionID: targetCollectionID,
+    ownerID: ownerID,
   );
 }
 


### PR DESCRIPTION
## Summary

- Move same-hash mapping cases into `ExistingUploadResolver`.
- Return the mapped `EnteFile?` directly and remove `Tuple2` from the upload flow.
- Keep `FileUploader` responsible for orchestration and completion cleanup.

## Rationale

Existing-upload resolution combines ordered matching policy with database updates, collection linking, row deletion, and event delivery. Giving it one focused boundary makes those side effects independently testable without changing their order or behavior.

## Tests

Add resolver coverage for cases a-d, branch priority, sandbox matching, exact side-effect order, and lookup/update/delete/link/event failures.
