### PR TITLE
[mobile][photos] Align Memory sharing with visual design

### DIFF
--- a/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
@@ -108,7 +108,6 @@ class _MemoryShareSelectionSheetState
             child: _buildHeader(context, l10n),
           ),
           showCloseButton: false,
-          useSafeArea: false,
           padding: const EdgeInsets.symmetric(vertical: Spacing.xl),
           borderSide: BorderSide(color: colors.strokeDark),
           content: Expanded(

--- a/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
@@ -92,8 +92,12 @@ class _MemoryShareSelectionSheetState
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final colors = context.componentColors;
     final screenHeight = MediaQuery.sizeOf(context).height;
-    final sheetHeight = math.min(screenHeight * 0.792, screenHeight - 80);
+    final sheetHeight = math.min(
+      screenHeight * _figmaSheetHeightRatio,
+      screenHeight - 80,
+    );
 
     return SizedBox(
       height: sheetHeight,
@@ -104,7 +108,9 @@ class _MemoryShareSelectionSheetState
             child: _buildHeader(context, l10n),
           ),
           showCloseButton: false,
+          useSafeArea: false,
           padding: const EdgeInsets.symmetric(vertical: Spacing.xl),
+          borderSide: BorderSide(color: colors.strokeDark),
           content: Expanded(
             child: Column(
               children: [
@@ -136,7 +142,7 @@ class _MemoryShareSelectionSheetState
                 l10n.shareMemory,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyles.h1.copyWith(color: colors.textBase),
+                style: TextStyles.h1Bold.copyWith(color: colors.textBase),
               ),
             ),
             const SizedBox(width: Spacing.md),
@@ -162,20 +168,20 @@ class _MemoryShareSelectionSheetState
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         _buildSelectionChip(
-          key: const ValueKey("memory-share-selected-count"),
-          label: l10n.selectedPhotos(count: _selectedFiles.files.length),
-          icon: HugeIcons.strokeRoundedCancel01,
-          semanticLabel: l10n.clearSelection,
-          selected: _hasSelection,
-          onTap: _hasSelection ? _clearSelection : null,
-        ),
-        _buildSelectionChip(
           key: const ValueKey("memory-share-select-all"),
           label: l10n.selectAll,
           icon: HugeIcons.strokeRoundedTick02,
           semanticLabel: l10n.selectAll,
           selected: _areAllSelected,
           onTap: _areAllSelected ? null : _selectAll,
+        ),
+        _buildSelectionChip(
+          key: const ValueKey("memory-share-selected-count"),
+          label: l10n.selectedPhotos(count: _selectedFiles.files.length),
+          icon: HugeIcons.strokeRoundedCancel01,
+          semanticLabel: l10n.clearSelection,
+          selected: _hasSelection,
+          onTap: _hasSelection ? _clearSelection : null,
         ),
       ],
     );
@@ -257,6 +263,10 @@ class _MemoryShareSelectionSheetState
               _buildAction(
                 l10n.shareMemory,
                 MemoryShareSheetAction.shareMemory,
+                leading: const HugeIcon(
+                  icon: HugeIcons.strokeRoundedLink02,
+                  size: IconSizes.small,
+                ),
               ),
               const SizedBox(height: Spacing.md),
             ],
@@ -277,12 +287,15 @@ class _MemoryShareSelectionSheetState
     String label,
     MemoryShareSheetAction action, {
     ButtonComponentVariant variant = ButtonComponentVariant.primary,
+    Widget? leading,
   }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: Spacing.xl),
       child: ButtonComponent(
         label: label,
         variant: variant,
+        density: ButtonComponentDensity.compact,
+        leading: leading,
         isDisabled: !_hasSelection,
         shouldSurfaceExecutionStates: false,
         onTap: _hasSelection ? () => _complete(action) : null,
@@ -303,6 +316,10 @@ class _MemoryShareSelectionSheetState
     );
   }
 }
+
+/// The reference sheet is 634px on the 812px Share memory viewport.
+/// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-312441&m=dev
+const double _figmaSheetHeightRatio = 634 / 812;
 
 class _MemoryShareSheetBoundary extends StatefulWidget {
   final BoundaryPosition position;

--- a/mobile/packages/ente_components/lib/components/bottom_sheet/bottom_sheet_component.dart
+++ b/mobile/packages/ente_components/lib/components/bottom_sheet/bottom_sheet_component.dart
@@ -117,6 +117,8 @@ class BottomSheetComponent extends StatelessWidget {
     this.contentSpacing = Spacing.lg,
     this.actionsTopSpacing,
     this.backgroundColor,
+    this.borderSide,
+    this.useSafeArea = true,
     this.isKeyboardAware = false,
     this.isScrollable = false,
     this.initialChildSize = 0.5,
@@ -144,6 +146,17 @@ class BottomSheetComponent extends StatelessWidget {
   final double contentSpacing;
   final double? actionsTopSpacing;
   final Color? backgroundColor;
+
+  /// Optional outline for sheet designs that specify a bordered surface.
+  /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=4809-8027&m=dev
+  final BorderSide? borderSide;
+
+  /// Whether to add the device's bottom safe-area inset inside the sheet.
+  /// Fixed-format sheets can opt out when their designed bottom padding keeps
+  /// actions clear of the home indicator.
+  /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-312441&m=dev
+  final bool useSafeArea;
+
   final bool isKeyboardAware;
   final bool isScrollable;
 
@@ -238,6 +251,23 @@ class BottomSheetComponent extends StatelessWidget {
             ),
           );
 
+    final safeAreaBody = useSafeArea
+        ? SafeArea(top: false, child: sheetBody)
+        : sheetBody;
+    final outlinedBody = borderSide == null
+        ? safeAreaBody
+        : DecoratedBox(
+            position: DecorationPosition.foreground,
+            decoration: BoxDecoration(
+              border: Border.fromBorderSide(borderSide!),
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(Radii.bottomSheet),
+                topRight: Radius.circular(Radii.bottomSheet),
+              ),
+            ),
+            child: safeAreaBody,
+          );
+
     return AnimatedPadding(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeOutCubic,
@@ -251,7 +281,7 @@ class BottomSheetComponent extends StatelessWidget {
             topRight: Radius.circular(Radii.bottomSheet),
           ),
         ),
-        child: SafeArea(top: false, child: sheetBody),
+        child: outlinedBody,
       ),
     );
   }

--- a/mobile/packages/ente_components/lib/components/bottom_sheet/bottom_sheet_component.dart
+++ b/mobile/packages/ente_components/lib/components/bottom_sheet/bottom_sheet_component.dart
@@ -118,7 +118,6 @@ class BottomSheetComponent extends StatelessWidget {
     this.actionsTopSpacing,
     this.backgroundColor,
     this.borderSide,
-    this.useSafeArea = true,
     this.isKeyboardAware = false,
     this.isScrollable = false,
     this.initialChildSize = 0.5,
@@ -150,12 +149,6 @@ class BottomSheetComponent extends StatelessWidget {
   /// Optional outline for sheet designs that specify a bordered surface.
   /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=4809-8027&m=dev
   final BorderSide? borderSide;
-
-  /// Whether to add the device's bottom safe-area inset inside the sheet.
-  /// Fixed-format sheets can opt out when their designed bottom padding keeps
-  /// actions clear of the home indicator.
-  /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-312441&m=dev
-  final bool useSafeArea;
 
   final bool isKeyboardAware;
   final bool isScrollable;
@@ -251,9 +244,7 @@ class BottomSheetComponent extends StatelessWidget {
             ),
           );
 
-    final safeAreaBody = useSafeArea
-        ? SafeArea(top: false, child: sheetBody)
-        : sheetBody;
+    final safeAreaBody = SafeArea(top: false, child: sheetBody);
     final outlinedBody = borderSide == null
         ? safeAreaBody
         : DecoratedBox(

--- a/mobile/packages/ente_components/lib/components/buttons/button_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/button_component.dart
@@ -23,6 +23,14 @@ enum ButtonComponentVariant {
 
 enum ButtonComponentSize { small, large }
 
+enum ButtonComponentDensity {
+  regular,
+
+  /// Opt-in 48px Button Large treatment used by the Memory sharing sheet.
+  /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-312441&m=dev
+  compact,
+}
+
 /// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=2207-41578&m=dev
 /// Section: Buttons / Button Small
 /// Specs: 52px height, 20px radius, 24px horizontal padding.
@@ -34,6 +42,7 @@ class ButtonComponent extends StatefulWidget {
     this.onTap,
     this.variant = ButtonComponentVariant.primary,
     this.size = ButtonComponentSize.large,
+    this.density = ButtonComponentDensity.regular,
     this.isDisabled = false,
     this.shouldSurfaceExecutionStates = true,
     this.shouldShowSuccessState = true,
@@ -47,6 +56,7 @@ class ButtonComponent extends StatefulWidget {
   final FutureOr<void> Function()? onTap;
   final ButtonComponentVariant variant;
   final ButtonComponentSize size;
+  final ButtonComponentDensity density;
   final bool isDisabled;
   final bool shouldSurfaceExecutionStates;
   final bool shouldShowSuccessState;
@@ -68,7 +78,8 @@ class _ButtonComponentState extends State<ButtonComponent>
     with SingleTickerProviderStateMixin {
   static const double _executionIconSize = IconSizes.medium;
   static const double _contentMinHeight = 24;
-  static const double _verticalPadding = 14;
+  static const double _regularVerticalPadding = 14;
+  static const double _compactVerticalPadding = 12;
   static const Duration _loadingDelay = Duration(milliseconds: 300);
   static const Duration _successDisplayDuration = Duration(seconds: 1);
   static const Duration _minimumPressDuration = Duration(milliseconds: 120);
@@ -241,11 +252,14 @@ class _ButtonComponentState extends State<ButtonComponent>
     final underlined =
         widget.variant == ButtonComponentVariant.link ||
         widget.variant == ButtonComponentVariant.tertiaryCritical;
+    final labelStyle = widget.density == ButtonComponentDensity.compact
+        ? TextStyles.body
+        : TextStyles.bodyBold;
     final label = Text(
       widget.label,
       overflow: TextOverflow.ellipsis,
       maxLines: 2,
-      style: TextStyles.bodyBold.copyWith(
+      style: labelStyle.copyWith(
         color: foreground,
         decoration: underlined ? TextDecoration.underline : null,
         decorationColor: underlined ? foreground : null,
@@ -340,7 +354,9 @@ class _ButtonComponentState extends State<ButtonComponent>
   }
 
   double get _buttonVerticalPadding {
-    return _verticalPadding;
+    return widget.density == ButtonComponentDensity.compact
+        ? _compactVerticalPadding
+        : _regularVerticalPadding;
   }
 
   _ResolvedButtonColors _colors(BuildContext context) {

--- a/mobile/packages/ente_components/test/components/button_test.dart
+++ b/mobile/packages/ente_components/test/components/button_test.dart
@@ -18,6 +18,25 @@ void main() {
     expect(tester.getSize(find.byType(AnimatedContainer)).height, 52);
   });
 
+  testWidgets("Compact ButtonComponent uses 48px geometry and body type", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        ButtonComponent(
+          label: "Save",
+          density: ButtonComponentDensity.compact,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(AnimatedContainer)).height, 48);
+    final style = tester.widget<Text>(find.text("Save")).style!;
+    expect(style.fontWeight, TextStyles.body.fontWeight);
+    expect(style.fontSize, TextStyles.body.fontSize);
+  });
+
   testWidgets("ButtonComponent calls onTap when tapped", (tester) async {
     var tapCount = 0;
 


### PR DESCRIPTION
- Align the Memory sharing sheet layout, selection controls, and actions with the current visual design.
- Add opt-in button and bottom-sheet variants without changing existing defaults.