### PR TITLE
[mob][photos] Refresh device cache settings UI

### DIFF
--- a/mobile/apps/photos/changes/device-cache-settings-ui.md
+++ b/mobile/apps/photos/changes/device-cache-settings-ui.md
@@ -1,0 +1,1 @@
+- Refreshes the device cache settings screen.

--- a/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/app_storage_viewer.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -9,13 +10,7 @@ import 'package:photos/core/cache/video_cache_manager.dart';
 import 'package:photos/core/configuration.dart';
 import "package:photos/generated/l10n.dart";
 import "package:photos/service_locator.dart";
-import 'package:photos/theme/ente_theme.dart';
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
-import 'package:photos/ui/components/captioned_text_widget.dart';
-import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
-import 'package:photos/ui/components/menu_section_title.dart';
-import 'package:photos/ui/components/title_bar_title_widget.dart';
-import 'package:photos/ui/components/title_bar_widget.dart';
+import 'package:photos/ui/settings/components/settings_page_scaffold.dart';
 import 'package:photos/ui/tools/debug/path_storage_viewer.dart';
 
 class AppStorageViewer extends StatefulWidget {
@@ -134,99 +129,58 @@ class _AppStorageViewerState extends State<AppStorageViewer> {
   Widget build(BuildContext context) {
     debugPrint("$runtimeType building");
 
-    return Scaffold(
-      body: CustomScrollView(
-        primary: false,
-        slivers: <Widget>[
-          TitleBarWidget(
-            flexibleSpaceTitle: TitleBarTitleWidget(
-              title: AppLocalizations.of(context).manageDeviceStorage,
-            ),
-            actionIcons: [
-              IconButtonWidget(
-                icon: Icons.close_outlined,
-                iconButtonType: IconButtonType.secondary,
-                onTap: () {
-                  Navigator.pop(context);
-                  if (Navigator.canPop(context)) {
-                    Navigator.pop(context);
-                  }
-                  if (Navigator.canPop(context)) {
-                    Navigator.pop(context);
-                  }
-                },
+    return SettingsPageScaffold(
+      title: AppLocalizations.of(context).manageDeviceStorage,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(
+            left: Spacing.lg,
+            top: Spacing.md,
+            bottom: Spacing.sm,
+          ),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              AppLocalizations.of(context).cachedData,
+              style: TextStyles.mini.copyWith(
+                color: context.componentColors.textLight,
               ),
-            ],
+            ),
           ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate((context, index) {
-              return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Column(
-                      children: [
-                        MenuSectionTitle(
-                          title: AppLocalizations.of(context).cachedData,
-                        ),
-                        ListView.builder(
-                          shrinkWrap: true,
-                          padding: const EdgeInsets.all(0),
-                          physics: const ScrollPhysics(),
-                          // to disable GridView's scrolling
-                          itemBuilder: (context, index) {
-                            final path = paths[index];
-                            return PathStorageViewer(
-                              path,
-                              removeTopRadius: index > 0,
-                              removeBottomRadius: index < paths.length - 1,
-                              enableDoubleTapClear: internalUser,
-                              key: ValueKey("$index-$_refreshCounterKey"),
-                            );
-                          },
-                          itemCount: paths.length,
-                        ),
-                        const SizedBox(height: 24),
-                        MenuItemWidget(
-                          leadingIcon: Icons.delete_sweep_outlined,
-                          captionedTextWidget: CaptionedTextWidget(
-                            title: AppLocalizations.of(context).clearCaches,
-                          ),
-                          menuItemColor: getEnteColorScheme(context).fillFaint,
-                          singleBorderRadius: 8,
-                          alwaysShowSuccessState: true,
-                          onTap: () async {
-                            for (var pathItem in paths) {
-                              if (pathItem.allowCacheClear) {
-                                await deleteDirectoryContents(pathItem.path);
-                              }
-                            }
-                            if (!Platform.isAndroid) {
-                              await deleteDirectoryContents(
-                                iosTempDirectoryPath,
-                              );
-                            }
-                            // Small delay to allow file system to sync
-                            await Future.delayed(
-                              const Duration(milliseconds: 300),
-                            );
-                            _refreshCounterKey++;
-                            if (mounted) {
-                              setState(() => {});
-                            }
-                          },
-                        ),
-                        const SizedBox(height: 24),
-                      ],
-                    ),
-                  ],
-                ),
-              );
-            }, childCount: 1),
-          ),
-        ],
-      ),
+        ),
+        MenuGroupComponent(
+          items: [
+            for (var index = 0; index < paths.length; index++)
+              PathStorageViewer(
+                paths[index],
+                enableDoubleTapClear: internalUser,
+                key: ValueKey("$index-$_refreshCounterKey"),
+              ),
+          ],
+        ),
+        const SizedBox(height: Spacing.xl),
+        ButtonComponent(
+          label: AppLocalizations.of(context).clearCaches,
+          variant: ButtonComponentVariant.neutral,
+          onTap: () async {
+            for (var pathItem in paths) {
+              if (pathItem.allowCacheClear) {
+                await deleteDirectoryContents(pathItem.path);
+              }
+            }
+            if (!Platform.isAndroid) {
+              await deleteDirectoryContents(iosTempDirectoryPath);
+            }
+            // Small delay to allow file system to sync
+            await Future.delayed(const Duration(milliseconds: 300));
+            _refreshCounterKey++;
+            if (mounted) {
+              setState(() => {});
+            }
+          },
+        ),
+        const SizedBox(height: Spacing.xl),
+      ],
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/tools/debug/path_storage_viewer.dart
+++ b/mobile/apps/photos/lib/ui/tools/debug/path_storage_viewer.dart
@@ -1,14 +1,12 @@
 import 'dart:io';
 
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import "package:photos/generated/l10n.dart";
-import 'package:photos/theme/ente_theme.dart';
-import 'package:photos/ui/components/captioned_text_widget.dart';
-import 'package:photos/ui/components/menu_item_widget/menu_item_widget.dart';
 import "package:photos/ui/settings/pending_sync/pending_sync_info_screen.dart";
 
 class PathStorageItem {
@@ -21,14 +19,10 @@ class PathStorageItem {
 
 class PathStorageViewer extends StatefulWidget {
   final PathStorageItem item;
-  final bool removeTopRadius;
-  final bool removeBottomRadius;
   final bool enableDoubleTapClear;
 
   const PathStorageViewer(
     this.item, {
-    this.removeTopRadius = false,
-    this.removeBottomRadius = false,
     this.enableDoubleTapClear = false,
     super.key,
   });
@@ -86,38 +80,27 @@ class _PathStorageViewerState extends State<PathStorageViewer> {
   }
 
   Widget _buildMenuItemWidget(DirectoryStat? stat, Object? err) {
-    return MenuItemWidget(
+    final colors = context.componentColors;
+    return MenuComponent(
       key: UniqueKey(),
-      alignCaptionedTextToLeft: true,
-      captionedTextWidget: CaptionedTextWidget(
-        title: widget.item.title,
-        subTitle: stat != null ? '${stat.fileCount}' : null,
-        subTitleColor: getEnteColorScheme(context).textFaint,
-      ),
-      trailingWidget: stat != null
-          ? Padding(
-              padding: const EdgeInsets.only(left: 12.0),
-              child: Text(
-                formatBytes(stat.size),
-                style: getEnteTextTheme(
-                  context,
-                ).small.copyWith(color: getEnteColorScheme(context).textFaint),
-              ),
+      title: widget.item.title,
+      subtitle: stat != null ? '${stat.fileCount}' : null,
+      trailing: err != null
+          ? Icon(Icons.error_outline_outlined, color: colors.textLight)
+          : stat != null
+          ? Text(
+              formatBytes(stat.size),
+              style: TextStyles.mini.copyWith(color: colors.textLight),
             )
           : SizedBox.fromSize(
               size: const Size.square(14),
               child: CircularProgressIndicator(
                 strokeWidth: 2,
-                color: getEnteColorScheme(context).strokeMuted,
+                color: colors.strokeFaint,
               ),
             ),
-      trailingIcon: err != null ? Icons.error_outline_outlined : null,
-      trailingIconIsMuted: err != null,
-      singleBorderRadius: 8,
-      menuItemColor: getEnteColorScheme(context).fillFaint,
-      isBottomBorderRadiusRemoved: widget.removeBottomRadius,
-      isTopBorderRadiusRemoved: widget.removeTopRadius,
       showOnlyLoadingState: true,
+      shouldSurfaceExecutionStates: false,
       onTap: () async {
         if (kDebugMode) {
           await Clipboard.setData(ClipboardData(text: widget.item.path));


### PR DESCRIPTION
Refreshes the device cache screen with the new app bar, menu group, and text-only Clear caches button.

Before:
<img width="1206" height="2622" alt="manage-device-cache-before" src="https://github.com/user-attachments/assets/37f36f9c-70b2-439e-ac96-b01ef2e3a62f" />

After:
<img width="1206" height="2622" alt="manage-device-cache-after" src="https://github.com/user-attachments/assets/ed6ceb25-93b7-49de-84e7-a6a0c5ae190b" />

Tested with Flutter analyze and on the iOS simulator.