### PR TITLE
[mobile] Translate Dart crypto derivation errors

### DIFF
--- a/mobile/packages/ente_crypto_dart_adapter/lib/ente_crypto_dart_adapter.dart
+++ b/mobile/packages/ente_crypto_dart_adapter/lib/ente_crypto_dart_adapter.dart
@@ -3,6 +3,18 @@ import 'dart:typed_data';
 
 import 'package:ente_crypto_api/ente_crypto_api.dart';
 import 'package:ente_crypto_dart/ente_crypto_dart.dart' as dart_impl;
+import 'package:meta/meta.dart';
+
+@visibleForTesting
+Future<T> translateDartCryptoErrors<T>(Future<T> Function() operation) async {
+  try {
+    return await operation();
+  } on dart_impl.KeyDerivationError {
+    throw KeyDerivationError();
+  } on dart_impl.LoginKeyDerivationError {
+    throw LoginKeyDerivationError();
+  }
+}
 
 class EnteCryptoDartAdapter implements CryptoApi {
   const EnteCryptoDartAdapter();
@@ -122,9 +134,8 @@ class EnteCryptoDartAdapter implements CryptoApi {
     Uint8List password,
     Uint8List salt,
   ) async {
-    final result = await dart_impl.CryptoUtil.deriveSensitiveKey(
-      password,
-      salt,
+    final result = await translateDartCryptoErrors(
+      () => dart_impl.CryptoUtil.deriveSensitiveKey(password, salt),
     );
     return DerivedKeyResult(result.key, result.memLimit, result.opsLimit);
   }
@@ -134,9 +145,8 @@ class EnteCryptoDartAdapter implements CryptoApi {
     Uint8List password,
     Uint8List salt,
   ) async {
-    final result = await dart_impl.CryptoUtil.deriveInteractiveKey(
-      password,
-      salt,
+    final result = await translateDartCryptoErrors(
+      () => dart_impl.CryptoUtil.deriveInteractiveKey(password, salt),
     );
     return DerivedKeyResult(result.key, result.memLimit, result.opsLimit);
   }
@@ -147,11 +157,13 @@ class EnteCryptoDartAdapter implements CryptoApi {
     Uint8List salt,
     int memLimit,
     int opsLimit,
-  ) => dart_impl.CryptoUtil.deriveKey(password, salt, memLimit, opsLimit);
+  ) => translateDartCryptoErrors(
+    () => dart_impl.CryptoUtil.deriveKey(password, salt, memLimit, opsLimit),
+  );
 
   @override
   Future<Uint8List> deriveLoginKey(Uint8List key) =>
-      dart_impl.CryptoUtil.deriveLoginKey(key);
+      translateDartCryptoErrors(() => dart_impl.CryptoUtil.deriveLoginKey(key));
 
   @override
   Uint8List getSaltToDeriveKey() => dart_impl.CryptoUtil.getSaltToDeriveKey();

--- a/mobile/packages/ente_crypto_dart_adapter/pubspec.yaml
+++ b/mobile/packages/ente_crypto_dart_adapter/pubspec.yaml
@@ -16,3 +16,5 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: 6.0.0
+  flutter_test:
+    sdk: flutter

--- a/mobile/packages/ente_crypto_dart_adapter/test/ente_crypto_dart_adapter_test.dart
+++ b/mobile/packages/ente_crypto_dart_adapter/test/ente_crypto_dart_adapter_test.dart
@@ -1,0 +1,31 @@
+import 'package:ente_crypto_api/ente_crypto_api.dart';
+import 'package:ente_crypto_dart/ente_crypto_dart.dart' as dart_impl;
+import 'package:ente_crypto_dart_adapter/ente_crypto_dart_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('translateDartCryptoErrors', () {
+    test('translates KeyDerivationError to the API error type', () async {
+      final future = translateDartCryptoErrors<void>(
+        () async => throw dart_impl.KeyDerivationError(),
+      );
+
+      await expectLater(future, throwsA(isA<KeyDerivationError>()));
+    });
+
+    test('translates LoginKeyDerivationError to the API error type', () async {
+      final future = translateDartCryptoErrors<void>(
+        () async => throw dart_impl.LoginKeyDerivationError(),
+      );
+
+      await expectLater(future, throwsA(isA<LoginKeyDerivationError>()));
+    });
+
+    test('preserves unrelated errors', () async {
+      final error = StateError('test');
+      final future = translateDartCryptoErrors<void>(() async => throw error);
+
+      await expectLater(future, throwsA(same(error)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- translate `ente_crypto_dart` key-derivation exceptions into the corresponding `ente_crypto_api` exception types at the adapter boundary
- preserve unrelated exceptions unchanged
- add focused regression tests for both derivation error types

## Why

The Auth login flow catches `ente_crypto_api.KeyDerivationError` to offer the lower-memory password recreation / recovery-key flow. The Dart adapter previously allowed the identically named—but type-distinct—`ente_crypto_dart.KeyDerivationError` to escape, so the typed catch never ran and users saw the generic “Verification failed” dialog instead.

This was reproduced on Android 11 Go devices with approximately 2 GB RAM while deriving a key configured for a 1 GiB memory limit.

Fixes #11560.

## Validation

- `flutter test packages/ente_crypto_dart_adapter/test` — passed
- `flutter analyze packages/ente_crypto_dart_adapter` — no issues
- `flutter build apk --debug --flavor independent --target-platform android-arm` — passed
- installed and tested the patched build on the affected CAT/Unifone S22 (Android 11 Go, 32-bit ARM, approximately 2 GB RAM); login now reaches the intended recovery flow successfully
