### PR TITLE
[server] Find scheduled deletions by email

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -966,6 +966,7 @@ func main() {
 	adminAPI.GET("/listmonk/missing-subscribers/count", adminHandler.GetListmonkMissingSubscribersCount)
 	adminAPI.GET("/users", adminHandler.GetUsers)
 	adminAPI.GET("/user", adminHandler.GetUser)
+	adminAPI.GET("/user/scheduled-deletions", adminHandler.GetScheduledDeletions)
 	adminAPI.POST("/user/disable-2fa", adminHandler.DisableTwoFactor)
 	adminAPI.POST("/user/update-referral", adminHandler.UpdateReferral)
 	adminAPI.POST("/user/disable-passkeys", adminHandler.RemovePasskeys)

--- a/server/ente/admin.go
+++ b/server/ente/admin.go
@@ -74,6 +74,15 @@ type RecoverAccountRequest struct {
 	EmailID string `json:"emailID" binding:"required"`
 }
 
+type ScheduledDeletion struct {
+	UserID                  int64 `json:"userID"`
+	UserCreatedAt           int64 `json:"userCreatedAt"`
+	ScheduledAt             int64 `json:"scheduledAt"`
+	DeletionStartsAt        int64 `json:"deletionStartsAt"`
+	StorageConsumed         int64 `json:"storageConsumed"`
+	AuthenticatorEntryCount int64 `json:"authenticatorEntryCount"`
+}
+
 // UpdateSubscriptionRequest is used to update a user's subscription
 type UpdateSubscriptionRequest struct {
 	AdminID         int64                  `json:"-"`

--- a/server/migrations/128_scheduled_deletion_email_hash.down.sql
+++ b/server/migrations/128_scheduled_deletion_email_hash.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_data_cleanup_scheduled_email_hash;
+
+ALTER TABLE data_cleanup DROP COLUMN IF EXISTS email_hash;

--- a/server/migrations/128_scheduled_deletion_email_hash.up.sql
+++ b/server/migrations/128_scheduled_deletion_email_hash.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE data_cleanup ADD COLUMN email_hash TEXT;
+
+CREATE INDEX idx_data_cleanup_scheduled_email_hash
+    ON data_cleanup (email_hash, created_at DESC)
+    WHERE stage = 'scheduled' AND email_hash IS NOT NULL;

--- a/server/pkg/api/admin.go
+++ b/server/pkg/api/admin.go
@@ -154,6 +154,15 @@ func (h *AdminHandler) GetUser(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+func (h *AdminHandler) GetScheduledDeletions(c *gin.Context) {
+	items, err := h.UserController.GetScheduledDeletions(c, c.Query("email"))
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"scheduledDeletions": items})
+}
+
 func (h *AdminHandler) DeleteUser(c *gin.Context) {
 	err := h.isFreshAdminToken(c)
 	if err != nil {

--- a/server/pkg/controller/data_cleanup/controller.go
+++ b/server/pkg/controller/data_cleanup/controller.go
@@ -116,8 +116,12 @@ func (c *DeleteUserCleanupController) deleteUserData(ctx context.Context, item *
 
 // startClean up will just verify that user
 func (c *DeleteUserCleanupController) startCleanup(ctx context.Context, item *entity.DataCleanup) error {
-	if err := c.isDeleted(item); err != nil {
+	deleted, err := c.isDeleted(ctx, item)
+	if err != nil {
 		return stacktrace.Propagate(err, "")
+	}
+	if !deleted {
+		return nil
 	}
 	// move to next stage for deleting collection
 	return c.Repo.MoveToNextStage(ctx, item.UserID, entity.Collection, time.Microseconds())
@@ -209,22 +213,20 @@ func (c *DeleteUserCleanupController) storageCheck(ctx context.Context, item *en
 	return c.completeCleanup(ctx, item)
 }
 
-func (c *DeleteUserCleanupController) isDeleted(item *entity.DataCleanup) error {
+func (c *DeleteUserCleanupController) isDeleted(ctx context.Context, item *entity.DataCleanup) (bool, error) {
 	u, err := c.UserRepo.Get(item.UserID)
 	if err == nil {
 		// user is not deleted, double check by verifying email is not empty
 		if u.Email != "" {
-			// todo: remove this logic after next deployment. This is to only handle cases
-			// where we have not removed scheduled delete entry for account post recovery.
-			remErr := c.Repo.RemoveScheduledDelete(context.Background(), item.UserID)
-			if remErr != nil {
-				return stacktrace.Propagate(remErr, "failed to remove scheduled delete entry")
+			if err := c.Repo.RemoveScheduledDeleteIfPresent(ctx, item.UserID); err != nil {
+				return false, stacktrace.Propagate(err, "failed to remove scheduled delete entry")
 			}
+			return false, nil
 		}
-		return stacktrace.Propagate(ente.NewBadRequestWithMessage("User ID is linked to undeleted account"), "")
+		return false, stacktrace.Propagate(ente.NewBadRequestWithMessage("User ID is linked to undeleted account"), "")
 	}
 	if !errors.Is(err, ente.ErrUserDeleted) {
-		return stacktrace.Propagate(err, "error while getting the user")
+		return false, stacktrace.Propagate(err, "error while getting the user")
 	}
-	return nil
+	return true, nil
 }

--- a/server/pkg/controller/data_cleanup/controller_test.go
+++ b/server/pkg/controller/data_cleanup/controller_test.go
@@ -1,0 +1,70 @@
+package data_cleanup
+
+import (
+	"testing"
+
+	cleanupentity "github.com/ente/museum/ente/data_cleanup"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/repo"
+	cleanuprepo "github.com/ente/museum/pkg/repo/datacleanup"
+)
+
+func TestStartCleanupCancelsRecoveredAccount(t *testing.T) {
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM data_cleanup`); err != nil {
+			t.Errorf("failed to clear data_cleanup: %v", err)
+		}
+		testutil.ResetTables(t, db)
+	})
+
+	tests := []struct {
+		name             string
+		cleanupRowExists bool
+	}{
+		{name: "stale fetched row"},
+		{name: "legacy cleanup row", cleanupRowExists: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := db.Exec(`DELETE FROM data_cleanup`); err != nil {
+				t.Fatalf("failed to clear data_cleanup: %v", err)
+			}
+			testutil.ResetTables(t, db)
+
+			userID := testutil.InsertUser(t, db, testutil.UserFixture{
+				UserID:       82,
+				Email:        "recovered@example.com",
+				CreationTime: 1,
+			})
+			if tt.cleanupRowExists {
+				if _, err := db.Exec(`INSERT INTO data_cleanup(user_id) VALUES($1)`, userID); err != nil {
+					t.Fatalf("failed to insert cleanup row: %v", err)
+				}
+			}
+			controller := &DeleteUserCleanupController{
+				Repo: &cleanuprepo.Repository{DB: db},
+				UserRepo: &repo.UserRepository{
+					DB:                  db,
+					SecretEncryptionKey: testutil.SecretEncryptionKey(),
+				},
+			}
+
+			if err := controller.startCleanup(t.Context(), &cleanupentity.DataCleanup{
+				UserID: userID,
+				Stage:  cleanupentity.Scheduled,
+			}); err != nil {
+				t.Fatalf("startCleanup() error = %v", err)
+			}
+			var cleanupRows int
+			if err := db.QueryRow(`SELECT count(*) FROM data_cleanup WHERE user_id = $1`, userID).Scan(&cleanupRows); err != nil {
+				t.Fatalf("failed to count cleanup rows: %v", err)
+			}
+			if cleanupRows != 0 {
+				t.Fatalf("cleanup row count = %d, want 0", cleanupRows)
+			}
+		})
+	}
+}

--- a/server/pkg/controller/user/account_recovery.go
+++ b/server/pkg/controller/user/account_recovery.go
@@ -111,6 +111,18 @@ func (c *UserController) accountRecoveryRequest(token string) (ente.RecoverAccou
 	return ente.RecoverAccountRequest{UserID: jwtToken.UserID, EmailID: jwtToken.Email}, nil
 }
 
+func (c *UserController) GetScheduledDeletions(ctx context.Context, emailID string) ([]ente.ScheduledDeletion, error) {
+	normalizedEmail := email.NormalizeEmail(emailID)
+	if normalizedEmail == "" {
+		return nil, stacktrace.Propagate(ente.NewBadRequestWithMessage("email is required"), "")
+	}
+	emailHash, err := crypto.GetHash(normalizedEmail, c.HashingKey)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to hash email")
+	}
+	return c.DataCleanupRepo.FindScheduledByEmailHash(ctx, emailHash)
+}
+
 func (c *UserController) accountRecoveryStatus(req ente.RecoverAccountRequest, allowAlreadyRecovered bool) (ente.AccountRecoveryStatus, error) {
 	user, err := c.UserRepo.Get(req.UserID)
 	if err == nil {
@@ -192,10 +204,15 @@ func (c *UserController) recoverAccount(ctx *gin.Context, req ente.RecoverAccoun
 		return "", stacktrace.Propagate(err, "failed to start account recovery transaction")
 	}
 	defer transaction.Rollback()
-	if err := c.DataCleanupRepo.LockScheduledDelete(ctx, transaction, req.UserID); errors.Is(err, sql.ErrNoRows) {
+	storedEmailHash, err := c.DataCleanupRepo.LockScheduledDelete(ctx, transaction, req.UserID)
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", stacktrace.Propagate(ErrAccountRecoveryUnavailable, "scheduled deletion is no longer recoverable")
-	} else if err != nil {
+	}
+	if err != nil {
 		return "", stacktrace.Propagate(err, "failed to lock scheduled deletion")
+	}
+	if storedEmailHash != nil && *storedEmailHash != emailHash {
+		return "", stacktrace.Propagate(ErrAccountRecoveryUnavailable, "recovery email does not match scheduled deletion")
 	}
 	if err := c.UserRepo.UpdateEmailTx(ctx, transaction, req.UserID, encryptedEmail, emailHash); err != nil {
 		if isEmailHashUniqueConstraint(err) {

--- a/server/pkg/controller/user/scheduled_deletion_recovery_test.go
+++ b/server/pkg/controller/user/scheduled_deletion_recovery_test.go
@@ -1,0 +1,151 @@
+package user
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/repo"
+	cleanuprepo "github.com/ente/museum/pkg/repo/datacleanup"
+	"github.com/ente/museum/pkg/utils/crypto"
+	"github.com/gin-gonic/gin"
+)
+
+func TestMarkAccountDeletedAndScheduleCleanupIsAtomic(t *testing.T) {
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM data_cleanup`); err != nil {
+			t.Errorf("failed to clear data_cleanup: %v", err)
+		}
+		testutil.ResetTables(t, db)
+	})
+
+	userRepo := &repo.UserRepository{
+		DB:                  db,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+	controller := &UserController{
+		UserRepo:        userRepo,
+		DataCleanupRepo: &cleanuprepo.Repository{DB: db},
+		HashingKey:      testutil.HashingKey(),
+	}
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       91,
+		Email:        "deleted@example.com",
+		CreationTime: 1,
+	})
+	if err := controller.markAccountDeletedAndScheduleCleanup(t.Context(), userID); err != nil {
+		t.Fatalf("markAccountDeletedAndScheduleCleanup() error = %v", err)
+	}
+	if _, err := userRepo.Get(userID); !errors.Is(err, ente.ErrUserDeleted) {
+		t.Fatalf("user state after deletion = %v, want deleted", err)
+	}
+
+	expectedHash, err := crypto.GetHash("deleted@example.com", testutil.HashingKey())
+	if err != nil {
+		t.Fatalf("GetHash() error = %v", err)
+	}
+	var storedHash string
+	if err := db.QueryRow(`SELECT email_hash FROM data_cleanup WHERE user_id = $1`, userID).Scan(&storedHash); err != nil {
+		t.Fatalf("failed to read scheduled deletion: %v", err)
+	}
+	if storedHash != expectedHash {
+		t.Fatalf("stored email hash = %q, want original hash", storedHash)
+	}
+
+	items, err := controller.GetScheduledDeletions(t.Context(), " DELETED@EXAMPLE.COM ")
+	if err != nil {
+		t.Fatalf("GetScheduledDeletions() error = %v", err)
+	}
+	if len(items) != 1 || items[0].UserID != userID {
+		t.Fatalf("GetScheduledDeletions() = %+v, want deleted user", items)
+	}
+
+	rollbackUserID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       92,
+		Email:        "rollback@example.com",
+		CreationTime: 1,
+	})
+	if _, err := db.Exec(`INSERT INTO data_cleanup(user_id) VALUES($1)`, rollbackUserID); err != nil {
+		t.Fatalf("failed to create conflicting cleanup row: %v", err)
+	}
+	if err := controller.markAccountDeletedAndScheduleCleanup(t.Context(), rollbackUserID); err == nil {
+		t.Fatal("markAccountDeletedAndScheduleCleanup() succeeded with conflicting cleanup row")
+	}
+	if _, err := userRepo.Get(rollbackUserID); err != nil {
+		t.Fatalf("user was left deleted after cleanup insert failed: %v", err)
+	}
+}
+
+func TestAccountRecoveryVerifiesScheduledEmailHash(t *testing.T) {
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM data_cleanup`); err != nil {
+			t.Errorf("failed to clear data_cleanup: %v", err)
+		}
+		testutil.ResetTables(t, db)
+	})
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       82,
+		Email:        "recover@example.com",
+		CreationTime: 1,
+	})
+	insertKeyAttributes(t, db, userID)
+	insertScheduledDelete(t, db, userID)
+
+	mismatchedHash, err := crypto.GetHash("different@example.com", testutil.HashingKey())
+	if err != nil {
+		t.Fatalf("GetHash() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE data_cleanup SET email_hash = $1 WHERE user_id = $2`, mismatchedHash, userID); err != nil {
+		t.Fatalf("failed to set scheduled email hash: %v", err)
+	}
+
+	userRepo := &repo.UserRepository{
+		DB:                  db,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+	if err := userRepo.Delete(userID); err != nil {
+		t.Fatalf("failed to delete user: %v", err)
+	}
+	controller := &UserController{
+		UserRepo:            userRepo,
+		DataCleanupRepo:     &cleanuprepo.Repository{DB: db},
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	request := ente.RecoverAccountRequest{UserID: userID, EmailID: "recover@example.com"}
+
+	if err := controller.HandleAccountRecovery(ctx, request); !errors.Is(err, ErrAccountRecoveryUnavailable) {
+		t.Fatalf("HandleAccountRecovery() mismatch error = %v, want ErrAccountRecoveryUnavailable", err)
+	}
+	if _, err := userRepo.Get(userID); !errors.Is(err, ente.ErrUserDeleted) {
+		t.Fatalf("user state after mismatched recovery = %v, want deleted", err)
+	}
+
+	matchingHash, err := crypto.GetHash(request.EmailID, testutil.HashingKey())
+	if err != nil {
+		t.Fatalf("GetHash() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE data_cleanup SET email_hash = $1 WHERE user_id = $2`, matchingHash, userID); err != nil {
+		t.Fatalf("failed to replace scheduled email hash: %v", err)
+	}
+	if err := controller.HandleAccountRecovery(ctx, request); err != nil {
+		t.Fatalf("HandleAccountRecovery() with matching hash error = %v", err)
+	}
+	if _, err := userRepo.Get(userID); err != nil {
+		t.Fatalf("user was not recovered with matching hash: %v", err)
+	}
+}

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -348,15 +348,8 @@ func (c *UserController) handleAccountDeletion(
 		}
 	}()
 
-	logger.Info("mark user as deleted")
-	err = c.UserRepo.Delete(userID)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "")
-	}
-
-	logger.Info("schedule data deletion")
-	err = c.DataCleanupRepo.Insert(ctx, userID)
-	if err != nil {
+	logger.Info("mark user as deleted and schedule data deletion")
+	if err := c.markAccountDeletedAndScheduleCleanup(ctx, userID); err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
 
@@ -369,6 +362,23 @@ func (c *UserController) handleAccountDeletion(
 		UserID:                  userID,
 	}, nil
 
+}
+
+func (c *UserController) markAccountDeletedAndScheduleCleanup(ctx context.Context, userID int64) error {
+	transaction, err := c.UserRepo.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to start account deletion transaction")
+	}
+	defer transaction.Rollback()
+
+	emailHash, err := c.UserRepo.DeleteTx(ctx, transaction, userID)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if err := c.DataCleanupRepo.InsertTx(ctx, transaction, userID, emailHash); err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	return stacktrace.Propagate(transaction.Commit(), "failed to commit account deletion")
 }
 
 func (c *UserController) NotifyAccountDeletion(userID int64, userEmail string, isSubscriptionCancelled bool) {

--- a/server/pkg/repo/datacleanup/repository.go
+++ b/server/pkg/repo/datacleanup/repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/ente/museum/ente"
 	entity "github.com/ente/museum/ente/data_cleanup"
 	"github.com/ente/museum/pkg/utils/time"
 	"github.com/ente/stacktrace"
@@ -14,9 +16,42 @@ type Repository struct {
 	DB *sql.DB
 }
 
-func (r *Repository) Insert(ctx context.Context, userID int64) error {
-	_, err := r.DB.ExecContext(ctx, `INSERT INTO data_cleanup(user_id) VALUES ($1)`, userID)
+func (r *Repository) InsertTx(ctx context.Context, tx *sql.Tx, userID int64, emailHash string) error {
+	_, err := tx.ExecContext(ctx, `INSERT INTO data_cleanup(user_id, email_hash) VALUES ($1, $2)`, userID, emailHash)
 	return stacktrace.Propagate(err, "failed to insert")
+}
+
+func (r *Repository) FindScheduledByEmailHash(ctx context.Context, emailHash string) ([]ente.ScheduledDeletion, error) {
+	rows, err := r.DB.QueryContext(ctx, `
+		SELECT d.user_id, u.creation_time, d.created_at, d.stage_schedule_time,
+			COALESCE(us.storage_consumed, 0),
+			(SELECT count(*) FROM authenticator_entity ae WHERE ae.user_id = d.user_id AND ae.is_deleted = FALSE)
+		FROM data_cleanup d
+		JOIN users u ON u.user_id = d.user_id
+		LEFT JOIN usage us ON us.user_id = d.user_id
+		WHERE d.stage = $1 AND d.email_hash = $2
+		ORDER BY d.created_at DESC, d.user_id DESC`, entity.Scheduled, emailHash)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to find scheduled deletions")
+	}
+	defer rows.Close()
+
+	items := make([]ente.ScheduledDeletion, 0)
+	for rows.Next() {
+		var item ente.ScheduledDeletion
+		if err := rows.Scan(
+			&item.UserID,
+			&item.UserCreatedAt,
+			&item.ScheduledAt,
+			&item.DeletionStartsAt,
+			&item.StorageConsumed,
+			&item.AuthenticatorEntryCount,
+		); err != nil {
+			return nil, stacktrace.Propagate(err, "failed to scan scheduled deletion")
+		}
+		items = append(items, item)
+	}
+	return items, stacktrace.Propagate(rows.Err(), "failed to iterate scheduled deletions")
 }
 
 func (r *Repository) HasScheduledDelete(ctx context.Context, userID int64) (bool, error) {
@@ -27,14 +62,22 @@ func (r *Repository) HasScheduledDelete(ctx context.Context, userID int64) (bool
 	return exists, stacktrace.Propagate(err, "failed to check scheduled delete")
 }
 
-func (r *Repository) LockScheduledDelete(ctx context.Context, tx *sql.Tx, userID int64) error {
-	var lockedUserID int64
-	return tx.QueryRowContext(ctx, `SELECT user_id FROM data_cleanup
-		WHERE user_id = $1 AND stage = $2 FOR UPDATE`, userID, entity.Scheduled).Scan(&lockedUserID)
+func (r *Repository) LockScheduledDelete(ctx context.Context, tx *sql.Tx, userID int64) (*string, error) {
+	var emailHash sql.NullString
+	err := tx.QueryRowContext(ctx, `SELECT email_hash FROM data_cleanup
+		WHERE user_id = $1 AND stage = $2 FOR UPDATE`, userID, entity.Scheduled).Scan(&emailHash)
+	if err != nil {
+		return nil, err
+	}
+	if !emailHash.Valid {
+		return nil, nil
+	}
+	return &emailHash.String, nil
 }
 
-func (r *Repository) RemoveScheduledDelete(ctx context.Context, userID int64) error {
-	return removeScheduledDelete(ctx, r.DB, userID)
+func (r *Repository) RemoveScheduledDeleteIfPresent(ctx context.Context, userID int64) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM data_cleanup WHERE user_id = $1 AND stage = $2`, userID, entity.Scheduled)
+	return stacktrace.Propagate(err, "failed to remove scheduled delete")
 }
 
 func (r *Repository) RemoveScheduledDeleteTx(ctx context.Context, tx *sql.Tx, userID int64) error {
@@ -84,8 +127,9 @@ func (r *Repository) GetItemsPendingCompletion(ctx context.Context, limit int) (
 
 // MoveToNextStage update stage with corresponding schedule
 func (r *Repository) MoveToNextStage(ctx context.Context, userID int64, stage entity.Stage, stageScheduleTime int64) error {
-	_, err := r.DB.ExecContext(ctx, `UPDATE data_cleanup SET stage = $1,stage_schedule_time = $2, stage_attempt_count=0
-			 WHERE user_id = $3`, stage, stageScheduleTime, userID)
+	_, err := r.DB.ExecContext(ctx, `UPDATE data_cleanup
+		SET stage = $1, stage_schedule_time = $2, stage_attempt_count = 0, email_hash = NULL
+		WHERE user_id = $3`, stage, stageScheduleTime, userID)
 	return stacktrace.Propagate(err, "failed to insert/update")
 }
 

--- a/server/pkg/repo/datacleanup/repository_test.go
+++ b/server/pkg/repo/datacleanup/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/utils/crypto"
 )
 
 func TestDeleteTableDataDeletesContactsAndAttachmentsForUser(t *testing.T) {
@@ -83,6 +84,87 @@ func TestDeleteTableDataDeletesContactsAndAttachmentsForUser(t *testing.T) {
 	}
 	if !isDeleted || !pendingSync {
 		t.Fatalf("target attachment row = {is_deleted:%v pending_sync:%v}, want both true", isDeleted, pendingSync)
+	}
+}
+
+func TestFindScheduledByEmailHash(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM data_cleanup`); err != nil {
+			t.Errorf("failed to clear data_cleanup: %v", err)
+		}
+		testutil.ResetTables(t, db)
+	})
+
+	for _, fixture := range []testutil.UserFixture{
+		{UserID: 1, Email: "first@ente.com", CreationTime: 11},
+		{UserID: 2, Email: "second@ente.com", CreationTime: 22},
+		{UserID: 3, Email: "advanced@ente.com", CreationTime: 33},
+		{UserID: 4, Email: "unrelated@ente.com", CreationTime: 44},
+	} {
+		testutil.InsertUser(t, db, fixture)
+	}
+
+	emailHash, err := crypto.GetHash("deleted@ente.com", testutil.HashingKey())
+	if err != nil {
+		t.Fatalf("GetHash() error = %v", err)
+	}
+	otherHash, err := crypto.GetHash("other@ente.com", testutil.HashingKey())
+	if err != nil {
+		t.Fatalf("GetHash() error = %v", err)
+	}
+
+	mustExecCleanupTest(t, db, `INSERT INTO usage(user_id, storage_consumed) VALUES($1, $2)`, 1, 2048)
+	mustExecCleanupTest(t, db, `INSERT INTO authenticator_key(user_id, encrypted_key, header) VALUES($1, $2, $3)`, 1, "key", "header")
+	mustExecCleanupTest(t, db, `INSERT INTO authenticator_entity(id, user_id, encrypted_data, header, is_deleted)
+		VALUES($1, $2, $3, $4, FALSE), ($5, $2, NULL, $4, TRUE)`,
+		"00000000-0000-0000-0000-000000000001", 1, "active", "header",
+		"00000000-0000-0000-0000-000000000002",
+	)
+	mustExecCleanupTest(t, db, `INSERT INTO data_cleanup(user_id, email_hash, stage, stage_schedule_time, created_at)
+		VALUES
+			(1, $1, 'scheduled', 1001, 101),
+			(2, $1, 'scheduled', 1002, 202),
+			(3, $1, 'collection', 1003, 303),
+			(4, $2, 'scheduled', 1004, 404)`,
+		emailHash, otherHash,
+	)
+
+	repository := &Repository{DB: db}
+	items, err := repository.FindScheduledByEmailHash(t.Context(), emailHash)
+	if err != nil {
+		t.Fatalf("FindScheduledByEmailHash() error = %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("FindScheduledByEmailHash() returned %d items, want 2", len(items))
+	}
+	if items[0].UserID != 2 || items[0].UserCreatedAt != 22 || items[0].ScheduledAt != 202 || items[0].DeletionStartsAt != 1002 {
+		t.Fatalf("newest scheduled deletion = %+v, want user 2", items[0])
+	}
+	if items[1].UserID != 1 || items[1].StorageConsumed != 2048 || items[1].AuthenticatorEntryCount != 1 {
+		t.Fatalf("older scheduled deletion = %+v, want user 1 details", items[1])
+	}
+
+	if err := repository.MoveToNextStage(t.Context(), 2, "collection", 2002); err != nil {
+		t.Fatalf("MoveToNextStage() error = %v", err)
+	}
+	var storedHash sql.NullString
+	if err := db.QueryRow(`SELECT email_hash FROM data_cleanup WHERE user_id = 2`).Scan(&storedHash); err != nil {
+		t.Fatalf("failed to read advanced cleanup row: %v", err)
+	}
+	if storedHash.Valid {
+		t.Fatalf("email hash was retained after stage advance: %q", storedHash.String)
+	}
+
+	items, err = repository.FindScheduledByEmailHash(t.Context(), emailHash)
+	if err != nil {
+		t.Fatalf("FindScheduledByEmailHash() after stage advance error = %v", err)
+	}
+	if len(items) != 1 || items[0].UserID != 1 {
+		t.Fatalf("scheduled deletions after stage advance = %+v, want only user 1", items)
 	}
 }
 

--- a/server/pkg/repo/user.go
+++ b/server/pkg/repo/user.go
@@ -41,7 +41,7 @@ type UserInactivityCandidate struct {
 	LastActivity int64
 }
 
-type emailUpdateExecutor interface {
+type userMutationExecutor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
@@ -98,8 +98,20 @@ func (repo *UserRepository) IsLikelySelfHosted() bool {
 // Delete removes the email_hash and encrypted email information for the user. It replaces email_hash with placeholder value
 // based on DELETED_EMAIL_HASH_FORMAT
 func (repo *UserRepository) Delete(userID int64) error {
-	emailHash := fmt.Sprintf(DELETED_EMAIL_HASH_FORMAT, userID)
-	_, err := repo.DB.Exec(`UPDATE users SET encrypted_email = null, email_decryption_nonce = null, email_hash = $1 WHERE user_id = $2`, emailHash, userID)
+	return deleteUser(context.Background(), repo.DB, userID)
+}
+
+func (repo *UserRepository) DeleteTx(ctx context.Context, tx *sql.Tx, userID int64) (string, error) {
+	var emailHash string
+	if err := tx.QueryRowContext(ctx, `SELECT email_hash FROM users WHERE user_id = $1 FOR UPDATE`, userID).Scan(&emailHash); err != nil {
+		return "", stacktrace.Propagate(err, "failed to read email hash")
+	}
+	return emailHash, deleteUser(ctx, tx, userID)
+}
+
+func deleteUser(ctx context.Context, executor userMutationExecutor, userID int64) error {
+	deletedEmailHash := fmt.Sprintf(DELETED_EMAIL_HASH_FORMAT, userID)
+	_, err := executor.ExecContext(ctx, `UPDATE users SET encrypted_email = null, email_decryption_nonce = null, email_hash = $1 WHERE user_id = $2`, deletedEmailHash, userID)
 	return stacktrace.Propagate(err, "")
 }
 
@@ -335,7 +347,7 @@ func (repo *UserRepository) UpdateEmailTx(ctx context.Context, tx *sql.Tx, userI
 	return updateEmail(ctx, tx, userID, encryptedEmail, emailHash)
 }
 
-func updateEmail(ctx context.Context, executor emailUpdateExecutor, userID int64, encryptedEmail ente.EncryptionResult, emailHash string) error {
+func updateEmail(ctx context.Context, executor userMutationExecutor, userID int64, encryptedEmail ente.EncryptionResult, emailHash string) error {
 	_, err := executor.ExecContext(ctx, `UPDATE users SET encrypted_email = $1, email_decryption_nonce = $2, email_hash = $3 WHERE user_id = $4`, encryptedEmail.Cipher, encryptedEmail.Nonce, emailHash, userID)
 	return stacktrace.Propagate(err, "")
 }


### PR DESCRIPTION
- Persist the original keyed email hash while account deletion remains recoverable.
- Add the admin lookup metadata and verify the stored hash during recovery.