### PR TITLE
[mob][photos] Truncate long user agents in logout confirmation

### DIFF
--- a/mobile/apps/photos/lib/ui/account/sessions_page.dart
+++ b/mobile/apps/photos/lib/ui/account/sessions_page.dart
@@ -151,9 +151,13 @@ class _SessionsPageState extends State<SessionsPage> {
     final l10n = AppLocalizations.of(context);
     final isLoggingOutFromThisDevice =
         session.token == Configuration.instance.getToken();
+    final displayedUserAgent = session.ua.length > 256
+        ? "${session.ua.substring(0, 253)}..."
+        : session.ua;
     final message = isLoggingOutFromThisDevice
         ? l10n.thisWillLogYouOutOfThisDevice
-        : "${l10n.thisWillLogYouOutOfTheFollowingDevice}\n\n${session.ua}";
+        : "${l10n.thisWillLogYouOutOfTheFollowingDevice}\n\n"
+              "$displayedUserAgent";
 
     showBottomSheetComponent<void>(
       context: context,


### PR DESCRIPTION
## Description

Truncates session User-Agent text to 256 characters in the logout confirmation, preventing oversized values from hiding the terminate action.

## Tests

`flutter analyze apps/photos/lib/ui/account/sessions_page.dart`

Verified with an oversized User-Agent on the iPhone simulator.

## Screenshots

**Before**

<img width="1206" height="2622" alt="Before: oversized User-Agent overflows the session termination sheet" src="https://github.com/user-attachments/assets/263aa72f-1453-4f66-98de-ba8a8f5d8ec3" />

**After**

<img width="1206" height="2622" alt="After: User-Agent is truncated and the terminate action remains visible" src="https://github.com/user-attachments/assets/7d231fa0-0062-4ad2-965b-ca6fc337896b" />
