### PR TITLE
[server] Read log level config

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1149,6 +1149,9 @@ func setupLogger(environment string) {
 			Compress: true,
 		})
 	}
+	if level, err := log.ParseLevel(viper.GetString("log-level")); err == nil {
+		log.SetLevel(level)
+	}
 }
 
 func setupDatabase() *sql.DB {

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -69,6 +69,13 @@
 # It must be specified if running in a non-local environment.
 log-file: ""
 
+# The minimum level of logs to emit: "panic", "fatal", "error", "warn", "info",
+# "debug" or "trace".
+#
+# Anything below the configured level is dropped, e.g. "warn" suppresses info
+# and debug logs. If not specified or invalid defaults to "info".
+#log-level: info
+
 # HTTP connection parameters
 http:
     # The port to bind to.


### PR DESCRIPTION
## Description

I was getting too much log noise in my self-hosted Ente instance so I wanted to reduce the log level but there was not a way to do it.

So I added some code to read `ENTE_LOG_LEVEL` from the env or `log-level` from the config.

If the option is absent (or invalid) no log level will be set, keeping the current behavior.

## Tests

```
$ ENTE_LOG_LEVEL=info ./museum
INFO[0000]main.go:123 main Booting up local server with commit #
INFO[0000]main.go:1163 setupDatabase Setting up db
INFO[0000]main.go:1170 setupDatabase Connected to DB
panic: dial tcp [::1]:5432: connect: connection refused
```

```
$ ENTE_LOG_LEVEL=blah ./museum
INFO[0000]main.go:123 main Booting up local server with commit #
INFO[0000]main.go:1163 setupDatabase Setting up db
INFO[0000]main.go:1170 setupDatabase Connected to DB
panic: dial tcp [::1]:5432: connect: connection refused
```

```
$ ENTE_LOG_LEVEL=warn ./museum
panic: dial tcp [::1]:5432: connect: connection refused
```
