### PR TITLE
[mob][locker] Enable synchronous build context lint

### DIFF
--- a/mobile/apps/locker/analysis_options.yaml
+++ b/mobile/apps/locker/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  errors:
+    use_build_context_synchronously: error

--- a/mobile/apps/locker/lib/l10n/app_en.arb
+++ b/mobile/apps/locker/lib/l10n/app_en.arb
@@ -1049,6 +1049,7 @@
   "editNotSupportedForSharedFiles": "Edit is not supported for shared files",
   "deleteNotSupportedForSharedFiles": "Delete is not supported for shared files",
   "importantNotSupportedForSharedFiles": "Important is not supported for shared files",
+  "canOnlyRemoveFilesOwnedByYou": "Can only remove files owned by you",
   "sharingSection": "Sharing",
   "sharingEnabledToggle": "Sharing enabled",
   "publicLinkSection": "Public Link",

--- a/mobile/apps/locker/lib/services/collections/collections_service.dart
+++ b/mobile/apps/locker/lib/services/collections/collections_service.dart
@@ -14,6 +14,7 @@ import "package:flutter/material.dart";
 import 'package:locker/core/errors.dart';
 import 'package:locker/events/collections_updated_event.dart';
 import 'package:locker/events/user_details_refresh_event.dart';
+import 'package:locker/l10n/l10n.dart';
 import "package:locker/services/collections/collections_api_client.dart";
 import 'package:locker/services/collections/models/collection.dart';
 import "package:locker/services/collections/models/files_split.dart";
@@ -475,7 +476,7 @@ class CollectionService {
   }
 
   Future<void> trashCollection(
-    BuildContext context,
+    BuildContext? context,
     Collection collection, {
     bool keepFiles = true,
   }) async {
@@ -487,14 +488,18 @@ class CollectionService {
   }
 
   Future<void> trashCollectionKeepingFiles(
-    BuildContext context,
+    BuildContext? context,
     Collection collection,
   ) async {
     try {
       final files = await _db.getFilesInCollection(collection);
 
       if (files.isNotEmpty) {
-        await moveFilesFromCurrentCollection(context, collection, files);
+        await moveFilesFromCurrentCollection(
+          context != null && context.mounted ? context : null,
+          collection,
+          files,
+        );
       }
 
       await _apiClient.trashCollection(collection, keepFiles: true);
@@ -558,7 +563,7 @@ class CollectionService {
   }
 
   Future<void> moveFilesFromCurrentCollection(
-    BuildContext context,
+    BuildContext? context,
     Collection collection,
     Iterable<EnteFile> files, {
     bool isHidden = false,
@@ -585,7 +590,9 @@ class CollectionService {
     }
 
     if (!isCollectionOwner && split.ownedByOtherUsers.isNotEmpty) {
-      showShortToast(context, "Can only remove files owned by you");
+      if (context != null && context.mounted) {
+        showShortToast(context, context.l10n.canOnlyRemoveFilesOwnedByYou);
+      }
       return;
     }
 

--- a/mobile/apps/locker/lib/services/favorites_service.dart
+++ b/mobile/apps/locker/lib/services/favorites_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:ente_events/event_bus.dart';
-import 'package:flutter/material.dart';
 import 'package:locker/events/collections_updated_event.dart';
 import 'package:locker/services/collections/collections_service.dart';
 import 'package:locker/services/collections/models/collection.dart';
@@ -134,7 +133,7 @@ class FavoritesService {
     }
   }
 
-  Future<void> addToFavorites(BuildContext context, EnteFile file) async {
+  Future<void> addToFavorites(EnteFile file) async {
     final collectionID = await _getOrCreateFavoriteCollectionID();
 
     final List<EnteFile> files = [file];
@@ -154,11 +153,7 @@ class FavoritesService {
     _collectionService.sync().ignore();
   }
 
-  Future<void> updateFavorites(
-    BuildContext context,
-    List<EnteFile> files,
-    bool favFlag,
-  ) async {
+  Future<void> updateFavorites(List<EnteFile> files, bool favFlag) async {
     final int currentUserID = Configuration.instance.getUserID()!;
     if (files.any((f) => f.uploadedFileID == null)) {
       throw AssertionError("Can only favorite uploaded items");
@@ -201,7 +196,7 @@ class FavoritesService {
     _updateFavoriteFilesCache(files, favFlag: favFlag);
   }
 
-  Future<void> removeFromFavorites(BuildContext context, EnteFile file) async {
+  Future<void> removeFromFavorites(EnteFile file) async {
     final inUploadID = file.uploadedFileID;
     if (inUploadID == null) {
       // Do nothing, ignore

--- a/mobile/apps/locker/lib/services/files/offline/offline_files_service.dart
+++ b/mobile/apps/locker/lib/services/files/offline/offline_files_service.dart
@@ -64,24 +64,25 @@ class OfflineFilesService {
       'Mark offline requested for ${eligibleFiles.length} eligible files',
     );
 
-    if (eligibleFiles.isEmpty || !context.mounted) {
+    if (eligibleFiles.isEmpty) {
       _logger.fine('No eligible files to mark offline');
       return false;
     }
 
     final total = eligibleFiles.length;
-    final dialog = createProgressDialog(
-      context,
-      total == 1
-          ? context.l10n.savingOffline
-          : '${context.l10n.savingOffline} 0/$total',
-      isDismissible: false,
-    );
+    final savingOffline = context.mounted ? context.l10n.savingOffline : null;
+    final dialog = savingOffline == null
+        ? null
+        : createProgressDialog(
+            context,
+            total == 1 ? savingOffline : '$savingOffline 0/$total',
+            isDismissible: false,
+          );
 
     var successCount = 0;
     var failureCount = 0;
 
-    await dialog.show();
+    await dialog?.show();
 
     try {
       for (var index = 0; index < eligibleFiles.length; index++) {
@@ -89,11 +90,13 @@ class OfflineFilesService {
         final fileID = file.uploadedFileID!;
         final currentStep = index + 1;
 
-        dialog.update(
-          message: total == 1
-              ? context.l10n.savingOffline
-              : '${context.l10n.savingOffline} $currentStep/$total',
-        );
+        if (context.mounted && dialog != null) {
+          dialog.update(
+            message: total == 1
+                ? savingOffline
+                : '$savingOffline $currentStep/$total',
+          );
+        }
 
         final alreadyHasOfflineCopy =
             LockerDB.instance.isFileMarkedOffline(file) &&
@@ -125,7 +128,7 @@ class OfflineFilesService {
       }
     } finally {
       try {
-        await dialog.hide();
+        await dialog?.hide();
       } catch (_) {}
     }
 

--- a/mobile/apps/locker/lib/ui/pages/base_info_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/base_info_page.dart
@@ -300,6 +300,8 @@ abstract class BaseInfoPageState<T extends InfoData, W extends BaseInfoPage<T>>
     // Handle collection membership changes
     await _updateCollectionMembership();
 
+    if (!mounted) return;
+
     // Update the local data to reflect the changes in the UI
     // Use the infoItem data directly since it contains the updated values
     setState(() {
@@ -336,15 +338,9 @@ abstract class BaseInfoPageState<T extends InfoData, W extends BaseInfoPage<T>>
     );
 
     if (wasFavorite && !isFavoriteNow) {
-      await FavoritesService.instance.removeFromFavorites(
-        context,
-        widget.existingFile!,
-      );
+      await FavoritesService.instance.removeFromFavorites(widget.existingFile!);
     } else if (!wasFavorite && isFavoriteNow) {
-      await FavoritesService.instance.addToFavorites(
-        context,
-        widget.existingFile!,
-      );
+      await FavoritesService.instance.addToFavorites(widget.existingFile!);
     }
 
     // Only favorites is special-cased; Uncategorized is treated as a normal
@@ -371,7 +367,7 @@ abstract class BaseInfoPageState<T extends InfoData, W extends BaseInfoPage<T>>
             (c) => c.id == collectionId,
           );
           await CollectionService.instance.moveFilesFromCurrentCollection(
-            context,
+            mounted ? context : null,
             collection,
             [widget.existingFile!],
           );
@@ -405,7 +401,7 @@ abstract class BaseInfoPageState<T extends InfoData, W extends BaseInfoPage<T>>
             (c) => c.id == collectionId,
           );
           await CollectionService.instance.moveFilesFromCurrentCollection(
-            context,
+            mounted ? context : null,
             collection,
             [widget.existingFile!],
           );
@@ -449,6 +445,8 @@ abstract class BaseInfoPageState<T extends InfoData, W extends BaseInfoPage<T>>
     // Trigger sync after successful save
     await CollectionService.instance.sync();
     Bus.instance.fire(UserDetailsRefreshEvent());
+
+    if (!mounted) return;
 
     // Show success message
     final collectionCount = selectedCollections.length;

--- a/mobile/apps/locker/lib/ui/pages/collection_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/collection_page.dart
@@ -178,6 +178,7 @@ class _CollectionPageState extends UploaderPageState<CollectionPage>
       }
     } catch (e, s) {
       _logger.severe(e, s);
+      if (!mounted) return;
       await showLockerErrorSheet(context, e);
     }
   }

--- a/mobile/apps/locker/lib/ui/pages/trash_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/trash_page.dart
@@ -72,26 +72,31 @@ class _TrashPageState extends State<TrashPage> {
       illustration: LockerBottomSheetIllustration.collectionDelete,
     );
 
-    if (result?.buttonResult.action == ButtonAction.first && mounted) {
+    if (result?.buttonResult.action == ButtonAction.first) {
       await _performEmptyTrash();
     }
   }
 
   Future<void> _performEmptyTrash() async {
     if (_trashFiles.isEmpty) {
-      showToast(context, context.l10n.trashIsEmpty);
+      if (mounted) {
+        showToast(context, context.l10n.trashIsEmpty);
+      }
       return;
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.clearingTrash,
-      isDismissible: false,
-    );
-    await dialog.show();
+    final dialog = mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.clearingTrash,
+            isDismissible: false,
+          )
+        : null;
+    await dialog?.show();
     try {
       await TrashService.instance.emptyTrash();
-      await dialog.hide();
+      await dialog?.hide();
+      if (!mounted) return;
       _selectedFiles.clearAll();
       setState(() {
         _trashFiles.clear();
@@ -99,7 +104,7 @@ class _TrashPageState extends State<TrashPage> {
       showToast(context, context.l10n.trashClearedSuccessfully);
       Navigator.of(context).pop();
     } catch (error) {
-      await dialog.hide();
+      await dialog?.hide();
       if (mounted) {
         await showLockerErrorSheet(context, error);
       }

--- a/mobile/apps/locker/lib/ui/pages/uploader_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/uploader_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:ente_components/ente_components.dart';
 import 'package:ente_events/event_bus.dart';
+import 'package:ente_ui/components/progress_dialog.dart';
 import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import "package:ente_utils/email_util.dart";
@@ -43,6 +44,10 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
       allowMultiple: true,
     );
 
+    if (!mounted) {
+      return false;
+    }
+
     if (result != null && result.files.isNotEmpty) {
       final selectedFiles = result.files
           .where((file) => file.path != null)
@@ -60,16 +65,19 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
   Future<bool> uploadFiles(List<File> files) async {
     var didUpload = false;
     var hasUploadError = false;
-    final progressDialog = createProgressDialog(
-      context,
-      context.l10n.uploadedFilesProgress(0, files.length),
-    );
+    var didShowDialog = false;
+    final l10n = context.l10n;
+    ProgressDialog? progressDialog;
 
     try {
-      final List<Future> futures = [];
+      final futures = <Future<void>>[];
 
       final regularCollections = await CollectionService.instance
           .getCollectionsForUI();
+
+      if (!mounted) {
+        return false;
+      }
 
       // Navigate to upload screen to get collection selection
       final uploadResult = await Navigator.of(context)
@@ -98,7 +106,14 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
           uploadResult.selectedCollections.add(uncategorizedCollection);
         }
 
-        await progressDialog.show();
+        if (mounted) {
+          final dialog = createProgressDialog(
+            context,
+            l10n.uploadedFilesProgress(0, files.length),
+          );
+          progressDialog = dialog;
+          didShowDialog = await dialog.show();
+        }
 
         int completedUploads = 0;
         for (final file in files) {
@@ -107,64 +122,79 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
             uploadResult.selectedCollections.first,
           );
           futures.add(
-            fileUploadFuture
-                .then((enteFile) async {
-                  completedUploads++;
-                  if (!hasUploadError && progressDialog.isShowing()) {
-                    progressDialog.update(
-                      message: context.l10n.uploadedFilesProgress(
+            fileUploadFuture.then<void>(
+              (enteFile) async {
+                completedUploads++;
+                if (didShowDialog &&
+                    mounted &&
+                    !hasUploadError &&
+                    progressDialog?.isShowing() == true) {
+                  try {
+                    progressDialog?.update(
+                      message: l10n.uploadedFilesProgress(
                         completedUploads,
                         files.length,
                       ),
                     );
+                  } catch (e, s) {
+                    _logger.warning('Failed to update upload progress', e, s);
                   }
-                  // Add to additional collections if multiple were selected
-                  for (
-                    int cIndex = 1;
-                    cIndex < uploadResult.selectedCollections.length;
-                    cIndex++
-                  ) {
-                    // Don't trigger a sync for each additional collection – do one
-                    // sync at the end after all files are processed.
-                    futures.add(
-                      CollectionService.instance.addToCollection(
-                        uploadResult.selectedCollections[cIndex],
-                        enteFile,
-                        runSync: false,
-                      ),
-                    );
-                  }
+                }
 
-                  if (uploadResult.note.isNotEmpty) {
-                    futures.add(
-                      MetadataUpdaterService.instance.editFileCaption(
-                        enteFile,
-                        uploadResult.note,
-                      ),
-                    );
-                  }
-                })
-                .catchError((e) async {
-                  completedUploads++;
-                  _logger.severe('File upload failed', e);
-                  if (hasUploadError) {
-                    return;
-                  }
-                  hasUploadError = true;
-                  if (progressDialog.isShowing()) {
-                    await progressDialog.hide();
-                  }
-                  if (mounted) {
-                    await _showUploadFailureError(e);
-                  }
-                }),
+                final postUploadFutures = <Future<dynamic>>[];
+                // Add to additional collections if multiple were selected
+                for (
+                  int cIndex = 1;
+                  cIndex < uploadResult.selectedCollections.length;
+                  cIndex++
+                ) {
+                  // Don't trigger a sync for each additional collection – do one
+                  // sync at the end after all files are processed.
+                  postUploadFutures.add(
+                    CollectionService.instance.addToCollection(
+                      uploadResult.selectedCollections[cIndex],
+                      enteFile,
+                      runSync: false,
+                    ),
+                  );
+                }
+
+                if (uploadResult.note.isNotEmpty) {
+                  postUploadFutures.add(
+                    MetadataUpdaterService.instance.editFileCaption(
+                      enteFile,
+                      uploadResult.note,
+                    ),
+                  );
+                }
+
+                await Future.wait(postUploadFutures);
+              },
+              onError: (Object e, StackTrace s) async {
+                completedUploads++;
+                _logger.severe('File upload failed', e, s);
+                if (hasUploadError) {
+                  return;
+                }
+                hasUploadError = true;
+                if (didShowDialog && progressDialog?.isShowing() == true) {
+                  await progressDialog?.hide();
+                  didShowDialog = false;
+                }
+                if (mounted) {
+                  await _showUploadFailureError(e);
+                }
+              },
+            ),
           );
         }
 
         if (futures.isNotEmpty) {
           await Future.wait(futures);
 
-          onFileUploadComplete();
+          if (mounted) {
+            onFileUploadComplete();
+          }
           Bus.instance.fire(UserDetailsRefreshEvent());
 
           await CollectionService.instance.sync().catchError((e) {
@@ -173,16 +203,18 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
         }
       }
     } catch (e, s) {
-      _logger.severe('Failed to upload file', e, s);
-      if (progressDialog.isShowing()) {
-        await progressDialog.hide();
+      _logger.severe('Failed to complete file upload', e, s);
+      if (didShowDialog && progressDialog?.isShowing() == true) {
+        await progressDialog?.hide();
+        didShowDialog = false;
       }
       if (mounted) {
         await _showUploadFailureError(e);
       }
     } finally {
-      if (progressDialog.isShowing()) {
-        await progressDialog.hide();
+      if (didShowDialog && progressDialog?.isShowing() == true) {
+        await progressDialog?.hide();
+        didShowDialog = false;
       }
     }
 

--- a/mobile/apps/locker/lib/ui/settings/pages/account_settings_page.dart
+++ b/mobile/apps/locker/lib/ui/settings/pages/account_settings_page.dart
@@ -63,61 +63,65 @@ class AccountSettingsPage extends StatelessWidget {
     final l10n = context.l10n;
     final hasAuthenticated = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, l10n.authToChangeYourEmail);
-    if (hasAuthenticated) {
-      // ignore: unawaited_futures
-      showChangeEmailDialog(context);
+    if (!context.mounted || !hasAuthenticated) {
+      return;
     }
+    // ignore: unawaited_futures
+    showChangeEmailDialog(context);
   }
 
   Future<void> _onRecoveryKeyTapped(BuildContext context) async {
     final l10n = context.l10n;
     final hasAuthenticated = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, l10n.authToViewYourRecoveryKey);
-    if (hasAuthenticated) {
-      String recoveryKey;
-      try {
-        recoveryKey = CryptoUtil.bin2hex(
-          Configuration.instance.getRecoveryKey(),
-        );
-      } catch (e) {
-        await showErrorBottomSheetComponent<void>(
-          context: context,
-          message: parseErrorForUI(
-            context,
-            context.strings.itLooksLikeSomethingWentWrongPleaseRetryAfterSome,
-            error: e,
-            surfaceError: false,
-          ),
-          title: context.strings.error,
-          actionLabel: context.strings.contactSupport,
-          onActionTap: () async {
-            await sendLogs(context, "support@ente.com", postShare: () {});
-          },
-        );
-        return;
-      }
-      await showRecoveryKeySheet(context, recoveryKey: recoveryKey);
+    if (!context.mounted || !hasAuthenticated) {
+      return;
     }
+    String recoveryKey;
+    try {
+      recoveryKey = CryptoUtil.bin2hex(Configuration.instance.getRecoveryKey());
+    } catch (e) {
+      await showErrorBottomSheetComponent<void>(
+        context: context,
+        message: parseErrorForUI(
+          context,
+          context.strings.itLooksLikeSomethingWentWrongPleaseRetryAfterSome,
+          error: e,
+          surfaceError: false,
+        ),
+        title: context.strings.error,
+        actionLabel: context.strings.contactSupport,
+        onActionTap: () async {
+          await sendLogs(context, "support@ente.com", postShare: () {});
+        },
+      );
+      return;
+    }
+    if (!context.mounted) {
+      return;
+    }
+    await showRecoveryKeySheet(context, recoveryKey: recoveryKey);
   }
 
   Future<void> _onChangePasswordTapped(BuildContext context) async {
     final l10n = context.l10n;
     final hasAuthenticated = await LocalAuthenticationService.instance
         .requestLocalAuthentication(context, l10n.authToChangeYourPassword);
-    if (hasAuthenticated) {
-      // ignore: unawaited_futures
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (BuildContext context) {
-            return PasswordEntryPage(
-              Configuration.instance,
-              PasswordEntryMode.update,
-              const HomePage(),
-            );
-          },
-        ),
-      );
+    if (!context.mounted || !hasAuthenticated) {
+      return;
     }
+    // ignore: unawaited_futures
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (BuildContext context) {
+          return PasswordEntryPage(
+            Configuration.instance,
+            PasswordEntryMode.update,
+            const HomePage(),
+          );
+        },
+      ),
+    );
   }
 
   Future<void> _onDeleteAccountTapped(BuildContext context) async {

--- a/mobile/apps/locker/lib/ui/settings/pages/security_settings_page.dart
+++ b/mobile/apps/locker/lib/ui/settings/pages/security_settings_page.dart
@@ -80,10 +80,11 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
           context,
           context.l10n.authToChangeEmailVerificationSetting,
         );
-    final isEmailMFAEnabled = UserService.instance.hasEmailMFAEnabled();
-    if (hasAuthenticated) {
-      await _updateEmailMFA(!isEmailMFAEnabled);
+    if (!hasAuthenticated) {
+      return;
     }
+    final isEmailMFAEnabled = UserService.instance.hasEmailMFAEnabled();
+    await _updateEmailMFA(!isEmailMFAEnabled);
   }
 
   Widget _buildPasskeyItem(BuildContext context) {
@@ -108,16 +109,17 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
               context,
               l10n.authToViewYourActiveSessions,
             );
-        if (hasAuthenticated) {
-          // ignore: unawaited_futures
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (BuildContext context) {
-                return SessionsPage(Configuration.instance);
-              },
-            ),
-          );
+        if (!context.mounted || !hasAuthenticated) {
+          return;
         }
+        // ignore: unawaited_futures
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (BuildContext context) {
+              return SessionsPage(Configuration.instance);
+            },
+          ),
+        );
       },
     );
   }
@@ -134,21 +136,27 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
 
   Future<void> _onAppLockTapped(BuildContext context) async {
     final l10n = context.l10n;
-    if (await LockScreenSettings.instance.isDeviceSupported()) {
+    final isDeviceSupported = await LockScreenSettings.instance
+        .isDeviceSupported();
+    if (!context.mounted) {
+      return;
+    }
+    if (isDeviceSupported) {
       final hasAuthenticated = await LocalAuthenticationService.instance
           .requestLocalAuthentication(
             context,
             l10n.authToChangeLockscreenSetting,
           );
-      if (hasAuthenticated) {
-        await Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (BuildContext context) {
-              return const LockScreenOptions();
-            },
-          ),
-        );
+      if (!context.mounted || !hasAuthenticated) {
+        return;
       }
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (BuildContext context) {
+            return const LockScreenOptions();
+          },
+        ),
+      );
     } else {
       await showBottomSheetComponent<void>(
         context: context,
@@ -174,13 +182,14 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
 
   Future<void> _onPasskeyClick(BuildContext buildContext) async {
     try {
+      final reason = buildContext.l10n.authToViewPasskey;
       final hasAuthenticated = await LocalAuthenticationService.instance
           .requestLocalAuthentication(
-            context,
-            context.l10n.authToViewPasskey,
+            buildContext,
+            reason,
             refocusWindows: false,
           );
-      if (!hasAuthenticated) {
+      if (!buildContext.mounted || !hasAuthenticated) {
         return;
       }
       final isPassKeyResetEnabled = await PasskeyService.instance
@@ -196,13 +205,19 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
           CryptoUtil.bin2base64(encryptionResult.nonce!),
         );
       }
+      if (!buildContext.mounted) {
+        return;
+      }
       await PasskeyService.instance.openPasskeyPage(buildContext);
     } catch (e, s) {
       _logger.severe("failed to open passkey page", e, s);
+      if (!buildContext.mounted) {
+        return;
+      }
       await showErrorBottomSheetComponent<void>(
-        context: context,
+        context: buildContext,
         message: e.toString(),
-        title: context.l10n.somethingWentWrong,
+        title: buildContext.l10n.somethingWentWrong,
       );
     }
   }
@@ -213,6 +228,9 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
         memoryCount: false,
       );
       if ((details.profileData?.canDisableEmailMFA ?? false) == false) {
+        if (!mounted) {
+          return;
+        }
         final result = await Navigator.of(context).push<bool>(
           MaterialPageRoute(
             builder: (BuildContext context) {
@@ -234,6 +252,9 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
       }
       await UserService.instance.updateEmailMFA(isEnabled);
     } catch (e) {
+      if (!mounted) {
+        return;
+      }
       await showErrorBottomSheetComponent<void>(
         context: context,
         message: e.toString(),

--- a/mobile/apps/locker/lib/ui/sharing/manage_links_widget.dart
+++ b/mobile/apps/locker/lib/ui/sharing/manage_links_widget.dart
@@ -91,7 +91,9 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                           context,
                           LinkExpiryPickerPage(widget.collection!),
                         ).then((value) {
-                          setState(() {});
+                          if (mounted) {
+                            setState(() {});
+                          }
                         }),
                       );
                     },
@@ -118,7 +120,9 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                           context,
                           DeviceLimitPickerPage(widget.collection!),
                         ).then((value) {
-                          setState(() {});
+                          if (mounted) {
+                            setState(() {});
+                          }
                         }),
                       );
                     },
@@ -153,7 +157,7 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                                 password,
                               );
                               await _updateUrlSettings(
-                                context,
+                                context.mounted ? context : null,
                                 propToUpdate,
                                 showProgressDialog: false,
                               );
@@ -196,6 +200,9 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                       showOnlyLoadingState: true,
                       onTap: () async {
                         await Clipboard.setData(ClipboardData(text: urlValue));
+                        if (!context.mounted) {
+                          return;
+                        }
                         showShortToast(
                           context,
                           context.l10n.linkCopiedToClipboard,
@@ -245,11 +252,12 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
                         context,
                         widget.collection!,
                       );
-                      if (result && mounted) {
+                      if (!context.mounted || !result) {
+                        return;
+                      }
+                      Navigator.of(context).pop();
+                      if (widget.collection!.isQuickLinkCollection()) {
                         Navigator.of(context).pop();
-                        if (widget.collection!.isQuickLinkCollection()) {
-                          Navigator.of(context).pop();
-                        }
                       }
                     },
                   ),
@@ -277,11 +285,11 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
   }
 
   Future<void> _updateUrlSettings(
-    BuildContext context,
+    BuildContext? context,
     Map<String, dynamic> prop, {
     bool showProgressDialog = true,
   }) async {
-    final dialog = showProgressDialog
+    final dialog = showProgressDialog && context != null && context.mounted
         ? createProgressDialog(context, context.l10n.pleaseWait)
         : null;
     await dialog?.show();
@@ -291,13 +299,17 @@ class _ManageSharedLinkWidgetState extends State<ManageSharedLinkWidget> {
         prop,
       );
       await dialog?.hide();
-      showShortToast(context, context.l10n.collectionUpdated);
+      if (context != null && context.mounted) {
+        showShortToast(context, context.l10n.collectionUpdated);
+      }
       if (mounted) {
         setState(() {});
       }
     } catch (e) {
       await dialog?.hide();
-      await showLockerErrorSheet(context, e);
+      if (context != null && context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       rethrow;
     }
   }

--- a/mobile/apps/locker/lib/ui/sharing/pickers/device_limit_picker_page.dart
+++ b/mobile/apps/locker/lib/ui/sharing/pickers/device_limit_picker_page.dart
@@ -125,11 +125,13 @@ class _ItemsWidgetState extends State<ItemsWidget> {
       isBottomBorderRadiusRemoved: !isLast,
       showOnlyLoadingState: true,
       onTap: () async {
-        await _updateUrlSettings(context, {'deviceLimit': deviceLimit}).then(
-          (value) => setState(() {
-            currentDeviceLimit = deviceLimit;
-          }),
-        );
+        await _updateUrlSettings(context, {'deviceLimit': deviceLimit});
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          currentDeviceLimit = deviceLimit;
+        });
       },
     );
   }
@@ -144,7 +146,9 @@ class _ItemsWidgetState extends State<ItemsWidget> {
         prop,
       );
     } catch (e) {
-      await showLockerErrorSheet(context, e);
+      if (context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       rethrow;
     }
   }

--- a/mobile/apps/locker/lib/ui/sharing/pickers/link_expiry_picker_page.dart
+++ b/mobile/apps/locker/lib/ui/sharing/pickers/link_expiry_picker_page.dart
@@ -139,18 +139,18 @@ class _ItemsWidgetState extends State<ItemsWidget> {
           debugPrint(
             "Setting expire date to  ${DateTime.fromMicrosecondsSinceEpoch(newValidTill)}",
           );
-          await updateTime(newValidTill, context);
+          await updateTime(newValidTill, context.mounted ? context : null);
         }
       },
     );
   }
 
-  Future<void> updateTime(int newValidTill, BuildContext context) async {
+  Future<void> updateTime(int newValidTill, BuildContext? context) async {
     await _updateUrlSettings(context, {'validTill': newValidTill});
   }
 
   Future<void> _updateUrlSettings(
-    BuildContext context,
+    BuildContext? context,
     Map<String, dynamic> prop,
   ) async {
     try {
@@ -159,7 +159,9 @@ class _ItemsWidgetState extends State<ItemsWidget> {
         prop,
       );
     } catch (e) {
-      await showLockerErrorSheet(context, e);
+      if (context != null && context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       rethrow;
     }
   }

--- a/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
+++ b/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
@@ -315,7 +315,7 @@ class _ShareCollectionSheetState extends State<ShareCollectionSheet> {
     }
 
     final result = await _collectionActions.addEmailToCollection(
-      context,
+      mounted ? context : null,
       widget.collection,
       user.email,
       role,

--- a/mobile/apps/locker/lib/ui/utils/legacy_utils.dart
+++ b/mobile/apps/locker/lib/ui/utils/legacy_utils.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: use_build_context_synchronously
-
 import "package:ente_legacy/pages/create_legacy_kit_sheet.dart";
 import "package:ente_legacy/pages/emergency_page.dart";
 import "package:ente_legacy/pages/legacy_kit_intro_page.dart";

--- a/mobile/apps/locker/lib/ui/viewer/actions/collection_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/collection_selection_overlay_bar.dart
@@ -305,9 +305,13 @@ class _CollectionSelectionOverlayBarState
       await CollectionActions.editCollection(context, collection);
     } catch (e, s) {
       _logger.severe(e, s);
-      await showLockerErrorSheet(context, e);
+      if (mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
-    widget.selectedCollections.clearAll();
+    if (mounted) {
+      widget.selectedCollections.clearAll();
+    }
   }
 
   Future<void> _deleteCollection(Collection collection) async {
@@ -321,9 +325,13 @@ class _CollectionSelectionOverlayBarState
       await CollectionActions.deleteCollection(context, collection);
     } catch (e, s) {
       _logger.severe(e, s);
-      await showLockerErrorSheet(context, e);
+      if (mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
-    widget.selectedCollections.clearAll();
+    if (mounted) {
+      widget.selectedCollections.clearAll();
+    }
   }
 
   Future<void> _deleteMultipleCollections(Set<Collection> collections) async {
@@ -340,9 +348,13 @@ class _CollectionSelectionOverlayBarState
       );
     } catch (e, s) {
       _logger.severe(e, s);
-      await showLockerErrorSheet(context, e);
+      if (mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
-    widget.selectedCollections.clearAll();
+    if (mounted) {
+      widget.selectedCollections.clearAll();
+    }
   }
 
   Future<void> _shareCollection(Collection collection) async {
@@ -362,9 +374,13 @@ class _CollectionSelectionOverlayBarState
       await showShareCollectionSheet(context, collection: collection);
     } catch (e, s) {
       _logger.severe(e, s);
-      await showLockerErrorSheet(context, e);
+      if (mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
-    widget.selectedCollections.clearAll();
+    if (mounted) {
+      widget.selectedCollections.clearAll();
+    }
   }
 
   Future<void> _leaveCollections(List<Collection> collections) async {
@@ -381,8 +397,12 @@ class _CollectionSelectionOverlayBarState
       }
     } catch (e, s) {
       _logger.severe(e, s);
-      await showLockerErrorSheet(context, e);
+      if (mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
-    widget.selectedCollections.clearAll();
+    if (mounted) {
+      widget.selectedCollections.clearAll();
+    }
   }
 }

--- a/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -536,11 +536,20 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     List<EnteFile> files, {
     required bool shouldRemoveOffline,
   }) async {
-    final success = shouldRemoveOffline
-        ? await OfflineFilesService.instance.unmarkFilesOffline(context, files)
-        : await OfflineFilesService.instance.markFilesOffline(context, files);
+    late final bool success;
+    if (shouldRemoveOffline) {
+      success = await OfflineFilesService.instance.unmarkFilesOffline(
+        context,
+        files,
+      );
+    } else {
+      success = await OfflineFilesService.instance.markFilesOffline(
+        context,
+        files,
+      );
+    }
 
-    if (success) {
+    if (success && mounted) {
       widget.selectedFiles.clearAll();
     }
   }
@@ -548,7 +557,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
   Future<void> _downloadFile(BuildContext context, EnteFile file) async {
     try {
       final success = await FileUtil.downloadFile(context, file);
-      if (success) {
+      if (success && mounted) {
         widget.selectedFiles.clearAll();
       }
     } catch (e, stackTrace) {
@@ -569,7 +578,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
 
     try {
       final success = await FileUtil.downloadFiles(context, files);
-      if (success) {
+      if (success && mounted) {
         widget.selectedFiles.clearAll();
       }
     } catch (e, stackTrace) {
@@ -596,7 +605,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       return;
     }
     await FileActions.editFile(context, file);
-    widget.selectedFiles.clearAll();
+    if (mounted) {
+      widget.selectedFiles.clearAll();
+    }
   }
 
   Future<void> _showAddToDialog(
@@ -621,86 +632,98 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       'to add files to.',
     );
 
+    if (!context.mounted) return;
     final result = await showAddToCollectionSheet(
       context,
       collections: dedupedCollections,
     );
 
-    if (result != null && context.mounted) {
-      _logger.info(
-        'Add-to dialog submitted with '
-        '${result.selectedCollections.length} selected collection(s).',
-      );
-      final dialog = createProgressDialog(
-        context,
-        context.l10n.pleaseWait,
-        isDismissible: false,
-      );
+    if (result == null) return;
 
-      await dialog.show();
+    _logger.info(
+      'Add-to dialog submitted with '
+      '${result.selectedCollections.length} selected collection(s).',
+    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.pleaseWait,
+            isDismissible: false,
+          )
+        : null;
 
-      try {
-        final addFutures = <Future<void>>[];
+    await dialog?.show();
 
-        for (final file in ownedFiles) {
-          _logger.fine(
-            'Processing file ${file.uploadedFileID} for add-to operation',
+    try {
+      final addFutures = <Future<void>>[];
+
+      for (final file in ownedFiles) {
+        _logger.fine(
+          'Processing file ${file.uploadedFileID} for add-to operation',
+        );
+        List<Collection> currentCollections;
+        try {
+          currentCollections = await CollectionService.instance
+              .getCollectionsForFile(file);
+        } catch (_) {
+          _logger.warning(
+            'Failed to fetch existing collections for file ${file.uploadedFileID}',
           );
-          List<Collection> currentCollections;
-          try {
-            currentCollections = await CollectionService.instance
-                .getCollectionsForFile(file);
-          } catch (_) {
-            _logger.warning(
-              'Failed to fetch existing collections for file ${file.uploadedFileID}',
-            );
-            currentCollections = <Collection>[];
-          }
-
-          final currentCollectionIds = currentCollections
-              .map((collection) => collection.id)
-              .toSet();
-
-          final collectionsToAdd = result.selectedCollections.where(
-            (collection) => !currentCollectionIds.contains(collection.id),
-          );
-
-          for (final collection in collectionsToAdd) {
-            _logger.fine(
-              'Adding file ${file.uploadedFileID} to collection ${collection.id}.',
-            );
-            addFutures.add(
-              CollectionService.instance.addToCollection(
-                collection,
-                file,
-                runSync: false,
-              ),
-            );
-          }
+          currentCollections = <Collection>[];
         }
 
-        if (addFutures.isEmpty) {
-          await dialog.hide();
-          widget.selectedFiles.clearAll();
-          showToast(context, context.l10n.noChangesWereMade);
-          return;
-        }
+        final currentCollectionIds = currentCollections
+            .map((collection) => collection.id)
+            .toSet();
 
-        await Future.wait(addFutures);
-        await CollectionService.instance.sync();
-        _logger.info(
-          'Completed add-to operation for ${ownedFiles.length} file(s).',
+        final collectionsToAdd = result.selectedCollections.where(
+          (collection) => !currentCollectionIds.contains(collection.id),
         );
 
-        await dialog.hide();
+        for (final collection in collectionsToAdd) {
+          _logger.fine(
+            'Adding file ${file.uploadedFileID} to collection ${collection.id}.',
+          );
+          addFutures.add(
+            CollectionService.instance.addToCollection(
+              collection,
+              file,
+              runSync: false,
+            ),
+          );
+        }
+      }
 
+      if (addFutures.isEmpty) {
+        await dialog?.hide();
+        if (mounted) {
+          widget.selectedFiles.clearAll();
+        }
+        if (context.mounted) {
+          showToast(context, context.l10n.noChangesWereMade);
+        }
+        return;
+      }
+
+      await Future.wait(addFutures);
+      await CollectionService.instance.sync();
+      _logger.info(
+        'Completed add-to operation for ${ownedFiles.length} file(s).',
+      );
+
+      await dialog?.hide();
+
+      if (mounted) {
         widget.selectedFiles.clearAll();
-
+      }
+      if (context.mounted) {
         showToast(context, context.l10n.fileUpdatedSuccessfully);
-      } catch (e) {
-        await dialog.hide();
-        _logger.severe('Failed add-to operation: $e');
+      }
+    } catch (e) {
+      await dialog?.hide();
+      _logger.severe('Failed add-to operation: $e');
 
+      if (context.mounted) {
         await showLockerErrorSheet(context, e);
       }
     }
@@ -716,7 +739,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       context,
       file,
       onSuccess: () {
-        widget.selectedFiles.clearAll();
+        if (mounted) {
+          widget.selectedFiles.clearAll();
+        }
         Bus.instance.fire(CollectionsUpdatedEvent('file_deleted'));
       },
     );
@@ -743,14 +768,16 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       return;
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.deletingFile,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.deletingFile,
+            isDismissible: false,
+          )
+        : null;
 
     try {
-      await dialog.show();
+      await dialog?.show();
 
       for (final file in ownedFiles) {
         final collections = await CollectionService.instance
@@ -761,13 +788,16 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
         }
       }
 
-      await dialog.hide();
+      await dialog?.hide();
 
-      widget.selectedFiles.clearAll();
-
-      showToast(context, context.l10n.fileDeletedSuccessfully);
+      if (mounted) {
+        widget.selectedFiles.clearAll();
+      }
+      if (context.mounted) {
+        showToast(context, context.l10n.fileDeletedSuccessfully);
+      }
     } catch (e, stackTrace) {
-      await dialog.hide();
+      await dialog?.hide();
 
       _logger.severe(
         'Failed to delete files via selection bar: $e',
@@ -791,7 +821,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       context,
       file,
       onSuccess: () {
-        widget.selectedFiles.clearAll();
+        if (mounted) {
+          widget.selectedFiles.clearAll();
+        }
         Bus.instance.fire(CollectionsUpdatedEvent('file_important_toggled'));
       },
     );
@@ -810,7 +842,9 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       context,
       ownedFiles,
       onSuccess: () {
-        widget.selectedFiles.clearAll();
+        if (mounted) {
+          widget.selectedFiles.clearAll();
+        }
         Bus.instance.fire(CollectionsUpdatedEvent('files_marked_important'));
       },
     );
@@ -824,6 +858,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
     );
     final dedupedCollections = uniqueCollectionsById(allCollections);
 
+    if (!context.mounted) return;
     final result = await showAddToCollectionSheet(
       context,
       collections: dedupedCollections,
@@ -833,24 +868,26 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       return;
     }
 
-    if (!context.mounted) return;
-
     final targetCollection = result.selectedCollections.first;
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.restoringFiles,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.restoringFiles,
+            isDismissible: false,
+          )
+        : null;
 
-    await dialog.show();
+    await dialog?.show();
 
     try {
       await TrashService.instance.restore(files, targetCollection);
 
-      await dialog.hide();
+      await dialog?.hide();
 
-      widget.selectedFiles.clearAll();
+      if (mounted) {
+        widget.selectedFiles.clearAll();
+      }
 
       if (context.mounted) {
         showToast(
@@ -859,7 +896,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
         );
       }
     } catch (e, stackTrace) {
-      await dialog.hide();
+      await dialog?.hide();
       _logger.severe('Failed to restore files: $e', e, stackTrace);
 
       if (context.mounted) {
@@ -884,28 +921,32 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       return;
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.deletingFiles,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.deletingFiles,
+            isDismissible: false,
+          )
+        : null;
 
-    await dialog.show();
+    await dialog?.show();
 
     try {
       await TrashService.instance.deleteFromTrash(files);
 
       Bus.instance.fire(CollectionsUpdatedEvent('files_deleted_from_trash'));
 
-      await dialog.hide();
+      await dialog?.hide();
 
-      widget.selectedFiles.clearAll();
+      if (mounted) {
+        widget.selectedFiles.clearAll();
+      }
 
       if (context.mounted) {
         showToast(context, context.l10n.filesDeletedPermanently(files.length));
       }
     } catch (e, stackTrace) {
-      await dialog.hide();
+      await dialog?.hide();
       _logger.severe('Failed to delete files from trash: $e', e, stackTrace);
 
       if (context.mounted) {

--- a/mobile/apps/locker/lib/utils/collection_actions.dart
+++ b/mobile/apps/locker/lib/utils/collection_actions.dart
@@ -74,31 +74,31 @@ class CollectionActions {
     Collection collection, {
     VoidCallback? onSuccess,
   }) async {
+    final l10n = context.l10n;
     if (!collection.type.canEdit) {
-      showToast(context, context.l10n.collectionCannotBeEdited);
+      showToast(context, l10n.collectionCannotBeEdited);
       return;
     }
 
     await showTextInputSheet(
       context,
-      title: context.l10n.renameCollection,
+      title: l10n.renameCollection,
       initialValue: collection.name ?? '',
-      hintText: context.l10n.documentsHint,
-      submitButtonLabel: context.l10n.save,
+      hintText: l10n.documentsHint,
+      submitButtonLabel: l10n.save,
       onSubmit: (String newName) async {
         if (newName.isEmpty || newName == collection.name) return;
 
-        final progressDialog = createProgressDialog(
-          context,
-          context.l10n.pleaseWait,
-        );
+        final progressDialog = createProgressDialog(context, l10n.pleaseWait);
         await progressDialog.show();
 
         try {
           await CollectionService.instance.rename(collection, newName);
           await progressDialog.hide();
 
-          showToast(context, context.l10n.collectionRenamedSuccessfully);
+          if (context.mounted) {
+            showToast(context, l10n.collectionRenamedSuccessfully);
+          }
 
           // Update the collection name locally
           collection.setName(newName);
@@ -108,7 +108,9 @@ class CollectionActions {
         } catch (error) {
           await progressDialog.hide();
 
-          await showLockerErrorSheet(context, error);
+          if (context.mounted) {
+            await showLockerErrorSheet(context, error);
+          }
         }
       },
     );
@@ -120,31 +122,31 @@ class CollectionActions {
     VoidCallback? onSuccess,
   }) async {
     if (collections.isEmpty) return;
+    final l10n = context.l10n;
 
     final dialogChoice = await showDeleteConfirmationSheet(
       context,
-      title: context.l10n.areYouSure,
-      body: context.l10n.deleteMultipleCollectionsDialogBody(
-        collections.length,
-      ),
-      deleteButtonLabel: context.l10n.yesDeleteCollections(collections.length),
+      title: l10n.areYouSure,
+      body: l10n.deleteMultipleCollectionsDialogBody(collections.length),
+      deleteButtonLabel: l10n.yesDeleteCollections(collections.length),
       illustration: LockerBottomSheetIllustration.collectionDelete,
       showDeleteFromAllCollectionsOption: true,
     );
 
     if (dialogChoice?.buttonResult.action != ButtonAction.first) return;
 
-    final progressDialog = createProgressDialog(
-      context,
-      context.l10n.pleaseWait,
-    );
-    await progressDialog.show();
+    ProgressDialog? progressDialog;
+    if (context.mounted) {
+      progressDialog = createProgressDialog(context, l10n.pleaseWait);
+      await progressDialog.show();
+    }
 
     bool isFavoriteCollection = false;
     final bool keepFiles = !(dialogChoice?.deleteFromAllCollections ?? false);
     final List<Collection> emptyCollections = [];
     final List<Collection> nonEmptyCollections = [];
     final List<dynamic> errors = [];
+    var deletedCount = 0;
 
     try {
       for (final collection in collections) {
@@ -173,6 +175,7 @@ class CollectionActions {
             collection,
             isBulkDelete: true,
           );
+          deletedCount++;
         } catch (e, s) {
           _logger.severe("Failed to trash empty collection", e, s);
           errors.add(e);
@@ -187,36 +190,42 @@ class CollectionActions {
       for (final collection in nonEmptyCollections) {
         try {
           await CollectionService.instance.trashCollection(
-            context,
+            context.mounted ? context : null,
             collection,
             keepFiles: keepFiles,
           );
+          deletedCount++;
         } catch (e, s) {
           _logger.severe("Failed to trash collection", e, s);
           errors.add(e);
         }
       }
 
-      await progressDialog.hide();
+      await progressDialog?.hide();
 
-      if (errors.isNotEmpty) {
+      if (deletedCount > 0) {
+        onSuccess?.call();
+      }
+
+      if (errors.isNotEmpty && context.mounted) {
         await showLockerErrorSheet(context, errors.first);
       }
 
-      showToast(
-        context,
-        context.l10n.collectionsDeletedSuccessfully(collections.length),
-      );
+      if (context.mounted) {
+        if (deletedCount > 0) {
+          showToast(context, l10n.collectionsDeletedSuccessfully(deletedCount));
+        }
 
-      if (isFavoriteCollection) {
-        showToast(context, context.l10n.actionNotSupportedOnFavouritesAlbum);
+        if (isFavoriteCollection) {
+          showToast(context, l10n.actionNotSupportedOnFavouritesAlbum);
+        }
       }
-
-      onSuccess?.call();
     } catch (error) {
-      await progressDialog.hide();
+      await progressDialog?.hide();
 
-      await showLockerErrorSheet(context, error);
+      if (context.mounted) {
+        await showLockerErrorSheet(context, error);
+      }
     }
   }
 
@@ -235,13 +244,16 @@ class CollectionActions {
     final fileCount = await CollectionService.instance.getFileCount(collection);
 
     if (fileCount == 0) {
-      final progressDialog = createProgressDialog(context, l10n.pleaseWait);
-      await progressDialog.show();
+      ProgressDialog? progressDialog;
+      if (context.mounted) {
+        progressDialog = createProgressDialog(context, l10n.pleaseWait);
+        await progressDialog.show();
+      }
 
       try {
         await CollectionService.instance.trashEmptyCollection(collection);
 
-        await progressDialog.hide();
+        await progressDialog?.hide();
 
         if (context.mounted) {
           showToast(context, l10n.collectionDeletedSuccessfully);
@@ -250,7 +262,7 @@ class CollectionActions {
         // Call success callback if provided
         onSuccess?.call();
       } catch (error) {
-        await progressDialog.hide();
+        await progressDialog?.hide();
 
         if (context.mounted) {
           await showLockerErrorSheet(context, error);
@@ -260,6 +272,7 @@ class CollectionActions {
     }
 
     final collectionName = collection.name ?? 'this collection';
+    if (!context.mounted) return;
 
     final result = await showDeleteConfirmationSheet(
       context,
@@ -270,23 +283,26 @@ class CollectionActions {
       showDeleteFromAllCollectionsOption: true,
     );
 
-    if (result?.buttonResult.action != ButtonAction.first && context.mounted) {
+    if (result?.buttonResult.action != ButtonAction.first) {
       return;
     }
 
-    final progressDialog = createProgressDialog(context, l10n.pleaseWait);
-    await progressDialog.show();
+    ProgressDialog? progressDialog;
+    if (context.mounted) {
+      progressDialog = createProgressDialog(context, l10n.pleaseWait);
+      await progressDialog.show();
+    }
 
     try {
       // If deleteFromAllCollections is true → keepFiles should be false (move files to trash)
       // If deleteFromAllCollections is false → keepFiles should be true (keep files in other collections)
       await CollectionService.instance.trashCollection(
-        context,
+        context.mounted ? context : null,
         collection,
         keepFiles: !(result?.deleteFromAllCollections ?? false),
       );
 
-      await progressDialog.hide();
+      await progressDialog?.hide();
 
       if (context.mounted) {
         showToast(context, l10n.collectionDeletedSuccessfully);
@@ -295,7 +311,7 @@ class CollectionActions {
       // Call success callback if provided
       onSuccess?.call();
     } catch (error) {
-      await progressDialog.hide();
+      await progressDialog?.hide();
 
       if (context.mounted) {
         await showLockerErrorSheet(context, error);
@@ -325,8 +341,8 @@ class CollectionActions {
     if (confirmed == true) {
       try {
         await CollectionApiClient.instance.leaveCollection(collection);
+        onSuccess?.call();
         if (context.mounted) {
-          onSuccess?.call();
           showToast(context, context.l10n.leaveCollectionSuccessfully);
         }
       } catch (e) {
@@ -362,8 +378,8 @@ class CollectionActions {
         for (final col in collections) {
           await CollectionApiClient.instance.leaveCollection(col);
         }
+        onSuccess?.call();
         if (context.mounted) {
-          onSuccess?.call();
           showToast(
             context,
             context.l10n.leftCollectionsSuccessfully(collections.length),
@@ -390,11 +406,15 @@ class CollectionActions {
       );
       return true;
     } catch (e) {
-      if (e is SharingNotPermittedForFreeAccountsError) {
-        await showSubscriptionRequiredSheet(context);
-      } else {
+      if (e is! SharingNotPermittedForFreeAccountsError) {
         _logger.severe("Failed to update shareUrl collection", e);
-        await showLockerErrorSheet(context, e);
+      }
+      if (context.mounted) {
+        if (e is SharingNotPermittedForFreeAccountsError) {
+          await showSubscriptionRequiredSheet(context);
+        } else {
+          await showLockerErrorSheet(context, e);
+        }
       }
       return false;
     }
@@ -457,7 +477,9 @@ class CollectionActions {
     } catch (e) {
       await dialog?.hide();
       _logger.severe("Failed to get public key", e);
-      await showLockerErrorSheet(context, e);
+      if (context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       return false;
     }
     // getPublicKey can return null when no user is associated with given
@@ -465,7 +487,9 @@ class CollectionActions {
     if (publicKey == null || publicKey == '') {
       // todo: neeraj replace this as per the design where a new screen
       // is used for error. Do this change along with handling of network errors
-      await showInviteSheet(context, email: email);
+      if (context.mounted) {
+        await showInviteSheet(context, email: email);
+      }
       return false;
     } else {
       return true;
@@ -474,37 +498,41 @@ class CollectionActions {
 
   // addEmailToCollection returns true if add operation was successful
   Future<bool> addEmailToCollection(
-    BuildContext context,
+    BuildContext? context,
     Collection collection,
     String email,
     CollectionParticipantRole role, {
     bool showProgress = false,
   }) async {
     if (!isValidEmail(email)) {
-      await showBottomSheetComponent(
-        context: context,
-        builder: (_) => BottomSheetComponent(
-          title: context.l10n.invalidEmailAddress,
-          message: context.l10n.enterValidEmail,
-          illustration: LockerBottomSheetIllustration.warningBlue,
-        ),
-      );
+      if (context != null && context.mounted) {
+        await showBottomSheetComponent(
+          context: context,
+          builder: (_) => BottomSheetComponent(
+            title: context.l10n.invalidEmailAddress,
+            message: context.l10n.enterValidEmail,
+            illustration: LockerBottomSheetIllustration.warningBlue,
+          ),
+        );
+      }
       return false;
     } else if (email.trim() == Configuration.instance.getEmail()) {
-      await showBottomSheetComponent(
-        context: context,
-        builder: (_) => BottomSheetComponent(
-          title: context.l10n.oops,
-          message: context.l10n.youCannotShareWithYourself,
-          illustration: LockerBottomSheetIllustration.warningBlue,
-        ),
-      );
+      if (context != null && context.mounted) {
+        await showBottomSheetComponent(
+          context: context,
+          builder: (_) => BottomSheetComponent(
+            title: context.l10n.oops,
+            message: context.l10n.youCannotShareWithYourself,
+            illustration: LockerBottomSheetIllustration.warningBlue,
+          ),
+        );
+      }
       return false;
     }
 
     ProgressDialog? dialog;
     String? publicKey;
-    if (showProgress) {
+    if (showProgress && context != null && context.mounted) {
       dialog = createProgressDialog(
         context,
         context.l10n.sharing,
@@ -518,14 +546,18 @@ class CollectionActions {
     } catch (e) {
       await dialog?.hide();
       _logger.severe("Failed to get public key", e);
-      await showLockerErrorSheet(context, e);
+      if (context != null && context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       return false;
     }
     // getPublicKey can return null when no user is associated with given
     // email id
     if (publicKey == null || publicKey == '') {
       await dialog?.hide();
-      await showInviteSheet(context, email: email);
+      if (context != null && context.mounted) {
+        await showInviteSheet(context, email: email);
+      }
       return false;
     } else {
       try {
@@ -540,11 +572,15 @@ class CollectionActions {
         return true;
       } catch (e) {
         await dialog?.hide();
-        if (e is SharingNotPermittedForFreeAccountsError) {
-          await showSubscriptionRequiredSheet(context);
-        } else {
+        if (e is! SharingNotPermittedForFreeAccountsError) {
           _logger.severe("failed to share collection", e);
-          await showLockerErrorSheet(context, e);
+        }
+        if (context != null && context.mounted) {
+          if (e is SharingNotPermittedForFreeAccountsError) {
+            await showSubscriptionRequiredSheet(context);
+          } else {
+            await showLockerErrorSheet(context, e);
+          }
         }
         return false;
       }
@@ -566,7 +602,9 @@ class CollectionActions {
       return true;
     } catch (e) {
       _logger.severe("Failed to remove participant", e);
-      await showLockerErrorSheet(context, e);
+      if (context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
       return false;
     }
   }

--- a/mobile/apps/locker/lib/utils/file_actions.dart
+++ b/mobile/apps/locker/lib/utils/file_actions.dart
@@ -61,13 +61,14 @@ class FileActions {
 
     final currentCollectionIds = currentCollections.map((c) => c.id).toSet();
 
+    if (!context.mounted) return;
     final result = await showFileEditSheet(
       context,
       file: file,
       collections: editableCollections,
     );
 
-    if (result == null || !context.mounted) {
+    if (result == null) {
       return;
     }
 
@@ -75,12 +76,14 @@ class FileActions {
     final updatedAllCollections = await CollectionService.instance
         .getCollections();
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.pleaseWait,
-      isDismissible: false,
-    );
-    await dialog.show();
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.pleaseWait,
+            isDismissible: false,
+          )
+        : null;
+    await dialog?.show();
 
     try {
       final currentTitle = file.displayName;
@@ -92,7 +95,7 @@ class FileActions {
             .editFileName(file, result.title);
 
         if (!metadataUpdateSuccess) {
-          await dialog.hide();
+          await dialog?.hide();
           if (!context.mounted) {
             return;
           }
@@ -113,9 +116,9 @@ class FileActions {
       );
 
       if (wasFavorite && !isFavoriteNow) {
-        await FavoritesService.instance.removeFromFavorites(context, file);
+        await FavoritesService.instance.removeFromFavorites(file);
       } else if (!wasFavorite && isFavoriteNow) {
-        await FavoritesService.instance.addToFavorites(context, file);
+        await FavoritesService.instance.addToFavorites(file);
       }
 
       final regularCurrentIds = currentCollectionIds
@@ -140,7 +143,7 @@ class FileActions {
               (c) => c.id == collectionId,
             );
             await CollectionService.instance.moveFilesFromCurrentCollection(
-              context,
+              context.mounted ? context : null,
               collection,
               [file],
             );
@@ -177,7 +180,7 @@ class FileActions {
             (c) => c.id == collectionId,
           );
           await CollectionService.instance.moveFilesFromCurrentCollection(
-            context,
+            context.mounted ? context : null,
             collection,
             [file],
           );
@@ -185,17 +188,16 @@ class FileActions {
       }
 
       await CollectionService.instance.sync();
-      await dialog.hide();
+      await dialog?.hide();
+      onSuccess?.call();
 
       if (!context.mounted) {
         return;
       }
 
       showToast(context, context.l10n.fileUpdatedSuccessfully);
-
-      onSuccess?.call();
     } catch (e) {
-      await dialog.hide();
+      await dialog?.hide();
       _logger.severe('Failed to update file collections: $e');
 
       if (!context.mounted) {
@@ -296,14 +298,16 @@ class FileActions {
       return;
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.deletingFile,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.deletingFile,
+            isDismissible: false,
+          )
+        : null;
 
     try {
-      await dialog.show();
+      await dialog?.show();
 
       final collections = await CollectionService.instance
           .getCollectionsForFile(file);
@@ -311,7 +315,7 @@ class FileActions {
         await CollectionService.instance.trashFile(file, collections.first);
       }
 
-      await dialog.hide();
+      await dialog?.hide();
 
       if (context.mounted) {
         showToast(context, context.l10n.fileDeletedSuccessfully);
@@ -319,7 +323,7 @@ class FileActions {
 
       onSuccess?.call();
     } catch (e) {
-      await dialog.hide();
+      await dialog?.hide();
 
       if (context.mounted) {
         await showLockerErrorSheet(context, e);
@@ -349,14 +353,16 @@ class FileActions {
       return;
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.deletingFile,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(
+            context,
+            context.l10n.deletingFile,
+            isDismissible: false,
+          )
+        : null;
 
     try {
-      await dialog.show();
+      await dialog?.show();
 
       for (final file in files) {
         final collections = await CollectionService.instance
@@ -374,7 +380,7 @@ class FileActions {
       await CollectionService.instance.sync();
       await TrashService.instance.syncTrash();
 
-      await dialog.hide();
+      await dialog?.hide();
 
       if (context.mounted) {
         showToast(context, context.l10n.fileDeletedSuccessfully);
@@ -382,7 +388,7 @@ class FileActions {
 
       onSuccess?.call();
     } catch (e, stackTrace) {
-      await dialog.hide();
+      await dialog?.hide();
 
       _logger.severe('Failed to delete files: $e', e, stackTrace);
       if (!context.mounted) {
@@ -416,9 +422,9 @@ class FileActions {
       await dialog.show();
 
       if (isCurrentlyImportant) {
-        await FavoritesService.instance.removeFromFavorites(context, file);
+        await FavoritesService.instance.removeFromFavorites(file);
       } else {
-        await FavoritesService.instance.addToFavorites(context, file);
+        await FavoritesService.instance.addToFavorites(file);
       }
 
       await dialog.hide();
@@ -470,11 +476,7 @@ class FileActions {
         return;
       }
 
-      await FavoritesService.instance.updateFavorites(
-        context,
-        filesToMark,
-        true,
-      );
+      await FavoritesService.instance.updateFavorites(filesToMark, true);
 
       await dialog.hide();
 

--- a/mobile/apps/locker/lib/utils/file_util.dart
+++ b/mobile/apps/locker/lib/utils/file_util.dart
@@ -2,7 +2,6 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:ente_components/ente_components.dart";
-import "package:ente_ui/components/progress_dialog.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:ente_utils/email_util.dart";
@@ -31,15 +30,29 @@ class FileUtil {
   static final Logger _logger = Logger("FileUtil");
 
   static Future<void> openFile(BuildContext context, EnteFile file) async {
+    final l10n = context.l10n;
+
+    Future<void> showOpenFileError({
+      required String error,
+      ResultType? resultType,
+    }) async {
+      if (!context.mounted) {
+        return;
+      }
+      await _showOpenFileError(
+        context,
+        error: error,
+        resultType: resultType,
+        lockerFile: file,
+      );
+    }
+
     if (InfoFileService.instance.isInfoFile(file)) {
       return _openInfoFile(context, file);
     }
 
     if (file.uploadedFileID == null) {
-      await showLockerErrorSheet(
-        context,
-        Exception(context.l10n.errorOpeningFile),
-      );
+      await showLockerErrorSheet(context, Exception(l10n.errorOpeningFile));
       return;
     }
 
@@ -48,31 +61,32 @@ class FileUtil {
       final cachedSize = await cachedDecryptedFile.length();
       if (cachedSize > 0) {
         await _launchFile(
-          context,
           cachedDecryptedFile,
           displayName: file.displayName,
           lockerFile: file,
+          showError: showOpenFileError,
         );
         return;
       }
       await cachedDecryptedFile.delete();
     }
 
-    final dialog = createProgressDialog(
-      context,
-      context.l10n.downloading,
-      isDismissible: false,
-    );
+    final dialog = context.mounted
+        ? createProgressDialog(context, l10n.downloading, isDismissible: false)
+        : null;
 
     try {
-      await dialog.show();
+      await dialog?.show();
       final fileKey = await CollectionService.instance.getFileKey(file);
       void progressCallback(int downloaded, int total) {
+        if (!context.mounted) {
+          return;
+        }
         if (total > 0 && downloaded >= 0) {
           final percentage = ((downloaded / total) * 100).clamp(0, 100).round();
-          dialog.update(message: context.l10n.downloadingProgress(percentage));
+          dialog?.update(message: l10n.downloadingProgress(percentage));
         } else {
-          dialog.update(message: context.l10n.downloading);
+          dialog?.update(message: l10n.downloading);
         }
       }
 
@@ -82,25 +96,25 @@ class FileUtil {
         progressCallback: progressCallback,
       );
 
-      await dialog.hide();
+      await dialog?.hide();
 
       if (decryptedFile != null) {
         await _launchFile(
-          context,
           decryptedFile,
           displayName: file.displayName,
           lockerFile: file,
+          showError: showOpenFileError,
         );
-      } else {
+      } else if (context.mounted) {
         await showBottomSheetComponent(
           context: context,
           builder: (_) => BottomSheetComponent(
-            title: context.l10n.downloadFailed,
-            message: context.l10n.failedToDownloadOrDecrypt,
+            title: l10n.downloadFailed,
+            message: l10n.failedToDownloadOrDecrypt,
             illustration: LockerBottomSheetIllustration.warningGrey,
             actions: [
               ButtonComponent(
-                label: context.l10n.contactSupport,
+                label: l10n.contactSupport,
                 onTap: () async {
                   await sendLogs(context, "support@ente.com", postShare: () {});
                 },
@@ -110,8 +124,10 @@ class FileUtil {
         );
       }
     } catch (e) {
-      await dialog.hide();
-      await showLockerErrorSheet(context, e);
+      await dialog?.hide();
+      if (context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
   }
 
@@ -135,9 +151,10 @@ class FileUtil {
     }
 
     final total = files.length;
+    final l10n = context.l10n;
     final dialog = createProgressDialog(
       context,
-      "${context.l10n.downloading} 0/$total",
+      "${l10n.downloading} 0/$total",
       isDismissible: false,
     );
 
@@ -151,17 +168,18 @@ class FileUtil {
     try {
       for (final file in files) {
         index += 1;
-        dialog.update(
-          message:
-              '${context.l10n.downloading} ${file.displayName} ($index/$total)',
-        );
+        if (context.mounted) {
+          dialog.update(
+            message: '${l10n.downloading} ${file.displayName} ($index/$total)',
+          );
+        }
 
         // Skip info items for now; they are meant to be viewed in-app.
         if (InfoFileService.instance.isInfoFile(file)) {
           _logger.fine(
             'Skipping info file download (ID: ${file.uploadedFileID})',
           );
-          if (!hasShownInfoSkipToast) {
+          if (!hasShownInfoSkipToast && context.mounted) {
             hasShownInfoSkipToast = true;
             showToast(
               context,
@@ -180,11 +198,15 @@ class FileUtil {
           targetFileName: fileExtension.isEmpty
               ? baseName
               : "$baseName.$fileExtension",
-          context: context,
-          progressDialog: dialog,
-          currentIndex: index,
-          totalCount: total,
           fileExtension: fileExtension,
+          onProgress: (percentage) {
+            if (context.mounted) {
+              dialog.update(
+                message:
+                    '${l10n.downloadingProgress(percentage)} ($index/$total)',
+              );
+            }
+          },
         );
 
         savedNames.add(file.displayName);
@@ -210,7 +232,7 @@ class FileUtil {
         if (e is UnsupportedError) {
           showToast(context, 'This file type is not supported for download');
         } else {
-          showToast(context, context.l10n.failedToDownloadOrDecrypt);
+          showToast(context, l10n.failedToDownloadOrDecrypt);
         }
       }
       return false;
@@ -226,11 +248,8 @@ class FileUtil {
   static Future<String?> _saveRegularFile({
     required EnteFile file,
     required String targetFileName,
-    required BuildContext context,
-    required ProgressDialog progressDialog,
-    required int currentIndex,
-    required int totalCount,
     required String fileExtension,
+    required ValueChanged<int> onProgress,
   }) async {
     final fileKey = await CollectionService.instance.getFileKey(file);
 
@@ -241,10 +260,7 @@ class FileUtil {
       progressCallback: (downloaded, total) {
         if (total > 0 && downloaded >= 0) {
           final percentage = ((downloaded / total) * 100).clamp(0, 100).round();
-          progressDialog.update(
-            message:
-                '${context.l10n.downloadingProgress(percentage)} ($currentIndex/$totalCount)',
-          );
+          onProgress(percentage);
         }
       },
     );
@@ -268,18 +284,10 @@ class FileUtil {
         throw Exception('Failed to save file');
       }
 
-      // After FileSaver returns, the context might be unmounted due to
-      // app lifecycle changes (e.g., LockScreen overlay appearing).
-      // Safely update the progress dialog if possible.
-      if (context.mounted) {
-        try {
-          progressDialog.update(
-            message:
-                '${context.l10n.downloadingProgress(100)} ($currentIndex/$totalCount)',
-          );
-        } catch (e) {
-          _logger.fine('Unable to update progress dialog after save: $e');
-        }
+      try {
+        onProgress(100);
+      } catch (e) {
+        _logger.fine('Unable to update progress dialog after save: $e');
       }
       return savedPath;
     } finally {
@@ -394,15 +402,21 @@ class FileUtil {
         context,
       ).push(MaterialPageRoute(builder: (context) => page));
     } catch (e) {
-      await showLockerErrorSheet(context, e);
+      if (context.mounted) {
+        await showLockerErrorSheet(context, e);
+      }
     }
   }
 
   static Future<void> _launchFile(
-    BuildContext context,
     File file, {
     String? displayName,
     EnteFile? lockerFile,
+    required Future<void> Function({
+      required String error,
+      ResultType? resultType,
+    })
+    showError,
   }) async {
     File fileToOpen = file;
 
@@ -419,23 +433,10 @@ class FileUtil {
 
       final result = await OpenFile.open(fileToOpen.path);
       if (result.type != ResultType.done) {
-        if (context.mounted) {
-          await _showOpenFileError(
-            context,
-            resultType: result.type,
-            error: result.message,
-            lockerFile: lockerFile,
-          );
-        }
+        await showError(error: result.message, resultType: result.type);
       }
     } catch (e) {
-      if (context.mounted) {
-        await _showOpenFileError(
-          context,
-          error: e.toString(),
-          lockerFile: lockerFile,
-        );
-      }
+      await showError(error: e.toString());
     }
   }
 


### PR DESCRIPTION
## Summary

- enable `use_build_context_synchronously` as an error for Locker
- keep accepted domain operations, refresh callbacks, and events running after their initiating UI is disposed
- guard context-bound UI work and fix upload completion, dialog ownership, partial-delete reporting, and offline-save lifecycle handling

