### PR TITLE
[mobile] Fix app bar titles with Bold Text

### DIFF
--- a/mobile/apps/photos/changes/bold-app-bar-titles.md
+++ b/mobile/apps/photos/changes/bold-app-bar-titles.md
@@ -1,0 +1,1 @@
+- Fix app bar titles being truncated when Bold Text is enabled.

--- a/mobile/packages/ente_components/lib/components/app_bar_component.dart
+++ b/mobile/packages/ente_components/lib/components/app_bar_component.dart
@@ -907,11 +907,14 @@ class _MovingHeaderTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
-    final textStyle = TextStyle.lerp(
+    var textStyle = TextStyle.lerp(
       TextStyles.display2,
       TextStyles.display3,
       progress,
     )!.copyWith(color: colors.textBase);
+    if (MediaQuery.boldTextOf(context)) {
+      textStyle = textStyle.merge(const TextStyle(fontWeight: FontWeight.bold));
+    }
 
     final customTitleBuilder = titleBuilder;
     if (customTitleBuilder != null) {

--- a/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
+++ b/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
@@ -17,12 +17,13 @@ Future<void> pumpComponent(
   double width = 420,
   double? height,
   TextScaler textScaler = TextScaler.noScaling,
+  bool boldText = false,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
       theme: ComponentTheme.lightTheme(),
       home: MediaQuery(
-        data: MediaQueryData(textScaler: textScaler),
+        data: MediaQueryData(textScaler: textScaler, boldText: boldText),
         child: Scaffold(
           body: Align(
             alignment: Alignment.topLeft,
@@ -608,6 +609,39 @@ void main() {
     expect(
       tester.getSize(find.byType(TooltipBubbleComponent)).width,
       lessThan(160),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('SliverAppBarComponent measures titles with bold text style', (
+    tester,
+  ) async {
+    const title = 'Summer Vacation';
+
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          const SliverAppBarComponent(
+            title: title,
+            actions: [Icon(Icons.more_vert)],
+          ),
+          SliverList.builder(
+            itemCount: 8,
+            itemBuilder: (context, index) {
+              return SizedBox(height: 60, child: Text('Item $index'));
+            },
+          ),
+        ],
+      ),
+      width: 320,
+      height: 360,
+      boldText: true,
+    );
+
+    expect(
+      tester.widget<Text>(find.text(title)).style?.fontWeight,
+      FontWeight.bold,
     );
     expect(tester.takeException(), isNull);
   });


### PR DESCRIPTION
Fix app bar titles being truncated when Bold Text is enabled.

Before
<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 - 2026-07-16 at 11 53 32" src="https://github.com/user-attachments/assets/355390c2-d7ff-4893-baf7-3e60e18e17bd" />

After
<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 - 2026-07-16 at 11 46 48"
 src="https://github.com/user-attachments/assets/6dcd3c5e-78c9-4996-bd8e-9081030b51ba" />
