### PR TITLE
[mobile] Set up Rive before Locker iOS archive

### DIFF
--- a/.github/workflows/locker-build.yml
+++ b/.github/workflows/locker-build.yml
@@ -238,6 +238,9 @@ jobs:
 
             - run: flutter pub get --enforce-lockfile
 
+            - name: Set up Rive iOS binaries
+              run: dart run rive_native:setup --clean --platform ios
+
             - run: cargo codegen frb shared
               working-directory: rust
 


### PR DESCRIPTION
Fix the Locker iOS archive by running Rive's setup from the Flutter project root before CocoaPods.

Rive was introduced to Locker in [PR #11392](https://github.com/ente/ente/pull/11392).