### PR TITLE
[mob][photos] Refresh Verification ID sheet

### DIFF
--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -518,12 +518,10 @@ class _SettingsBody extends StatelessWidget {
   }
 
   Future<void> _showVerifyIdentityDialog(BuildContext context) async {
-    await showDialog(
-      useRootNavigator: false,
-      context: context,
-      builder: (BuildContext context) {
-        return VerifyIdentifyDialog(self: true);
-      },
+    await showVerifyIdentitySheet(
+      context,
+      self: true,
+      title: AppLocalizations.of(context).verifyIDLabel,
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/sharing/verify_identity_dialog.dart
+++ b/mobile/apps/photos/lib/ui/sharing/verify_identity_dialog.dart
@@ -11,9 +11,24 @@ import "package:photos/generated/l10n.dart";
 import "package:photos/services/account/user_service.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/common/loading_widget.dart";
+import "package:photos/ui/components/base_bottom_sheet.dart";
 import 'package:photos/ui/components/buttons/button_widget.dart';
 import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/utils/share_util.dart";
+
+Future<void> showVerifyIdentitySheet(
+  BuildContext context, {
+  required bool self,
+  String email = '',
+  String? title,
+}) {
+  return showBaseBottomSheet<void>(
+    context,
+    title: title ?? AppLocalizations.of(context).verify,
+    headerSpacing: 20,
+    child: VerifyIdentifyDialog(self: self, email: email, asSheet: true),
+  );
+}
 
 class VerifyIdentifyDialog extends StatefulWidget {
   // email id of the user who's verification ID is being displayed for
@@ -22,8 +37,14 @@ class VerifyIdentifyDialog extends StatefulWidget {
 
   // self is true when the user is viewing their own verification ID
   final bool self;
+  final bool asSheet;
 
-  VerifyIdentifyDialog({super.key, required this.self, this.email = ''}) {
+  VerifyIdentifyDialog({
+    super.key,
+    required this.self,
+    this.email = '',
+    this.asSheet = false,
+  }) {
     if (!self && email.isEmpty) {
       throw ArgumentError("email cannot be empty when self is false");
     }
@@ -49,6 +70,10 @@ class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
             context,
           ).someoneSharingAlbumsWithYouShouldSeeTheSameId
         : AppLocalizations.of(context).howToViewShareeVerificationID;
+
+    if (widget.asSheet) {
+      return _buildSheetContent(context, subTitle, bottomText);
+    }
 
     final AlertDialog alert = AlertDialog(
       title: Text(
@@ -130,6 +155,75 @@ class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
     return alert;
   }
 
+  Widget _buildSheetContent(
+    BuildContext context,
+    String subTitle,
+    String bottomText,
+  ) {
+    final colorScheme = getEnteColorScheme(context);
+    final textStyle = getEnteTextTheme(context);
+
+    return FutureBuilder<String>(
+      future: _getPublicKey(),
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          final publicKey = snapshot.data!;
+          if (publicKey.isEmpty) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  AppLocalizations.of(
+                    context,
+                  ).emailNoEnteAccount(email: widget.email),
+                  style: textStyle.small.copyWith(color: colorScheme.textMuted),
+                ),
+                const SizedBox(height: 20),
+                ButtonWidget(
+                  buttonType: ButtonType.neutral,
+                  icon: Icons.adaptive.share,
+                  labelText: AppLocalizations.of(context).sendInvite,
+                  onTap: () async {
+                    await shareText(
+                      AppLocalizations.of(context).shareTextRecommendUsingEnte,
+                    );
+                  },
+                ),
+              ],
+            );
+          }
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                subTitle,
+                style: textStyle.small.copyWith(color: colorScheme.textMuted),
+              ),
+              const SizedBox(height: 20),
+              _verificationIDSheetWidget(context, publicKey),
+              const SizedBox(height: 20),
+              Text(
+                bottomText,
+                style: textStyle.small.copyWith(color: colorScheme.textMuted),
+              ),
+            ],
+          );
+        } else if (snapshot.hasError) {
+          Logger(
+            "VerificationID",
+          ).severe("failed to end userID", snapshot.error);
+          return Text(
+            AppLocalizations.of(context).somethingWentWrong,
+            style: textStyle.bodyMuted,
+          );
+        }
+        return const SizedBox(height: 200, child: EnteLoadingWidget());
+      },
+    );
+  }
+
   Future<String> _getPublicKey() async {
     if (widget.self) {
       return Configuration.instance.getKeyAttributes()!.publicKey;
@@ -190,6 +284,54 @@ class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _verificationIDSheetWidget(BuildContext context, String publicKey) {
+    final colorScheme = getEnteColorScheme(context);
+    final textTheme = getEnteTextTheme(context);
+    final String verificationID = _generateVerificationID(publicKey);
+
+    return GestureDetector(
+      onTap: () => _shareVerificationID(context, verificationID),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: colorScheme.primary700,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 24),
+        width: double.infinity,
+        child: Text(
+          verificationID,
+          style: textTheme.body.copyWith(
+            color: Colors.white,
+            fontFamily: 'monospace',
+            letterSpacing: 0.5,
+            height: 1.5,
+          ),
+          textAlign: TextAlign.justify,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _shareVerificationID(
+    BuildContext context,
+    String verificationID,
+  ) async {
+    if (verificationID.isEmpty) {
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: verificationID));
+    if (!context.mounted) return;
+    await shareText(
+      widget.self
+          ? AppLocalizations.of(
+              context,
+            ).shareMyVerificationID(verificationID: verificationID)
+          : AppLocalizations.of(context).shareTextConfirmOthersVerificationID(
+              verificationID: verificationID,
+            ),
     );
   }
 


### PR DESCRIPTION
Refreshes the Verification ID dialog shown from the account email to match Locker's sheet styling while preserving the existing copy and share behavior.

## Tests

- `flutter analyze --no-pub apps/photos/lib/ui/settings_page.dart apps/photos/lib/ui/sharing/verify_identity_dialog.dart`
- Tested the email tap and long-press flows on the Android 15 emulator.

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/aman-pilot/ente/f71435f71d9f9e926102aaff76f1aed414747b4f/before.png" width="360" alt="Verification ID dialog before"> | <img src="https://raw.githubusercontent.com/aman-pilot/ente/f71435f71d9f9e926102aaff76f1aed414747b4f/after.png" width="360" alt="Verification ID sheet after"> |