### PR TITLE
[mobile] Enforce safe BuildContext use across async flows

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -66,7 +66,7 @@ analyzer:
 
     unawaited_futures: warning # convert to warning after fixing existing issues
     invalid_dependency: info
-    use_build_context_synchronously: ignore # experimental lint, requires many changes
+    use_build_context_synchronously: error
     prefer_interpolation_to_compose_strings: ignore # later too many warnings
     prefer_double_quotes: ignore # too many warnings
     avoid_renaming_method_parameters: ignore # incorrect warnings for `equals` overrides

--- a/mobile/apps/locker/changes/improve-async-action-reliability.md
+++ b/mobile/apps/locker/changes/improve-async-action-reliability.md
@@ -1,0 +1,1 @@
+- Improved the reliability of file and collection actions when navigating between screens.

--- a/mobile/packages/accounts/lib/pages/email_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/email_entry_page.dart
@@ -144,12 +144,14 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                 await _referralSourceForSubmission(),
               );
               await UserService.instance.sendOtt(
-                context,
+                context.mounted ? context : null,
                 _email!,
                 isCreateAccountScreen: true,
                 purpose: "signup",
               );
-              FocusScope.of(context).unfocus();
+              if (context.mounted) {
+                FocusScope.of(context).unfocus();
+              }
             },
           ),
         ],

--- a/mobile/packages/accounts/lib/pages/login_page.dart
+++ b/mobile/packages/accounts/lib/pages/login_page.dart
@@ -41,22 +41,26 @@ class _LoginPageState extends State<LoginPage> {
       }
     }
     if (attr != null && !isEmailVerificationEnabled) {
-      await Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (BuildContext context) {
-            return LoginPasswordVerificationPage(widget.config, attr!);
-          },
-        ),
-      );
+      if (mounted) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (BuildContext context) {
+              return LoginPasswordVerificationPage(widget.config, attr!);
+            },
+          ),
+        );
+      }
     } else {
       await UserService.instance.sendOtt(
-        context,
+        mounted ? context : null,
         _email!,
         isCreateAccountScreen: false,
         purpose: 'login',
       );
     }
-    FocusScope.of(context).unfocus();
+    if (mounted) {
+      FocusScope.of(context).unfocus();
+    }
   }
 
   @override

--- a/mobile/packages/accounts/lib/pages/login_pwd_verification_page.dart
+++ b/mobile/packages/accounts/lib/pages/login_pwd_verification_page.dart
@@ -115,13 +115,16 @@ class _LoginPasswordVerificationPageState
     await dialog.show();
     try {
       await UserService.instance.verifyEmailViaPassword(
-        context,
+        context.mounted ? context : null,
         widget.srpAttributes,
         password,
         dialog,
       );
     } on DioException catch (e, s) {
       await dialog.hide();
+      if (!context.mounted) {
+        return;
+      }
 
       if (e.response != null && e.response!.statusCode == 401) {
         _logger.severe('server reject, failed verify SRP login', e, s);
@@ -154,12 +157,15 @@ class _LoginPasswordVerificationPageState
         _logger.severe('loginKey derivation error', e, s);
         // LoginKey err, perform regular login via ott verification
         await UserService.instance.sendOtt(
-          context,
+          context.mounted ? context : null,
           email!,
           isCreateAccountScreen: true,
         );
         return;
       } else if (e is KeyDerivationError) {
+        if (!context.mounted) {
+          return;
+        }
         // device is not powerful enough to perform derive key
         final result = await showAlertBottomSheet<bool>(
           context,
@@ -177,7 +183,7 @@ class _LoginPasswordVerificationPageState
         );
         if (result == true) {
           await UserService.instance.sendOtt(
-            context,
+            context.mounted ? context : null,
             email!,
             isResetPasswordScreen: true,
           );
@@ -185,11 +191,13 @@ class _LoginPasswordVerificationPageState
         return;
       } else {
         _logger.severe('unexpected error while verifying password', e, s);
-        await _showContactSupportDialog(
-          context,
-          title: context.strings.oops,
-          message: context.strings.verificationFailedPleaseTryAgain,
-        );
+        if (context.mounted) {
+          await _showContactSupportDialog(
+            context,
+            title: context.strings.oops,
+            message: context.strings.verificationFailedPleaseTryAgain,
+          );
+        }
       }
     }
   }
@@ -213,7 +221,7 @@ class _LoginPasswordVerificationPageState
         ),
       ],
     );
-    if (result == true) {
+    if (result == true && context.mounted) {
       await sendLogs(context, "support@ente.com", postShare: () {});
     }
   }
@@ -355,9 +363,11 @@ class _LoginPasswordVerificationPageState
                               await dialog.show();
                               await widget.config.logout();
                               await dialog.hide();
-                              Navigator.of(
-                                context,
-                              ).popUntil((route) => route.isFirst);
+                              if (mounted) {
+                                Navigator.of(
+                                  context,
+                                ).popUntil((route) => route.isFirst);
+                              }
                             },
                             child: Text(
                               context.strings.changeEmail,

--- a/mobile/packages/accounts/lib/pages/passkey_page.dart
+++ b/mobile/packages/accounts/lib/pages/passkey_page.dart
@@ -70,23 +70,35 @@ class _PasskeyPageState extends State<PasskeyPage> {
         widget.sessionID,
       );
     } on PassKeySessionNotVerifiedError {
-      showToast(context, context.strings.passKeyPendingVerification);
+      if (mounted) {
+        showToast(context, context.strings.passKeyPendingVerification);
+      }
       return;
     } on PassKeySessionExpiredError {
+      if (!mounted) {
+        return;
+      }
       await showAlertBottomSheet(
         context,
         title: context.strings.loginSessionExpired,
         message: context.strings.loginSessionExpiredDetails,
         assetPath: 'assets/warning-grey.png',
       );
-      Navigator.of(context).pop();
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
       return;
     } catch (e, s) {
       _logger.severe("failed to check status", e, s);
-      showGenericErrorDialog(context: context, error: e).ignore();
+      if (mounted) {
+        showGenericErrorDialog(context: context, error: e).ignore();
+      }
       return;
     }
-    await UserService.instance.onPassKeyVerified(context, response);
+    await UserService.instance.onPassKeyVerified(
+      mounted ? context : null,
+      response,
+    );
   }
 
   Future<void> _handleDeeplink(String? link) async {
@@ -118,13 +130,18 @@ class _PasskeyPageState extends State<PasskeyPage> {
         }
         final res = utf8.decode(base64.decode(base64String));
         final json = jsonDecode(res) as Map<String, dynamic>;
-        await UserService.instance.onPassKeyVerified(context, json);
+        await UserService.instance.onPassKeyVerified(
+          mounted ? context : null,
+          json,
+        );
       } else {
         _logger.info('ignored deeplink: $link mounted $mounted');
       }
     } catch (e, s) {
       _logger.severe('passKey: failed to handle deeplink', e, s);
-      showGenericErrorDialog(context: context, error: e).ignore();
+      if (mounted) {
+        showGenericErrorDialog(context: context, error: e).ignore();
+      }
     }
   }
 
@@ -203,7 +220,9 @@ class _PasskeyPageState extends State<PasskeyPage> {
                   await checkStatus();
                 } catch (e) {
                   debugPrint('failed to check status %e');
-                  showGenericErrorDialog(context: context, error: e).ignore();
+                  if (mounted) {
+                    showGenericErrorDialog(context: context, error: e).ignore();
+                  }
                 }
               },
             ),

--- a/mobile/packages/accounts/lib/pages/password_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_entry_page.dart
@@ -430,11 +430,13 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
     if (logOutFromOthers == null) {
       return;
     }
-    final dialog = createProgressDialog(
-      context,
-      context.strings.generatingEncryptionKeys,
-    );
-    await dialog.show();
+    final dialog = mounted
+        ? createProgressDialog(
+            context,
+            context.strings.generatingEncryptionKeys,
+          )
+        : null;
+    await dialog?.show();
     try {
       final result = await widget.config.getAttributesForNewPassword(
         _passwordController1.text,
@@ -444,17 +446,21 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
         result.item2,
         logoutOtherDevices: logOutFromOthers,
       );
-      await dialog.hide();
-      showShortToast(context, context.strings.passwordChangedSuccessfully);
-      Navigator.of(context).pop();
-      if (widget.mode == PasswordEntryMode.reset) {
-        Navigator.of(context).popUntil((route) => route.isFirst);
+      await dialog?.hide();
+      if (mounted) {
+        showShortToast(context, context.strings.passwordChangedSuccessfully);
+        Navigator.of(context).pop();
+        if (widget.mode == PasswordEntryMode.reset) {
+          Navigator.of(context).popUntil((route) => route.isFirst);
+        }
       }
     } catch (e, s) {
       _logger.severe("Failed to change password", e, s);
-      await dialog.hide();
-      // ignore: unawaited_futures
-      showGenericErrorDialog(context: context, error: e);
+      await dialog?.hide();
+      if (mounted) {
+        // ignore: unawaited_futures
+        showGenericErrorDialog(context: context, error: e);
+      }
     }
   }
 
@@ -526,30 +532,36 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
       final result = await widget.config.generateKey(password);
       widget.config.resetVolatilePassword();
       await dialog.hide();
+      if (!mounted) {
+        return;
+      }
       onDone() async {
-        final dialog = createProgressDialog(
-          context,
-          context.strings.pleaseWait,
-        );
-        await dialog.show();
+        final dialog = mounted
+            ? createProgressDialog(context, context.strings.pleaseWait)
+            : null;
+        await dialog?.show();
         try {
           await UserService.instance.setAttributes(result);
-          await dialog.hide();
+          await dialog?.hide();
           widget.config.resetVolatilePassword();
-          // ignore: unawaited_futures
-          Navigator.of(context).pushAndRemoveUntil(
-            MaterialPageRoute(
-              builder: (BuildContext context) {
-                return widget.homePage;
-              },
-            ),
-            (route) => false,
-          );
+          if (mounted) {
+            // ignore: unawaited_futures
+            Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(
+                builder: (BuildContext context) {
+                  return widget.homePage;
+                },
+              ),
+              (route) => false,
+            );
+          }
         } catch (e, s) {
           _logger.severe("Failed to configure account", e, s);
-          await dialog.hide();
-          // ignore: unawaited_futures
-          showGenericErrorDialog(context: context, error: e);
+          await dialog?.hide();
+          if (mounted) {
+            // ignore: unawaited_futures
+            showGenericErrorDialog(context: context, error: e);
+          }
         }
       }
 
@@ -569,6 +581,9 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
     } catch (e) {
       _logger.severe(e);
       await dialog.hide();
+      if (!mounted) {
+        return;
+      }
       if (e is UnsupportedError) {
         // ignore: unawaited_futures
         showAlertBottomSheet(

--- a/mobile/packages/accounts/lib/pages/password_reentry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_reentry_page.dart
@@ -120,6 +120,9 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
     } on KeyDerivationError catch (e, s) {
       _logger.severe("Password verification failed", e, s);
       await dialog.hide();
+      if (!mounted) {
+        return;
+      }
 
       final result = await showAlertBottomSheet<bool>(
         context,
@@ -135,7 +138,7 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
           ),
         ],
       );
-      if (result == true) {
+      if (result == true && mounted) {
         // ignore: unawaited_futures
         Navigator.of(context).push(
           MaterialPageRoute(
@@ -149,6 +152,9 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
     } catch (e, s) {
       _logger.severe("Password verification failed", e, s);
       await dialog.hide();
+      if (!mounted) {
+        return;
+      }
 
       final result = await showAlertBottomSheet<bool>(
         context,
@@ -164,23 +170,25 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
           ),
         ],
       );
-      if (result == true) {
+      if (result == true && mounted) {
         await sendLogs(context, "support@ente.com", postShare: () {});
       }
       return;
     }
     widget.config.resetVolatilePassword();
     await dialog.hide();
-    unawaited(
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(
-          builder: (BuildContext context) {
-            return widget.homePage;
-          },
+    if (mounted) {
+      unawaited(
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+            builder: (BuildContext context) {
+              return widget.homePage;
+            },
+          ),
+          (route) => false,
         ),
-        (route) => false,
-      ),
-    );
+      );
+    }
   }
 
   Future<void> _registerSRPForExistingUsers(Uint8List key) async {
@@ -322,9 +330,11 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
                               await dialog.show();
                               await widget.config.logout();
                               await dialog.hide();
-                              Navigator.of(
-                                context,
-                              ).popUntil((route) => route.isFirst);
+                              if (mounted) {
+                                Navigator.of(
+                                  context,
+                                ).popUntil((route) => route.isFirst);
+                              }
                             },
                             child: Text(
                               context.strings.changeEmail,

--- a/mobile/packages/accounts/lib/pages/recovery_key_page.dart
+++ b/mobile/packages/accounts/lib/pages/recovery_key_page.dart
@@ -73,10 +73,12 @@ class _RecoveryKeyPageState extends State<RecoveryKeyPage> {
 
     Future<void> copy() async {
       await Clipboard.setData(ClipboardData(text: recoveryKey));
-      showShortToast(context, context.strings.recoveryKeyCopiedToClipboard);
-      setState(() {
-        _hasTriedToSave = true;
-      });
+      if (context.mounted) {
+        showShortToast(context, context.strings.recoveryKeyCopiedToClipboard);
+        setState(() {
+          _hasTriedToSave = true;
+        });
+      }
     }
 
     return Scaffold(
@@ -296,7 +298,7 @@ class _RecoveryKeyPageState extends State<RecoveryKeyPage> {
     _recoveryKeyFile.writeAsStringSync(recoveryKey);
     await shareFiles([
       XFile(_recoveryKeyFile.path, mimeType: 'text/plain'),
-    ], context: context);
+    ], context: mounted ? context : null);
     Future.delayed(const Duration(milliseconds: 500), () {
       if (mounted) {
         setState(() {

--- a/mobile/packages/accounts/lib/pages/recovery_page.dart
+++ b/mobile/packages/accounts/lib/pages/recovery_page.dart
@@ -32,6 +32,9 @@ class _RecoveryPageState extends State<RecoveryPage> {
     try {
       await widget.config.recover(_recoveryKey.text.trim());
       await dialog.hide();
+      if (!mounted) {
+        return;
+      }
       showToast(context, "Recovery successful!");
       await Navigator.of(context).pushReplacement(
         MaterialPageRoute(
@@ -53,12 +56,14 @@ class _RecoveryPageState extends State<RecoveryPage> {
       if (e is AssertionError) {
         errMessage = '$errMessage : ${e.message}';
       }
-      await showAlertBottomSheet(
-        context,
-        title: context.strings.incorrectRecoveryKey,
-        message: errMessage,
-        assetPath: 'assets/warning-grey.png',
-      );
+      if (mounted) {
+        await showAlertBottomSheet(
+          context,
+          title: context.strings.incorrectRecoveryKey,
+          message: errMessage,
+          assetPath: 'assets/warning-grey.png',
+        );
+      }
     }
   }
 

--- a/mobile/packages/accounts/lib/pages/request_pwd_verification_page.dart
+++ b/mobile/packages/accounts/lib/pages/request_pwd_verification_page.dart
@@ -103,13 +103,15 @@ class _RequestPasswordVerificationPageState
             // pop
             await widget.onPasswordVerified(keyEncryptionKey);
             await dialog.hide();
-            Navigator.of(context).pop(true);
+            if (context.mounted) {
+              Navigator.of(context).pop(true);
+            }
           } catch (e, s) {
             _logger.severe("Error while verifying password", e, s);
             await dialog.hide();
             if (widget.onPasswordError != null) {
               widget.onPasswordError!();
-            } else {
+            } else if (context.mounted) {
               // ignore: unawaited_futures
               showErrorDialog(
                 context,

--- a/mobile/packages/accounts/lib/pages/sessions_page.dart
+++ b/mobile/packages/accounts/lib/pages/sessions_page.dart
@@ -28,7 +28,9 @@ class _SessionsPageState extends State<SessionsPage> {
   @override
   void initState() {
     _fetchActiveSessions().onError((error, stackTrace) {
-      showToast(context, "Failed to fetch active sessions");
+      if (mounted) {
+        showToast(context, "Failed to fetch active sessions");
+      }
     });
     super.initState();
   }
@@ -117,12 +119,14 @@ class _SessionsPageState extends State<SessionsPage> {
     } catch (e) {
       await dialog.hide();
       _logger.severe('failed to terminate');
-      // ignore: unawaited_futures
-      showErrorDialog(
-        context,
-        context.strings.oops,
-        context.strings.somethingWentWrongPleaseTryAgain,
-      );
+      if (mounted) {
+        // ignore: unawaited_futures
+        showErrorDialog(
+          context,
+          context.strings.oops,
+          context.strings.somethingWentWrongPleaseTryAgain,
+        );
+      }
     }
   }
 

--- a/mobile/packages/accounts/lib/services/passkey_service.dart
+++ b/mobile/packages/accounts/lib/services/passkey_service.dart
@@ -43,7 +43,9 @@ class PasskeyService {
       await launchUrlString(url, mode: LaunchMode.externalApplication);
     } catch (e) {
       Logger('PasskeyService').severe("failed to open passkey page", e);
-      showGenericErrorDialog(context: context, error: e).ignore();
+      if (context.mounted) {
+        showGenericErrorDialog(context: context, error: e).ignore();
+      }
     }
   }
 }

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -79,15 +79,17 @@ class UserService {
   }
 
   Future<void> sendOtt(
-    BuildContext context,
+    BuildContext? context,
     String email, {
     bool isChangeEmail = false,
     bool isCreateAccountScreen = false,
     bool isResetPasswordScreen = false,
     String? purpose,
   }) async {
-    final dialog = createProgressDialog(context, context.strings.pleaseWait);
-    await dialog.show();
+    final dialog = context != null && context.mounted
+        ? createProgressDialog(context, context.strings.pleaseWait)
+        : null;
+    await dialog?.show();
     try {
       final response = await _dio.post(
         "${_config.getHttpEndpoint()}/users/ott",
@@ -97,7 +99,10 @@ class UserService {
           "mobile": Platform.isIOS || Platform.isAndroid,
         },
       );
-      await dialog.hide();
+      await dialog?.hide();
+      if (context == null || !context.mounted) {
+        return;
+      }
       if (response.statusCode == 200) {
         unawaited(
           Navigator.of(context).push(
@@ -117,8 +122,11 @@ class UserService {
       }
       unawaited(showGenericErrorDialog(context: context, error: null));
     } on DioException catch (e) {
-      await dialog.hide();
+      await dialog?.hide();
       _logger.info(e);
+      if (context == null || !context.mounted) {
+        return;
+      }
       final responseData = e.response?.data;
       final Object? enteErrCode = responseData is Map
           ? responseData["code"]
@@ -163,9 +171,11 @@ class UserService {
         unawaited(showGenericErrorDialog(context: context, error: e));
       }
     } catch (e) {
-      await dialog.hide();
+      await dialog?.hide();
       _logger.severe(e);
-      unawaited(showGenericErrorDialog(context: context, error: e));
+      if (context != null && context.mounted) {
+        unawaited(showGenericErrorDialog(context: context, error: e));
+      }
     }
   }
 
@@ -278,7 +288,7 @@ class UserService {
     try {
       final response = await _enteDio.post("/users/logout");
       if (response.statusCode == 200) {
-        await _logoutLocally(context);
+        await _logoutLocally(context.mounted ? context : null);
       } else {
         throw Exception("Log out action failed");
       }
@@ -295,28 +305,30 @@ class UserService {
         } else {
           _logger.info("Token already invalid, proceeding with local logout");
         }
-        await _logoutLocally(context);
+        await _logoutLocally(context.mounted ? context : null);
         return;
       }
 
       _logger.severe(e);
       //This future is for waiting for the dialog from which logout() is called
       //to close and only then to show the error dialog.
-      Future.delayed(
-        const Duration(milliseconds: 150),
-        () => showGenericErrorDialog(context: context, error: e),
-      );
+      Future.delayed(const Duration(milliseconds: 150), () {
+        if (context.mounted) {
+          unawaited(showGenericErrorDialog(context: context, error: e));
+        }
+      });
       rethrow;
     }
   }
 
-  Future<void> _logoutLocally(BuildContext context) async {
+  Future<void> _logoutLocally(BuildContext? context) async {
     await _config.logout();
-    if (context.mounted) {
-      unawaited(
-        Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false),
-      );
+    if (context == null || !context.mounted) {
+      return;
     }
+    unawaited(
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false),
+    );
   }
 
   Future<dynamic> getTokenForPasskeySession(String sessionID) async {
@@ -342,27 +354,21 @@ class UserService {
     }
   }
 
-  Future<void> onPassKeyVerified(BuildContext context, Map response) async {
-    final ProgressDialog dialog = createProgressDialog(
-      context,
-      context.strings.pleaseWait,
-    );
-    await dialog.show();
+  Future<void> onPassKeyVerified(BuildContext? context, Map response) async {
+    final ProgressDialog? dialog = context != null && context.mounted
+        ? createProgressDialog(context, context.strings.pleaseWait)
+        : null;
+    await dialog?.show();
     try {
       final userPassword = _config.getVolatilePassword();
       await _saveConfiguration(response);
-      if (!context.mounted) {
-        await dialog.hide();
-        return;
-      }
-      final navigator = Navigator.of(context);
       if (userPassword == null) {
-        await dialog.hide();
-        if (!context.mounted) {
+        await dialog?.hide();
+        if (context == null || !context.mounted) {
           return;
         }
         // ignore: unawaited_futures
-        navigator.pushAndRemoveUntil(
+        Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
             builder: (BuildContext _) {
               return PasswordReentryPage(_config, _homePage);
@@ -384,13 +390,13 @@ class UserService {
         } else {
           throw Exception("unexpected response during passkey verification");
         }
-        await dialog.hide();
-        if (!context.mounted) {
+        await dialog?.hide();
+        if (context == null || !context.mounted) {
           return;
         }
 
         // ignore: unawaited_futures
-        navigator.pushAndRemoveUntil(
+        Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
             builder: (BuildContext _) {
               return page;
@@ -402,7 +408,7 @@ class UserService {
       }
     } catch (e) {
       _logger.severe(e);
-      await dialog.hide();
+      await dialog?.hide();
       rethrow;
     }
   }
@@ -458,6 +464,9 @@ class UserService {
             page = PasswordEntryPage(_config, PasswordEntryMode.set, _homePage);
           }
         }
+        if (!context.mounted) {
+          return;
+        }
         // ignore: unawaited_futures
         Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
@@ -474,6 +483,9 @@ class UserService {
     } on DioException catch (e) {
       _logger.info(e);
       await dialog.hide();
+      if (!context.mounted) {
+        return;
+      }
       if (e.response != null && e.response!.statusCode == 410) {
         await showAlertBottomSheet(
           context,
@@ -481,7 +493,9 @@ class UserService {
           message: context.strings.yourVerificationCodeHasExpired,
           assetPath: 'assets/warning-grey.png',
         );
-        Navigator.of(context).pop();
+        if (context.mounted) {
+          Navigator.of(context).pop();
+        }
       } else {
         // ignore: unawaited_futures
         showAlertBottomSheet(
@@ -494,13 +508,15 @@ class UserService {
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      // ignore: unawaited_futures
-      showAlertBottomSheet(
-        context,
-        title: context.strings.oops,
-        message: context.strings.verificationFailedPleaseTryAgain,
-        assetPath: 'assets/warning-grey.png',
-      );
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showAlertBottomSheet(
+          context,
+          title: context.strings.oops,
+          message: context.strings.verificationFailedPleaseTryAgain,
+          assetPath: 'assets/warning-grey.png',
+        );
+      }
     }
   }
 
@@ -523,10 +539,15 @@ class UserService {
       );
       await dialog.hide();
       if (response.statusCode == 200) {
-        showShortToast(context, context.strings.emailChangedTo(email));
         await setEmail(email);
-        Navigator.of(context).popUntil((route) => route.isFirst);
         Bus.instance.fire(UserDetailsChangedEvent());
+        if (context.mounted) {
+          showShortToast(context, context.strings.emailChangedTo(email));
+          Navigator.of(context).popUntil((route) => route.isFirst);
+        }
+        return;
+      }
+      if (!context.mounted) {
         return;
       }
       // ignore: unawaited_futures
@@ -537,6 +558,9 @@ class UserService {
       );
     } on DioException catch (e) {
       await dialog.hide();
+      if (!context.mounted) {
+        return;
+      }
       if (e.response != null && e.response!.statusCode == 403) {
         // ignore: unawaited_futures
         showErrorDialog(
@@ -555,12 +579,14 @@ class UserService {
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      // ignore: unawaited_futures
-      showErrorDialog(
-        context,
-        context.strings.oops,
-        context.strings.verificationFailedPleaseTryAgain,
-      );
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showErrorDialog(
+          context,
+          context.strings.oops,
+          context.strings.verificationFailedPleaseTryAgain,
+        );
+      }
     }
   }
 
@@ -687,7 +713,7 @@ class UserService {
   }
 
   Future<void> verifyEmailViaPassword(
-    BuildContext context,
+    BuildContext? context,
     SrpAttributes srpAttributes,
     String userPassword,
     ProgressDialog dialog,
@@ -778,17 +804,19 @@ class UserService {
         }
       }
       await dialog.hide();
-      // ignore: unawaited_futures
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(
-          builder: (BuildContext context) {
-            return page!;
-          },
-        ),
-        identical(page, _homePage)
-            ? (route) => false
-            : (route) => route.isFirst,
-      );
+      if (context != null && context.mounted) {
+        // ignore: unawaited_futures
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+            builder: (BuildContext context) {
+              return page!;
+            },
+          ),
+          identical(page, _homePage)
+              ? (route) => false
+              : (route) => route.isFirst,
+        );
+      }
     } else {
       // should never reach here
       throw Exception("unexpected response during email verification");
@@ -853,21 +881,26 @@ class UserService {
       );
       await dialog.hide();
       if (response.statusCode == 200) {
-        showShortToast(context, context.strings.authenticationSuccessful);
         await _saveConfiguration(response);
-        // ignore: unawaited_futures
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (BuildContext context) {
-              return PasswordReentryPage(_config, _homePage);
-            },
-          ),
-          (route) => route.isFirst,
-        );
+        if (context.mounted) {
+          showShortToast(context, context.strings.authenticationSuccessful);
+          // ignore: unawaited_futures
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return PasswordReentryPage(_config, _homePage);
+              },
+            ),
+            (route) => route.isFirst,
+          );
+        }
       }
     } on DioException catch (e) {
       await dialog.hide();
       _logger.severe(e);
+      if (!context.mounted) {
+        return;
+      }
       if (e.response != null && e.response!.statusCode == 404) {
         showToast(context, "Session expired");
         // ignore: unawaited_futures
@@ -891,13 +924,15 @@ class UserService {
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      // ignore: unawaited_futures
-      showAlertBottomSheet(
-        context,
-        title: context.strings.oops,
-        message: context.strings.authenticationFailedPleaseTryAgain,
-        assetPath: 'assets/warning-grey.png',
-      );
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showAlertBottomSheet(
+          context,
+          title: context.strings.oops,
+          message: context.strings.authenticationFailedPleaseTryAgain,
+          assetPath: 'assets/warning-grey.png',
+        );
+      }
     }
   }
 
@@ -918,24 +953,29 @@ class UserService {
       );
       await dialog.hide();
       if (response.statusCode == 200) {
-        // ignore: unawaited_futures
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (BuildContext context) {
-              return TwoFactorRecoveryPage(
-                type,
-                sessionID,
-                response.data["encryptedSecret"],
-                response.data["secretDecryptionNonce"],
-              );
-            },
-          ),
-          (route) => route.isFirst,
-        );
+        if (context.mounted) {
+          // ignore: unawaited_futures
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return TwoFactorRecoveryPage(
+                  type,
+                  sessionID,
+                  response.data["encryptedSecret"],
+                  response.data["secretDecryptionNonce"],
+                );
+              },
+            ),
+            (route) => route.isFirst,
+          );
+        }
       }
     } on DioException catch (e) {
       await dialog.hide();
       _logger.severe(e);
+      if (!context.mounted) {
+        return;
+      }
       if (e.response != null && e.response!.statusCode == 404) {
         showToast(context, context.strings.sessionExpired);
         // ignore: unawaited_futures
@@ -959,13 +999,15 @@ class UserService {
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      // ignore: unawaited_futures
-      showAlertBottomSheet(
-        context,
-        title: context.strings.oops,
-        message: context.strings.somethingWentWrongPleaseTryAgain,
-        assetPath: 'assets/warning-grey.png',
-      );
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showAlertBottomSheet(
+          context,
+          title: context.strings.oops,
+          message: context.strings.somethingWentWrongPleaseTryAgain,
+          assetPath: 'assets/warning-grey.png',
+        );
+      }
     } finally {
       await dialog.hide();
     }
@@ -1000,6 +1042,9 @@ class UserService {
       );
     } catch (e) {
       await dialog.hide();
+      if (!context.mounted) {
+        return;
+      }
       await showAlertBottomSheet(
         context,
         title: context.strings.incorrectRecoveryKey,
@@ -1019,24 +1064,29 @@ class UserService {
       );
       await dialog.hide();
       if (response.statusCode == 200) {
-        showShortToast(
-          context,
-          context.strings.twofactorAuthenticationSuccessfullyReset,
-        );
         await _saveConfiguration(response);
-        // ignore: unawaited_futures
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (BuildContext context) {
-              return PasswordReentryPage(_config, _homePage);
-            },
-          ),
-          (route) => route.isFirst,
-        );
+        if (context.mounted) {
+          showShortToast(
+            context,
+            context.strings.twofactorAuthenticationSuccessfullyReset,
+          );
+          // ignore: unawaited_futures
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(
+              builder: (BuildContext context) {
+                return PasswordReentryPage(_config, _homePage);
+              },
+            ),
+            (route) => route.isFirst,
+          );
+        }
       }
     } on DioException catch (e) {
       await dialog.hide();
       _logger.severe(e);
+      if (!context.mounted) {
+        return;
+      }
       if (e.response != null && e.response!.statusCode == 404) {
         showToast(context, "Session expired");
         // ignore: unawaited_futures
@@ -1060,13 +1110,15 @@ class UserService {
     } catch (e) {
       await dialog.hide();
       _logger.severe(e);
-      // ignore: unawaited_futures
-      showAlertBottomSheet(
-        context,
-        title: context.strings.oops,
-        message: context.strings.somethingWentWrongPleaseTryAgain,
-        assetPath: 'assets/warning-grey.png',
-      );
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showAlertBottomSheet(
+          context,
+          title: context.strings.oops,
+          message: context.strings.somethingWentWrongPleaseTryAgain,
+          assetPath: 'assets/warning-grey.png',
+        );
+      }
     } finally {
       await dialog.hide();
     }

--- a/mobile/packages/ente_components/lib/components/text_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/text_input_component.dart
@@ -607,6 +607,7 @@ class _TextInputComponentState extends State<TextInputComponent> {
     if (widget.onSubmit == null || widget.isDisabled || _isSubmitting) {
       return;
     }
+    final popNavAfterSubmission = widget.popNavAfterSubmission;
 
     setState(() {
       _isSubmitting = true;
@@ -619,18 +620,19 @@ class _TextInputComponentState extends State<TextInputComponent> {
     try {
       await widget.onSubmit!.call(_controller.text);
     } catch (error) {
-      if (error.toString().contains('Incorrect password')) {
-        _surfaceWrongPasswordState();
-      }
       if (mounted) {
+        if (error.toString().contains('Incorrect password')) {
+          _surfaceWrongPasswordState();
+        }
         setState(() => _isSubmitting = false);
+        if (popNavAfterSubmission) {
+          _popNavigatorStack(
+            context,
+            e: error is Exception ? error : Exception(error.toString()),
+          );
+        }
       }
-      if (widget.popNavAfterSubmission) {
-        _popNavigatorStack(
-          context,
-          e: error is Exception ? error : Exception(error.toString()),
-        );
-      } else {
+      if (!popNavAfterSubmission) {
         rethrow;
       }
       return;

--- a/mobile/packages/legacy/lib/pages/emergency_page.dart
+++ b/mobile/packages/legacy/lib/pages/emergency_page.dart
@@ -598,6 +598,9 @@ class _EmergencyPageState extends State<EmergencyPage> {
     final result = await showTrustedContactSheet(context, contact: contact);
 
     if (result?.action == TrustedContactAction.revoke) {
+      if (!context.mounted) {
+        return;
+      }
       final isPending = contact.isPendingInvite();
       final colorScheme = getEnteColorScheme(context);
       final confirmed = await showAlertBottomSheet<bool>(
@@ -652,7 +655,7 @@ class _EmergencyPageState extends State<EmergencyPage> {
             setState(() {});
           }
         } else {
-          if (mounted) {
+          if (context.mounted) {
             await showAlertBottomSheet(
               context,
               title: context.strings.cannotUpdateRecoveryTime,
@@ -662,7 +665,7 @@ class _EmergencyPageState extends State<EmergencyPage> {
           }
         }
       } catch (e) {
-        if (mounted) {
+        if (context.mounted) {
           showShortToast(context, context.strings.somethingWentWrong);
         }
       }

--- a/mobile/packages/legacy/lib/pages/other_contact_page.dart
+++ b/mobile/packages/legacy/lib/pages/other_contact_page.dart
@@ -182,12 +182,20 @@ class _OtherContactPageState extends State<OtherContactPage> {
                     ) = await EmergencyContactService.instance.getRecoveryInfo(
                       recoverySession!,
                     );
+                    if (!context.mounted) {
+                      return;
+                    }
                     routeToPage(
                       context,
                       RecoverOthersAccount(key, attributes, recoverySession!),
                     ).ignore();
                   } catch (e) {
-                    showGenericErrorDialog(context: context, error: e).ignore();
+                    if (context.mounted) {
+                      showGenericErrorDialog(
+                        context: context,
+                        error: e,
+                      ).ignore();
+                    }
                   }
                 },
               ),

--- a/mobile/packages/legacy/lib/pages/other_contact_page.dart
+++ b/mobile/packages/legacy/lib/pages/other_contact_page.dart
@@ -147,7 +147,7 @@ class _OtherContactPageState extends State<OtherContactPage> {
                           try {
                             await EmergencyContactService.instance
                                 .startRecovery(widget.contact);
-                            if (mounted) {
+                            if (context.mounted) {
                               _fetchData().ignore();
                               await showAlertBottomSheet(
                                 context,
@@ -160,10 +160,12 @@ class _OtherContactPageState extends State<OtherContactPage> {
                               );
                             }
                           } catch (e) {
-                            showGenericErrorDialog(
-                              context: context,
-                              error: e,
-                            ).ignore();
+                            if (context.mounted) {
+                              showGenericErrorDialog(
+                                context: context,
+                                error: e,
+                              ).ignore();
+                            }
                           }
                         }
                       },
@@ -283,7 +285,9 @@ class _OtherContactPageState extends State<OtherContactPage> {
           _fetchData().ignore();
         }
       } catch (e) {
-        showGenericErrorDialog(context: context, error: e).ignore();
+        if (mounted) {
+          showGenericErrorDialog(context: context, error: e).ignore();
+        }
       }
     }
   }
@@ -317,7 +321,9 @@ class _OtherContactPageState extends State<OtherContactPage> {
           Navigator.of(context).pop();
         }
       } catch (e) {
-        showGenericErrorDialog(context: context, error: e).ignore();
+        if (mounted) {
+          showGenericErrorDialog(context: context, error: e).ignore();
+        }
       }
     }
   }

--- a/mobile/packages/legacy/lib/pages/recover_others_account.dart
+++ b/mobile/packages/legacy/lib/pages/recover_others_account.dart
@@ -341,17 +341,21 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
         widget.sessions,
       );
       await dialog.hide();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.strings.passwordChangedSuccessfully),
-          backgroundColor: Colors.green,
-        ),
-      );
-      Navigator.of(context).pop();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.strings.passwordChangedSuccessfully),
+            backgroundColor: Colors.green,
+          ),
+        );
+        Navigator.of(context).pop();
+      }
     } catch (e, s) {
       _logger.severe("Failed to recover account", e, s);
       await dialog.hide();
-      await showGenericErrorDialog(context: context, error: e);
+      if (mounted) {
+        await showGenericErrorDialog(context: context, error: e);
+      }
     }
   }
 

--- a/mobile/packages/legacy/lib/pages/select_contact_page.dart
+++ b/mobile/packages/legacy/lib/pages/select_contact_page.dart
@@ -337,7 +337,7 @@ class _AddContactSheetState extends State<AddContactSheet> {
     if (confirmed == true) {
       try {
         final success = await EmergencyContactService.instance.addContact(
-          context,
+          mounted ? context : null,
           emailToAdd,
           _selectedRecoveryDays,
         );

--- a/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
+++ b/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
@@ -401,6 +401,7 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
   }
 
   Future<void> _editRecoveryWaitTime() async {
+    final authReason = context.strings.authToManageLegacyKit;
     if (_kit.hasActiveRecoverySession) {
       await showAlertBottomSheet(
         context,
@@ -417,7 +418,7 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
     if (selectedDays == null || selectedDays * 24 == _kit.noticePeriodInHours) {
       return;
     }
-    if (!await _authenticate(context.strings.authToManageLegacyKit)) {
+    if (!await _authenticate(authReason)) {
       return;
     }
     if (!mounted) {

--- a/mobile/packages/legacy/lib/services/emergency_service.dart
+++ b/mobile/packages/legacy/lib/services/emergency_service.dart
@@ -42,37 +42,45 @@ class EmergencyContactService {
   }
 
   Future<bool> addContact(
-    BuildContext context,
+    BuildContext? context,
     String email,
     int recoveryNoticeInDays,
   ) async {
     if (!isValidEmail(email)) {
-      await showAlertBottomSheet(
-        context,
-        title: context.strings.letsTryThatAgain,
-        message: context.strings.enterValidEmail,
-        assetPath: "assets/warning-blue.png",
-      );
+      if (context != null && context.mounted) {
+        await showAlertBottomSheet(
+          context,
+          title: context.strings.letsTryThatAgain,
+          message: context.strings.enterValidEmail,
+          assetPath: "assets/warning-blue.png",
+        );
+      }
       return false;
     }
     if (email.trim() == _config.getEmail()) {
-      await showAlertBottomSheet(
-        context,
-        title: context.strings.oops,
-        message: context.strings.youCannotShareWithYourself,
-        assetPath: "assets/warning-blue.png",
-      );
+      if (context != null && context.mounted) {
+        await showAlertBottomSheet(
+          context,
+          title: context.strings.oops,
+          message: context.strings.youCannotShareWithYourself,
+          assetPath: "assets/warning-blue.png",
+        );
+      }
       return false;
     }
 
-    final dialog = createProgressDialog(context, context.strings.pleaseWait);
-    await dialog.show();
+    final dialog = context != null && context.mounted
+        ? createProgressDialog(context, context.strings.pleaseWait)
+        : null;
+    await dialog?.show();
 
     try {
       final String? publicKey = await _userService.getPublicKey(email);
       if (publicKey == null) {
-        await dialog.hide();
-        await showInviteSheet(context, email: email);
+        await dialog?.hide();
+        if (context != null && context.mounted) {
+          await showInviteSheet(context, email: email);
+        }
         return false;
       }
 
@@ -89,10 +97,10 @@ class EmergencyContactService {
           "recoveryNoticeInDays": recoveryNoticeInDays,
         },
       );
-      await dialog.hide();
+      await dialog?.hide();
       return true;
     } catch (e) {
-      await dialog.hide();
+      await dialog?.hide();
       rethrow;
     }
   }

--- a/mobile/packages/lock_screen/lib/auth_util.dart
+++ b/mobile/packages/lock_screen/lib/auth_util.dart
@@ -276,9 +276,13 @@ Future<bool> requestAuthentication(
   bool isOpeningApp = false,
   bool isAuthenticatingForInAppChange = false,
 }) async {
+  final l10n = context.strings;
   final String? savedPin = await LockScreenSettings.instance.getPin();
   final String? savedPassword = await LockScreenSettings.instance.getPassword();
   if (savedPassword != null || savedPin != null) {
+    if (!context.mounted) {
+      return false;
+    }
     return await LocalAuthenticationService.instance
         .requestEnteAuthForLockScreen(
           context,
@@ -292,7 +296,6 @@ Future<bool> requestAuthentication(
   try {
     await localAuth.stopAuthentication();
     await _logLocalAuthState(localAuth);
-    final l10n = context.strings;
     final result = await localAuth.authenticate(
       localizedReason: Platform.isMacOS
           ? (macOSReason ?? defaultReason)

--- a/mobile/packages/lock_screen/lib/local_authentication_service.dart
+++ b/mobile/packages/lock_screen/lib/local_authentication_service.dart
@@ -31,6 +31,7 @@ class LocalAuthenticationService {
     bool refocusWindows = true,
     bool useDebugAuthCache = true,
   }) async {
+    final unlockReason = context.strings.unlock;
     if (kDebugMode && useDebugAuthCache) {
       // if last auth time is less than 60 seconds, don't ask for auth again
       if (lastAuthTime != 0 &&
@@ -40,6 +41,9 @@ class LocalAuthenticationService {
     }
     if (await isLocalAuthSupportedOnDevice() ||
         LockScreenSettings.instance.getIsAppLockSet()) {
+      if (!context.mounted) {
+        return false;
+      }
       final appLock = AppLock.of(context);
       appLock?.setEnabled(false);
       bool result = false;
@@ -50,7 +54,7 @@ class LocalAuthenticationService {
           context,
           infoMessage,
           title: title,
-          macOSReason: context.strings.unlock,
+          macOSReason: unlockReason,
           isAuthenticatingForInAppChange: true,
         );
       } on WindowsLocalAuthenticationException catch (e, s) {
@@ -83,7 +87,9 @@ class LocalAuthenticationService {
         return false;
       }
       if (!result) {
-        showToast(context, infoMessage);
+        if (context.mounted) {
+          showToast(context, infoMessage);
+        }
         return false;
       } else {
         if (useDebugAuthCache) {
@@ -120,6 +126,9 @@ class LocalAuthenticationService {
       }
     }
     if (savedPin != null) {
+      if (!context.mounted) {
+        return false;
+      }
       final result = await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (BuildContext context) {
@@ -146,17 +155,22 @@ class LocalAuthenticationService {
     String errorDialogContent, [
     String errorDialogTitle = "",
   ]) async {
+    final unlockReason = context.strings.unlock;
     if (await isLocalAuthSupportedOnDevice()) {
+      if (!context.mounted) {
+        return false;
+      }
+      final appLock = AppLock.of(context)!;
       bool didEnableLockScreen = false;
-      AppLock.of(context)!.disable();
+      appLock.disable();
       try {
         final result = await requestAuthentication(
           context,
           infoMessage,
-          macOSReason: context.strings.unlock,
+          macOSReason: unlockReason,
         );
         if (result) {
-          AppLock.of(context)!.setEnabled(shouldEnableLockScreen);
+          appLock.setEnabled(shouldEnableLockScreen);
           await LockScreenSettings.instance.setSystemLockScreen(
             shouldEnableLockScreen,
           );
@@ -175,14 +189,16 @@ class LocalAuthenticationService {
         }
       } finally {
         if (!didEnableLockScreen) {
-          AppLock.of(context)!.setEnabled(
+          appLock.setEnabled(
             await LockScreenSettings.instance.shouldShowLockScreen(),
           );
         }
       }
     } else {
-      // ignore: unawaited_futures
-      showErrorDialog(context, errorDialogTitle, errorDialogContent);
+      if (context.mounted) {
+        // ignore: unawaited_futures
+        showErrorDialog(context, errorDialogTitle, errorDialogContent);
+      }
     }
     return false;
   }

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_password.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_password.dart
@@ -37,8 +37,10 @@ class _LockScreenConfirmPasswordState extends State<LockScreenConfirmPassword> {
     if (widget.password == _confirmPasswordController.text) {
       await _lockscreenSetting.setPassword(_confirmPasswordController.text);
 
-      Navigator.of(context).pop(true);
-      Navigator.of(context).pop(true);
+      if (mounted) {
+        Navigator.of(context).pop(true);
+        Navigator.of(context).pop(true);
+      }
       return;
     }
     await HapticFeedback.vibrate();

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_pin.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_confirm_pin.dart
@@ -41,8 +41,10 @@ class _LockScreenConfirmPinState extends State<LockScreenConfirmPin> {
     if (widget.pin == _confirmPinController.text) {
       await _lockscreenSetting.setPin(_confirmPinController.text);
 
-      Navigator.of(context).pop(true);
-      Navigator.of(context).pop(true);
+      if (mounted) {
+        Navigator.of(context).pop(true);
+        Navigator.of(context).pop(true);
+      }
       return;
     }
     setState(() {
@@ -50,10 +52,12 @@ class _LockScreenConfirmPinState extends State<LockScreenConfirmPin> {
     });
     await HapticFeedback.vibrate();
     await Future.delayed(const Duration(milliseconds: 75));
-    _confirmPinController.clear();
-    setState(() {
-      isConfirmPinValid = false;
-    });
+    if (mounted) {
+      _confirmPinController.clear();
+      setState(() {
+        isConfirmPinValid = false;
+      });
+    }
   }
 
   @override

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_options.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_options.dart
@@ -55,6 +55,9 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
         .getShouldHideAppContent();
     final bool systemLockEnabled = _lockScreenSettings
         .shouldShowSystemLockScreen();
+    if (!mounted) {
+      return;
+    }
     setState(() {
       isPasswordEnabled = passwordEnabled;
       isPinEnabled = pinEnabled;
@@ -72,23 +75,27 @@ class _LockScreenOptionsState extends State<LockScreenOptions> {
       final linuxStatus = await LocalAuthenticationService.instance
           .getLinuxLocalAuthSetupStatus();
       if (Platform.isLinux && linuxStatus?.setupRequired == true) {
-        await showLinuxSystemAuthSetupDialog(context);
+        if (mounted) {
+          await showLinuxSystemAuthSetupDialog(context);
+        }
         await _initializeSettings();
         return;
       }
-      await showDialogWidget(
-        context: context,
-        title: context.strings.noSystemLockFound,
-        body: context.strings.deviceLockEnablePreSteps,
-        isDismissible: true,
-        buttons: [
-          ButtonWidget(
-            buttonType: ButtonType.secondary,
-            labelText: context.strings.ok,
-            isInAlert: true,
-          ),
-        ],
-      );
+      if (mounted) {
+        await showDialogWidget(
+          context: context,
+          title: context.strings.noSystemLockFound,
+          body: context.strings.deviceLockEnablePreSteps,
+          isDismissible: true,
+          buttons: [
+            ButtonWidget(
+              buttonType: ButtonType.secondary,
+              labelText: context.strings.ok,
+              isInAlert: true,
+            ),
+          ],
+        );
+      }
     }
     await _initializeSettings();
   }

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_password.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_password.dart
@@ -178,20 +178,22 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
     if (matched) {
       await _lockscreenSetting.setInvalidAttemptCount(0);
 
-      widget.isAuthenticatingOnAppLaunch ||
-              widget.isAuthenticatingForInAppChange
-          ? Navigator.of(context).pop(true)
-          : Navigator.of(context).pushReplacement(
-              MaterialPageRoute(
-                builder: (context) => const LockScreenOptions(),
-              ),
-            );
+      if (mounted) {
+        widget.isAuthenticatingOnAppLaunch ||
+                widget.isAuthenticatingForInAppChange
+            ? Navigator.of(context).pop(true)
+            : Navigator.of(context).pushReplacement(
+                MaterialPageRoute(
+                  builder: (context) => const LockScreenOptions(),
+                ),
+              );
+      }
       return true;
     } else {
       if (widget.isAuthenticatingOnAppLaunch) {
         invalidAttemptsCount++;
         await _lockscreenSetting.setInvalidAttemptCount(invalidAttemptsCount);
-        if (invalidAttemptsCount > 4) {
+        if (invalidAttemptsCount > 4 && mounted) {
           Navigator.of(context).pop(false);
         }
       }
@@ -212,7 +214,9 @@ class _LockScreenPasswordState extends State<LockScreenPassword> {
               LockScreenConfirmPassword(password: _passwordController.text),
         ),
       );
-      _passwordController.clear();
+      if (mounted) {
+        _passwordController.clear();
+      }
     }
   }
 }

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_pin.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_pin.dart
@@ -76,30 +76,36 @@ class _LockScreenPinState extends State<LockScreenPin> {
     if (matched) {
       invalidAttemptsCount = 0;
       await _lockscreenSetting.setInvalidAttemptCount(0);
-      widget.isAuthenticatingOnAppLaunch ||
-              widget.isAuthenticatingForInAppChange
-          ? Navigator.of(context).pop(true)
-          : Navigator.of(context).pushReplacement(
-              MaterialPageRoute(
-                builder: (context) => const LockScreenOptions(),
-              ),
-            );
+      if (mounted) {
+        widget.isAuthenticatingOnAppLaunch ||
+                widget.isAuthenticatingForInAppChange
+            ? Navigator.of(context).pop(true)
+            : Navigator.of(context).pushReplacement(
+                MaterialPageRoute(
+                  builder: (context) => const LockScreenOptions(),
+                ),
+              );
+      }
       return true;
     } else {
-      setState(() {
-        isPinValid = true;
-      });
+      if (mounted) {
+        setState(() {
+          isPinValid = true;
+        });
+      }
       await HapticFeedback.vibrate();
       await Future.delayed(const Duration(milliseconds: 75));
-      _pinController.clear();
-      setState(() {
-        isPinValid = false;
-      });
+      if (mounted) {
+        _pinController.clear();
+        setState(() {
+          isPinValid = false;
+        });
+      }
 
       if (widget.isAuthenticatingOnAppLaunch) {
         invalidAttemptsCount++;
         await _lockscreenSetting.setInvalidAttemptCount(invalidAttemptsCount);
-        if (invalidAttemptsCount > 4) {
+        if (invalidAttemptsCount > 4 && mounted) {
           Navigator.of(context).pop(false);
         }
       }
@@ -118,7 +124,9 @@ class _LockScreenPinState extends State<LockScreenPin> {
               LockScreenConfirmPin(pin: inputtedPin),
         ),
       );
-      _pinController.clear();
+      if (mounted) {
+        _pinController.clear();
+      }
     }
   }
 

--- a/mobile/packages/log_viewer/lib/log_viewer.dart
+++ b/mobile/packages/log_viewer/lib/log_viewer.dart
@@ -66,6 +66,9 @@ class LogViewer {
     if (!_initialized) {
       await initialize();
     }
+    if (!context.mounted) {
+      return;
+    }
 
     await Navigator.push(
       context,

--- a/mobile/packages/qr/lib/qr_code_dialog.dart
+++ b/mobile/packages/qr/lib/qr_code_dialog.dart
@@ -121,6 +121,9 @@ class _QrCodeDialogState extends State<QrCodeDialog> {
       final directory = await getTemporaryDirectory();
       final file = File('${directory.path}/${widget.shareFileName}');
       await file.writeAsBytes(pngBytes);
+      if (!mounted) {
+        return;
+      }
 
       final box = context.findRenderObject() as RenderBox?;
       final shareOrigin = box != null

--- a/mobile/packages/sharing/lib/verify_identity_dialog.dart
+++ b/mobile/packages/sharing/lib/verify_identity_dialog.dart
@@ -144,15 +144,14 @@ class _VerifyIdentitySheetState extends State<VerifyIdentitySheet> {
         if (verificationID.isEmpty) {
           return;
         }
+        final shareMessage = widget.self
+            ? context.strings.shareMyVerificationID(verificationID)
+            : context.strings.shareTextConfirmOthersVerificationID(
+                verificationID,
+              );
         await Clipboard.setData(ClipboardData(text: verificationID));
         // ignore: unawaited_futures
-        shareText(
-          widget.self
-              ? context.strings.shareMyVerificationID(verificationID)
-              : context.strings.shareTextConfirmOthersVerificationID(
-                  verificationID,
-                ),
-        );
+        shareText(shareMessage);
       },
       child: Container(
         decoration: BoxDecoration(

--- a/mobile/packages/ui/lib/components/buttons/button_widget.dart
+++ b/mobile/packages/ui/lib/components/buttons/button_widget.dart
@@ -419,9 +419,11 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
     if (widget.onTap != null) {
       _debouncer.run(
         () => Future(() {
-          setState(() {
-            executionState = ExecutionState.inProgress;
-          });
+          if (mounted) {
+            setState(() {
+              executionState = ExecutionState.inProgress;
+            });
+          }
         }),
       );
       await widget.onTap!.call().then(
@@ -434,6 +436,10 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
           _debouncer.cancelDebounce();
         },
       );
+      if (!mounted) {
+        _debouncer.cancelDebounce();
+        return;
+      }
       widget.shouldShowSuccessConfirmation && _debouncer.isActive()
           ? executionState = ExecutionState.successful
           : null;
@@ -449,6 +455,9 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       // condition so that the calback in the debouncer finishes execution before.
       await Future.delayed(const Duration(milliseconds: 5));
     }
+    if (!mounted) {
+      return;
+    }
     if (executionState == ExecutionState.inProgress ||
         executionState == ExecutionState.error) {
       if (executionState == ExecutionState.inProgress) {
@@ -462,6 +471,9 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
                     : 0,
               ),
               () {
+                if (!mounted) {
+                  return;
+                }
                 widget.isInAlert
                     ? _popWithButtonAction(
                         context,
@@ -482,14 +494,16 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
         setState(() {
           executionState = ExecutionState.idle;
           widget.isInAlert
-              ? Future.delayed(
-                  const Duration(seconds: 0),
-                  () => _popWithButtonAction(
+              ? Future.delayed(const Duration(seconds: 0), () {
+                  if (!mounted) {
+                    return;
+                  }
+                  _popWithButtonAction(
                     context,
                     buttonAction: ButtonAction.error,
                     exception: _exception,
-                  ),
-                )
+                  );
+                })
               : null;
         });
       }
@@ -497,8 +511,12 @@ class _ButtonChildWidgetState extends State<ButtonChildWidget> {
       if (widget.isInAlert) {
         Future.delayed(
           Duration(seconds: widget.shouldShowSuccessConfirmation ? 1 : 0),
-          () =>
-              _popWithButtonAction(context, buttonAction: widget.buttonAction),
+          () {
+            if (!mounted) {
+              return;
+            }
+            _popWithButtonAction(context, buttonAction: widget.buttonAction);
+          },
         );
       }
     }

--- a/mobile/packages/ui/lib/components/text_input_widget.dart
+++ b/mobile/packages/ui/lib/components/text_input_widget.dart
@@ -229,9 +229,11 @@ class _TextInputWidgetState extends State<TextInputWidget> {
   void _onSubmit() async {
     _debouncer.run(
       () => Future(() {
-        setState(() {
-          executionState = ExecutionState.inProgress;
-        });
+        if (mounted) {
+          setState(() {
+            executionState = ExecutionState.inProgress;
+          });
+        }
       }),
     );
     if (widget.shouldUnfocusOnCancelOrSubmit) {
@@ -240,6 +242,13 @@ class _TextInputWidgetState extends State<TextInputWidget> {
     try {
       await widget.onSubmit!.call(_textController.text);
     } catch (e) {
+      if (!mounted) {
+        _debouncer.cancelDebounce();
+        if (!widget.popNavAfterSubmission) {
+          rethrow;
+        }
+        return;
+      }
       executionState = ExecutionState.error;
       _debouncer.cancelDebounce();
       _exception = e as Exception;
@@ -250,6 +259,10 @@ class _TextInputWidgetState extends State<TextInputWidget> {
       if (!widget.popNavAfterSubmission) {
         rethrow;
       }
+    }
+    if (!mounted) {
+      _debouncer.cancelDebounce();
+      return;
     }
     widget.alwaysShowSuccessState && _debouncer.isActive()
         ? executionState = ExecutionState.successful
@@ -265,6 +278,9 @@ class _TextInputWidgetState extends State<TextInputWidget> {
     // idle state. This Future is for delaying the execution of the if
     // condition so that the calback in the debouncer finishes execution before.
     await Future.delayed(const Duration(milliseconds: 5));
+    if (!mounted) {
+      return;
+    }
     if (executionState == ExecutionState.inProgress ||
         executionState == ExecutionState.error) {
       if (executionState == ExecutionState.inProgress) {
@@ -284,6 +300,9 @@ class _TextInputWidgetState extends State<TextInputWidget> {
                       : 0,
                 ),
                 () {
+                  if (!mounted) {
+                    return;
+                  }
                   widget.popNavAfterSubmission
                       ? _popNavigatorStack(context)
                       : null;
@@ -302,10 +321,12 @@ class _TextInputWidgetState extends State<TextInputWidget> {
         setState(() {
           executionState = ExecutionState.idle;
           widget.popNavAfterSubmission
-              ? Future.delayed(
-                  const Duration(seconds: 0),
-                  () => _popNavigatorStack(context, e: _exception),
-                )
+              ? Future.delayed(const Duration(seconds: 0), () {
+                  if (!mounted) {
+                    return;
+                  }
+                  _popNavigatorStack(context, e: _exception);
+                })
               : null;
         });
       }
@@ -313,7 +334,12 @@ class _TextInputWidgetState extends State<TextInputWidget> {
       if (widget.popNavAfterSubmission) {
         Future.delayed(
           Duration(seconds: widget.alwaysShowSuccessState ? 1 : 0),
-          () => _popNavigatorStack(context),
+          () {
+            if (!mounted) {
+              return;
+            }
+            _popNavigatorStack(context);
+          },
         );
       }
     }

--- a/mobile/packages/ui/lib/pages/developer_settings_page.dart
+++ b/mobile/packages/ui/lib/pages/developer_settings_page.dart
@@ -64,18 +64,24 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                   if ((uri.scheme == "http" || uri.scheme == "https")) {
                     await _ping(url);
                     await widget.setEndpoint(url);
-                    showToast(context, context.strings.endpointUpdatedMessage);
-                    Navigator.of(context).pop();
                   } else {
                     throw const FormatException();
                   }
                 } catch (e) {
+                  if (!context.mounted) {
+                    return;
+                  }
                   // ignore: unawaited_futures
                   showErrorDialog(
                     context,
                     context.strings.invalidEndpoint,
                     context.strings.invalidEndpointMessage,
                   );
+                  return;
+                }
+                if (context.mounted) {
+                  showToast(context, context.strings.endpointUpdatedMessage);
+                  Navigator.of(context).pop();
                 }
               },
               text: context.strings.save,

--- a/mobile/packages/ui/lib/utils/toast_util.dart
+++ b/mobile/packages/ui/lib/utils/toast_util.dart
@@ -9,6 +9,7 @@ void showToast(
   toastLength = Toast.LENGTH_LONG,
   iOSDismissOnTap = true,
 }) async {
+  final colorScheme = getEnteColorScheme(context);
   try {
     await Fluttertoast.cancel();
     await Fluttertoast.showToast(
@@ -16,23 +17,23 @@ void showToast(
       toastLength: toastLength,
       gravity: ToastGravity.BOTTOM,
       timeInSecForIosWeb: 1,
-      backgroundColor: getEnteColorScheme(context).toastBackgroundColor,
-      textColor: getEnteColorScheme(context).toastTextColor,
+      backgroundColor: colorScheme.toastBackgroundColor,
+      textColor: colorScheme.toastTextColor,
       fontSize: 16.0,
     );
   } on MissingPluginException catch (_) {
+    if (!context.mounted) {
+      return;
+    }
     final toast = Container(
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(25.0),
-        color: getEnteColorScheme(context).toastBackgroundColor,
+        color: colorScheme.toastBackgroundColor,
       ),
       child: Text(
         message,
-        style: TextStyle(
-          color: getEnteColorScheme(context).toastTextColor,
-          fontSize: 16.0,
-        ),
+        style: TextStyle(color: colorScheme.toastTextColor, fontSize: 16.0),
       ),
     );
 

--- a/mobile/packages/utils/lib/email_util.dart
+++ b/mobile/packages/utils/lib/email_util.dart
@@ -87,7 +87,7 @@ Future<void> sendLogs(
         buttonAction: ButtonAction.third,
         onTap: () async {
           final zipFilePath = await getZippedLogsFile();
-          await exportLogs(context, zipFilePath);
+          await exportLogs(null, zipFilePath);
         },
       ),
       ButtonWidget(
@@ -118,6 +118,9 @@ Future<void> _sendLogs(
     await FlutterEmailSender.send(email);
   } catch (e, s) {
     _logger.severe('email sender failed', e, s);
+    if (!context.mounted) {
+      return;
+    }
     Navigator.of(context).pop();
     await shareLogs(context, toEmail, zipFilePath);
   }
@@ -158,7 +161,7 @@ Future<void> shareLogs(
     ],
   );
   if (result?.action != null && result!.action == ButtonAction.second) {
-    await exportLogs(context, zipFilePath);
+    await exportLogs(null, zipFilePath);
   }
 }
 
@@ -184,7 +187,7 @@ Future<String> getZippedLogsFile({String logsSubPath = "logs"}) async {
 }
 
 Future<void> exportLogs(
-  BuildContext context,
+  BuildContext? context,
   String zipFilePath, [
   bool isSharing = false,
 ]) async {
@@ -251,11 +254,16 @@ Future<void> sendEmail(
         throw Exception('Could not launch ${params.toString()}');
       }
     } else {
+      if (!context.mounted) {
+        return;
+      }
       _showNoMailAppsDialog(context, to);
     }
   } catch (e) {
     _logger.severe("Failed to send email to $to", e);
-    _showNoMailAppsDialog(context, to);
+    if (context.mounted) {
+      _showNoMailAppsDialog(context, to);
+    }
   }
 }
 
@@ -292,8 +300,12 @@ void _showNoMailAppsDialog(BuildContext context, String toEmail) {
               text: 'Copy Email Address',
               onTap: () async {
                 await Clipboard.setData(ClipboardData(text: toEmail));
-                Navigator.of(bottomSheetContext).pop();
-                showShortToast(context, 'Email address copied');
+                if (bottomSheetContext.mounted) {
+                  Navigator.of(bottomSheetContext).pop();
+                }
+                if (context.mounted) {
+                  showShortToast(context, 'Email address copied');
+                }
               },
             ),
           ],


### PR DESCRIPTION
Enables `use_build_context_synchronously` as an error across mobile and updates affected account, legacy, lock-screen, and shared-package async flows. UI work is guarded by the relevant mounted context while non-UI operations continue when possible.

Validation: `flutter analyze --no-pub`
