### PR TITLE
[server] Propagate request context through AddFiles

### DIFF
--- a/server/pkg/controller/collections/file_action.go
+++ b/server/pkg/controller/collections/file_action.go
@@ -11,6 +11,7 @@ import (
 
 // AddFiles adds files to a collection
 func (c *CollectionController) AddFiles(ctx *gin.Context, userID int64, files []ente.CollectionFileItem, cID int64) error {
+	requestCtx := ctx.Request.Context()
 	resp, err := c.AccessCtrl.GetCollection(ctx, &access.GetCollectionParams{
 		CollectionID:   cID,
 		ActorUserID:    userID,
@@ -45,7 +46,7 @@ func (c *CollectionController) AddFiles(ctx *gin.Context, userID int64, files []
 	}
 
 	// Verify that none of the files are in trash or permanently deleted
-	trashedOrDeletedFileIDs, err := c.TrashRepo.GetFilesInTrashOrDeleted(ctx, userID, fileIDs)
+	trashedOrDeletedFileIDs, err := c.TrashRepo.GetFilesInTrashOrDeleted(requestCtx, userID, fileIDs)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to check trash state")
 	}
@@ -58,7 +59,7 @@ func (c *CollectionController) AddFiles(ctx *gin.Context, userID int64, files []
 		return stacktrace.Propagate(&ente.ErrFileInTrash, "")
 	}
 
-	err = c.CollectionRepo.AddFiles(cID, collectionOwnerID, files, filesOwnerID)
+	err = c.CollectionRepo.AddFiles(requestCtx, cID, collectionOwnerID, files, filesOwnerID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -613,19 +613,19 @@ func (repo *CollectionRepository) UnShare(collectionID int64, toUserID int64) er
 
 // AddFiles adds files to a collection
 func (repo *CollectionRepository) AddFiles(
+	ctx context.Context,
 	collectionID int64,
 	collectionOwnerID int64,
 	files []ente.CollectionFileItem,
 	fileOwnerID int64,
 ) error {
 	updationTime := time.Microseconds()
-	context := context.Background()
-	tx, err := repo.DB.BeginTx(context, nil)
+	tx, err := repo.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
 	for _, file := range files {
-		_, err := tx.ExecContext(context, `INSERT INTO collection_files
+		_, err := tx.ExecContext(ctx, `INSERT INTO collection_files
             (collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
             VALUES($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT ON CONSTRAINT unique_collection_files_cid_fid
@@ -645,7 +645,7 @@ func (repo *CollectionRepository) AddFiles(
 			return stacktrace.Propagate(err, "")
 		}
 	}
-	_, err = tx.ExecContext(context, `UPDATE collections SET updation_time = $1
+	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 		 WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
 		tx.Rollback()


### PR DESCRIPTION
- AddFiles discarded the HTTP request context before starting its transaction, so client cancellation or disconnects could not stop that database work.
- Reuse the request-scoped context for the Trash-state validation and the AddFiles transaction. This is an independently safe prerequisite for future row locking, where a request may otherwise continue waiting after cancellation.
- This PR does not change SQL, locking, or AddFiles behavior, and intentionally does not claim to fix the AddFiles-Trash race by itself.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh docker`