### PR TITLE
[mob][photos] Use Verification ID sheet everywhere

### DIFF
--- a/mobile/apps/photos/lib/emergency/select_contact_page.dart
+++ b/mobile/apps/photos/lib/emergency/select_contact_page.dart
@@ -290,12 +290,7 @@ class _AddContactSheetState extends State<AddContactSheet> {
       return;
     }
 
-    await showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return VerifyIdentifyDialog(self: false, email: emailToAdd);
-      },
-    );
+    await showVerifyIdentitySheet(context, self: false, email: emailToAdd);
   }
 
   List<User> _getSuggestedUser() {

--- a/mobile/apps/photos/lib/ui/sharing/add_participant_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/add_participant_page.dart
@@ -219,16 +219,11 @@ class _AddParticipantPage extends State<AddParticipantPage> {
             }
             setState(() => {});
           },
-          onLongPress: () {
-            showDialog(
-              useRootNavigator: false,
-              context: context,
-              builder: (BuildContext context) {
-                return VerifyIdentifyDialog(
-                  self: false,
-                  email: currentUser.email,
-                );
-              },
+          onLongPress: () async {
+            await showVerifyIdentitySheet(
+              context,
+              self: false,
+              email: currentUser.email,
             );
           },
         ),

--- a/mobile/apps/photos/lib/ui/sharing/verify_identity_dialog.dart
+++ b/mobile/apps/photos/lib/ui/sharing/verify_identity_dialog.dart
@@ -2,7 +2,6 @@ import "dart:convert";
 
 import 'package:bip39/bip39.dart' as bip39;
 import "package:crypto/crypto.dart";
-import "package:dotted_border/dotted_border.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:logging/logging.dart";
@@ -26,40 +25,33 @@ Future<void> showVerifyIdentitySheet(
     context,
     title: title ?? AppLocalizations.of(context).verify,
     headerSpacing: 20,
-    child: VerifyIdentifyDialog(self: self, email: email, asSheet: true),
+    child: _VerifyIdentitySheetContent(self: self, email: email),
   );
 }
 
-class VerifyIdentifyDialog extends StatefulWidget {
+class _VerifyIdentitySheetContent extends StatefulWidget {
   // email id of the user who's verification ID is being displayed for
   // verification
   final String email;
 
   // self is true when the user is viewing their own verification ID
   final bool self;
-  final bool asSheet;
 
-  VerifyIdentifyDialog({
-    super.key,
-    required this.self,
-    this.email = '',
-    this.asSheet = false,
-  }) {
+  _VerifyIdentitySheetContent({required this.self, this.email = ''}) {
     if (!self && email.isEmpty) {
       throw ArgumentError("email cannot be empty when self is false");
     }
   }
 
   @override
-  State<VerifyIdentifyDialog> createState() => _VerifyIdentifyDialogState();
+  State<_VerifyIdentitySheetContent> createState() =>
+      _VerifyIdentitySheetContentState();
 }
 
-class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
-  final bool doesUserExist = true;
-
+class _VerifyIdentitySheetContentState
+    extends State<_VerifyIdentitySheetContent> {
   @override
   Widget build(BuildContext context) {
-    final textStyle = getEnteTextTheme(context);
     final String subTitle = widget.self
         ? AppLocalizations.of(context).thisIsYourVerificationId
         : AppLocalizations.of(
@@ -71,95 +63,6 @@ class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
           ).someoneSharingAlbumsWithYouShouldSeeTheSameId
         : AppLocalizations.of(context).howToViewShareeVerificationID;
 
-    if (widget.asSheet) {
-      return _buildSheetContent(context, subTitle, bottomText);
-    }
-
-    final AlertDialog alert = AlertDialog(
-      title: Text(
-        widget.self
-            ? AppLocalizations.of(context).verificationId
-            : AppLocalizations.of(context).verifyEmailID(email: widget.email),
-      ),
-      content: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          FutureBuilder<String>(
-            future: _getPublicKey(),
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                final publicKey = snapshot.data!;
-                if (publicKey.isEmpty) {
-                  return Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        AppLocalizations.of(
-                          context,
-                        ).emailNoEnteAccount(email: widget.email),
-                      ),
-                      const SizedBox(height: 24),
-                      ButtonWidget(
-                        buttonType: ButtonType.neutral,
-                        icon: Icons.adaptive.share,
-                        labelText: AppLocalizations.of(context).sendInvite,
-                        isInAlert: true,
-                        onTap: () async {
-                          // ignore: unawaited_futures
-                          shareText(
-                            AppLocalizations.of(
-                              context,
-                            ).shareTextRecommendUsingEnte,
-                          );
-                        },
-                      ),
-                    ],
-                  );
-                } else {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(subTitle, style: textStyle.bodyMuted),
-                      const SizedBox(height: 20),
-                      _verificationIDWidget(context, publicKey),
-                      const SizedBox(height: 16),
-                      Text(bottomText, style: textStyle.bodyMuted),
-                      const SizedBox(height: 24),
-                      ButtonWidget(
-                        buttonType: ButtonType.neutral,
-                        isInAlert: true,
-                        labelText: widget.self
-                            ? AppLocalizations.of(context).ok
-                            : AppLocalizations.of(context).done,
-                      ),
-                    ],
-                  );
-                }
-              } else if (snapshot.hasError) {
-                Logger(
-                  "VerificationID",
-                ).severe("failed to end userID", snapshot.error);
-                return Text(
-                  AppLocalizations.of(context).somethingWentWrong,
-                  style: textStyle.bodyMuted,
-                );
-              } else {
-                return const SizedBox(height: 200, child: EnteLoadingWidget());
-              }
-            },
-          ),
-        ],
-      ),
-    );
-    return alert;
-  }
-
-  Widget _buildSheetContent(
-    BuildContext context,
-    String subTitle,
-    String bottomText,
-  ) {
     final colorScheme = getEnteColorScheme(context);
     final textStyle = getEnteTextTheme(context);
 
@@ -236,55 +139,6 @@ class _VerifyIdentifyDialogState extends State<VerifyIdentifyDialog> {
       return "";
     }
     return userPublicKey;
-  }
-
-  Widget _verificationIDWidget(BuildContext context, String publicKey) {
-    final colorScheme = getEnteColorScheme(context);
-    final textStyle = getEnteTextTheme(context);
-    final String verificationID = _generateVerificationID(publicKey);
-    return DottedBorder(
-      options: RectDottedBorderOptions(
-        color: colorScheme.strokeMuted,
-        //color of dotted/dash line
-        strokeWidth: 1,
-        dashPattern: const [12, 6],
-        //dash patterns, 10 is dash width, 6 is space width
-      ),
-      child: Column(
-        children: [
-          GestureDetector(
-            onTap: () async {
-              if (verificationID.isEmpty) {
-                return;
-              }
-              await Clipboard.setData(ClipboardData(text: verificationID));
-              if (!context.mounted) return;
-              // ignore: unawaited_futures
-              shareText(
-                widget.self
-                    ? AppLocalizations.of(
-                        context,
-                      ).shareMyVerificationID(verificationID: verificationID)
-                    : AppLocalizations.of(
-                        context,
-                      ).shareTextConfirmOthersVerificationID(
-                        verificationID: verificationID,
-                      ),
-              );
-            },
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: const BorderRadius.all(Radius.circular(2)),
-                color: colorScheme.backgroundElevated2,
-              ),
-              padding: const EdgeInsets.all(20),
-              width: double.infinity,
-              child: Text(verificationID, style: textStyle.bodyBold),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 
   Widget _verificationIDSheetWidget(BuildContext context, String publicKey) {


### PR DESCRIPTION
Uses the refreshed Verification ID bottom sheet for album participant and trusted-contact email verification, removing the legacy alert dialog.

Before / After:
<img src="https://github.com/user-attachments/assets/47c19b88-6523-41aa-8269-d983bb2bbdd9" alt="Verification ID before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/b27f7212-d1ba-43c2-bc3a-7c7ef55aebfd" alt="Verification ID after" width="300" height="650">

Tested with Flutter analyze and on the iOS simulator.