### PR TITLE
[server] Return user IDs for joined family members

### DIFF
--- a/infra/staff/src/services/admin-user.ts
+++ b/infra/staff/src/services/admin-user.ts
@@ -26,6 +26,7 @@ const FamilyMember = z.object({
     id: z.string(),
     email: z.string(),
     status: z.string(),
+    userID: z.number().nullish().transform(nullToUndefined),
     usage: z.number().nullish().transform(nullToUndefined),
     storageLimit: z.number().nullish().transform(nullToUndefined),
 });

--- a/mobile/apps/photos/lib/models/user_details.dart
+++ b/mobile/apps/photos/lib/models/user_details.dart
@@ -162,6 +162,7 @@ class FamilyMember {
   final String email;
   final int usage;
   final String id;
+  final int? userID;
   final bool isAdmin;
   final FamilyMemberStatus status;
   final int? storageLimit;
@@ -170,6 +171,7 @@ class FamilyMember {
     this.email,
     this.usage,
     this.id,
+    this.userID,
     this.isAdmin,
     this.status,
     this.storageLimit,
@@ -186,6 +188,7 @@ class FamilyMember {
       (map['email'] ?? '') as String,
       (map['usage'] ?? 0) as int,
       map['id'] as String,
+      map['userID'] as int?,
       map['isAdmin'] as bool,
       FamilyMemberStatus.fromServerValue(map['status'] as String?),
       map['storageLimit'] as int?,
@@ -197,6 +200,7 @@ class FamilyMember {
       'email': email,
       'usage': usage,
       'id': id,
+      'userID': userID,
       'isAdmin': isAdmin,
       'status': status.serverValue,
       'storageLimit': storageLimit,

--- a/mobile/packages/accounts/lib/models/user_details.dart
+++ b/mobile/packages/accounts/lib/models/user_details.dart
@@ -167,6 +167,7 @@ class FamilyMember {
   final String email;
   final int usage;
   final String id;
+  final int? userID;
   final bool isAdmin;
   final int? storageLimit;
 
@@ -174,6 +175,7 @@ class FamilyMember {
     this.email,
     this.usage,
     this.id,
+    this.userID,
     this.isAdmin,
     this.storageLimit,
   );
@@ -183,6 +185,7 @@ class FamilyMember {
       (map['email'] ?? '') as String,
       map['usage'] as int,
       map['id'] as String,
+      map['userID'] as int?,
       map['isAdmin'] as bool,
       map['storageLimit'] as int?,
     );
@@ -193,6 +196,7 @@ class FamilyMember {
       'email': email,
       'usage': usage,
       'id': id,
+      'userID': userID,
       'isAdmin': isAdmin,
       'storageLimit': storageLimit,
     };

--- a/server/ente/family.go
+++ b/server/ente/family.go
@@ -42,6 +42,7 @@ type FamilyMember struct {
 	Email        string       `json:"email" binding:"required"`
 	Status       MemberStatus `json:"status" binding:"required"`
 	StorageLimit *int64       `json:"storageLimit" binding:"omitempty"`
+	UserID       *int64       `json:"userID"`
 	// This information should not be sent back in the response if the membership status is `INVITED`
 	Usage        int64 `json:"usage"`
 	IsAdmin      bool  `json:"isAdmin"`

--- a/server/pkg/api/family_test.go
+++ b/server/pkg/api/family_test.go
@@ -12,9 +12,11 @@ import (
 	"testing"
 
 	"github.com/ente/museum/ente"
+	"github.com/ente/museum/ente/cache"
 	"github.com/ente/museum/internal/testutil"
 	museumcontroller "github.com/ente/museum/pkg/controller"
 	familycontroller "github.com/ente/museum/pkg/controller/family"
+	"github.com/ente/museum/pkg/controller/usercache"
 	"github.com/ente/museum/pkg/repo"
 	storagebonusrepo "github.com/ente/museum/pkg/repo/storagebonus"
 	"github.com/gin-gonic/gin"
@@ -32,6 +34,65 @@ func TestInviteMemberAllowsResendWhenFamilyIsFull(t *testing.T) {
 	if got := performInviteMemberRequest(t, router, adminID, "not-on-ente@ente.com").Code; got != http.StatusPreconditionFailed {
 		t.Fatalf("unregistered invite status = %d, want %d", got, http.StatusPreconditionFailed)
 	}
+}
+
+func TestFetchFamilyMembersReturnsUserIDOnlyForJoinedMembers(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+
+	userRepo := &repo.UserRepository{
+		DB:                  db,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+	familyRepo := &repo.FamilyRepository{DB: db}
+	adminEmail := "family-admin@ente.com"
+	memberEmail := "family-member@ente.com"
+	adminID := int64(1)
+	memberID := int64(2)
+	insertFreeFamilyTestUser(t, db, adminID, adminEmail)
+	insertFreeFamilyTestUser(t, db, memberID, memberEmail)
+
+	if err := familyRepo.CreateFamily(context.Background(), adminID); err != nil {
+		t.Fatalf("create family: %v", err)
+	}
+	if _, err := familyRepo.AddMemberInvite(context.Background(), adminID, memberID, "initial-token", nil); err != nil {
+		t.Fatalf("add family invite: %v", err)
+	}
+
+	handler := &FamilyHandler{Controller: &familycontroller.Controller{
+		UserRepo:   userRepo,
+		FamilyRepo: familyRepo,
+		UserCacheCtrl: &usercache.Controller{
+			StoreBonusRepo: &storagebonusrepo.Repository{DB: db},
+			UserCache:      cache.NewUserCache(),
+		},
+	}}
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/family/members", handler.FetchMembers)
+
+	members := fetchFamilyMemberUserIDs(t, router, adminID)
+	requireFamilyMemberUserID(t, members, adminEmail, &adminID)
+	requireFamilyMemberUserID(t, members, memberEmail, nil)
+
+	if err := familyRepo.AcceptInvite(context.Background(), adminID, memberID, "initial-token"); err != nil {
+		t.Fatalf("accept family invite: %v", err)
+	}
+	members = fetchFamilyMemberUserIDs(t, router, adminID)
+	requireFamilyMemberUserID(t, members, memberEmail, &memberID)
+
+	if err := familyRepo.RemoveMember(context.Background(), adminID, memberID, ente.LEFT); err != nil {
+		t.Fatalf("leave family: %v", err)
+	}
+	if _, err := familyRepo.AddMemberInvite(context.Background(), adminID, memberID, "reinvite-token", nil); err != nil {
+		t.Fatalf("re-invite family member: %v", err)
+	}
+	members = fetchFamilyMemberUserIDs(t, router, adminID)
+	requireFamilyMemberUserID(t, members, memberEmail, nil)
 }
 
 func setupFullFamilyTest(t *testing.T) (http.Handler, int64, string, string) {
@@ -106,6 +167,60 @@ func insertFreeFamilyTestUser(t *testing.T, db *sql.DB, userID int64, email stri
 		ExpiryTime: 4102444800000000,
 		ProductID:  ente.FreePlanProductID,
 	})
+}
+
+func fetchFamilyMemberUserIDs(t *testing.T, router http.Handler, userID int64) map[string]json.RawMessage {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/family/members", nil)
+	request.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("fetch family members status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Members []struct {
+			Email  string          `json:"email"`
+			UserID json.RawMessage `json:"userID"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode family members: %v", err)
+	}
+
+	result := make(map[string]json.RawMessage, len(response.Members))
+	for _, member := range response.Members {
+		result[member.Email] = member.UserID
+	}
+	return result
+}
+
+func requireFamilyMemberUserID(t *testing.T, members map[string]json.RawMessage, email string, want *int64) {
+	t.Helper()
+
+	rawUserID, ok := members[email]
+	if !ok {
+		t.Fatalf("family member %q not found", email)
+	}
+	if len(rawUserID) == 0 {
+		t.Fatalf("family member %q response omitted userID", email)
+	}
+	if want == nil {
+		if string(rawUserID) != "null" {
+			t.Fatalf("family member %q userID = %s, want null", email, rawUserID)
+		}
+		return
+	}
+
+	var got int64
+	if err := json.Unmarshal(rawUserID, &got); err != nil {
+		t.Fatalf("decode family member %q userID: %v", email, err)
+	}
+	if got != *want {
+		t.Fatalf("family member %q userID = %d, want %d", email, got, *want)
+	}
 }
 
 func performInviteMemberRequest(t *testing.T, router http.Handler, adminID int64, email string) *httptest.ResponseRecorder {

--- a/server/pkg/controller/family/family.go
+++ b/server/pkg/controller/family/family.go
@@ -65,6 +65,9 @@ func (c *Controller) FetchMembersForAdminID(ctx context.Context, familyAdminID i
 	var adminSubStorage, adminSubExpiryTime int64
 	for i := 0; i < len(familyMembers); i++ {
 		member := &familyMembers[i]
+		if member.Status == ente.ACCEPTED || member.Status == ente.SELF {
+			member.UserID = &member.MemberUserID
+		}
 		for _, userUsageData := range usersUsageWithSubData {
 			if member.MemberUserID == userUsageData.UserID {
 				member.Email = *userUsageData.Email

--- a/web/packages/new/photos/services/user-details.ts
+++ b/web/packages/new/photos/services/user-details.ts
@@ -64,6 +64,12 @@ const FamilyMember = z.object({
     email: z.string(),
     status: z.enum(["SELF", "INVITED", "ACCEPTED"]),
     /**
+     * ID of the family member's Ente account.
+     *
+     * This is not available until the member joins the family.
+     */
+    userID: z.number().nullish().transform(nullToUndefined),
+    /**
      * `true` if this is the admin.
      *
      * This field will not be sent for invited members until they accept.


### PR DESCRIPTION
- Return userID only for joined family members; serialize null for invited or re-invited members.
- Parse the nullable or missing field across active clients, preserving compatibility with older self-hosted servers.