### PR TITLE
[mobile] Fix text input tap grouping

### DIFF
--- a/mobile/packages/ente_components/lib/components/text_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/text_input_component.dart
@@ -166,6 +166,9 @@ class _TextInputComponentState extends State<TextInputComponent> {
   @override
   void didUpdateWidget(covariant TextInputComponent oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.isDisabled != widget.isDisabled) {
+      _configureGroupId();
+    }
     if (oldWidget.submitNotifier != widget.submitNotifier) {
       oldWidget.submitNotifier?.removeListener(_handleSubmitRequested);
       widget.submitNotifier?.addListener(_handleSubmitRequested);
@@ -216,7 +219,7 @@ class _TextInputComponentState extends State<TextInputComponent> {
     super.dispose();
   }
 
-  Object? _groupId;
+  late Object _groupId;
   final _defaultGroupId = Object();
   final _disabledGroupId = Object();
 
@@ -300,6 +303,7 @@ class _TextInputComponentState extends State<TextInputComponent> {
                         ],
                         Expanded(
                           child: TextField(
+                            groupId: _groupId,
                             controller: _controller,
                             focusNode: _focusNode,
                             enabled: !widget.isDisabled,


### PR DESCRIPTION
## What changed

- Give the inner `TextField` the same tap-region group ID as its wrapper.
- Refresh the group ID when the disabled state changes.
- Make the stored group ID non-null after setup.

## Why

The wrapper used a custom group ID, but the inner field kept Flutter's default ID. This split one text input across two tap groups and broke the intended focus behavior around disabled fields and field affordances.

## Impact

Each text input now acts as one tap region, while enabled and disabled states keep separate IDs as intended.

## Checks

- `fvm flutter test test/components/text_input_component_test.dart` (19 tests passed)
