### PR TITLE
docs: note multi-session cast controls

### DIFF
--- a/docs/docs/photos/faq/advanced-features.md
+++ b/docs/docs/photos/faq/advanced-features.md
@@ -226,7 +226,7 @@ To avoid this, ensure video streaming is enabled so that streamable versions are
 
 ### How does Cast work? {#how-does-cast-work}
 
-Ente Cast lets you play slideshow albums on Chromecast TVs or any internet-connected large screen. You can pair using auto-pair (Chromium browsers with Chromecast) or PIN pairing (works with any device).
+Ente Cast lets you play slideshow albums on Chromecast TVs or any internet-connected large screen. You can pair using auto-pair (Chromium browsers with Chromecast) or PIN pairing (works with any device). You can also manage multiple active cast sessions and disconnect screens you are no longer using.
 
 For setup instructions, see the [Cast feature guide](/photos/features/utilities/cast/).
 

--- a/docs/docs/photos/features/utilities/cast/index.md
+++ b/docs/docs/photos/features/utilities/cast/index.md
@@ -5,7 +5,7 @@ description: Casting your photos on to a large screen or a TV or a Chromecast de
 
 # Cast
 
-With Ente Cast, you can play a slideshow of your favourite albums on your Google Chromecast TVs or any other internet-connected large screen devices.
+With Ente Cast, you can play a slideshow of your favourite albums on your Google Chromecast TVs or any other internet-connected large screen devices. You can also manage multiple active cast sessions, making it easier to switch between screens or control more than one ongoing cast.
 
 ## Get Started
 
@@ -44,6 +44,16 @@ With Ente Cast, you can play a slideshow of your favourite albums on your Google
 </div>
 
 6. Once you enter the correct PIN, you will see a screen on your TV with a green checkmark confirming the connection. Your photos will start showing up in a bit.
+
+## Managing cast sessions
+
+After you start casting, Ente lets you return to the cast controls to manage your active sessions.
+
+- Reopen the cast controls from the album you started casting from.
+- Switch between active cast sessions if you have more than one screen connected.
+- Disconnect a screen when you no longer want that session to keep playing.
+
+This is especially useful if you cast the same album to different screens at different times, or if you accidentally leave an older cast session running.
 
 ## Pairing options explained
 


### PR DESCRIPTION
## Summary\n- update the Cast guide to mention managing multiple active cast sessions\n- note in the advanced features FAQ that users can disconnect unused screens\n\n## Why\nThe photos-v1.3.58 release adds support for managing multiple active cast sessions, but the public help docs only described pairing and initial setup.\n\n## Test plan\n- reviewed the updated cast guide and FAQ entries\n- verified the diff is docs-only