### PR TITLE
Use lazy HEIC image adapter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3574,8 +3574,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heic_decoder"
-version = "0.1.0"
-source = "git+https://github.com/ente/heic-decoder.git?rev=3fd83f1c1f0c88b8c4b511355b4041c7bb2d393b#3fd83f1c1f0c88b8c4b511355b4041c7bb2d393b"
+version = "0.2.0"
+source = "git+https://github.com/ente/heic-decoder.git?rev=0998ddc52085b38fa359049d1fe28baf144fe79b#0998ddc52085b38fa359049d1fe28baf144fe79b"
 dependencies = [
  "archmage",
  "brotli",

--- a/rust/crates/image/Cargo.toml
+++ b/rust/crates/image/Cargo.toml
@@ -7,7 +7,7 @@ fast_image_resize = { version = "5.5.0", features = ["image"] }
 image = { version = "0.25.10", default-features = true }
 jxl-oxide = { version = "0.12.6", features = ["image"] }
 kamadak-exif = "0.6.1"
-ente_heic = { package = "heic_decoder", git = "https://github.com/ente/heic-decoder.git", rev = "3fd83f1c1f0c88b8c4b511355b4041c7bb2d393b", features = [
+ente_heic = { package = "heic_decoder", git = "https://github.com/ente/heic-decoder.git", rev = "0998ddc52085b38fa359049d1fe28baf144fe79b", features = [
     "image-integration",
 ] }
 moxcms = "0.8.1"

--- a/rust/crates/image/src/decode.rs
+++ b/rust/crates/image/src/decode.rs
@@ -127,6 +127,9 @@ fn decode_reader_with_image_crate<R>(
 where
     R: BufRead + Seek,
 {
+    // HEIF-family readers resolve to ente_heic's lazy hook adapter here. Keep
+    // the decoder intact until DynamicImage allocates and supplies its output
+    // buffer so the adapter can decode directly into it.
     let mut decoder = reader.into_decoder()?;
     let icc_profile = match decoder.icc_profile() {
         Ok(icc_profile) => icc_profile,
@@ -471,6 +474,15 @@ mod tests {
         init_image_decoders();
 
         assert!(decoding_hook_registered(OsStr::new("jxl")));
+    }
+
+    #[test]
+    fn registers_heif_family_decoder_hooks() {
+        init_image_decoders();
+
+        assert!(decoding_hook_registered(OsStr::new("heic")));
+        assert!(decoding_hook_registered(OsStr::new("heif")));
+        assert!(decoding_hook_registered(OsStr::new("avif")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- update `heic_decoder` to `0998ddc` (v0.2.0)
- keep HEIF-family decoding on its lazy `ImageDecoder` hook path
- cover HEIC, HEIF, and AVIF hook registration

## Why

The previous adapter decoded into an extra owned RGBA buffer. The updated adapter decodes directly into the destination buffer, reducing peak image-decoding memory.

## Validation

- `cargo check -p ente-image`
- `cargo test -p ente-image` (25 passed)
