### PR TITLE
[server] Harden file data cleanup

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -314,7 +314,7 @@ func main() {
 		AccessCtrl:     accessCtrl,
 		AnonUsersRepo:  anonUsersRepo,
 	}
-	fileDataCtrl := filedata.New(fileDataRepo, accessCtrl, objectCleanupController, s3Config, fileRepo, collectionRepo)
+	fileDataCtrl := filedata.New(fileDataRepo, accessCtrl, objectCleanupController, s3Config, fileRepo, collectionRepo, discordController)
 
 	fileController := &controller.FileController{
 		FileRepo:              fileRepo,

--- a/server/pkg/controller/filedata/controller.go
+++ b/server/pkg/controller/filedata/controller.go
@@ -13,6 +13,7 @@ import (
 	fileData "github.com/ente/museum/ente/filedata"
 	"github.com/ente/museum/pkg/controller"
 	"github.com/ente/museum/pkg/controller/access"
+	"github.com/ente/museum/pkg/controller/discord"
 	"github.com/ente/museum/pkg/repo"
 	fileDataRepo "github.com/ente/museum/pkg/repo/filedata"
 	"github.com/ente/museum/pkg/utils/array"
@@ -52,6 +53,7 @@ type Controller struct {
 	S3Config                *s3config.S3Config
 	FileRepo                *repo.FileRepository
 	CollectionRepo          *repo.CollectionRepository
+	DiscordController       *discord.DiscordController
 	downloadManagerCache    map[string]*s3manager.Downloader
 	// for downloading objects from s3 for replication
 	workerURL   string
@@ -64,6 +66,7 @@ func New(repo *fileDataRepo.Repository,
 	s3Config *s3config.S3Config,
 	fileRepo *repo.FileRepository,
 	collectionRepo *repo.CollectionRepository,
+	discordController *discord.DiscordController,
 ) *Controller {
 	embeddingDcs := []string{s3Config.GetHotBackblazeDC(), s3Config.GetHotWasabiDC(), s3Config.GetWasabiDerivedDC(), s3Config.GetDerivedStorageDataCenter(), "b5", "b6"}
 	cache := make(map[string]*s3manager.Downloader, len(embeddingDcs))
@@ -78,6 +81,7 @@ func New(repo *fileDataRepo.Repository,
 		S3Config:                s3Config,
 		FileRepo:                fileRepo,
 		CollectionRepo:          collectionRepo,
+		DiscordController:       discordController,
 		downloadManagerCache:    cache,
 	}
 }

--- a/server/pkg/controller/filedata/delete.go
+++ b/server/pkg/controller/filedata/delete.go
@@ -83,12 +83,15 @@ func (c *Controller) deleteFileRow(fileDataRow filedata.Row) error {
 		return err
 	}
 	if fileDataRow.UserID != ownerID {
-		// this should never happen
-		panic(fmt.Sprintf("file %d does not belong to user %d", fileID, ownerID))
+		return c.reportDeletionInvariant(fileDataRow, fmt.Errorf(
+			"file data owner mismatch for file %d: row user %d, file owner %d",
+			fileID, fileDataRow.UserID, ownerID))
 	}
 	ctxLogger := log.WithField("file_id", fileDataRow.DeleteFromBuckets).WithField("type", fileDataRow.Type).WithField("user_id", fileDataRow.UserID)
 	if fileDataRow.Type != ente.MlData {
-		panic(fmt.Sprintf("unsupported object type for filedata deletion %s", fileDataRow.Type))
+		return c.reportDeletionInvariant(fileDataRow, fmt.Errorf(
+			"unexpected file data type for deletion: got %s, want %s",
+			fileDataRow.Type, ente.MlData))
 	}
 	objectKeys := filedata.AllObjects(fileID, ownerID, fileDataRow.Type)
 	bucketColumnMap, err := getMapOfBucketItToColumn(fileDataRow)
@@ -127,9 +130,8 @@ func (c *Controller) deleteFileRow(fileDataRow filedata.Row) error {
 			return err
 		}
 	}
-	dbErr := c.Repo.DeleteFileData(context.Background(), fileDataRow)
-	if dbErr != nil {
-		ctxLogger.WithError(dbErr).Error("Failed to remove from db")
+	if err := c.Repo.DeleteFileData(context.Background(), fileDataRow); err != nil {
+		ctxLogger.WithError(err).Error("Failed to remove from db")
 		return err
 	}
 	return nil
@@ -145,12 +147,15 @@ func (c *Controller) deleteFileRowV2(fileDataRow filedata.Row) error {
 		return err
 	}
 	if fileDataRow.UserID != ownerID {
-		// this should never happen
-		panic(fmt.Sprintf("file %d does not belong to user %d", fileID, ownerID))
+		return c.reportDeletionInvariant(fileDataRow, fmt.Errorf(
+			"file data owner mismatch for file %d: row user %d, file owner %d",
+			fileID, fileDataRow.UserID, ownerID))
 	}
 	ctxLogger := log.WithField("file_id", fileDataRow.DeleteFromBuckets).WithField("type", fileDataRow.Type).WithField("user_id", fileDataRow.UserID)
 	if fileDataRow.Type != ente.PreviewVideo {
-		panic(fmt.Sprintf("unsupported object type for filedata deletion %s", fileDataRow.Type))
+		return c.reportDeletionInvariant(fileDataRow, fmt.Errorf(
+			"unexpected file data type for deletion: got %s, want %s",
+			fileDataRow.Type, ente.PreviewVideo))
 	}
 	delPrefix := filedata.DeletePrefix(fileID, ownerID, fileDataRow.Type)
 
@@ -188,9 +193,8 @@ func (c *Controller) deleteFileRowV2(fileDataRow filedata.Row) error {
 		return err
 	}
 
-	dbErr := c.Repo.DeleteFileData(context.Background(), fileDataRow)
-	if dbErr != nil {
-		ctxLogger.WithError(dbErr).Error("Failed to remove from db")
+	if err := c.Repo.DeleteFileData(context.Background(), fileDataRow); err != nil {
+		ctxLogger.WithError(err).Error("Failed to remove from db")
 		return err
 	}
 	return nil
@@ -217,4 +221,14 @@ func getMapOfBucketItToColumn(row filedata.Row) (map[string]string, error) {
 		bucketColumnMap[bucketID] = fileDataRepo.InflightRepColumn
 	}
 	return bucketColumnMap, nil
+}
+
+func (c *Controller) reportDeletionInvariant(row filedata.Row, err error) error {
+	log.WithFields(log.Fields{
+		"file_id": row.FileID,
+		"user_id": row.UserID,
+		"type":    row.Type,
+	}).WithError(err).Error("File data deletion invariant failed")
+	c.DiscordController.Notify(fmt.Sprintf("%s: file data deletion invariant failed: %v", c.DiscordController.HostName, err))
+	return err
 }

--- a/server/pkg/repo/filedata/repository.go
+++ b/server/pkg/repo/filedata/repository.go
@@ -311,7 +311,19 @@ func (r *Repository) DeleteFileData(ctx context.Context, row filedata.Row) error
 		return stacktrace.Propagate(err, "")
 	}
 	if rowsAffected == 0 {
-		return stacktrace.NewError("file data not deleted")
+		// A concurrent cleanup may already have removed the row. Only accept a
+		// no-op when the primary key is absent; a surviving row means one of the
+		// deletion invariants did not match.
+		var exists bool
+		err = r.DB.QueryRowContext(ctx, `SELECT EXISTS (
+			SELECT 1 FROM file_data WHERE file_id = $1 AND data_type = $2
+		)`, row.FileID, string(row.Type)).Scan(&exists)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to check file data after delete")
+		}
+		if exists {
+			return stacktrace.NewError("file data row exists but does not satisfy deletion conditions")
+		}
 	}
 	return nil
 }

--- a/server/pkg/repo/filedata/repository_test.go
+++ b/server/pkg/repo/filedata/repository_test.go
@@ -1,0 +1,93 @@
+package filedata
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	enteFileData "github.com/ente/museum/ente/filedata"
+	"github.com/ente/museum/internal/testutil"
+)
+
+func TestDeleteFileData(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	if _, err := db.Exec(`DELETE FROM file_data`); err != nil {
+		t.Fatalf("failed to reset file_data: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM file_data`); err != nil {
+			t.Errorf("failed to reset file_data: %v", err)
+		}
+	})
+
+	repo := &Repository{DB: db}
+
+	t.Run("deletes eligible row", func(t *testing.T) {
+		row := enteFileData.Row{
+			FileID:       1,
+			UserID:       10,
+			Type:         ente.MlData,
+			LatestBucket: "b2-eu-cen",
+		}
+		insertFileDataForDeleteTest(t, repo, row, true)
+
+		if err := repo.DeleteFileData(t.Context(), row); err != nil {
+			t.Fatalf("DeleteFileData() error = %v", err)
+		}
+		assertFileDataExists(t, repo, row, false)
+	})
+
+	t.Run("succeeds when row is already absent", func(t *testing.T) {
+		row := enteFileData.Row{
+			FileID:       2,
+			UserID:       10,
+			Type:         ente.MlData,
+			LatestBucket: "b2-eu-cen",
+		}
+
+		if err := repo.DeleteFileData(t.Context(), row); err != nil {
+			t.Fatalf("DeleteFileData() error = %v", err)
+		}
+	})
+
+	t.Run("rejects row that is not eligible for deletion", func(t *testing.T) {
+		row := enteFileData.Row{
+			FileID:       3,
+			UserID:       10,
+			Type:         ente.MlData,
+			LatestBucket: "b2-eu-cen",
+		}
+		insertFileDataForDeleteTest(t, repo, row, false)
+
+		if err := repo.DeleteFileData(t.Context(), row); err == nil {
+			t.Fatal("DeleteFileData() error = nil, want ineligible-row error")
+		}
+		assertFileDataExists(t, repo, row, true)
+	})
+}
+
+func insertFileDataForDeleteTest(t *testing.T, repo *Repository, row enteFileData.Row, isDeleted bool) {
+	t.Helper()
+	_, err := repo.DB.ExecContext(t.Context(), `
+		INSERT INTO file_data (file_id, user_id, data_type, size, latest_bucket, is_deleted)
+		VALUES ($1, $2, $3, 1, $4, $5)`,
+		row.FileID, row.UserID, string(row.Type), row.LatestBucket, isDeleted)
+	if err != nil {
+		t.Fatalf("failed to insert file_data: %v", err)
+	}
+}
+
+func assertFileDataExists(t *testing.T, repo *Repository, row enteFileData.Row, want bool) {
+	t.Helper()
+	var got bool
+	err := repo.DB.QueryRowContext(t.Context(), `SELECT EXISTS (
+		SELECT 1 FROM file_data WHERE file_id = $1 AND data_type = $2
+	)`, row.FileID, string(row.Type)).Scan(&got)
+	if err != nil {
+		t.Fatalf("failed to check file_data: %v", err)
+	}
+	if got != want {
+		t.Fatalf("file_data existence = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Prevent file-data cleanup panics, propagate deletion errors, and safely accept already-removed rows.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh host`