### PR TITLE
[mobile] Clear temporary files on logout

### DIFF
--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -8,6 +8,7 @@ import 'package:ente_account_deletion/account_deletion.dart';
 import 'package:ente_contacts/contacts.dart';
 import "package:ente_crypto/ente_crypto.dart";
 import 'package:ente_lock_screen/lock_screen_host.dart';
+import 'package:ente_pure_utils/ente_pure_utils.dart';
 import "package:flutter/services.dart";
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -208,6 +209,8 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
       }
     }
 
+    await _clearTempFolderOnLogout();
+
     // Clear preferences and secure storage
     await _preferences.clear();
     await _secureStorage.deleteAll();
@@ -303,6 +306,16 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
       Bus.instance.fire(UserLoggedOutEvent());
     } else {
       await _preferences.setBool("auto_logout", true);
+    }
+  }
+
+  Future<void> _clearTempFolderOnLogout() async {
+    try {
+      await deleteDirectoryContents(_tempDocumentsDirPath);
+      await Directory(_tempDocumentsDirPath).create(recursive: true);
+      _logger.info("Cleared temp folder on logout");
+    } catch (e, s) {
+      _logger.warning("Failed to clear temp folder on logout", e, s);
     }
   }
 

--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -76,6 +76,7 @@ abstract class BaseConfiguration {
   }
 
   Future<void> logout({bool autoLogout = false}) async {
+    await _clearTempFolderOnLogout();
     await _preferences.clear();
     await resetSecureStorage();
     for (final db in _databases) {
@@ -85,6 +86,19 @@ abstract class BaseConfiguration {
     _cachedToken = null;
     _secretKey = null;
     Bus.instance.fire(SignedOutEvent());
+  }
+
+  Future<void> _clearTempFolderOnLogout() async {
+    final tempDirectory = io.Directory(_tempDocumentsDirPath);
+    try {
+      if (await tempDirectory.exists()) {
+        await tempDirectory.delete(recursive: true);
+      }
+      await tempDirectory.create(recursive: true);
+      _logger.info("Cleared temp folder on logout");
+    } catch (e, s) {
+      _logger.warning("Failed to clear temp folder on logout", e, s);
+    }
   }
 
   Future<void> resetSecureStorage() async {


### PR DESCRIPTION
Clears temporary files during logout across Photos, Auth, and Locker.

Previously, startup cleanup could be skipped because of its cleanup interval, and a subsequent auto-logout caused by missing secure-storage keys could leave plaintext temporary files until the next app launch. Logout now performs a best-effort temp-directory cleanup before clearing account state, recreates the directory for continued app use, and logs cleanup failures without preventing logout.