### PR TITLE
[mob][photos] Show sync progress in empty galleries

### DIFF
--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -244,6 +244,10 @@ class RemoteSyncService {
     return false;
   }
 
+  bool isNonSilentSyncInProgress() {
+    return _existingSync != null && !_isExistingSyncSilent;
+  }
+
   Future<void> _pullDiff() async {
     _logger.info("Pulling remote diff");
     final isFirstSync = !_collectionsService.hasSyncedCollections();

--- a/mobile/apps/photos/lib/ui/viewer/gallery/collection_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/collection_page.dart
@@ -25,6 +25,7 @@ import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.da
 import "package:photos/ui/viewer/gallery/state/inherited_search_filter_data.dart";
 import "package:photos/ui/viewer/gallery/state/search_filter_data_provider.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
+import "package:photos/ui/viewer/gallery/sync_aware_empty_state.dart";
 
 class CollectionPage extends StatelessWidget {
   final CollectionWithThumbnail c;
@@ -116,7 +117,7 @@ class CollectionPage extends StatelessWidget {
                 );
               },
             )
-          : const EmptyState(),
+          : const SyncAwareEmptyState(),
       footer: const SizedBox(height: 212),
       fileToJumpTo: fileToJumpTo,
     );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery.dart
@@ -26,7 +26,6 @@ import "package:photos/ui/viewer/gallery/component/gallery_file_widget.dart";
 import "package:photos/ui/viewer/gallery/component/group/group_header_widget.dart";
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
 import "package:photos/ui/viewer/gallery/component/sectioned_sliver_list.dart";
-import 'package:photos/ui/viewer/gallery/empty_state.dart';
 import "package:photos/ui/viewer/gallery/gallery_app_bar_config.dart";
 import "package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart";
 import "package:photos/ui/viewer/gallery/scrollbar/custom_scroll_bar.dart";
@@ -37,6 +36,7 @@ import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.da
 import "package:photos/ui/viewer/gallery/state/inherited_search_filter_data.dart";
 import "package:photos/ui/viewer/gallery/swipe_selection_wrapper.dart";
 import "package:photos/ui/viewer/gallery/swipe_to_select_helper.dart";
+import "package:photos/ui/viewer/gallery/sync_aware_empty_state.dart";
 import "package:photos/utils/hierarchical_search_util.dart";
 import "package:photos/utils/misc_util.dart";
 import "package:photos/utils/widget_util.dart";
@@ -110,7 +110,7 @@ class Gallery extends StatefulWidget {
     this.header,
     this.footer = const SizedBox(height: 212),
     this.addHeaderOrFooterEmptyState = true,
-    this.emptyState = const EmptyState(),
+    this.emptyState = const SyncAwareEmptyState(),
     this.albumName = '',
     this.groupType,
     this.enableFileGrouping = true,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/sync_aware_empty_state.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/sync_aware_empty_state.dart
@@ -1,0 +1,98 @@
+import "dart:async";
+
+import "package:flutter/material.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/ente_theme_data.dart";
+import "package:photos/events/sync_status_update_event.dart";
+import "package:photos/generated/l10n.dart";
+import "package:photos/services/sync/remote_sync_service.dart";
+import "package:photos/services/sync/sync_service.dart";
+import "package:photos/ui/common/loading_widget.dart";
+import "package:photos/ui/viewer/gallery/empty_state.dart";
+
+class SyncAwareEmptyState extends StatefulWidget {
+  @visibleForTesting
+  static const recheckInterval = Duration(seconds: 3);
+
+  final Widget child;
+
+  @visibleForTesting
+  final ValueGetter<bool>? isSyncInProgress;
+
+  const SyncAwareEmptyState({
+    this.child = const EmptyState(),
+    this.isSyncInProgress,
+    super.key,
+  });
+
+  @override
+  State<SyncAwareEmptyState> createState() => _SyncAwareEmptyStateState();
+}
+
+class _SyncAwareEmptyStateState extends State<SyncAwareEmptyState> {
+  late final StreamSubscription<SyncStatusUpdate> _syncStatusSubscription;
+  late final Timer _recheckTimer;
+  late bool _isSyncInProgress;
+
+  @override
+  void initState() {
+    super.initState();
+    _isSyncInProgress = _readSyncState();
+    _syncStatusSubscription = Bus.instance.on<SyncStatusUpdate>().listen((_) {
+      _refreshSyncState();
+    });
+    _recheckTimer = Timer.periodic(
+      SyncAwareEmptyState.recheckInterval,
+      (_) => _refreshSyncState(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _recheckTimer.cancel();
+    _syncStatusSubscription.cancel();
+    super.dispose();
+  }
+
+  bool _readSyncState() {
+    return widget.isSyncInProgress?.call() ??
+        (SyncService.instance.isSyncInProgress() ||
+            RemoteSyncService.instance.isNonSilentSyncInProgress());
+  }
+
+  void _refreshSyncState() {
+    if (!mounted) return;
+    final isSyncInProgress = _readSyncState();
+    if (_isSyncInProgress != isSyncInProgress) {
+      setState(() {
+        _isSyncInProgress = isSyncInProgress;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isSyncInProgress) {
+      return widget.child;
+    }
+
+    final textColor = Theme.of(
+      context,
+    ).colorScheme.defaultTextColor.withValues(alpha: 0.35);
+    return Center(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox.square(dimension: 24, child: EnteLoadingWidget()),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              AppLocalizations.of(context).syncing,
+              style: TextStyle(color: textColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/search/result/contact_result_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/contact_result_page.dart
@@ -30,7 +30,6 @@ import "package:photos/ui/collections/album/row_item.dart";
 import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/components/end_to_end_banner.dart";
 import "package:photos/ui/viewer/actions/file_selection_overlay_bar.dart";
-import "package:photos/ui/viewer/gallery/empty_state.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
 import "package:photos/ui/viewer/gallery/gallery_app_bar_config.dart";
 import "package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart";
@@ -40,6 +39,7 @@ import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.da
 import "package:photos/ui/viewer/gallery/state/inherited_search_filter_data.dart";
 import "package:photos/ui/viewer/gallery/state/search_filter_data_provider.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
+import "package:photos/ui/viewer/gallery/sync_aware_empty_state.dart";
 import "package:photos/ui/viewer/hierarchicial_search/app_bar_filter_chips.dart";
 import "package:photos/ui/viewer/people/person_selection_action_widgets.dart";
 import "package:photos/ui/viewer/search/contact_avatar_widget.dart";
@@ -155,7 +155,7 @@ class _ContactResultPageState extends State<ContactResultPage> {
       header: _buildPageHeader(context),
       emptyState: _shouldShowUnsavedContactEmptyState
           ? _UnsavedContactEmptyState(email: _contactEmail)
-          : const EmptyState(),
+          : const SyncAwareEmptyState(),
     );
 
     return GalleryBoundariesProvider(

--- a/mobile/apps/photos/test/ui/viewer/gallery/sync_aware_empty_state_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/gallery/sync_aware_empty_state_test.dart
@@ -1,0 +1,130 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/sync_status_update_event.dart";
+import "package:photos/generated/intl/app_localizations.dart";
+import "package:photos/models/file_load_result.dart";
+import "package:photos/ui/common/loading_widget.dart";
+import "package:photos/ui/viewer/gallery/empty_state.dart";
+import "package:photos/ui/viewer/gallery/gallery.dart";
+import "package:photos/ui/viewer/gallery/sync_aware_empty_state.dart";
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale("en"));
+
+  Widget testApp({required bool Function() isSyncInProgress, Widget? child}) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: SyncAwareEmptyState(
+        isSyncInProgress: isSyncInProgress,
+        child: child ?? const EmptyState(),
+      ),
+    );
+  }
+
+  test("Gallery uses the sync-aware empty state by default", () {
+    final gallery = Gallery(
+      asyncLoader: (_, _, {limit, asc}) async => FileLoadResult([], false),
+      tagPrefix: "test_gallery",
+    );
+
+    expect(gallery.emptyState, isA<SyncAwareEmptyState>());
+  });
+
+  testWidgets("shows syncing row only while sync is active", (tester) async {
+    var isSyncInProgress = false;
+    await tester.pumpWidget(testApp(isSyncInProgress: () => isSyncInProgress));
+
+    expect(find.text(l10n.nothingToSeeHere), findsOneWidget);
+    expect(find.text(l10n.syncing), findsNothing);
+    expect(find.byType(EnteLoadingWidget), findsNothing);
+
+    isSyncInProgress = true;
+    Bus.instance.fire(SyncStatusUpdate(SyncStatus.applyingRemoteDiff));
+    await tester.pump(Duration.zero);
+
+    expect(find.text(l10n.nothingToSeeHere), findsNothing);
+    expect(find.text(l10n.syncing), findsOneWidget);
+    expect(find.byType(EnteLoadingWidget), findsOneWidget);
+
+    isSyncInProgress = false;
+    Bus.instance.fire(SyncStatusUpdate(SyncStatus.completedBackup));
+    await tester.pump(Duration.zero);
+
+    expect(find.text(l10n.nothingToSeeHere), findsOneWidget);
+    expect(find.text(l10n.syncing), findsNothing);
+    expect(find.byType(EnteLoadingWidget), findsNothing);
+  });
+
+  testWidgets("reads active sync state on first build", (tester) async {
+    await tester.pumpWidget(testApp(isSyncInProgress: () => true));
+
+    expect(find.text(l10n.syncing), findsOneWidget);
+    expect(find.byType(EnteLoadingWidget), findsOneWidget);
+  });
+
+  testWidgets("rechecks an active sync without a terminal event", (
+    tester,
+  ) async {
+    var isSyncInProgress = true;
+    await tester.pumpWidget(testApp(isSyncInProgress: () => isSyncInProgress));
+    expect(find.text(l10n.syncing), findsOneWidget);
+
+    isSyncInProgress = false;
+    await tester.pump(SyncAwareEmptyState.recheckInterval);
+
+    expect(find.text(l10n.nothingToSeeHere), findsOneWidget);
+    expect(find.text(l10n.syncing), findsNothing);
+  });
+
+  testWidgets("rechecks an idle gallery when sync starts quietly", (
+    tester,
+  ) async {
+    var isSyncInProgress = false;
+    await tester.pumpWidget(testApp(isSyncInProgress: () => isSyncInProgress));
+    expect(find.text(l10n.nothingToSeeHere), findsOneWidget);
+
+    isSyncInProgress = true;
+    await tester.pump(SyncAwareEmptyState.recheckInterval);
+
+    expect(find.text(l10n.syncing), findsOneWidget);
+    expect(find.byType(EnteLoadingWidget), findsOneWidget);
+  });
+
+  testWidgets("preserves a custom empty state while idle", (tester) async {
+    const customEmptyState = Text("Custom empty state");
+    await tester.pumpWidget(
+      testApp(isSyncInProgress: () => false, child: customEmptyState),
+    );
+
+    expect(find.byWidget(customEmptyState), findsOneWidget);
+    expect(find.text(l10n.syncing), findsNothing);
+  });
+
+  testWidgets("fits narrow screens at large accessibility text sizes", (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale("de"),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: const TextScaler.linear(3)),
+            child: SyncAwareEmptyState(isSyncInProgress: () => true),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Description

- show the Ente loading indicator and localized `Syncing...` text in a horizontal row whenever a default gallery empty state is visible during an active sync
- make this the default for `Gallery`, including shared-collection and contact-result galleries that explicitly used the generic empty state
- preserve deliberate custom empty states and actions, including Albums, owned albums, Archive, Hidden, Trash, Uncategorized, cleanup, and unsaved-contact surfaces
- recheck the live sync predicate every three seconds so both quiet sync starts and quiet sync finishes are reflected even when no status event is emitted
- constrain the spinner and make the label flexible so long translations and accessibility text scaling do not overflow

## Claude review follow-up

Claude ran `/code-review` with focused correctness, lifecycle, scope, event-ordering, and layout checks.

- removed the redundant first-sync Home reload; remote file batches already publish `LocalPhotosUpdatedEvent`
- closed the idle-to-syncing event gap with the same low-frequency fallback already needed for terminal ordering
- fixed the confirmed `RenderFlex` overflow with a 24x24 spinner slot and flexible label
- retained the default behavior for every gallery that would otherwise show the generic empty state, including filtered or utility galleries, because that is the requested product scope
- kept custom product empty states excluded
- squashed the branch to one reviewable commit

## Verification

### Automated

- `flutter test test/ui/viewer/gallery/sync_aware_empty_state_test.dart` - 7/7 passed
- `flutter analyze` on all changed Dart files - no issues
- `cargo codegen frb` - passed
- `flutter build ios --simulator --debug --no-pub` - passed
- GitHub `Lint (Mobile)` full lint-and-test workflow - passed in 15m28s

The focused tests cover:

- default generic gallery while idle
- active sync on first mount
- event-driven idle -> syncing -> idle transitions
- quiet idle -> syncing fallback
- quiet syncing -> idle fallback
- custom empty-state preservation
- 320px-wide screen with German localization at 3x accessibility text scale

### Manual iOS Simulator matrix

Tested on the `Ente Sync State` iOS 26.5 simulator with a temporary 45-second sync delay that was removed before commit.

| Scenario | Result |
| --- | --- |
| Empty Home gallery during active account-less local sync | Ente spinner and localized `Syncing...` row shown |
| Accessibility tree during active sync | Exposes `Syncing...` as readable text |
| Albums tab during the same active sync | Custom `No albums on this device` state remains unchanged |
| Return to Home while sync is active | Syncing row remains visible |
| Home after sync completion | Restores `Nothing to see here` within the fallback interval |
| Repeated relaunches | Active and completed states remain consistent |

## Screen recording

The recording shows Home during sync, the custom Albums empty state during the same sync, and Home after sync completion.

https://github.com/user-attachments/assets/35902b88-8632-4073-89f0-bf218bf49c60

