### PR TITLE
[mob][photos] Remove cast feature flag

### DIFF
--- a/mobile/apps/photos/lib/ui/cast/cast.dart
+++ b/mobile/apps/photos/lib/ui/cast/cast.dart
@@ -1,4 +1,3 @@
-import "dart:async";
 import "dart:io";
 
 import "package:ente_components/ente_components.dart";
@@ -22,36 +21,16 @@ Future<void> showCastSheet(BuildContext context, Collection collection) async {
   final textStyle = getEnteTextTheme(context);
   final gw = CastGateway(NetworkClient.instance.enteDio);
   final showAutoPair = Platform.isAndroid || kDebugMode;
-  if (!flagService.enableMultiCast) {
-    if (castService.getActiveSessions().isNotEmpty) {
-      await showChoiceDialog(
-        context,
-        title: l10n.stopCastingTitle,
-        body: l10n.stopCastingBody,
-        firstButtonLabel: l10n.yes,
-        secondButtonLabel: l10n.no,
-        firstButtonOnTap: () async {
-          unawaited(gw.revokeAllTokens());
-          await castService.closeActiveCasts();
-        },
-      );
-      return;
-    }
-    unawaited(gw.revokeAllTokens());
-  } else {
-    await castService.closeActiveCasts();
-  }
+  await castService.closeActiveCasts();
   final logger = Logger("showCastSheet");
   List<CastInfo> sessions = [];
-  if (flagService.enableMultiCast) {
-    try {
-      sessions = await gw.getAllCastSessions();
-    } catch (e, s) {
-      logger.severe('Failed to fetch active sessions in cast sheet: ', e, s);
-      if (!context.mounted) return;
-      await showGenericErrorDialog(context: context, error: e);
-      return;
-    }
+  try {
+    sessions = await gw.getAllCastSessions();
+  } catch (e, s) {
+    logger.severe('Failed to fetch active sessions in cast sheet: ', e, s);
+    if (!context.mounted) return;
+    await showGenericErrorDialog(context: context, error: e);
+    return;
   }
   if (!context.mounted) return;
   return showBottomSheetComponent(
@@ -89,12 +68,11 @@ Future<void> showCastSheet(BuildContext context, Collection collection) async {
             await showPairWithCodeSheet(context, collection);
           },
         ),
-        if (flagService.enableMultiCast)
-          CastSessionsList(
-            showTitle: true,
-            fallback: const SizedBox.shrink(),
-            initialSessions: sessions,
-          ),
+        CastSessionsList(
+          showTitle: true,
+          fallback: const SizedBox.shrink(),
+          initialSessions: sessions,
+        ),
       ],
     ),
   );

--- a/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
+++ b/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
@@ -21,9 +21,6 @@ Future<void> _pairWithCode(
   String code,
 ) async {
   final gw = CastGateway(NetworkClient.instance.enteDio);
-  if (!flagService.enableMultiCast) {
-    await gw.revokeAllTokens();
-  }
   final publicKey = await gw.getPublicKey(code);
   if (publicKey == null) {
     throw const _DeviceNotFoundException();

--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -430,14 +430,13 @@ class _SettingsBody extends StatelessWidget {
             await routeToPage(context, const VideoStreamingSettingsPage());
           },
         ),
-        if (flagService.enableMultiCast)
-          _buildMenuItem(
-            title: AppLocalizations.of(context).castSessions,
-            icon: HugeIcons.strokeRoundedTvSmart,
-            onTap: () async {
-              await routeToPage(context, const CastSettingsPage());
-            },
-          ),
+        _buildMenuItem(
+          title: AppLocalizations.of(context).castSessions,
+          icon: HugeIcons.strokeRoundedTvSmart,
+          onTap: () async {
+            await routeToPage(context, const CastSettingsPage());
+          },
+        ),
         _buildMapsMenuItem(context),
       ],
     );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -775,13 +775,7 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
         _menuOption(
           AlbumPopupAction.castAlbum,
           strings.castAlbum,
-          galleryAppBarMenuIcon(
-            !flagService.enableMultiCast &&
-                    castService.getActiveSessions().isNotEmpty
-                ? HugeIcons.strokeRoundedTvSmart
-                : HugeIcons.strokeRoundedTv02,
-            iconColor,
-          ),
+          galleryAppBarMenuIcon(HugeIcons.strokeRoundedTv02, iconColor),
         ),
       if (canAutoAdd)
         _menuOption(

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -14,7 +14,6 @@ import "model.dart";
 class FlagService {
   static const int _commentsFlag = 1 << 1;
   static const int _videoStreamingFlag = 1 << 3;
-  static const int _castSessionsV2Flag = 1 << 5;
   static const int _cfUploadWorkerRolloutPercent = 20;
 
   static const String _userIdKey = "user_id";
@@ -117,9 +116,6 @@ class FlagService {
   bool get syncRecoveryDiagnostics => internalUser;
 
   bool get mLHydrationStaleFileRecovery => internalUser;
-
-  bool get enableMultiCast =>
-      internalUser || _isServerFlagEnabled(_castSessionsV2Flag);
 
   Future<void> tryRefreshFlags() async {
     try {


### PR DESCRIPTION
## Summary

- remove the `enableMultiCast` rollout checks now that the server rollout is complete
- use the cast sessions flow unconditionally for pairing, active sessions, settings, and gallery actions
- remove the obsolete cast feature-flag bit and getter

## Impact

The mobile Photos app no longer keeps or executes the legacy cast fallback. Cast sessions and the new cast UX are available consistently without depending on the per-user server flag.

## Checks

- `dart format` on the changed Dart files
- focused `flutter analyze` on the five changed files
- `git diff --check`

The full Photos test suite was not runnable from a fresh checkout because generated Rust and shared-strings bindings were absent; the focused analyzer completed without issues.
