### PR TITLE
[mobile] Focus added Auth codes by issuer

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -78,6 +78,11 @@ class HomePage extends BaseHomePage {
   State<HomePage> createState() => _HomePageState();
 }
 
+@visibleForTesting
+String addedCodeFocusSearchQuery(Code code) {
+  return code.issuer.trim().isNotEmpty ? code.issuer : code.account;
+}
+
 class _HomePageState extends State<HomePage> {
   final _codeDisplayStore = CodeDisplayStore.instance;
   late final _settingsPage = SettingsPage(
@@ -2021,8 +2026,9 @@ class _HomePageState extends State<HomePage> {
     _showSearchBox = true;
     selectedTag = "";
     _isTrashOpen = false;
-    _textController.text = newCode.account;
-    _searchText = newCode.account;
+    final searchQuery = addedCodeFocusSearchQuery(newCode);
+    _textController.text = searchQuery;
+    _searchText = searchQuery;
     _applyFilteringAndRefresh();
   }
 

--- a/mobile/apps/auth/test/ui/home_page_test.dart
+++ b/mobile/apps/auth/test/ui/home_page_test.dart
@@ -1,0 +1,21 @@
+import 'package:ente_auth/models/code.dart';
+import 'package:ente_auth/ui/home_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('newly added code focus search prefers issuer', () {
+    final code = Code.fromOTPAuthUrl(
+      'otpauth://totp/person@example.com?secret=ASKZNWOU6SVYAMVS&issuer=GitHub',
+    );
+
+    expect(addedCodeFocusSearchQuery(code), 'GitHub');
+  });
+
+  test('newly added code focus search falls back to account', () {
+    final code = Code.fromOTPAuthUrl(
+      'otpauth://totp/person@example.com?secret=ASKZNWOU6SVYAMVS',
+    );
+
+    expect(addedCodeFocusSearchQuery(code), 'person@example.com');
+  });
+}


### PR DESCRIPTION
## Summary
- Focus newly added Auth codes by searching for the issuer/provider first
- Fall back to account when the issuer is missing
- Add Flutter coverage for the focus query