### PR TITLE
[server] Validate social write file membership

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -297,13 +297,15 @@ func main() {
 	reactionsRepo := &socialrepo.ReactionsRepository{DB: db}
 	anonUsersRepo := &socialrepo.AnonUsersRepository{DB: db}
 	commentsController := &socialcontroller.CommentsController{
-		Repo:       commentsRepo,
-		AccessCtrl: accessCtrl,
+		Repo:           commentsRepo,
+		CollectionRepo: collectionRepo,
+		AccessCtrl:     accessCtrl,
 	}
 	reactionsController := &socialcontroller.ReactionsController{
-		Repo:         reactionsRepo,
-		CommentsRepo: commentsRepo,
-		AccessCtrl:   accessCtrl,
+		Repo:           reactionsRepo,
+		CommentsRepo:   commentsRepo,
+		CollectionRepo: collectionRepo,
+		AccessCtrl:     accessCtrl,
 	}
 	socialController := &socialcontroller.Controller{
 		CommentsRepo:   commentsRepo,

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -439,11 +439,11 @@ func (c *FileController) GetPublicOrCastFileURL(ctx *gin.Context, fileID int64, 
 }
 
 func (c *FileController) DoesFileExistInCollection(ctx *gin.Context, fileID int64, collectionID int64) error {
-	accessible, err := c.CollectionRepo.DoesFileExistInCollections(fileID, []int64{collectionID})
+	state, err := c.CollectionRepo.GetCollectionFileState(ctx, collectionID, fileID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	if !accessible {
+	if state != repo.CollectionFileActive {
 		return stacktrace.Propagate(ente.ErrPermissionDenied, "")
 	}
 	return nil

--- a/server/pkg/controller/social/comment_validation_test.go
+++ b/server/pkg/controller/social/comment_validation_test.go
@@ -1,11 +1,40 @@
 package social
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/ente/museum/ente"
 	socialentity "github.com/ente/museum/ente/social"
+	"github.com/ente/museum/pkg/repo"
 	"github.com/stretchr/testify/require"
 )
+
+type fileCollectionRepoStub struct {
+	state repo.CollectionFileState
+	err   error
+}
+
+func (s fileCollectionRepoStub) GetCollectionFileState(_ context.Context, _, _ int64) (repo.CollectionFileState, error) {
+	return s.state, s.err
+}
+
+func TestValidateFileInCollection(t *testing.T) {
+	require.NoError(t, validateFileInCollection(t.Context(), fileCollectionRepoStub{state: repo.CollectionFileActive}, 1, 2))
+	for _, state := range []repo.CollectionFileState{
+		repo.CollectionFileAbsent,
+		repo.CollectionFileDeleted,
+		repo.CollectionFilePendingRemove,
+	} {
+		err := validateFileInCollection(t.Context(), fileCollectionRepoStub{state: state}, 1, 2)
+		require.ErrorIs(t, err, ente.ErrPermissionDenied)
+		require.ErrorContains(t, err, "membership_"+string(state))
+	}
+
+	repoErr := errors.New("lookup failed")
+	require.ErrorIs(t, validateFileInCollection(t.Context(), fileCollectionRepoStub{err: repoErr}, 1, 2), repoErr)
+}
 
 func TestValidateReplyFileContext(t *testing.T) {
 	fileID := int64(42)

--- a/server/pkg/controller/social/comments_controller.go
+++ b/server/pkg/controller/social/comments_controller.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ente/museum/ente"
 	socialentity "github.com/ente/museum/ente/social"
 	"github.com/ente/museum/pkg/controller/access"
+	"github.com/ente/museum/pkg/repo"
 	socialrepo "github.com/ente/museum/pkg/repo/social"
 	"github.com/ente/stacktrace"
 	"github.com/gin-gonic/gin"
@@ -11,8 +12,9 @@ import (
 
 // CommentsController wires comment-specific business logic.
 type CommentsController struct {
-	Repo       *socialrepo.CommentsRepository
-	AccessCtrl access.Controller
+	Repo           *socialrepo.CommentsRepository
+	CollectionRepo *repo.CollectionRepository
+	AccessCtrl     access.Controller
 }
 
 // CreateCommentRequest encapsulates parameters for adding a comment.
@@ -80,6 +82,11 @@ func (c *CommentsController) Create(ctx *gin.Context, req CreateCommentRequest) 
 			ActorUserID:  userID,
 		}); err != nil {
 			return "", stacktrace.Propagate(err, "")
+		}
+	}
+	if req.FileID != nil {
+		if err := validateFileInCollection(ctx, c.CollectionRepo, req.CollectionID, *req.FileID); err != nil {
+			return "", err
 		}
 	}
 

--- a/server/pkg/controller/social/file_validation.go
+++ b/server/pkg/controller/social/file_validation.go
@@ -1,0 +1,24 @@
+package social
+
+import (
+	"context"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/pkg/repo"
+	"github.com/ente/stacktrace"
+)
+
+type fileCollectionRepository interface {
+	GetCollectionFileState(ctx context.Context, collectionID, fileID int64) (repo.CollectionFileState, error)
+}
+
+func validateFileInCollection(ctx context.Context, files fileCollectionRepository, collectionID, fileID int64) error {
+	state, err := files.GetCollectionFileState(ctx, collectionID, fileID)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if state != repo.CollectionFileActive {
+		return stacktrace.Propagate(ente.ErrPermissionDenied, "membership_%s", state)
+	}
+	return nil
+}

--- a/server/pkg/controller/social/reactions_controller.go
+++ b/server/pkg/controller/social/reactions_controller.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ente/museum/ente"
 	socialentity "github.com/ente/museum/ente/social"
 	"github.com/ente/museum/pkg/controller/access"
+	"github.com/ente/museum/pkg/repo"
 	socialrepo "github.com/ente/museum/pkg/repo/social"
 	"github.com/ente/stacktrace"
 	"github.com/gin-gonic/gin"
@@ -11,9 +12,10 @@ import (
 
 // ReactionsController orchestrates reactions operations.
 type ReactionsController struct {
-	Repo         *socialrepo.ReactionsRepository
-	CommentsRepo *socialrepo.CommentsRepository
-	AccessCtrl   access.Controller
+	Repo           *socialrepo.ReactionsRepository
+	CommentsRepo   *socialrepo.CommentsRepository
+	CollectionRepo *repo.CollectionRepository
+	AccessCtrl     access.Controller
 }
 
 // UpsertReactionRequest holds the payload for creating or updating a reaction.
@@ -73,6 +75,11 @@ func (c *ReactionsController) Upsert(ctx *gin.Context, req UpsertReactionRequest
 			ActorUserID:  userID,
 		}); err != nil {
 			return "", stacktrace.Propagate(err, "")
+		}
+	}
+	if req.FileID != nil {
+		if err := validateFileInCollection(ctx, c.CollectionRepo, req.CollectionID, *req.FileID); err != nil {
+			return "", err
 		}
 	}
 

--- a/server/pkg/repo/collection_files.go
+++ b/server/pkg/repo/collection_files.go
@@ -2,6 +2,8 @@ package repo
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/ente/museum/ente"
@@ -24,13 +26,32 @@ func (repo *CollectionRepository) GetCollectionFileIDs(collectionID int64, colle
 	return convertRowsToFileId(rows)
 }
 
-// DoesFileExistInCollections returns true if the file exists in one of the
-// provided collections
-func (repo *CollectionRepository) DoesFileExistInCollections(fileID int64, cIDs []int64) (bool, error) {
-	var exists bool
-	err := repo.DB.QueryRow(`SELECT EXISTS (SELECT 1 FROM collection_files WHERE file_id = $1 AND is_deleted = $2 AND collection_id = ANY ($3))`,
-		fileID, false, pq.Array(cIDs)).Scan(&exists)
-	return exists, stacktrace.Propagate(err, "")
+type CollectionFileState string
+
+const (
+	CollectionFileActive        CollectionFileState = "active"
+	CollectionFileAbsent        CollectionFileState = "absent"
+	CollectionFileDeleted       CollectionFileState = "deleted"
+	CollectionFilePendingRemove CollectionFileState = "pending_remove"
+)
+
+func (repo *CollectionRepository) GetCollectionFileState(ctx context.Context, collectionID, fileID int64) (CollectionFileState, error) {
+	var isDeleted, isPendingRemove bool
+	err := repo.DB.QueryRowContext(ctx, `SELECT is_deleted, action IS NOT DISTINCT FROM $3 FROM collection_files WHERE collection_id = $1 AND file_id = $2`,
+		collectionID, fileID, ente.ActionRemove).Scan(&isDeleted, &isPendingRemove)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CollectionFileAbsent, nil
+	}
+	if err != nil {
+		return CollectionFileAbsent, stacktrace.Propagate(err, "")
+	}
+	if isDeleted {
+		return CollectionFileDeleted, nil
+	}
+	if isPendingRemove {
+		return CollectionFilePendingRemove, nil
+	}
+	return CollectionFileActive, nil
 }
 
 func (repo *CollectionRepository) DoAllFilesExistInGivenCollections(fileIDs []int64, cIDs []int64) error {

--- a/server/pkg/repo/collection_files_test.go
+++ b/server/pkg/repo/collection_files_test.go
@@ -1,0 +1,56 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+)
+
+func TestGetCollectionFileState(t *testing.T) {
+	_, db := setupAccessibleObjectTest(t)
+	repository := &CollectionRepository{DB: db}
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-file-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	otherCollectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+
+	assertState := func(want CollectionFileState, candidateCollectionID, candidateFileID int64) {
+		t.Helper()
+		state, err := repository.GetCollectionFileState(t.Context(), candidateCollectionID, candidateFileID)
+		if err != nil || state != want {
+			t.Fatalf("state=%q, want=%q, err=%v", state, want, err)
+		}
+	}
+	assertState(CollectionFileActive, collectionID, fileID)
+	for _, candidate := range []struct {
+		state        CollectionFileState
+		fileID       int64
+		collectionID int64
+	}{
+		{state: CollectionFileAbsent, fileID: fileID + 1, collectionID: collectionID},
+		{state: CollectionFileAbsent, fileID: fileID, collectionID: otherCollectionID},
+	} {
+		assertState(candidate.state, candidate.collectionID, candidate.fileID)
+	}
+
+	if _, err := db.Exec(`UPDATE collection_files SET action = $1 WHERE collection_id = $2 AND file_id = $3`, ente.ActionRemove, collectionID, fileID); err != nil {
+		t.Fatal(err)
+	}
+	assertState(CollectionFilePendingRemove, collectionID, fileID)
+
+	if _, err := db.Exec(`UPDATE collection_files SET action = NULL WHERE collection_id = $1 AND file_id = $2`, collectionID, fileID); err != nil {
+		t.Fatal(err)
+	}
+	assertState(CollectionFileActive, collectionID, fileID)
+
+	if _, err := db.Exec(`UPDATE collection_files SET is_deleted = TRUE WHERE collection_id = $1 AND file_id = $2`, collectionID, fileID); err != nil {
+		t.Fatal(err)
+	}
+	assertState(CollectionFileDeleted, collectionID, fileID)
+}


### PR DESCRIPTION
- Reject comment and reaction writes whose file is not active in the target collection.
- Cover absent, deleted, and cross-collection membership.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh host`