### PR TITLE
[mobile][web] Distinguish owned uncategorized collections

### DIFF
--- a/mobile/apps/locker/lib/services/collections/collections_service.dart
+++ b/mobile/apps/locker/lib/services/collections/collections_service.dart
@@ -25,6 +25,7 @@ import 'package:locker/services/files/offline/offline_files_service.dart';
 import 'package:locker/services/files/sync/models/file.dart';
 import 'package:locker/services/trash/models/trash_item_request.dart';
 import "package:locker/services/trash/trash_service.dart";
+import "package:locker/utils/collection_list_util.dart";
 import "package:locker/utils/crypto_helper.dart";
 import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -214,7 +215,9 @@ class CollectionService {
     final int userID = Configuration.instance.getUserID()!;
 
     return collections.where((c) {
-      if (!includeUncategorized && c.type == CollectionType.uncategorized) {
+      if (!includeUncategorized &&
+          c.type == CollectionType.uncategorized &&
+          c.isOwner(userID)) {
         return false;
       }
 
@@ -362,10 +365,10 @@ class CollectionService {
 
   Future<Collection> getOrCreateUncategorizedCollection() async {
     final collections = await getCollections();
-    for (final collection in collections) {
-      if (collection.type == CollectionType.uncategorized) {
-        return collection;
-      }
+    final userID = Configuration.instance.getUserID()!;
+    final collection = findUserUncategorizedCollection(collections, userID);
+    if (collection != null) {
+      return collection;
     }
     _logger.info("No collections found, creating uncategorized collection.");
     return await createCollection(

--- a/mobile/apps/locker/lib/ui/components/collection_selection_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/collection_selection_widget.dart
@@ -1,10 +1,10 @@
-import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dotted_border/dotted_border.dart';
 import "package:ente_components/ente_components.dart";
 import 'package:flutter/material.dart';
 import 'package:locker/extensions/collection_extension.dart';
 import 'package:locker/l10n/l10n.dart';
 import 'package:locker/services/collections/models/collection.dart';
+import 'package:locker/services/configuration.dart';
 import 'package:locker/utils/collection_actions.dart';
 import 'package:locker/utils/collection_list_util.dart';
 
@@ -46,25 +46,26 @@ class _CollectionSelectionWidgetState extends State<CollectionSelectionWidget> {
   @override
   void initState() {
     super.initState();
-    _availableCollections = uniqueCollectionsById(widget.collections);
-    _uncategorizedCollection = _availableCollections.firstWhereOrNull(
-      (collection) => collection.type == CollectionType.uncategorized,
-    );
-    _availableCollections.removeWhere(
-      (collection) => collection.type == CollectionType.uncategorized,
-    );
+    _updateCollections();
   }
 
   @override
   void didUpdateWidget(CollectionSelectionWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.collections != widget.collections) {
-      _availableCollections = uniqueCollectionsById(widget.collections);
-      _uncategorizedCollection = _availableCollections.firstWhereOrNull(
-        (collection) => collection.type == CollectionType.uncategorized,
-      );
+      _updateCollections();
+    }
+  }
+
+  void _updateCollections() {
+    _availableCollections = uniqueCollectionsById(widget.collections);
+    _uncategorizedCollection = findUserUncategorizedCollection(
+      _availableCollections,
+      Configuration.instance.getUserID()!,
+    );
+    if (_uncategorizedCollection != null) {
       _availableCollections.removeWhere(
-        (collection) => collection.type == CollectionType.uncategorized,
+        (collection) => collection.id == _uncategorizedCollection!.id,
       );
     }
   }

--- a/mobile/apps/locker/lib/ui/pages/all_collections_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/all_collections_page.dart
@@ -9,6 +9,7 @@ import 'package:locker/l10n/l10n.dart';
 import 'package:locker/models/selected_collections.dart';
 import 'package:locker/services/collections/collections_service.dart';
 import 'package:locker/services/collections/models/collection.dart';
+import 'package:locker/services/configuration.dart';
 import 'package:locker/ui/components/collection_list_widget.dart';
 import "package:locker/ui/components/empty_state_widget.dart";
 import 'package:locker/ui/components/item_list_view.dart';
@@ -70,9 +71,11 @@ class _AllCollectionsPageState extends State<AllCollectionsPage> {
 
       final regularCollections = <Collection>[];
       Collection? uncategorized;
+      final userID = Configuration.instance.getUserID()!;
 
       for (final collection in collections) {
-        if (collection.type == CollectionType.uncategorized) {
+        if (collection.type == CollectionType.uncategorized &&
+            collection.isOwner(userID)) {
           uncategorized = collection;
         } else {
           regularCollections.add(collection);

--- a/mobile/apps/locker/lib/ui/pages/file_upload_screen.dart
+++ b/mobile/apps/locker/lib/ui/pages/file_upload_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import "package:hugeicons/hugeicons.dart";
 import 'package:locker/l10n/l10n.dart';
 import 'package:locker/services/collections/models/collection.dart';
+import 'package:locker/services/configuration.dart';
 import 'package:locker/ui/components/collection_selection_widget.dart';
 import "package:locker/utils/file_icon_utils.dart";
 import 'package:path/path.dart' as path;
@@ -47,9 +48,11 @@ class _FileUploadScreenState extends State<FileUploadScreen> {
     _files = List.from(widget.files);
     _availableCollections = List.from(widget.collections);
 
-    if (widget.selectedCollection != null &&
-        widget.selectedCollection!.type != CollectionType.uncategorized) {
-      _selectedCollectionIds.add(widget.selectedCollection!.id);
+    final selectedCollection = widget.selectedCollection;
+    if (selectedCollection != null &&
+        (selectedCollection.type != CollectionType.uncategorized ||
+            !selectedCollection.isOwner(Configuration.instance.getUserID()!))) {
+      _selectedCollectionIds.add(selectedCollection.id);
     }
   }
 

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -224,7 +224,10 @@ class _HomePageState extends UploaderPageState<HomePage>
   }
 
   List<Collection> _filterOutUncategorized(List<Collection> collections) {
-    return CollectionSortUtil.filterAndSortCollections(collections);
+    return CollectionSortUtil.filterAndSortCollections(
+      collections,
+      Configuration.instance.getUserID()!,
+    );
   }
 
   @override

--- a/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
+++ b/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
@@ -194,27 +194,29 @@ class _ShareCollectionSheetState extends State<ShareCollectionSheet> {
             );
           },
         ),
-        const SizedBox(width: 16),
-        _ShareActionOption(
-          icon: HugeIcons.strokeRoundedLink02,
-          label: _hasPublicLink
-              ? context.l10n.manageLink
-              : context.l10n.linkLabel,
-          onTap: () async {
-            if (!_hasPublicLink) {
-              await _createAndSharePublicLink();
-              return;
-            }
+        if (widget.collection.type != CollectionType.uncategorized) ...[
+          const SizedBox(width: 16),
+          _ShareActionOption(
+            icon: HugeIcons.strokeRoundedLink02,
+            label: _hasPublicLink
+                ? context.l10n.manageLink
+                : context.l10n.linkLabel,
+            onTap: () async {
+              if (!_hasPublicLink) {
+                await _createAndSharePublicLink();
+                return;
+              }
 
-            await routeToPage(
-              context,
-              ManageSharedLinkWidget(collection: widget.collection),
-            );
-            if (mounted) {
-              setState(() {});
-            }
-          },
-        ),
+              await routeToPage(
+                context,
+                ManageSharedLinkWidget(collection: widget.collection),
+              );
+              if (mounted) {
+                setState(() {});
+              }
+            },
+          ),
+        ],
       ],
     );
   }

--- a/mobile/apps/locker/lib/utils/collection_list_util.dart
+++ b/mobile/apps/locker/lib/utils/collection_list_util.dart
@@ -1,30 +1,21 @@
 import 'package:locker/services/collections/models/collection.dart';
 
 /// Returns a list of collections with duplicate IDs removed while preserving
-/// order. Stops at the first uncategorized collection encountered.
+/// order.
 List<Collection> uniqueCollectionsById(List<Collection> collections) {
   final seenIds = <int>{};
-  final unique = <Collection>[];
-
-  bool uncategorizedSeen = false;
-
-  for (final collection in collections) {
-    final isUncategorizedCollection = _isUncategorized(collection);
-
-    if (seenIds.add(collection.id)) {
-      if (isUncategorizedCollection) {
-        if (uncategorizedSeen) {
-          continue;
-        }
-        uncategorizedSeen = true;
-      }
-      unique.add(collection);
-    }
-  }
-
-  return unique;
+  return collections.where((collection) => seenIds.add(collection.id)).toList();
 }
 
-bool _isUncategorized(Collection collection) {
-  return collection.type == CollectionType.uncategorized;
+Collection? findUserUncategorizedCollection(
+  Iterable<Collection> collections,
+  int userID,
+) {
+  for (final collection in collections) {
+    if (collection.type == CollectionType.uncategorized &&
+        collection.isOwner(userID)) {
+      return collection;
+    }
+  }
+  return null;
 }

--- a/mobile/apps/locker/lib/utils/collection_sort_util.dart
+++ b/mobile/apps/locker/lib/utils/collection_sort_util.dart
@@ -28,12 +28,15 @@ class CollectionSortUtil {
     return sortedList;
   }
 
-  /// Filters out uncategorized collections and sorts the remaining ones
+  /// Filters out the user's uncategorized collection and sorts the rest.
   static List<Collection> filterAndSortCollections(
     List<Collection> collections,
+    int userID,
   ) {
     final filtered = collections
-        .where((c) => c.type != CollectionType.uncategorized)
+        .where(
+          (c) => c.type != CollectionType.uncategorized || !c.isOwner(userID),
+        )
         .toList();
     sortCollections(filtered);
     return filtered;

--- a/mobile/apps/locker/test/utils/collection_list_util_test.dart
+++ b/mobile/apps/locker/test/utils/collection_list_util_test.dart
@@ -1,0 +1,45 @@
+import "package:ente_sharing/models/user.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:locker/services/collections/models/collection.dart";
+import "package:locker/utils/collection_list_util.dart";
+
+void main() {
+  test("keeps distinct uncategorized collections", () {
+    final ownCollection = _uncategorizedCollection(1, 10);
+    final sharedCollection = _uncategorizedCollection(2, 20);
+
+    expect(
+      uniqueCollectionsById([
+        sharedCollection,
+        ownCollection,
+        sharedCollection,
+      ]),
+      [sharedCollection, ownCollection],
+    );
+  });
+
+  test("finds the uncategorized collection owned by the user", () {
+    final sharedCollection = _uncategorizedCollection(1, 20);
+    final ownCollection = _uncategorizedCollection(2, 10);
+
+    expect(
+      findUserUncategorizedCollection([sharedCollection, ownCollection], 10),
+      ownCollection,
+    );
+  });
+}
+
+Collection _uncategorizedCollection(int id, int ownerID) => Collection(
+  id,
+  User(id: ownerID, email: "owner@example.com"),
+  "",
+  null,
+  "Uncategorized",
+  null,
+  null,
+  CollectionType.uncategorized,
+  CollectionAttributes(),
+  const [],
+  const [],
+  0,
+);

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -495,7 +495,8 @@ class CollectionsService {
           (c) =>
               !c.isDeleted &&
               (includeUncategorized ||
-                  c.type != CollectionType.uncategorized) &&
+                  c.type != CollectionType.uncategorized ||
+                  !c.isOwner(userID)) &&
               !c.isHidden() &&
               allowedRoles.contains(c.getRole(userID)),
         )
@@ -555,6 +556,7 @@ class CollectionsService {
     final List<Collection> quickLinks = [];
     final List<Collection> collections = getCollectionsForUI(
       includedShared: true,
+      includeUncategorized: true,
     );
     for (final c in collections) {
       if (c.owner.id == Configuration.instance.getUserID()) {

--- a/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
+++ b/mobile/apps/photos/lib/ui/collections/collection_action_sheet.dart
@@ -452,12 +452,14 @@ class _CollectionActionSheetState extends State<CollectionActionSheet> {
       final List<Collection> pinned = [];
       final List<Collection> unpinned = [];
       final List<Collection> recentlyCreated = [];
+      final userID = Configuration.instance.getUserID()!;
       // show uncategorized collection only for restore files action
       Collection? uncategorized;
       for (final collection in collections) {
         if (collection.isQuickLinkCollection() ||
             collection.type == CollectionType.favorites ||
-            collection.type == CollectionType.uncategorized) {
+            (collection.type == CollectionType.uncategorized &&
+                collection.isOwner(userID))) {
           if (collection.type == CollectionType.uncategorized) {
             uncategorized = collection;
           }

--- a/mobile/apps/photos/lib/ui/sharing/album_participants_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/album_participants_page.dart
@@ -76,7 +76,10 @@ class _AlbumParticipantsPageState extends State<AlbumParticipantsPage> {
     final bool hasActivePublicLink =
         _collection.hasLink &&
         !(_collection.publicURLs.firstOrNull?.isExpired ?? true);
-    final bool shouldShowPublicLink = !isOwner && hasActivePublicLink;
+    final bool shouldShowPublicLink =
+        _collection.type != CollectionType.uncategorized &&
+        !isOwner &&
+        hasActivePublicLink;
     final int participants = 1 + _collection.getSharees().length;
     final User owner = _collection.owner;
     if (owner.id == currentUserID && owner.email == "") {

--- a/mobile/apps/photos/lib/ui/sharing/share_collection_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/share_collection_page.dart
@@ -170,7 +170,7 @@ class _ShareCollectionPageState extends State<ShareCollectionPage> {
       ]);
     }
 
-    if (isOwner) {
+    if (isOwner && _collection.type != CollectionType.uncategorized) {
       children.addAll([
         const SizedBox(height: Spacing.xxl),
         ShareSectionTitle(

--- a/mobile/apps/photos/lib/ui/tabs/albums/albums_manage_sheet.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums/albums_manage_sheet.dart
@@ -6,6 +6,7 @@ import "package:ente_lock_screen/local_authentication_service.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
+import "package:photos/core/configuration.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/services/collections_service.dart";
@@ -59,7 +60,9 @@ Future<void> showAlbumsManageSheet(BuildContext context) {
                 Collection? collection = CollectionsService.instance
                     .getActiveCollections()
                     .firstWhereOrNull(
-                      (c) => c.type == CollectionType.uncategorized,
+                      (c) =>
+                          c.type == CollectionType.uncategorized &&
+                          c.isOwner(Configuration.instance.getUserID()!),
                     );
                 collection ??= await CollectionsService.instance
                     .getUncategorizedCollection();

--- a/web/apps/locker/src/types.ts
+++ b/web/apps/locker/src/types.ts
@@ -170,7 +170,7 @@ export const canLeaveCollection = (
     collection: LockerCollection,
     currentUserID: number | undefined,
 ) =>
-    canOpenCollectionSharing(collection) &&
+    !isImportantCollection(collection) &&
     !isCollectionOwner(collection, currentUserID);
 
 export const isLockerItemOwner = (

--- a/web/apps/photos/src/components/Collections/CollectionShare.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionShare.tsx
@@ -186,7 +186,9 @@ export const CollectionShare: React.FC<CollectionShareProps> = ({
     const isSharedIncoming = collectionSummary?.type == "sharedIncoming";
     const showEmailSection = !isSharedIncoming || canManageParticipants;
     const hasPublicLink = collection?.publicURLs.length > 0;
-    const showPublicShare = isOwner || (isSharedIncoming && hasPublicLink);
+    const showPublicShare =
+        collection?.type != "uncategorized" &&
+        (isOwner || (isSharedIncoming && hasPublicLink));
 
     // Use a ref to track if we've already fetched for this dialog session
     const hasFetchedForSession = useRef(false);
@@ -206,6 +208,7 @@ export const CollectionShare: React.FC<CollectionShareProps> = ({
             const shouldFetch =
                 open &&
                 collection &&
+                collection.type != "uncategorized" &&
                 !isOwner &&
                 isSharedIncoming &&
                 !hasPublicLink &&

--- a/web/apps/photos/tests/collection.test.ts
+++ b/web/apps/photos/tests/collection.test.ts
@@ -1,0 +1,24 @@
+import { findUserUncategorizedCollection } from "ente-media/collection";
+import { describe, expect, test } from "vitest";
+
+describe("findUserUncategorizedCollection", () => {
+    test("selects the collection owned by the user", () => {
+        const sharedCollection = { type: "uncategorized", owner: { id: 20 } };
+        const ownCollection = { type: "uncategorized", owner: { id: 10 } };
+
+        expect(
+            findUserUncategorizedCollection(
+                [sharedCollection, ownCollection],
+                10,
+            ),
+        ).toBe(ownCollection);
+    });
+
+    test("does not return another user's collection", () => {
+        const sharedCollection = { type: "uncategorized", owner: { id: 20 } };
+
+        expect(
+            findUserUncategorizedCollection([sharedCollection], 10),
+        ).toBeUndefined();
+    });
+});

--- a/web/apps/photos/tests/file-actions.test.ts
+++ b/web/apps/photos/tests/file-actions.test.ts
@@ -1,0 +1,33 @@
+import type { CollectionSummary } from "ente-new/photos/services/collection-summary";
+import { getAvailableFileActions } from "ente-new/photos/utils/file-actions";
+import { describe, expect, test } from "vitest";
+
+describe("getAvailableFileActions", () => {
+    test("uses shared actions for an incoming uncategorized collection", () => {
+        const collectionSummary: CollectionSummary = {
+            id: 1,
+            type: "sharedIncoming",
+            attributes: new Set([
+                "sharedIncoming",
+                "sharedIncomingAdmin",
+                "uncategorized",
+            ]),
+            name: "Shared uncategorized",
+            latestFile: undefined,
+            coverFile: undefined,
+            fileCount: 1,
+            updationTime: undefined,
+            sortPriority: 0,
+        };
+
+        expect(
+            getAvailableFileActions({
+                isInSearchMode: false,
+                collectionSummary,
+                hasOnlyOwnFiles: false,
+                showAddPerson: false,
+                showEditLocation: false,
+            }),
+        ).toEqual(["favorite", "download", "addToAlbum", "removeFromAlbum"]);
+    });
+});

--- a/web/packages/media/collection.ts
+++ b/web/packages/media/collection.ts
@@ -171,11 +171,27 @@ export const collectionTypes = [
  *   corresponding operation moves the file to the user's special
  *   "uncategorized" collection, creating it if needed.
  *
- *   Similar to "favorites", the user can have only one "uncategorized"
- *   collection. However, unlike "favorites", the "uncategorized" collection
- *   cannot be shared.
+ *   Similar to "favorites", the user can own only one "uncategorized"
+ *   collection. Shared collections of this type can also be present locally,
+ *   so callers must include the owner when resolving the user's collection.
  */
 export type CollectionType = (typeof collectionTypes)[number];
+
+interface CollectionTypeAndOwner {
+    type: string;
+    owner: { id: number };
+}
+
+export const findUserUncategorizedCollection = <
+    T extends CollectionTypeAndOwner,
+>(
+    collections: readonly T[],
+    userID: number,
+) =>
+    collections.find(
+        (collection) =>
+            collection.type == "uncategorized" && collection.owner.id == userID,
+    );
 
 /**
  * The privilege level of a participant associated with a collection.

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -7,6 +7,7 @@ import {
 import {
     CollectionOrder,
     collectionTypes,
+    findUserUncategorizedCollection,
     type Collection,
 } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
@@ -655,7 +656,10 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 hiddenCollectionSummaries,
                 archivedCollectionSummaries,
                 uncategorizedCollectionSummaryID:
-                    deriveUncategorizedCollectionSummaryID(normalCollections),
+                    deriveUncategorizedCollectionSummaryID(
+                        normalCollections,
+                        user.id,
+                    ),
                 view,
             });
         }
@@ -786,7 +790,10 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 hiddenCollectionSummaries,
                 archivedCollectionSummaries,
                 uncategorizedCollectionSummaryID:
-                    deriveUncategorizedCollectionSummaryID(normalCollections),
+                    deriveUncategorizedCollectionSummaryID(
+                        normalCollections,
+                        state.user!.id,
+                    ),
                 selectedCollectionSummaryID,
                 pendingSearchSuggestions:
                     enqueuePendingSearchSuggestionsIfNeeded(
@@ -1541,8 +1548,9 @@ const deriveNormalCollectionSummaries = (
         collectionFiles,
     );
 
-    const uncategorizedCollection = normalCollections.find(
-        ({ type }) => type == "uncategorized",
+    const uncategorizedCollection = findUserUncategorizedCollection(
+        normalCollections,
+        user.id,
     );
     if (!uncategorizedCollection) {
         const id = PseudoCollectionID.uncategorizedPlaceholder;
@@ -1698,8 +1706,9 @@ const deriveArchivedCollectionSummaries = (
  */
 const deriveUncategorizedCollectionSummaryID = (
     normalCollections: Collection[],
+    userID: number,
 ) =>
-    normalCollections.find(({ type }) => type == "uncategorized")?.id ??
+    findUserUncategorizedCollection(normalCollections, userID)?.id ??
     PseudoCollectionID.uncategorizedPlaceholder;
 
 const createCollectionSummaries = (

--- a/web/packages/new/photos/services/collection.ts
+++ b/web/packages/new/photos/services/collection.ts
@@ -15,6 +15,7 @@ import { groupFilesByCollectionID } from "ente-gallery/utils/file";
 import {
     CollectionSubType,
     decryptRemoteCollection,
+    findUserUncategorizedCollection,
     RemoteCollection,
     RemotePublicURL,
     type Collection,
@@ -1015,10 +1016,7 @@ export const copyFiles = async (
  */
 const savedUserUncategorizedCollection = async () => {
     const userID = ensureLocalUser().id;
-    return (await savedCollections()).find(
-        (collection) =>
-            collection.type == "uncategorized" && collection.owner.id == userID,
-    );
+    return findUserUncategorizedCollection(await savedCollections(), userID);
 };
 
 /**
@@ -1490,7 +1488,7 @@ const removeOwnFilesFromOwnCollection = async (
     const remainingFiles = filesToRemove.filter(pendingRemove);
     if (remainingFiles.length) {
         const uncategorizedCollection =
-            collections.find((c) => c.type == "uncategorized") ??
+            findUserUncategorizedCollection(collections, userID) ??
             (await createUncategorizedCollection());
 
         await moveFromCollection(
@@ -2426,6 +2424,7 @@ export const fetchPendingRemovalActions = async (): Promise<
 export const movePendingRemovalActionsToUncategorized = async (
     collections: Collection[],
 ) => {
+    const userID = ensureLocalUser().id;
     const pendingActions = await fetchPendingRemovalActions();
     if (!pendingActions.length) return;
 
@@ -2489,7 +2488,7 @@ export const movePendingRemovalActionsToUncategorized = async (
             // Move files from normal collections to uncategorized
             if (!uncategorizedCollection) {
                 uncategorizedCollection =
-                    collections.find((c) => c.type == "uncategorized") ??
+                    findUserUncategorizedCollection(collections, userID) ??
                     (await createUncategorizedCollection());
             }
             targetCollection = uncategorizedCollection;

--- a/web/packages/new/photos/utils/file-actions.ts
+++ b/web/packages/new/photos/utils/file-actions.ts
@@ -143,16 +143,8 @@ function getBaseActions(
         return ["restore", "deletePermanently"];
     }
 
-    // Uncategorized actions
-    if (collectionSummary?.attributes.has("uncategorized")) {
-        const actions: FileContextAction[] = ["download"];
-        if (hasOnlyOwnFiles) {
-            actions.push("moveToAlbum", "trash");
-        }
-        return actions;
-    }
-
-    // Shared incoming actions
+    // Incoming summaries also retain their underlying collection type,
+    // so shared actions must take precedence over type-specific actions.
     if (collectionSummary?.attributes.has("sharedIncoming")) {
         const actions: FileContextAction[] = [
             "favorite",
@@ -164,6 +156,15 @@ function getBaseActions(
             collectionSummary.attributes.has("sharedIncomingAdmin")
         ) {
             actions.push("removeFromAlbum");
+        }
+        return actions;
+    }
+
+    // Uncategorized actions
+    if (collectionSummary?.attributes.has("uncategorized")) {
+        const actions: FileContextAction[] = ["download"];
+        if (hasOnlyOwnFiles) {
+            actions.push("moveToAlbum", "trash");
         }
         return actions;
     }


### PR DESCRIPTION
Treat only the current user's uncategorized collection as the special fallback, while preserving incoming collections owned by others. Sharing controls remain disabled.