### PR TITLE
fix(gallery): read caption as fallback when description missing in Google Takeout metadata

### DIFF
--- a/web/packages/gallery/services/upload/metadata-json.ts
+++ b/web/packages/gallery/services/upload/metadata-json.ts
@@ -258,7 +258,7 @@ const parseMetadataJSONText = (text: string) => {
         parseGTLocation(metadataJSON.geoDataExif);
 
     parsedMetadataJSON.description = parseGTNonEmptyString(
-        metadataJSON.description,
+        metadataJSON.description ?? metadataJSON.caption,
     );
 
     if (metadataJSON.favorited === true) {


### PR DESCRIPTION
Fixes #11594.

When importing from Google Takeout, video descriptions are silently dropped if the `.json` sidecar uses `"caption"` instead of `"description"`.

**Root cause:** `parseMetadataJSONText` reads `metadataJSON.description` for the description field. Google Photos consistently uses `"description"`, but some Takeout exports (especially for videos and for content imported from external sources) store the value under `"caption"` instead. There is no fallback, so those descriptions are lost on import.

**Fix:** Fall back to `metadataJSON.caption` when `metadataJSON.description` is absent. This is a one-character change (`?? metadataJSON.caption`) and is safe — `parseGTNonEmptyString` rejects empty/null values, so a `null` caption won't overwrite a valid description.