### PR TITLE
[server] Keep collection trash processing batch-scoped

### DIFF
--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -599,7 +599,7 @@ func (c *FileController) Trash(ctx *gin.Context, userID int64, request ente.Tras
 			return stacktrace.Propagate(ente.ErrPermissionDenied, "user doesn't own collection")
 		}
 	}
-	return c.TrashRepository.TrashFiles(fileIDs, userID, request)
+	return c.TrashRepository.TrashFiles(userID, request)
 }
 
 // GetSize returns the size of files indicated by fileIDs that are owned by userID

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -987,7 +987,7 @@ func (repo *CollectionRepository) TrashV3(ctx context.Context, collectionID int6
 				CollectionID: collectionID,
 			})
 		}
-		err = repo.TrashRepo.TrashFiles(fileIDs, ownerID, ente.TrashRequest{OwnerID: ownerID, TrashItems: items})
+		err = repo.TrashRepo.TrashFiles(ownerID, ente.TrashRequest{OwnerID: ownerID, TrashItems: items})
 		if err != nil {
 			log.WithError(err).Error("failed to trash file")
 			return stacktrace.Propagate(err, "")

--- a/server/pkg/repo/trash.go
+++ b/server/pkg/repo/trash.go
@@ -117,7 +117,11 @@ func (t *TrashRepository) GetFilesWithVersion(userID int64, updateAtTime int64, 
 	return convertRowsToTrash(rows)
 }
 
-func (t *TrashRepository) TrashFiles(fileIDs []int64, userID int64, trash ente.TrashRequest) error {
+func (t *TrashRepository) TrashFiles(userID int64, trash ente.TrashRequest) error {
+	fileIDs := make([]int64, 0, len(trash.TrashItems))
+	for _, item := range trash.TrashItems {
+		fileIDs = append(fileIDs, item.FileID)
+	}
 	updationTime := time.Microseconds()
 	ctx := context.Background()
 	tx, err := t.DB.BeginTx(ctx, nil)

--- a/server/pkg/repo/trash_test.go
+++ b/server/pkg/repo/trash_test.go
@@ -1,0 +1,65 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/repo/public"
+)
+
+func TestTrashFilesOnlyTransitionsRequestedItems(t *testing.T) {
+	_, db := setupAccessibleObjectTest(t)
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "trash-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	requestedFileID := insertObjectTestFile(t, db, ownerID)
+	untouchedFileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, requestedFileID, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, untouchedFileID, ownerID)
+
+	repository := &TrashRepository{
+		DB:           db,
+		FileLinkRepo: public.NewFileLinkRepo(db),
+	}
+	err := repository.TrashFiles(ownerID, ente.TrashRequest{
+		OwnerID: ownerID,
+		TrashItems: []ente.TrashItemRequest{{
+			FileID:       requestedFileID,
+			CollectionID: collectionID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("TrashFiles() error = %v", err)
+	}
+
+	var requestedDeleted, untouchedDeleted bool
+	err = db.QueryRow(
+		`SELECT requested.is_deleted, untouched.is_deleted
+		 FROM collection_files AS requested
+		 JOIN collection_files AS untouched ON untouched.collection_id = requested.collection_id
+		 WHERE requested.collection_id = $1
+		   AND requested.file_id = $2
+		   AND untouched.file_id = $3`,
+		collectionID,
+		requestedFileID,
+		untouchedFileID,
+	).Scan(&requestedDeleted, &untouchedDeleted)
+	if err != nil {
+		t.Fatalf("failed to read collection file states: %v", err)
+	}
+	if !requestedDeleted || untouchedDeleted {
+		t.Fatalf("unexpected collection file states: requested deleted=%t, untouched deleted=%t", requestedDeleted, untouchedDeleted)
+	}
+
+	var trashCount, trashedFileID int64
+	if err := db.QueryRow(`SELECT COUNT(*), COALESCE(MAX(file_id), 0) FROM trash`).Scan(&trashCount, &trashedFileID); err != nil {
+		t.Fatalf("failed to read trash state: %v", err)
+	}
+	if trashCount != 1 || trashedFileID != requestedFileID {
+		t.Fatalf("unexpected trash state: count=%d file=%d, want count=1 file=%d", trashCount, trashedFileID, requestedFileID)
+	}
+}


### PR DESCRIPTION
- Use Trash items as the single source for membership updates and public-link cleanup.
- Keeps collection deletion batches bounded and their retry progress aligned.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh docker`