### PR TITLE
fix(gallery): skip NaN aperture and exposure time from manual lens EXIF

### DIFF
--- a/web/packages/gallery/components/FileInfo.tsx
+++ b/web/packages/gallery/components/FileInfo.tsx
@@ -658,10 +658,10 @@ const annotateExif = (
         if (exif.Make && exif.Model)
             info.takenOnDevice = `${exif.Make.description} ${exif.Model.description}`;
 
-        if (exif.FNumber)
+        if (exif.FNumber && exif.FNumber.description !== "NaN")
             info.fNumber = exif.FNumber.description; /* e.g. "f/16" */
 
-        if (exif.ExposureTime)
+        if (exif.ExposureTime && exif.ExposureTime.description !== "NaN")
             info.exposureTime = exif.ExposureTime.description; /* "1/10" */
 
         if (exif.ISOSpeedRatings)


### PR DESCRIPTION
Fixes #11581

When a manual lens has no electronic coupling, it reports `FNumber` and `ExposureTime` as rational `0/0`. ExifReader resolves this to `.description = "NaN"` — the object exists (truthy) but the value is unusable. The file info panel then displays "NaN" as the aperture.

**Fix:** guard both `FNumber` and `ExposureTime` with `&& exif.FNumber.description !== "NaN"` before assigning to the display info object. `ISOSpeedRatings` uses a separate numeric path and is unaffected.