### PR TITLE
[mobile][photos] send files to system trash instead of deleting on Android when supported

### DIFF
--- a/mobile/apps/photos/changes/android-system-trash.md
+++ b/mobile/apps/photos/changes/android-system-trash.md
@@ -1,0 +1,1 @@
+- (i) Move files to the system trash on Android 11 and later (internal users only).

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -38,6 +38,23 @@ import 'package:photos/utils/dialog_util.dart';
 
 final _logger = Logger("DeleteFileUtil");
 
+Future<Set<String>> _tryTrashOrDeleteFiles(List<String> assetIDs) async {
+  try {
+    if (!flagService.internalUser ||
+        !Platform.isAndroid ||
+        await isAndroidSDKVersionLowerThan(android11SDKINT)) {
+      return (await PhotoManager.editor.deleteWithIds(assetIDs)).toSet();
+    }
+    final assets = (await Future.wait(
+      assetIDs.map(AssetEntity.fromId),
+    )).whereType<AssetEntity>().toList();
+    return (await PhotoManager.editor.android.moveToTrash(assets)).toSet();
+  } catch (e, s) {
+    _logger.severe("Could not delete file", e, s);
+    return {};
+  }
+}
+
 Future<void> deleteFilesFromEverywhere(
   BuildContext context,
   List<EnteFile> files,
@@ -62,14 +79,7 @@ Future<void> deleteFilesFromEverywhere(
       hasLocalOnlyFiles = true;
     }
   }
-  Set<String> deletedIDs = <String>{};
-  try {
-    deletedIDs = (await PhotoManager.editor.deleteWithIds(
-      localAssetIDs,
-    )).toSet();
-  } catch (e, s) {
-    _logger.severe("Could not delete file", e, s);
-  }
+  final deletedIDs = await _tryTrashOrDeleteFiles(localAssetIDs);
   deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
   final updatedCollectionIDs = <int>{};
   final List<TrashRequest> uploadedFilesToBeTrashed = [];
@@ -221,14 +231,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
       localOnlyIDs.add(file.localID);
     }
   }
-  Set<String> deletedIDs = <String>{};
-  try {
-    deletedIDs = (await PhotoManager.editor.deleteWithIds(
-      localAssetIDs,
-    )).toSet();
-  } catch (e, s) {
-    _logger.severe("Could not delete file", e, s);
-  }
+  final deletedIDs = await _tryTrashOrDeleteFiles(localAssetIDs);
   deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -38,28 +38,34 @@ import 'package:photos/utils/dialog_util.dart';
 
 final _logger = Logger("DeleteFileUtil");
 
-Future<(bool, Set<String>)> _tryTrashOrDeleteFiles(
-  List<String> assetIDs,
-) async {
+Future<({Set<String> deletedIDs, Set<String> trashedIDs})>
+_tryTrashOrDeleteFiles(List<String> assetIDs) async {
+  if (assetIDs.isEmpty) {
+    return (deletedIDs: <String>{}, trashedIDs: <String>{});
+  }
   try {
-    if (!flagService.internalUser ||
-        !Platform.isAndroid ||
-        await isAndroidSDKVersionLowerThan(android11SDKINT)) {
+    if (flagService.internalUser &&
+        Platform.isAndroid &&
+        !await isAndroidSDKVersionLowerThan(android11SDKINT)) {
+      final assets = (await Future.wait(
+        assetIDs.map(AssetEntity.fromId),
+      )).whereType<AssetEntity>().toList();
       return (
-        false,
-        (await PhotoManager.editor.deleteWithIds(assetIDs)).toSet(),
+        deletedIDs: <String>{},
+        trashedIDs: (await PhotoManager.editor.android.moveToTrash(
+          assets,
+        )).toSet(),
       );
     }
-    final assets = (await Future.wait(
-      assetIDs.map(AssetEntity.fromId),
-    )).whereType<AssetEntity>().toList();
-    return (
-      true,
-      (await PhotoManager.editor.android.moveToTrash(assets)).toSet(),
-    );
+    final removedIDs = (await PhotoManager.editor.deleteWithIds(
+      assetIDs,
+    )).toSet();
+    return Platform.isAndroid
+        ? (deletedIDs: removedIDs, trashedIDs: <String>{})
+        : (deletedIDs: <String>{}, trashedIDs: removedIDs);
   } catch (e, s) {
     _logger.severe("Could not delete file", e, s);
-    return (false, <String>{});
+    return (deletedIDs: <String>{}, trashedIDs: <String>{});
   }
 }
 
@@ -87,15 +93,17 @@ Future<void> deleteFilesFromEverywhere(
       hasLocalOnlyFiles = true;
     }
   }
-  final (trashed, deletedIDs) = await _tryTrashOrDeleteFiles(localAssetIDs);
-  deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
+  final result = await _tryTrashOrDeleteFiles(localAssetIDs);
+  final deletedIDs = result.deletedIDs
+    ..addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
+  final removedIDs = deletedIDs.union(result.trashedIDs);
   final updatedCollectionIDs = <int>{};
   final List<TrashRequest> uploadedFilesToBeTrashed = [];
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {
     if (file.localID != null) {
       // Remove only those files that have already been removed from disk
-      if (deletedIDs.contains(file.localID) ||
+      if (removedIDs.contains(file.localID) ||
           alreadyDeletedIDs.contains(file.localID)) {
         deletedFiles.add(file);
         if (file.uploadedFileID != null) {
@@ -148,11 +156,10 @@ Future<void> deleteFilesFromEverywhere(
       ),
     );
     if (context.mounted) {
-      if (hasLocalOnlyFiles && Platform.isAndroid && !trashed) {
-        showShortToast(context, AppLocalizations.of(context).filesDeleted);
-      } else {
-        showShortToast(context, AppLocalizations.of(context).movedToTrash);
-      }
+      final message = hasLocalOnlyFiles && deletedIDs.isNotEmpty
+          ? AppLocalizations.of(context).filesDeleted
+          : AppLocalizations.of(context).movedToTrash;
+      showShortToast(context, message);
     }
   }
   if (uploadedFilesToBeTrashed.isNotEmpty) {
@@ -221,8 +228,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
   final List<String> localAssetIDs = [];
   final List<String> localSharedMediaIDs = [];
   final List<String> alreadyDeletedIDs = []; // to ignore already deleted files
-  final List<String?> localOnlyIDs = [];
-  bool hasLocalOnlyFiles = false;
+  final localOnlyIDs = <String?>{};
   for (final file in files) {
     if (file.localID != null) {
       if (!(await _localFileExist(file))) {
@@ -235,19 +241,20 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
       }
     }
     if (file.uploadedFileID == null) {
-      hasLocalOnlyFiles = true;
       localOnlyIDs.add(file.localID);
     }
   }
-  final (trashed, deletedIDs) = await _tryTrashOrDeleteFiles(localAssetIDs);
-  deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
+  final result = await _tryTrashOrDeleteFiles(localAssetIDs);
+  final deletedIDs = result.deletedIDs
+    ..addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
+  final removedIDs = deletedIDs.union(result.trashedIDs);
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {
     // Remove only those files that have been removed from disk
-    if (deletedIDs.contains(file.localID) ||
+    if (removedIDs.contains(file.localID) ||
         alreadyDeletedIDs.contains(file.localID)) {
       deletedFiles.add(file);
-      if (hasLocalOnlyFiles && localOnlyIDs.contains(file.localID)) {
+      if (localOnlyIDs.contains(file.localID)) {
         await FilesDB.instance.deleteLocalFile(file);
       } else {
         file.localID = null;
@@ -264,14 +271,11 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
       ),
     );
   }
-  if (deletedIDs.isNotEmpty && Platform.isAndroid && !trashed) {
-    if (context.mounted) {
-      showShortToast(context, AppLocalizations.of(context).filesDeleted);
-    }
-  } else if (deletedIDs.isNotEmpty) {
-    if (context.mounted) {
-      showToast(context, AppLocalizations.of(context).movedToTrash);
-    }
+  if (removedIDs.isNotEmpty && context.mounted) {
+    final message = deletedIDs.isNotEmpty
+        ? AppLocalizations.of(context).filesDeleted
+        : AppLocalizations.of(context).movedToTrash;
+    showShortToast(context, message);
   }
   return deletedFiles;
 }

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -38,20 +38,28 @@ import 'package:photos/utils/dialog_util.dart';
 
 final _logger = Logger("DeleteFileUtil");
 
-Future<Set<String>> _tryTrashOrDeleteFiles(List<String> assetIDs) async {
+Future<(bool, Set<String>)> _tryTrashOrDeleteFiles(
+  List<String> assetIDs,
+) async {
   try {
     if (!flagService.internalUser ||
         !Platform.isAndroid ||
         await isAndroidSDKVersionLowerThan(android11SDKINT)) {
-      return (await PhotoManager.editor.deleteWithIds(assetIDs)).toSet();
+      return (
+        false,
+        (await PhotoManager.editor.deleteWithIds(assetIDs)).toSet(),
+      );
     }
     final assets = (await Future.wait(
       assetIDs.map(AssetEntity.fromId),
     )).whereType<AssetEntity>().toList();
-    return (await PhotoManager.editor.android.moveToTrash(assets)).toSet();
+    return (
+      true,
+      (await PhotoManager.editor.android.moveToTrash(assets)).toSet(),
+    );
   } catch (e, s) {
     _logger.severe("Could not delete file", e, s);
-    return {};
+    return (false, <String>{});
   }
 }
 
@@ -79,7 +87,7 @@ Future<void> deleteFilesFromEverywhere(
       hasLocalOnlyFiles = true;
     }
   }
-  final deletedIDs = await _tryTrashOrDeleteFiles(localAssetIDs);
+  final (trashed, deletedIDs) = await _tryTrashOrDeleteFiles(localAssetIDs);
   deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
   final updatedCollectionIDs = <int>{};
   final List<TrashRequest> uploadedFilesToBeTrashed = [];
@@ -140,7 +148,7 @@ Future<void> deleteFilesFromEverywhere(
       ),
     );
     if (context.mounted) {
-      if (hasLocalOnlyFiles && Platform.isAndroid) {
+      if (hasLocalOnlyFiles && Platform.isAndroid && !trashed) {
         showShortToast(context, AppLocalizations.of(context).filesDeleted);
       } else {
         showShortToast(context, AppLocalizations.of(context).movedToTrash);
@@ -231,7 +239,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
       localOnlyIDs.add(file.localID);
     }
   }
-  final deletedIDs = await _tryTrashOrDeleteFiles(localAssetIDs);
+  final (trashed, deletedIDs) = await _tryTrashOrDeleteFiles(localAssetIDs);
   deletedIDs.addAll(await _tryDeleteSharedMediaFiles(localSharedMediaIDs));
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {
@@ -255,6 +263,15 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
         source: "deleteFilesOnDeviceOnly",
       ),
     );
+  }
+  if (deletedIDs.isNotEmpty && Platform.isAndroid && !trashed) {
+    if (context.mounted) {
+      showShortToast(context, AppLocalizations.of(context).filesDeleted);
+    }
+  } else if (deletedIDs.isNotEmpty) {
+    if (context.mounted) {
+      showToast(context, AppLocalizations.of(context).movedToTrash);
+    }
   }
   return deletedFiles;
 }

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -76,7 +76,7 @@ Future<void> deleteFilesFromEverywhere(
   _logger.info("Trying to deleteFilesFromEverywhere " + files.toString());
   final List<String> localAssetIDs = [];
   final List<String> localSharedMediaIDs = [];
-  final List<String> alreadyDeletedIDs = []; // to ignore already deleted files
+  final List<String> alreadyDeletedIDs = []; // Files already missing from disk.
   bool hasLocalOnlyFiles = false;
   for (final file in files) {
     if (file.localID != null) {
@@ -102,7 +102,7 @@ Future<void> deleteFilesFromEverywhere(
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {
     if (file.localID != null) {
-      // Remove only those files that have already been removed from disk
+      // Handle only files deleted, moved to trash, or already missing.
       if (removedIDs.contains(file.localID) ||
           alreadyDeletedIDs.contains(file.localID)) {
         deletedFiles.add(file);
@@ -227,7 +227,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
   _logger.info("Trying to deleteFilesOnDeviceOnly" + files.toString());
   final List<String> localAssetIDs = [];
   final List<String> localSharedMediaIDs = [];
-  final List<String> alreadyDeletedIDs = []; // to ignore already deleted files
+  final List<String> alreadyDeletedIDs = []; // Files already missing from disk.
   final localOnlyIDs = <String?>{};
   for (final file in files) {
     if (file.localID != null) {
@@ -250,7 +250,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
   final removedIDs = deletedIDs.union(result.trashedIDs);
   final List<EnteFile> deletedFiles = [];
   for (final file in files) {
-    // Remove only those files that have been removed from disk
+    // Handle only files deleted, moved to trash, or already missing.
     if (removedIDs.contains(file.localID) ||
         alreadyDeletedIDs.contains(file.localID)) {
       deletedFiles.add(file);


### PR DESCRIPTION
Moves files to trash on Android if supported.

Displays appropriate toast message after delete actions, on iOS it will always say trash because iOS deletion == trash.