### PR TITLE
[mobile][photos] Fix Family member identity display

### DIFF
--- a/mobile/apps/photos/lib/ui/family/family_dashboard.dart
+++ b/mobile/apps/photos/lib/ui/family/family_dashboard.dart
@@ -68,6 +68,7 @@ class FamilyDashboard extends StatelessWidget {
     required this.contactsByUserId,
     required this.profilePictureBytesByUserId,
     required this.linkedPersonIdsByUserId,
+    required this.linkedPersonNamesByUserId,
     required this.onMemberTap,
     required this.onAddMember,
     required this.remainingSlots,
@@ -80,6 +81,7 @@ class FamilyDashboard extends StatelessWidget {
   final Map<int, contacts.ContactRecord?> contactsByUserId;
   final Map<int, Uint8List?> profilePictureBytesByUserId;
   final Map<int, String> linkedPersonIdsByUserId;
+  final Map<int, String> linkedPersonNamesByUserId;
   final ValueChanged<FamilyMember> onMemberTap;
   final VoidCallback onAddMember;
   final int remainingSlots;
@@ -158,14 +160,21 @@ class FamilyDashboard extends StatelessWidget {
   }
 
   String _displayNameFor(FamilyMember member) =>
-      _savedNameFor(member) ?? member.email;
+      _savedNameFor(member) ?? _linkedPersonNameFor(member) ?? member.email;
 
   String _storageLabelFor(FamilyMember member) =>
-      _savedNameFor(member) ?? member.email.split('@').first;
+      _savedNameFor(member) ??
+      _linkedPersonNameFor(member) ??
+      member.email.split('@').first;
 
   String? _savedNameFor(FamilyMember member) {
     final savedName = contactsByUserId[member.userID]?.data?.name.trim();
     return savedName == null || savedName.isEmpty ? null : savedName;
+  }
+
+  String? _linkedPersonNameFor(FamilyMember member) {
+    final personName = linkedPersonNamesByUserId[member.userID]?.trim();
+    return personName == null || personName.isEmpty ? null : personName;
   }
 
   AvatarComponentColor _avatarColorFor(FamilyMember member) =>

--- a/mobile/apps/photos/lib/ui/family/family_dashboard.dart
+++ b/mobile/apps/photos/lib/ui/family/family_dashboard.dart
@@ -19,17 +19,9 @@ enum FamilyMemberAction {
   revokeInvite,
 }
 
-AvatarComponentColor familyMemberAvatarComponentColor(
-  FamilyMember member, {
-  required String currentUserEmail,
-}) {
-  return avatarComponentColorForAvatarIdentity(
-    AvatarIdentity.account(
-      label: member.email,
-      email: member.email,
-      userID: member.userID,
-      currentUserEmail: currentUserEmail,
-    ),
+AvatarComponentColor familyMemberAvatarComponentColor(FamilyMember member) {
+  return avatarComponentColorForIdentity(
+    avatarIdentityKey(email: member.email, userID: member.userID),
   );
 }
 
@@ -177,10 +169,7 @@ class FamilyDashboard extends StatelessWidget {
   }
 
   AvatarComponentColor _avatarColorFor(FamilyMember member) =>
-      familyMemberAvatarComponentColor(
-        member,
-        currentUserEmail: userDetails.email,
-      );
+      familyMemberAvatarComponentColor(member);
 }
 
 class _FamilyStorageCard extends StatelessWidget {

--- a/mobile/apps/photos/lib/ui/family/family_plan_page.dart
+++ b/mobile/apps/photos/lib/ui/family/family_plan_page.dart
@@ -348,38 +348,48 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
 
   Widget _buildDashboard(BuildContext context, {required bool isAdminView}) {
     final members = _userDetails.familyData?.members ?? const <FamilyMember>[];
+    final linkedPersons = _linkedPersonsFor(members);
     return FamilyDashboard(
       userDetails: _userDetails,
       members: members,
       isAdmin: isAdminView,
       contactsByUserId: _contactsByUserId,
       profilePictureBytesByUserId: _profilePictureBytesByUserId,
-      linkedPersonIdsByUserId: _linkedPersonIdsFor(members),
+      linkedPersonIdsByUserId: linkedPersons.idsByUserId,
+      linkedPersonNamesByUserId: linkedPersons.namesByUserId,
       onMemberTap: _showMemberActions,
       onAddMember: () => unawaited(_openInvitePage()),
       remainingSlots: _remainingSlots,
     );
   }
 
-  Map<int, String> _linkedPersonIdsFor(List<FamilyMember> members) {
+  ({Map<int, String> idsByUserId, Map<int, String> namesByUserId})
+  _linkedPersonsFor(List<FamilyMember> members) {
     if (!PersonService.isInitialized) {
-      return const {};
+      return (idsByUserId: const {}, namesByUserId: const {});
     }
-    final result = <int, String>{};
+    final idsByUserId = <int, String>{};
+    final namesByUserId = <int, String>{};
     for (final member in members) {
       final userID = member.userID;
       if (userID == null) {
         continue;
       }
-      final personID = PersonService.instance.getCachedPartialPersonData(
+      final personData = PersonService.instance.getCachedPartialPersonData(
         userID: userID,
         email: member.email,
-      )?[PersonService.kPersonIDKey];
-      if (personID != null) {
-        result[userID] = personID;
+      );
+      final personID = personData?[PersonService.kPersonIDKey];
+      if (personID == null) {
+        continue;
+      }
+      idsByUserId[userID] = personID;
+      final personName = personData?[PersonService.kNameKey]?.trim();
+      if (personName != null && personName.isNotEmpty) {
+        namesByUserId[userID] = personName;
       }
     }
-    return result;
+    return (idsByUserId: idsByUserId, namesByUserId: namesByUserId);
   }
 
   Widget _buildDashboardOverflow(BuildContext context) {

--- a/mobile/apps/photos/lib/ui/family/family_plan_page.dart
+++ b/mobile/apps/photos/lib/ui/family/family_plan_page.dart
@@ -568,10 +568,7 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
                 totalStorageInBytes: _userDetails.getTotalStorage(),
                 avatarColor: avatarComponentColorValue(
                   context,
-                  familyMemberAvatarComponentColor(
-                    member,
-                    currentUserEmail: _userDetails.email,
-                  ),
+                  familyMemberAvatarComponentColor(member),
                 ),
               ),
             );

--- a/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
+++ b/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
@@ -192,6 +192,10 @@ void main() {
                   },
                   profilePictureBytesByUserId: const {},
                   linkedPersonIdsByUserId: const {},
+                  linkedPersonNamesByUserId: const {
+                    1: 'Person current user',
+                    42: 'Person saved member',
+                  },
                   onMemberTap: (member) => selectedMember = member,
                   onAddMember: () {},
                   remainingSlots: 2,
@@ -261,10 +265,14 @@ void main() {
     },
   );
 
-  testWidgets('uses a linked Person face when no contact photo is saved', (
+  testWidgets('uses a linked Person name and face without a saved contact', (
     tester,
   ) async {
-    final member = _member(email: 'me@example.com', userID: 42);
+    final member = _member(
+      email: 'admin@example.com',
+      userID: 42,
+      status: FamilyMemberStatus.self,
+    );
     final members = [member];
 
     await tester.pumpWidget(
@@ -280,6 +288,7 @@ void main() {
             contactsByUserId: const {},
             profilePictureBytesByUserId: const {},
             linkedPersonIdsByUserId: const {42: 'person-42'},
+            linkedPersonNamesByUserId: const {42: 'Current person'},
             onMemberTap: (_) {},
             onAddMember: () {},
             remainingSlots: 0,
@@ -288,6 +297,7 @@ void main() {
       ),
     );
 
+    expect(find.text('Current person'), findsWidgets);
     expect(find.byType(PersonFaceWidget), findsOneWidget);
     final personAvatar = tester.widget<PersonFaceWidget>(
       find.byType(PersonFaceWidget),
@@ -326,6 +336,7 @@ void main() {
               },
               profilePictureBytesByUserId: const {},
               linkedPersonIdsByUserId: const {},
+              linkedPersonNamesByUserId: const {4: 'Aaron'},
               onMemberTap: (_) {},
               onAddMember: () {},
               remainingSlots: 0,
@@ -339,7 +350,7 @@ void main() {
       tester
           .widgetList<MenuComponent>(find.byType(MenuComponent))
           .map((item) => item.title),
-      ['admin@example.com', 'Amy', 'bob@example.com', 'Zoe'],
+      ['admin@example.com', 'Aaron', 'Amy', 'Zoe'],
     );
   });
 }

--- a/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
+++ b/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
@@ -127,22 +127,21 @@ void main() {
   });
 
   group('familyMemberAvatarComponentColor', () {
-    test('uses black for the current user and hashes other members', () {
+    test('hashes every member including the current user', () {
       final currentUser = _member(email: 'admin@example.com', userID: 1);
       final otherMember = _member(email: 'saved@example.com', userID: 42);
 
       expect(
-        familyMemberAvatarComponentColor(
-          currentUser,
-          currentUserEmail: 'ADMIN@example.com',
+        familyMemberAvatarComponentColor(currentUser),
+        avatarComponentColorForIdentity(
+          avatarIdentityKey(
+            email: currentUser.email,
+            userID: currentUser.userID,
+          ),
         ),
-        AvatarComponentColor.black,
       );
       expect(
-        familyMemberAvatarComponentColor(
-          otherMember,
-          currentUserEmail: currentUser.email,
-        ),
+        familyMemberAvatarComponentColor(otherMember),
         avatarComponentColorForIdentity(
           avatarIdentityKey(
             email: otherMember.email,
@@ -165,16 +164,13 @@ void main() {
         email: 'pending@example.com',
         status: FamilyMemberStatus.invited,
       );
-      final members = [
-        _member(
-          email: 'admin@example.com',
-          userID: 1,
-          isAdmin: true,
-          status: FamilyMemberStatus.self,
-        ),
-        savedMember,
-        pendingMember,
-      ];
+      final currentUser = _member(
+        email: 'admin@example.com',
+        userID: 1,
+        isAdmin: true,
+        status: FamilyMemberStatus.self,
+      );
+      final members = [currentUser, savedMember, pendingMember];
       FamilyMember? selectedMember;
 
       await tester.pumpWidget(
@@ -191,6 +187,7 @@ void main() {
                   members: members,
                   isAdmin: true,
                   contactsByUserId: {
+                    1: _contact(currentUser, name: 'Current user'),
                     42: _contact(savedMember, name: 'Saved member'),
                   },
                   profilePictureBytesByUserId: const {},
@@ -206,8 +203,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('admin@example.com'), findsOneWidget);
-      expect(find.text('admin'), findsOneWidget);
+      expect(find.text('Current user'), findsWidgets);
       expect(find.text('Saved member'), findsNWidgets(2));
       expect(find.text('pending@example.com'), findsOneWidget);
       expect(
@@ -236,9 +232,9 @@ void main() {
       );
       expect(avatars.map((avatar) => avatar.seed), everyElement(isNull));
       final currentUserAvatar = avatars.singleWhere(
-        (avatar) => avatar.semanticLabel == 'admin@example.com',
+        (avatar) => avatar.semanticLabel == 'Current user',
       );
-      expect(currentUserAvatar.color, AvatarComponentColor.black);
+      expect(currentUserAvatar.color, isIn(avatarComponentIdentityPalette));
       final savedMemberAvatar = avatars.singleWhere(
         (avatar) => avatar.semanticLabel == 'Saved member',
       );


### PR DESCRIPTION
- Keep used storage visually distinct from remaining capacity.
- Prefer saved contact names, then linked Person names, over email.

Validation: Mobile lint workflow passed locally.