### PR TITLE
[mobile][photos] Keep contact name field focused

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
@@ -132,8 +132,9 @@ class _EditContactPageState extends State<EditContactPage> {
           children: [
             Expanded(
               child: NotificationListener<ScrollStartNotification>(
-                onNotification: (_) {
-                  if (_nameFocusNode.hasFocus) {
+                onNotification: (notification) {
+                  if (notification.dragDetails != null &&
+                      _nameFocusNode.hasFocus) {
                     _nameFocusNode.unfocus();
                   }
                   return false;


### PR DESCRIPTION
Avoid dismissing the contact name keyboard during programmatic scroll-to-visible.