### PR TITLE
[mobile][photos] Set search debounce to 314ms

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -40,7 +40,7 @@ class SearchWidgetState extends State<SearchWidget> {
   //Debouncing + querying
   static final isLoading = ValueNotifier(false);
   final _searchService = SearchService.instance;
-  final _debouncer = Debouncer(const Duration(milliseconds: 200));
+  final _debouncer = Debouncer(const Duration(milliseconds: 314));
   late FocusNode focusNode;
   StreamSubscription<TabChangedEvent>? _tabChangedEvent;
   StreamSubscription<TabDoubleTapEvent>? _tabDoubleTapEvent;


### PR DESCRIPTION
## What changed

- Set the Photos global search debounce from 200 ms to 314 ms.

## Why

This gives the user a slightly longer typing gap before a search starts.

## Impact

Global search now starts 314 ms after the last input change.

## Checks

- `git diff --check`