### PR TITLE
[mobile][photos] Fix multipart boundary length

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/multipart.dart
+++ b/mobile/apps/photos/lib/module/upload/service/multipart.dart
@@ -285,7 +285,7 @@ class MultiPartUploader {
       count++;
       final partURL = partsURLs[i];
       final isLastPart = i == partsLength - 1;
-      final fileSize = isLastPart ? encFileLength % partSize : partSize;
+      final fileSize = isLastPart ? encFileLength - (i * partSize) : partSize;
       _logger.info(
         "Uploading part ${i + 1} / $partsLength of size $fileSize bytes (total size $encFileLength). ObjectKey=${partInfo.urls.objectKey}",
       );


### PR DESCRIPTION
Fix the final multipart `Content-Length` when the encrypted size is an exact multiple of the part size. This prevents the last part from declaring zero bytes while streaming a full part.

Validation: Photos formatter, analyzer, and tests.