### PR TITLE
[mobile] Use contact-first avatars across Photos

### DIFF
--- a/mobile/apps/photos/lib/ui/family/edit_storage_limit_page.dart
+++ b/mobile/apps/photos/lib/ui/family/edit_storage_limit_page.dart
@@ -8,6 +8,7 @@ import 'package:photos/services/family_service.dart';
 import 'package:photos/theme/ente_theme.dart';
 import 'package:photos/ui/components/buttons/button_widget_v2.dart';
 import 'package:photos/ui/family/family_ui.dart';
+import 'package:photos/ui/viewer/search/contact_avatar_widget.dart';
 import 'package:photos/utils/dialog_util.dart';
 
 class EditStorageLimitPage extends StatefulWidget {
@@ -15,14 +16,14 @@ class EditStorageLimitPage extends StatefulWidget {
     required this.member,
     required this.displayName,
     required this.totalStorageInBytes,
-    required this.avatarColor,
+    required this.linkedPersonId,
     super.key,
   });
 
   final FamilyMember member;
   final String displayName;
   final int totalStorageInBytes;
-  final Color avatarColor;
+  final String? linkedPersonId;
 
   @override
   State<EditStorageLimitPage> createState() => _EditStorageLimitPageState();
@@ -95,15 +96,12 @@ class _EditStorageLimitPageState extends State<EditStorageLimitPage> {
                 children: [
                   Row(
                     children: [
-                      CircleAvatar(
-                        radius: 20,
-                        backgroundColor: widget.avatarColor,
-                        child: Text(
-                          widget.displayName.substring(0, 1).toUpperCase(),
-                          style: textTheme.bodyBold.copyWith(
-                            color: Colors.white,
-                          ),
-                        ),
+                      ContactAvatarWidget(
+                        contactUserId: widget.member.userID,
+                        email: widget.member.email,
+                        personId: widget.linkedPersonId,
+                        size: 40,
+                        borderRadius: 20,
                       ),
                       const SizedBox(width: 12),
                       Expanded(

--- a/mobile/apps/photos/lib/ui/family/family_dashboard.dart
+++ b/mobile/apps/photos/lib/ui/family/family_dashboard.dart
@@ -416,9 +416,16 @@ class _MemberAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cachedPixelWidth =
+        (AvatarComponentSize.large.dimension *
+                MediaQuery.devicePixelRatioOf(context))
+            .round();
     final avatar = profilePictureBytes != null
         ? AvatarComponent.image(
-            image: MemoryImage(profilePictureBytes!),
+            image: ResizeImage(
+              MemoryImage(profilePictureBytes!),
+              width: cachedPixelWidth,
+            ),
             size: AvatarComponentSize.large,
             semanticLabel: displayName,
           )
@@ -431,10 +438,7 @@ class _MemberAvatar extends StatelessWidget {
               child: ClipOval(
                 child: PersonFaceWidget(
                   personId: linkedPersonId,
-                  cachedPixelWidth:
-                      (AvatarComponentSize.large.dimension *
-                              MediaQuery.devicePixelRatioOf(context))
-                          .round(),
+                  cachedPixelWidth: cachedPixelWidth,
                 ),
               ),
             ),

--- a/mobile/apps/photos/lib/ui/family/family_plan_page.dart
+++ b/mobile/apps/photos/lib/ui/family/family_plan_page.dart
@@ -504,6 +504,12 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
     final displayName = savedContactName == null || savedContactName.isEmpty
         ? fallbackDisplayName
         : savedContactName;
+    final linkedPersonId = member.userID == null || !PersonService.isInitialized
+        ? null
+        : PersonService.instance.getCachedPartialPersonData(
+            userID: member.userID,
+            email: member.email,
+          )?[PersonService.kPersonIDKey];
     final l10n = AppLocalizations.of(context);
     await showBottomSheetComponent<void>(
       context: context,
@@ -517,6 +523,7 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
                 sheetContext,
                 member: member,
                 displayName: displayName,
+                linkedPersonId: linkedPersonId,
                 action: actions[index],
                 l10n: l10n,
               ),
@@ -533,6 +540,7 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
     BuildContext sheetContext, {
     required FamilyMember member,
     required String displayName,
+    required String? linkedPersonId,
     required FamilyMemberAction action,
     required AppLocalizations l10n,
   }) {
@@ -582,11 +590,8 @@ class _FamilyPlanPageState extends State<FamilyPlanPage> {
               EditStorageLimitPage(
                 member: member,
                 displayName: displayName,
+                linkedPersonId: linkedPersonId,
                 totalStorageInBytes: _userDetails.getTotalStorage(),
-                avatarColor: avatarComponentColorValue(
-                  context,
-                  familyMemberAvatarComponentColor(member),
-                ),
               ),
             );
             if (!mounted) {

--- a/mobile/apps/photos/lib/ui/sharing/user_avator_widget.dart
+++ b/mobile/apps/photos/lib/ui/sharing/user_avator_widget.dart
@@ -110,9 +110,10 @@ class _UserAvatarWidgetState extends State<UserAvatarWidget> {
     _debouncer.run(() async {
       if (!mounted) return;
       setState(() {
-        final data = PersonService
-            .instance
-            .emailToPartialPersonDataMapCache[widget.user.email];
+        final data = PersonService.instance.getCachedPartialPersonData(
+          userID: widget.user.id,
+          email: widget.user.email,
+        );
         if (data != null && data.containsKey(PersonService.kPersonIDKey)) {
           _canUsePersonFaceWidget = true;
           _personId = data[PersonService.kPersonIDKey] as String;
@@ -159,6 +160,7 @@ class _UserAvatarWidgetState extends State<UserAvatarWidget> {
             _contactPhotoBytes!,
             fit: BoxFit.cover,
             gaplessPlayback: true,
+            cacheWidth: cachedPixelWidth,
           ),
         ),
       );

--- a/mobile/apps/photos/lib/ui/viewer/people/person_face_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/person_face_widget.dart
@@ -307,8 +307,12 @@ class _PersonFaceWidgetState extends State<PersonFaceWidget>
               contactUserId: personData.userID,
               email: personData.userID == null ? personData.email : null,
             );
+        final resolvedName = PhotosContactsService.instance.getCachedSavedName(
+          contactUserId: personData.userID,
+          email: personData.userID == null ? personData.email : null,
+        );
         _personIdentity = AvatarIdentity.account(
-          label: personData.name,
+          label: resolvedName ?? personData.name,
           email: resolvedEmail ?? personData.email,
           userID: personData.userID,
           personID: personEntity.remoteID,

--- a/mobile/apps/photos/lib/ui/viewer/search/contact_avatar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/contact_avatar_widget.dart
@@ -16,12 +16,14 @@ class ContactAvatarWidget extends StatefulWidget {
   final String email;
   final String? personId;
   final double size;
+  final double? borderRadius;
 
   const ContactAvatarWidget({
     required this.contactUserId,
     required this.email,
     required this.size,
     this.personId,
+    this.borderRadius,
     super.key,
   });
 
@@ -68,38 +70,51 @@ class _ContactAvatarWidgetState extends State<ContactAvatarWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final cachedPixelWidth =
+        (widget.size * MediaQuery.devicePixelRatioOf(context)).toInt();
+    final avatar = FutureBuilder<Uint8List?>(
+      future: _photoFuture,
+      builder: (context, snapshot) {
+        final photoBytes = snapshot.data;
+        if (photoBytes != null) {
+          return Image.memory(
+            photoBytes,
+            fit: BoxFit.cover,
+            cacheWidth: cachedPixelWidth,
+          );
+        }
+        final personId = widget.personId;
+        if (_canUsePersonFaceWidget &&
+            personId != null &&
+            personId.isNotEmpty) {
+          return PersonFaceWidget(
+            key: ValueKey(personId),
+            personId: personId,
+            cachedPixelWidth: cachedPixelWidth,
+            onErrorCallback: () {
+              if (mounted) {
+                setState(() {
+                  _canUsePersonFaceWidget = false;
+                });
+              }
+            },
+          );
+        }
+        return FirstLetterUserAvatar(_fallbackUser());
+      },
+    );
     return SizedBox(
       width: widget.size,
       height: widget.size,
-      child: FaceThumbnailSquircleClip(
-        borderRadius: faceThumbnailSquircleBorderRadius(widget.size),
-        child: FutureBuilder<Uint8List?>(
-          future: _photoFuture,
-          builder: (context, snapshot) {
-            final photoBytes = snapshot.data;
-            if (photoBytes != null) {
-              return Image.memory(photoBytes, fit: BoxFit.cover);
-            }
-            final personId = widget.personId;
-            if (_canUsePersonFaceWidget &&
-                personId != null &&
-                personId.isNotEmpty) {
-              return PersonFaceWidget(
-                key: ValueKey(personId),
-                personId: personId,
-                onErrorCallback: () {
-                  if (mounted) {
-                    setState(() {
-                      _canUsePersonFaceWidget = false;
-                    });
-                  }
-                },
-              );
-            }
-            return FirstLetterUserAvatar(_fallbackUser());
-          },
-        ),
-      ),
+      child: widget.borderRadius == null
+          ? FaceThumbnailSquircleClip(
+              borderRadius: faceThumbnailSquircleBorderRadius(widget.size),
+              child: avatar,
+            )
+          : ClipRRect(
+              borderRadius: BorderRadius.circular(widget.borderRadius!),
+              child: avatar,
+            ),
     );
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/search/result/contact_result_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/contact_result_page.dart
@@ -21,6 +21,7 @@ import "package:photos/models/search/generic_search_result.dart";
 import "package:photos/models/search/search_constants.dart";
 import "package:photos/models/search/search_result.dart";
 import "package:photos/models/selected_files.dart";
+import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
 import "package:photos/services/photos_contacts_service.dart";
 import "package:photos/theme/colors.dart";
 import "package:photos/theme/ente_theme.dart";
@@ -71,6 +72,7 @@ class _ContactResultPageState extends State<ContactResultPage> {
   late final int _contactUserId;
   late final SearchFilterDataProvider _searchFilterDataProvider;
   contacts.ContactRecord? _savedContact;
+  String? _personId;
   bool _resolvedSavedContact = false;
 
   @override
@@ -82,6 +84,7 @@ class _ContactResultPageState extends State<ContactResultPage> {
     _searchResultName = widget.searchResult.name();
     _contactEmail = params[kContactEmail] as String? ?? _searchResultName;
     _contactUserId = params[kContactUserId] as int;
+    _personId = params[kPersonParamID] as String?;
     _filesUpdatedEvent = Bus.instance.on<LocalPhotosUpdatedEvent>().listen((
       event,
     ) {
@@ -284,15 +287,16 @@ class _ContactResultPageState extends State<ContactResultPage> {
       ),
     );
     if (updated is contacts.ContactRecord && mounted) {
+      final personData = PersonService.instance.getCachedPartialPersonData(
+        userID: _contactUserId,
+        email: _contactEmail,
+      );
       setState(() {
         _savedContact = updated;
+        _personId = personData?[PersonService.kPersonIDKey];
       });
     }
   }
-
-  String? get _personId =>
-      (widget.searchResult as GenericSearchResult).params[kPersonParamID]
-          as String?;
 
   String get _savedContactDisplayName {
     final savedName = _savedContact?.data?.name.trim();

--- a/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
@@ -224,6 +224,8 @@ class _EditContactPageState extends State<EditContactPage> {
   Widget _buildAvatar(BuildContext context, {required double size}) {
     final colorScheme = getEnteColorScheme(context);
     final textTheme = getEnteTextTheme(context);
+    final cachedPixelWidth = (size * MediaQuery.devicePixelRatioOf(context))
+        .round();
     final trimmedName = _nameController.text.trim();
     final identity = AvatarIdentity.account(
       label: trimmedName.isNotEmpty ? trimmedName : widget.email,
@@ -243,7 +245,11 @@ class _EditContactPageState extends State<EditContactPage> {
     if (_draftPhotoBytes != null) {
       return _ContactThumbnailShell(
         size: size,
-        child: Image.memory(_draftPhotoBytes!, fit: BoxFit.cover),
+        child: Image.memory(
+          _draftPhotoBytes!,
+          fit: BoxFit.cover,
+          cacheWidth: cachedPixelWidth,
+        ),
       );
     }
 

--- a/mobile/apps/photos/lib/ui/viewer/search/result/search_thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/search_thumbnail_widget.dart
@@ -1,16 +1,13 @@
 import "package:flutter/material.dart";
-import "package:logging/logging.dart";
-import "package:photos/models/api/collection/user.dart";
 import 'package:photos/models/file/file.dart';
 import "package:photos/models/search/generic_search_result.dart";
 import "package:photos/models/search/search_constants.dart";
 import "package:photos/models/search/search_result.dart";
 import "package:photos/models/search/search_types.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/sharing/user_avator_widget.dart";
 import 'package:photos/ui/viewer/file/no_thumbnail_widget.dart';
 import 'package:photos/ui/viewer/file/thumbnail_widget.dart';
 import 'package:photos/ui/viewer/people/person_face_widget.dart';
+import "package:photos/ui/viewer/search/contact_avatar_widget.dart";
 
 class SearchThumbnailWidget extends StatelessWidget {
   final EnteFile? file;
@@ -54,7 +51,7 @@ class SearchThumbnailWidget extends StatelessWidget {
   }
 }
 
-class ContactSearchThumbnailWidget extends StatefulWidget {
+class ContactSearchThumbnailWidget extends StatelessWidget {
   final GenericSearchResult searchResult;
   final String tagPrefix;
   final double size;
@@ -69,87 +66,13 @@ class ContactSearchThumbnailWidget extends StatefulWidget {
   });
 
   @override
-  State<ContactSearchThumbnailWidget> createState() =>
-      _ContactSearchThumbnailWidgetState();
-}
-
-class _ContactSearchThumbnailWidgetState
-    extends State<ContactSearchThumbnailWidget> {
-  bool _canUsePersonFaceWidget = true;
-  late String? _personID;
-  late String _email;
-  final _logger = Logger("_ContactSearchThumbnailWidgetState");
-
-  @override
-  void initState() {
-    super.initState();
-    _personID = widget.searchResult.params[kPersonParamID];
-    _email = widget.searchResult.params[kContactEmail];
-    _canUsePersonFaceWidget = _personID != null;
-  }
-
-  @override
-  void didUpdateWidget(covariant ContactSearchThumbnailWidget oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    final newPersonID = widget.searchResult.params[kPersonParamID];
-    final newEmail = widget.searchResult.params[kContactEmail];
-    if (newPersonID != _personID) {
-      _personID = newPersonID;
-      _canUsePersonFaceWidget = newPersonID != null;
-    }
-    if (newEmail != _email) {
-      _email = newEmail;
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: widget.size,
-      width: widget.size,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(widget.borderRadius),
-        child: _canUsePersonFaceWidget
-            ? PersonFaceWidget(
-                personId: _personID,
-                onErrorCallback: () {
-                  if (mounted) {
-                    _logger.severe(
-                      "Failed to load face for person with ID: $_personID",
-                    );
-                    setState(() {
-                      _canUsePersonFaceWidget = false;
-                    });
-                  }
-                },
-              )
-            : NoFaceForContactWidget(user: User(email: _email)),
-      ),
-    );
-  }
-}
-
-class NoFaceForContactWidget extends StatelessWidget {
-  final User user;
-  final bool addBorder;
-  const NoFaceForContactWidget({
-    this.addBorder = true,
-    required this.user,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final enteColorScheme = getEnteColorScheme(context);
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        border: addBorder
-            ? Border.all(color: enteColorScheme.strokeFaint, width: 1)
-            : null,
-        color: enteColorScheme.fillFaint,
-      ),
-      child: Center(child: FirstLetterUserAvatar(user)),
+    return ContactAvatarWidget(
+      contactUserId: searchResult.params[kContactUserId] as int,
+      email: searchResult.params[kContactEmail] as String,
+      personId: searchResult.params[kPersonParamID] as String?,
+      size: size,
+      borderRadius: borderRadius,
     );
   }
 }


### PR DESCRIPTION
Prefer saved contact photos and names before linked-person fallbacks across search, sharing, and family surfaces.

Reuse the shared contact avatar renderer and size decoded images to their displayed dimensions.