### PR TITLE
[mob][packages] Update account email wording and simplify signup

### DIFF
--- a/mobile/packages/accounts/lib/pages/email_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/email_entry_page.dart
@@ -36,7 +36,6 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
   double _passwordStrength = 0.0;
   bool _emailIsValid = false;
   bool _hasAgreedToTOS = true;
-  bool _hasAgreedToE2E = false;
   bool _password1Visible = false;
   bool _password2Visible = false;
   bool _passwordsMatch = false;
@@ -450,9 +449,7 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
                     ),
                   ),
                   const SizedBox(height: 16),
-                  Column(
-                    children: [_getTOSAgreement(), _getPasswordAgreement()],
-                  ),
+                  _getTOSAgreement(),
                 ],
               ),
             ),
@@ -548,64 +545,10 @@ class _EmailEntryPageState extends State<EmailEntryPage> {
     );
   }
 
-  Widget _getPasswordAgreement() {
-    final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
-
-    return GestureDetector(
-      onTap: () {
-        setState(() {
-          _hasAgreedToE2E = !_hasAgreedToE2E;
-        });
-      },
-      behavior: HitTestBehavior.translucent,
-      child: Row(
-        children: [
-          Checkbox(
-            value: _hasAgreedToE2E,
-            side: CheckboxTheme.of(context).side,
-            fillColor: WidgetStateProperty.resolveWith((states) {
-              if (states.contains(WidgetState.selected)) {
-                return colorScheme.primary700;
-              }
-              return Colors.transparent;
-            }),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(4),
-            ),
-            onChanged: (value) {
-              setState(() {
-                _hasAgreedToE2E = value!;
-              });
-            },
-          ),
-          Expanded(
-            child: StyledText(
-              text: context.strings.ackPasswordLostWarning,
-              style: textTheme.small.copyWith(color: colorScheme.textMuted),
-              tags: {
-                'underline': StyledTextActionTag(
-                  (String? text, Map<String?, String?> attrs) =>
-                      PlatformUtil.openWebView(
-                        context,
-                        context.strings.encryption,
-                        "https://ente.com/architecture",
-                      ),
-                  style: const TextStyle(decoration: TextDecoration.underline),
-                ),
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   bool _isFormValid() {
     return _emailIsValid &&
         _passwordsMatch &&
         _hasAgreedToTOS &&
-        _hasAgreedToE2E &&
         _passwordIsValid;
   }
 }

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -137,7 +137,7 @@
   "@email": {
     "description": "Email field label"
   },
-  "emailHint": "Enter your email id",
+  "emailHint": "Enter your email address",
   "verify": "Verify",
   "@verify": {
     "description": "Verify button label"


### PR DESCRIPTION
## Description

Uses ‘email address’ instead of ‘email id’ on the shared login and sign-up screens. Removes the password-loss acknowledgement checkbox and requirement while retaining the Terms and Privacy agreement.

## Tests

`flutter analyze` from `mobile/apps/locker`

Built Locker for the iOS Simulator and verified login and sign-up on iPhone 17 (iOS 26.4).

## Screenshots

<img width="192" height="470" alt="locker-login-email-address" src="https://github.com/user-attachments/assets/c1705d69-d771-4604-8b2d-c13e3b64dbc3" />

<img width="192" height="470" alt="locker-signup-email-address" src="https://github.com/user-attachments/assets/c96adb64-228e-423e-bf60-f57229b2fec1" />
