### PR TITLE
[mobile] Add JitPack repository for QR dependency

### DIFF
--- a/mobile/packages/ente_qr/android/build.gradle
+++ b/mobile/packages/ente_qr/android/build.gradle
@@ -19,6 +19,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
Fixes #11468.

Add JitPack to the repository scope used by ente_qr dependencies.