### PR TITLE
[docs] Update mobile workspace setup instructions

### DIFF
--- a/mobile/apps/auth/README.md
+++ b/mobile/apps/auth/README.md
@@ -39,9 +39,7 @@ You can view your 2FA codes at [auth.ente.com](https://auth.ente.com). For addin
 
 2. Pull in submodules with `git submodule update --init --recursive`
 
-3. Install dependencies using one of these methods:
-   - **Using Flutter:** From any folder inside `mobile/`, run `flutter pub get --enforce-lockfile`.
-   - **Using Melos:** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies.
+3. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`.
 
 4. Run the app:
    - Android: `flutter run --flavor independent`

--- a/mobile/apps/auth/README.md
+++ b/mobile/apps/auth/README.md
@@ -39,7 +39,7 @@ You can view your 2FA codes at [auth.ente.com](https://auth.ente.com). For addin
 
 2. Pull in submodules with `git submodule update --init --recursive`
 
-3. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`.
+3. From any folder inside `mobile/`, install the workspace dependencies with `flutter pub get --enforce-lockfile`.
 
 4. Run the app:
    - Android: `flutter run --flavor independent`

--- a/mobile/apps/locker/README.md
+++ b/mobile/apps/locker/README.md
@@ -6,9 +6,7 @@ Ente's secure document storage app. An end-to-end encrypted app for storing impo
 
 1. [Install Flutter v3.38.10](https://flutter.dev/docs/get-started/install).
 
-2. Install dependencies using one of these methods:
-   - **Using Flutter:** From any folder inside `mobile/`, run `flutter pub get --enforce-lockfile`.
-   - **Using Melos:** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap`. This will install dependencies.
+2. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
 
 3. Run the app:
    - Android: `flutter run --flavor independent`

--- a/mobile/apps/locker/README.md
+++ b/mobile/apps/locker/README.md
@@ -6,7 +6,7 @@ Ente's secure document storage app. An end-to-end encrypted app for storing impo
 
 1. [Install Flutter v3.38.10](https://flutter.dev/docs/get-started/install).
 
-2. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
+2. From any folder inside `mobile/`, install the workspace dependencies with `flutter pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
 
 3. Run the app:
    - Android: `flutter run --flavor independent`

--- a/mobile/apps/photos/README.md
+++ b/mobile/apps/photos/README.md
@@ -39,9 +39,7 @@ You can alternatively install the build from PlayStore or F-Droid.
 
 1. Install [Flutter v3.38.10](https://flutter.dev/docs/get-started/install) and [Rust](https://www.rust-lang.org/tools/install).
 
-2. Install dependencies and generate Rust bindings using one of these methods:
-   - **Using Flutter:** From any folder inside `mobile/`, run `flutter pub get --enforce-lockfile`, then from `rust/`, run `cargo codegen frb`.
-   - **Using Melos:** Install Melos with `dart pub global activate melos`, then from any folder inside `mobile/`, run `melos bootstrap` and `melos run codegen:rust`.
+2. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
 
 3. Run the app:
    - Android: `flutter run --flavor independent`

--- a/mobile/apps/photos/README.md
+++ b/mobile/apps/photos/README.md
@@ -39,7 +39,7 @@ You can alternatively install the build from PlayStore or F-Droid.
 
 1. Install [Flutter v3.38.10](https://flutter.dev/docs/get-started/install) and [Rust](https://www.rust-lang.org/tools/install).
 
-2. From any folder inside `mobile/`, install the workspace dependencies with `dart pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
+2. From any folder inside `mobile/`, install the workspace dependencies with `flutter pub get --enforce-lockfile`. Then, from `rust/`, generate the Rust bindings with `cargo codegen frb`.
 
 3. Run the app:
    - Android: `flutter run --flavor independent`


### PR DESCRIPTION
Updates the Auth, Locker, and Photos build instructions to use Dart pub workspaces directly, including Rust binding generation where required.
