### PR TITLE
Add fullwiki and enable Ensu pack 

### DIFF
--- a/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/knowledge/KnowledgeStore.kt
+++ b/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/knowledge/KnowledgeStore.kt
@@ -159,6 +159,7 @@ class KnowledgeStore(
         ownerScope.launch {
             val result = runCatching { provider.cancel(dataset) }.getOrNull()
             ownerJob?.join()
+            if (jobs[stableId]?.isActive == true) return@launch
             updatePack(stableId) { current ->
                 (result?.let { current.fromReconciliation(it, current.enabled) } ?: current).copy(
                     mutationProgress = null

--- a/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/settings/KnowledgeSettingsScreen.kt
+++ b/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/settings/KnowledgeSettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -33,11 +34,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import io.ente.ensu.designsystem.EnsuColor
 import io.ente.ensu.designsystem.EnsuCornerRadius
 import io.ente.ensu.designsystem.EnsuSpacing
 import io.ente.ensu.designsystem.EnsuTypography
+import io.ente.ensu.designsystem.HugeIcons
 import io.ente.ensu.format.formatBytes
 import io.ente.ensu.bindings.KnowledgeDatasetConfig
 import io.ente.ensu.bindings.KnowledgeReconciliationStatus
@@ -117,18 +120,29 @@ private fun KnowledgePackCard(
 
         if (pack.isMutating) {
             Spacer(Modifier.height(EnsuSpacing.md.dp))
-            LinearProgressIndicator(
-                progress = { (pack.mutationProgress?.percentage ?: 0.0).coerceIn(0.0, 100.0).toFloat() / 100f },
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                color = EnsuColor.accent(),
-                trackColor = EnsuColor.border()
-            )
-            Text(
-                pack.mutationProgress?.label ?: "Downloading...",
-                style = EnsuTypography.small,
-                color = EnsuColor.textMuted()
-            )
-            TextButton(onClick = onCancel) { Text("Cancel") }
+                horizontalArrangement = Arrangement.spacedBy(EnsuSpacing.sm.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LinearProgressIndicator(
+                    progress = { (pack.mutationProgress?.percentage ?: 0.0).coerceIn(0.0, 100.0).toFloat() / 100f },
+                    modifier = Modifier.weight(1f),
+                    color = EnsuColor.action(),
+                    trackColor = EnsuColor.border()
+                )
+                IconButton(
+                    onClick = onCancel,
+                    modifier = Modifier.size(32.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(HugeIcons.Cancel01Icon),
+                        contentDescription = "Cancel download",
+                        modifier = Modifier.size(14.dp),
+                        tint = EnsuColor.textMuted()
+                    )
+                }
+            }
         } else if (
             packDownloadsAllowed &&
             pack.status == KnowledgeReconciliationStatus.UPDATE_AVAILABLE

--- a/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/settings/SettingsScreen.kt
+++ b/mobile/native/android/apps/ensu/app/src/main/java/io/ente/ensu/settings/SettingsScreen.kt
@@ -43,7 +43,7 @@ import io.ente.ensu.designsystem.EnsuSpacing
 import io.ente.ensu.designsystem.EnsuTypography
 import io.ente.ensu.designsystem.HugeIcons
 
-internal const val IS_ENSU_PACKS_ENABLED = false
+internal const val IS_ENSU_PACKS_ENABLED = true
 
 @Composable
 fun SettingsScreen(

--- a/mobile/native/apple/apps/ensu/Ensu/Services/KnowledgeStore.swift
+++ b/mobile/native/apple/apps/ensu/Ensu/Services/KnowledgeStore.swift
@@ -149,6 +149,9 @@ final class KnowledgeStore: ObservableObject {
             guard let self else { return }
             let result = await provider.cancel(dataset: dataset)
             await ownerTask?.value
+            guard mutationTasks[stableId] == nil else {
+                return
+            }
             if let result {
                 let enabled = packs
                     .first(where: { $0.id == stableId })?.enabled == true

--- a/mobile/native/apple/apps/ensu/Ensu/Settings/KnowledgeSettingsView.swift
+++ b/mobile/native/apple/apps/ensu/Ensu/Settings/KnowledgeSettingsView.swift
@@ -62,6 +62,7 @@ struct KnowledgeSettingsView: View {
                         )
                     )
                     .labelsHidden()
+                    .tint(EnsuColor.accent)
                 } else if store.downloadsAllowed && pack.status == .download && !pack.isMutating {
                     Button {
                         store.downloadOrUpdate(stableId: pack.id)
@@ -77,13 +78,22 @@ struct KnowledgeSettingsView: View {
             }
 
             if pack.isMutating {
-                ProgressView(value: Double(pack.progressPercent ?? 0), total: 100)
-                    .tint(EnsuColor.action)
-                Text(pack.progressLabel ?? "Downloading...")
-                    .font(EnsuTypography.small)
-                    .foregroundStyle(EnsuColor.textMuted)
-                Button("Cancel") {
-                    store.cancel(stableId: pack.id)
+                HStack(spacing: EnsuSpacing.sm) {
+                    ProgressView(value: Double(pack.progressPercent ?? 0), total: 100)
+                        .tint(EnsuColor.action)
+                    Button {
+                        store.cancel(stableId: pack.id)
+                    } label: {
+                        Image("Cancel01Icon")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 12, height: 12)
+                            .foregroundStyle(EnsuColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
+                    .accessibilityLabel("Cancel download")
                 }
             } else if store.downloadsAllowed && pack.status == .updateAvailable {
                 Button {

--- a/mobile/native/apple/apps/ensu/Ensu/Settings/SettingsView.swift
+++ b/mobile/native/apple/apps/ensu/Ensu/Settings/SettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Foundation
 
-let isEnsuPacksEnabled = false
+let isEnsuPacksEnabled = true
 
 struct SettingsView: View {
     @ObservedObject var knowledgeStore: KnowledgeStore

--- a/rust/crates/ensu/src/config/knowledge.rs
+++ b/rust/crates/ensu/src/config/knowledge.rs
@@ -126,7 +126,7 @@ pub(crate) fn knowledge_datasets() -> Vec<KnowledgeDatasetConfig> {
             download_size_bytes: 167_849_446,
             max_chars: 600,
             source_url_template: "https://simple.wikipedia.org/wiki/{title}".to_owned(),
-            relevance_threshold: 0.5,
+            relevance_threshold: 0.55,
             attribution: AttributionConfig {
                 credit: "Simple English Wikipedia contributors".to_owned(),
                 license_label: KNOWLEDGE_LICENSE_LABEL.to_owned(),
@@ -149,12 +149,35 @@ pub(crate) fn knowledge_datasets() -> Vec<KnowledgeDatasetConfig> {
             download_size_bytes: 202_595_475,
             max_chars: 1_400,
             source_url_template: "https://en.wikibooks.org/wiki/{title}".to_owned(),
-            relevance_threshold: 0.5,
+            relevance_threshold: 0.58,
             attribution: AttributionConfig {
                 credit: "Wikibooks contributors".to_owned(),
                 license_label: KNOWLEDGE_LICENSE_LABEL.to_owned(),
                 license_url: KNOWLEDGE_LICENSE_URL.to_owned(),
                 public_pack_url: "https://huggingface.co/datasets/ente-ai/ensu-knowledge-packs/tree/a13b90e443dcdc1561ac777ea17ee6ed4703e35f/wikibooks".to_owned(),
+                modification_notice: MODIFICATION_NOTICE.to_owned(),
+            },
+        },
+        KnowledgeDatasetConfig {
+            stable_id: "fullwiki".to_owned(),
+            label: "English Wikipedia".to_owned(),
+            current_download_identity: "enwiki-2026-07-07".to_owned(),
+            artifact_base_url: "https://huggingface.co/datasets/ente-ai/ensu-knowledge-packs/resolve/61f12c75fe451efe6c0d06af3903add4292e06af/fullwiki/data/".to_owned(),
+            artifact_sha256: vec![
+                "0c000cf313b642c9a25695c645c9cef2062e3d4c9e33d0cb05f19bf3145c8084".to_owned(),
+                "36fcb1045e20aac98f8477cbd4f15b79ffb337ced756a457d55180fa862c5453".to_owned(),
+                "a891fc7d87554dacd2d59e8f89a71507be24247df0e84ecd2b2ee3d8bfcb7c21".to_owned(),
+                "5c90adbe8c18c053f1977f6c3b00f83d9b381daf234d2d559d8eaa29c9597c70".to_owned(),
+            ],
+            download_size_bytes: 363_051_703,
+            max_chars: 600,
+            source_url_template: "https://en.wikipedia.org/wiki/{title}".to_owned(),
+            relevance_threshold: 0.55,
+            attribution: AttributionConfig {
+                credit: "English Wikipedia contributors".to_owned(),
+                license_label: KNOWLEDGE_LICENSE_LABEL.to_owned(),
+                license_url: KNOWLEDGE_LICENSE_URL.to_owned(),
+                public_pack_url: "https://huggingface.co/datasets/ente-ai/ensu-knowledge-packs/tree/61f12c75fe451efe6c0d06af3903add4292e06af/fullwiki".to_owned(),
                 modification_notice: MODIFICATION_NOTICE.to_owned(),
             },
         },
@@ -205,7 +228,7 @@ mod tests {
         let datasets = knowledge_datasets();
         let embedding = knowledge_embedding_config();
 
-        assert_eq!(datasets.len(), 2);
+        assert_eq!(datasets.len(), 3);
         assert_eq!(
             datasets
                 .iter()
@@ -216,6 +239,7 @@ mod tests {
         );
         assert_eq!(datasets[0].stable_id, "simplewiki");
         assert_eq!(datasets[1].stable_id, "wikibooks");
+        assert_eq!(datasets[2].stable_id, "fullwiki");
         assert!(
             datasets
                 .iter()
@@ -223,6 +247,10 @@ mod tests {
         );
         assert_eq!(datasets[0].download_size_bytes, 167_849_446);
         assert_eq!(datasets[1].download_size_bytes, 202_595_475);
+        assert_eq!(datasets[2].download_size_bytes, 363_051_703);
+        assert_eq!(datasets[0].relevance_threshold, 0.55);
+        assert_eq!(datasets[1].relevance_threshold, 0.58);
+        assert_eq!(datasets[2].relevance_threshold, 0.55);
         assert!(datasets.iter().all(|dataset| {
             dataset.artifact_sha256.len() == KNOWLEDGE_ARTIFACT_FILENAMES.len()
                 && dataset


### PR DESCRIPTION
## Summary
- add the English Wikipedia fullwiki knowledge pack
- update knowledge pack relevance thresholds
- enable Ensu Packs on Android and iOS
- simplify download progress UI with compact cancel controls