### PR TITLE
[mob][photos] Clear device album cache on logout

### DIFF
--- a/mobile/apps/photos/lib/core/cache/device_collections_cache.dart
+++ b/mobile/apps/photos/lib/core/cache/device_collections_cache.dart
@@ -1,0 +1,37 @@
+import 'package:logging/logging.dart';
+import 'package:photos/models/device_collection.dart';
+
+class DeviceCollectionsCache {
+  static final _logger = Logger("DeviceCollectionsCache");
+
+  static List<DeviceCollection>? _deviceCollections;
+  static int _generation = 0;
+
+  static List<DeviceCollection>? get deviceCollections => _deviceCollections;
+  static int get generation => _generation;
+
+  static void putIfCurrent(
+    int generation,
+    List<DeviceCollection> deviceCollections,
+  ) {
+    if (generation != _generation) {
+      _logger.info(
+        "[DeviceAlbumCache] Ignored stale cache update after logout",
+      );
+      return;
+    }
+    _deviceCollections = deviceCollections;
+    _logger.info(
+      "[DeviceAlbumCache] Cached ${deviceCollections.length} device albums",
+    );
+  }
+
+  static void clearAll() {
+    final cachedAlbumCount = _deviceCollections?.length ?? 0;
+    _deviceCollections = null;
+    _generation++;
+    _logger.info(
+      "[DeviceAlbumCache] Cleared $cachedAlbumCount cached device albums",
+    );
+  }
+}

--- a/mobile/apps/photos/lib/core/cache/device_collections_cache.dart
+++ b/mobile/apps/photos/lib/core/cache/device_collections_cache.dart
@@ -10,7 +10,7 @@ class DeviceCollectionsCache {
   static List<DeviceCollection>? get deviceCollections => _deviceCollections;
   static int get generation => _generation;
 
-  static void putIfCurrent(
+  static bool putIfCurrent(
     int generation,
     List<DeviceCollection> deviceCollections,
   ) {
@@ -18,12 +18,13 @@ class DeviceCollectionsCache {
       _logger.info(
         "[DeviceAlbumCache] Ignored stale cache update after logout",
       );
-      return;
+      return false;
     }
     _deviceCollections = deviceCollections;
     _logger.info(
       "[DeviceAlbumCache] Cached ${deviceCollections.length} device albums",
     );
+    return true;
   }
 
   static void clearAll() {

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -15,6 +15,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import "package:photos/app_mode.dart";
+import 'package:photos/core/cache/device_collections_cache.dart';
 import 'package:photos/core/cache/image_cache.dart';
 import 'package:photos/core/cache/thumbnail_in_memory_cache.dart';
 import 'package:photos/core/cache/video_cache_manager.dart';
@@ -238,6 +239,7 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
     // Clear all in-memory caches
     ThumbnailInMemoryLruCache.clearAll();
     FileLruCache.clearAll();
+    DeviceCollectionsCache.clearAll();
 
     // Clear image cache
     try {

--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -147,7 +147,13 @@ class _DeviceFolderVerticalGridViewBodyState
     final deviceCollections = await FilesDB.instance.getDeviceCollections(
       includeCoverThumbnail: true,
     );
-    DeviceCollectionsCache.putIfCurrent(cacheGeneration, deviceCollections);
+    final didCache = DeviceCollectionsCache.putIfCurrent(
+      cacheGeneration,
+      deviceCollections,
+    );
+    if (!didCache) {
+      return const <DeviceCollection>[];
+    }
     return deviceCollections;
   }
 

--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -5,6 +5,7 @@ import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:photos/core/cache/device_collections_cache.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/device_files_db.dart';
 import 'package:photos/db/files_db.dart';
@@ -104,8 +105,6 @@ class DeviceFolderVerticalGridSliver extends StatefulWidget {
 
 class _DeviceFolderVerticalGridViewBodyState
     extends State<DeviceFolderVerticalGridSliver> {
-  static List<DeviceCollection>? _cachedDeviceCollections;
-
   StreamSubscription<BackupFoldersUpdatedEvent>? _backupFoldersUpdatedEvent;
   StreamSubscription<LocalPhotosUpdatedEvent>? _localFilesSubscription;
   late Future<List<DeviceCollection>> _deviceCollectionsFuture;
@@ -144,10 +143,11 @@ class _DeviceFolderVerticalGridViewBodyState
   }
 
   Future<List<DeviceCollection>> _loadDeviceCollections() async {
+    final cacheGeneration = DeviceCollectionsCache.generation;
     final deviceCollections = await FilesDB.instance.getDeviceCollections(
       includeCoverThumbnail: true,
     );
-    _cachedDeviceCollections = deviceCollections;
+    DeviceCollectionsCache.putIfCurrent(cacheGeneration, deviceCollections);
     return deviceCollections;
   }
 
@@ -180,7 +180,7 @@ class _DeviceFolderVerticalGridViewBodyState
 
     return FutureBuilder<List<DeviceCollection>>(
       future: _deviceCollectionsFuture,
-      initialData: _cachedDeviceCollections,
+      initialData: DeviceCollectionsCache.deviceCollections,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           List<DeviceCollection> deviceCollections = snapshot.data!.toList();


### PR DESCRIPTION
## Description

- Move the device album list cache into a dedicated in-memory cache.
- Clear the cache during both manual and automatic logout.