### PR TITLE
[mobile][photos] Format account deletion file counts

### DIFF
--- a/mobile/apps/photos/changes/account-deletion-file-count-formatting.md
+++ b/mobile/apps/photos/changes/account-deletion-file-count-formatting.md
@@ -1,0 +1,1 @@
+- Format account deletion file counts with locale-aware separators.

--- a/mobile/packages/account_deletion/lib/src/ui/delete_account_confirmation_step.dart
+++ b/mobile/packages/account_deletion/lib/src/ui/delete_account_confirmation_step.dart
@@ -26,6 +26,7 @@ class DeleteAccountConfirmationStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
+    final canConfirm = summary != null || summaryUnsupported;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -43,12 +44,12 @@ class DeleteAccountConfirmationStep extends StatelessWidget {
         _buildSummary(context),
         const SizedBox(height: Spacing.lg),
         InkWell(
-          onTap: () => onConfirmationChanged(!confirmed),
+          onTap: canConfirm ? () => onConfirmationChanged(!confirmed) : null,
           borderRadius: BorderRadius.circular(Radii.sm),
           child: LabeledControlComponent(
             control: CheckboxComponent(
               selected: confirmed,
-              onChanged: onConfirmationChanged,
+              onChanged: canConfirm ? onConfirmationChanged : null,
               selectedColor: colors.warning,
             ),
             label: context.strings.confirmDeleteAccountAcrossApps,

--- a/mobile/packages/account_deletion/lib/src/ui/delete_account_confirmation_step.dart
+++ b/mobile/packages/account_deletion/lib/src/ui/delete_account_confirmation_step.dart
@@ -3,6 +3,7 @@ import 'package:ente_components/ente_components.dart';
 import 'package:ente_strings/ente_strings.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:intl/intl.dart';
 
 class DeleteAccountConfirmationStep extends StatelessWidget {
   const DeleteAccountConfirmationStep({
@@ -100,6 +101,9 @@ class _SummaryRows extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final summary = this.summary;
+    final numberFormat = NumberFormat.decimalPattern(
+      Localizations.localeOf(context).toLanguageTag(),
+    );
     return Column(
       children: [
         _row(
@@ -108,6 +112,7 @@ class _SummaryRows extends StatelessWidget {
               ? context.strings.entePhotos
               : context.strings.photosAndVideosCount(
                   summary.photosAndVideosCount,
+                  numberFormat.format(summary.photosAndVideosCount),
                 ),
           subtitle: summary == null ? null : context.strings.entePhotos,
         ),
@@ -118,6 +123,7 @@ class _SummaryRows extends StatelessWidget {
               ? context.strings.enteAuth
               : context.strings.authenticatorCodesCount(
                   summary.authenticatorCodesCount,
+                  numberFormat.format(summary.authenticatorCodesCount),
                 ),
           subtitle: summary == null ? null : context.strings.enteAuth,
         ),
@@ -126,7 +132,10 @@ class _SummaryRows extends StatelessWidget {
           assetName: 'locker.png',
           title: summary == null
               ? context.strings.enteLocker
-              : context.strings.lockerRecordsCount(summary.lockerRecordsCount),
+              : context.strings.lockerRecordsCount(
+                  summary.lockerRecordsCount,
+                  numberFormat.format(summary.lockerRecordsCount),
+                ),
           subtitle: summary == null ? null : context.strings.enteLocker,
         ),
       ],

--- a/mobile/packages/account_deletion/pubspec.yaml
+++ b/mobile/packages/account_deletion/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   hugeicons: 1.1.7
+  intl: 0.20.2
   logging: 1.3.0
 
 dev_dependencies:

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -286,30 +286,39 @@
   "@oneAccountAcrossEnteApps": {
     "description": "Explains that account deletion affects all Ente apps"
   },
-  "photosAndVideosCount": "{count, plural, one {{count} photo & video} other {{count} photos & videos}}",
+  "photosAndVideosCount": "{count, plural, one {{formattedCount} photo & video} other {{formattedCount} photos & videos}}",
   "@photosAndVideosCount": {
     "description": "Delete impact row for Photos data",
     "placeholders": {
       "count": {
         "type": "int"
+      },
+      "formattedCount": {
+        "type": "String"
       }
     }
   },
-  "authenticatorCodesCount": "{count, plural, one {{count} authenticator code} other {{count} authenticator codes}}",
+  "authenticatorCodesCount": "{count, plural, one {{formattedCount} authenticator code} other {{formattedCount} authenticator codes}}",
   "@authenticatorCodesCount": {
     "description": "Delete impact row for Auth data",
     "placeholders": {
       "count": {
         "type": "int"
+      },
+      "formattedCount": {
+        "type": "String"
       }
     }
   },
-  "lockerRecordsCount": "{count, plural, one {{count} record} other {{count} records}}",
+  "lockerRecordsCount": "{count, plural, one {{formattedCount} record} other {{formattedCount} records}}",
   "@lockerRecordsCount": {
     "description": "Delete impact row for Locker data",
     "placeholders": {
       "count": {
         "type": "int"
+      },
+      "formattedCount": {
+        "type": "String"
       }
     }
   },


### PR DESCRIPTION
Formats account deletion file counts with locale-aware separators.


<img width="495" height="937" alt="User attachment (2)" src="https://github.com/user-attachments/assets/31d39a33-a427-4990-be75-ec5f9562cdde" />
