### PR TITLE
[mob][photos] Refresh Legacy UI components

### DIFF
--- a/mobile/apps/photos/lib/emergency/components/email_action_sheet.dart
+++ b/mobile/apps/photos/lib/emergency/components/email_action_sheet.dart
@@ -1,6 +1,10 @@
+import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/base_bottom_sheet.dart";
+import "package:hugeicons/hugeicons.dart";
+import "package:photos/generated/l10n.dart";
+import "package:photos/utils/dialog_util.dart";
+import "package:photos/utils/email_util.dart";
+import "package:photos/utils/share_util.dart";
 
 Future<T?> showEmailActionSheet<T>(
   BuildContext context, {
@@ -9,47 +13,92 @@ Future<T?> showEmailActionSheet<T>(
   required List<Widget> buttons,
   String? title,
 }) {
-  return showBaseBottomSheet<T>(
-    context,
-    title: title ?? email,
-    headerSpacing: 20,
-    padding: const EdgeInsets.all(16),
-    backgroundColor: getEnteColorScheme(context).backgroundColour,
-    child: EmailActionSheetContent(message: message, buttons: buttons),
+  return showBottomSheetComponent<T>(
+    context: context,
+    builder: (_) => BottomSheetComponent(
+      title: title ?? email,
+      content: Text(
+        message,
+        style: TextStyles.body.copyWith(
+          color: context.componentColors.textLight,
+        ),
+      ),
+      actions: buttons,
+    ),
   );
 }
 
-class EmailActionSheetContent extends StatelessWidget {
-  final String message;
-  final List<Widget> buttons;
+Future<T?> showLegacyAlertSheet<T>(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String assetPath = "assets/warning-grey.png",
+  List<Widget> actions = const [],
+}) {
+  return showBottomSheetComponent<T>(
+    context: context,
+    builder: (_) => BottomSheetComponent(
+      title: title,
+      message: message,
+      illustration: Image.asset(assetPath),
+      actions: actions,
+    ),
+  );
+}
 
-  const EmailActionSheetContent({
-    required this.message,
-    required this.buttons,
-    super.key,
-  });
+Future<void> showLegacyErrorSheet(
+  BuildContext context, {
+  required Object? error,
+}) async {
+  final l10n = AppLocalizations.of(context);
+  final errorBody = parseErrorForUI(
+    context,
+    l10n.itLooksLikeSomethingWentWrongPleaseRetryAfterSome,
+    error: error,
+  );
+  await showErrorBottomSheetComponent<void>(
+    context: context,
+    title: l10n.error,
+    message: errorBody,
+    illustration: Image.asset("assets/warning-grey.png"),
+    actionLabel: l10n.contactSupport,
+    onActionTap: () async {
+      await sendLogs(
+        context,
+        l10n.contactSupport,
+        "support@ente.com",
+        postShare: () {},
+      );
+    },
+  );
+}
 
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          message,
-          style: textTheme.small.copyWith(color: colorScheme.textMuted),
-        ),
-        const SizedBox(height: 20),
-        ListView.separated(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: buttons.length,
-          separatorBuilder: (_, _) => const SizedBox(height: 12),
-          itemBuilder: (_, index) => buttons[index],
+Future<void> showLegacyInviteSheet(
+  BuildContext context, {
+  required String email,
+}) async {
+  final l10n = AppLocalizations.of(context);
+  await showBottomSheetComponent<void>(
+    context: context,
+    builder: (sheetContext) => BottomSheetComponent(
+      title: l10n.inviteToEnte,
+      message: l10n.emailNoEnteAccount(email: email),
+      actions: [
+        ButtonComponent(
+          label: l10n.sendInvite,
+          leading: const HugeIcon(
+            icon: HugeIcons.strokeRoundedShare08,
+            size: IconSizes.small,
+          ),
+          shouldShowSuccessState: false,
+          onTap: () async {
+            await shareText(
+              l10n.shareTextRecommendUsingEnte,
+              context: sheetContext,
+            );
+          },
         ),
       ],
-    );
-  }
+    ),
+  );
 }

--- a/mobile/apps/photos/lib/emergency/components/recovery_date_selector.dart
+++ b/mobile/apps/photos/lib/emergency/components/recovery_date_selector.dart
@@ -1,8 +1,6 @@
+import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
 import "package:photos/l10n/l10n.dart";
-import "package:photos/theme/colors.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/theme/text_style.dart";
 
 class RecoveryDateSelector extends StatelessWidget {
   final int selectedDays;
@@ -16,75 +14,22 @@ class RecoveryDateSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
-      children: [
-        _DayChip(
-          label: context.l10n.trashDaysLeft(count: 7),
-          isSelected: selectedDays == 7,
-          onTap: () => onDaysChanged(7),
-          colorScheme: colorScheme,
-          textTheme: textTheme,
-        ),
-        const SizedBox(width: 12),
-        _DayChip(
-          label: context.l10n.trashDaysLeft(count: 14),
-          isSelected: selectedDays == 14,
-          onTap: () => onDaysChanged(14),
-          colorScheme: colorScheme,
-          textTheme: textTheme,
-        ),
-        const SizedBox(width: 12),
-        _DayChip(
-          label: context.l10n.trashDaysLeft(count: 30),
-          isSelected: selectedDays == 30,
-          onTap: () => onDaysChanged(30),
-          colorScheme: colorScheme,
-          textTheme: textTheme,
-        ),
-      ],
-    );
-  }
-}
-
-class _DayChip extends StatelessWidget {
-  final String label;
-  final bool isSelected;
-  final VoidCallback onTap;
-  final EnteColorScheme colorScheme;
-  final EnteTextTheme textTheme;
-
-  const _DayChip({
-    required this.label,
-    required this.isSelected,
-    required this.onTap,
-    required this.colorScheme,
-    required this.textTheme,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOutCubic,
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: isSelected ? colorScheme.greenBase : colorScheme.fillFaint,
-          borderRadius: BorderRadius.circular(14),
-        ),
-        child: Text(
-          label,
-          textAlign: TextAlign.center,
-          style: textTheme.bodyBold.copyWith(
-            color: isSelected ? Colors.white : colorScheme.textBase,
-          ),
-        ),
-      ),
+    return Wrap(
+      spacing: Spacing.sm,
+      runSpacing: Spacing.sm,
+      children: [7, 14, 30]
+          .map((days) {
+            final isSelected = selectedDays == days;
+            return FilterChipComponent(
+              label: context.l10n.trashDaysLeft(count: days),
+              state: isSelected
+                  ? FilterChipComponentState.selected
+                  : FilterChipComponentState.unselected,
+              trailing: isSelected ? const Icon(Icons.check_rounded) : null,
+              onChanged: (_) => onDaysChanged(days),
+            );
+          })
+          .toList(growable: false),
     );
   }
 }

--- a/mobile/apps/photos/lib/emergency/components/trusted_contact_sheet.dart
+++ b/mobile/apps/photos/lib/emergency/components/trusted_contact_sheet.dart
@@ -1,22 +1,19 @@
+import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
 import "package:photos/emergency/components/recovery_date_selector.dart";
 import "package:photos/emergency/model.dart";
 import "package:photos/generated/l10n.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/base_bottom_sheet.dart";
-import "package:photos/ui/components/buttons/button_widget_v2.dart";
 
 Future<TrustedContactResult?> showTrustedContactSheet(
   BuildContext context, {
   required EmergencyContact contact,
 }) {
-  return showBaseBottomSheet<TrustedContactResult>(
-    context,
-    title: contact.emergencyContact.email,
-    headerSpacing: 20,
-    padding: const EdgeInsets.all(16),
-    backgroundColor: getEnteColorScheme(context).backgroundColour,
-    child: TrustedContactSheet(contact: contact),
+  return showBottomSheetComponent<TrustedContactResult>(
+    context: context,
+    builder: (_) => BottomSheetComponent(
+      title: contact.emergencyContact.email,
+      content: TrustedContactSheet(contact: contact),
+    ),
   );
 }
 
@@ -53,8 +50,6 @@ class _TrustedContactSheetState extends State<TrustedContactSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
     final l10n = AppLocalizations.of(context);
 
     final isPending = widget.contact.isPendingInvite();
@@ -70,9 +65,11 @@ class _TrustedContactSheetState extends State<TrustedContactSheet> {
       children: [
         Text(
           description,
-          style: textTheme.small.copyWith(color: colorScheme.textMuted),
+          style: TextStyles.body.copyWith(
+            color: context.componentColors.textLight,
+          ),
         ),
-        const SizedBox(height: 20),
+        const SizedBox(height: Spacing.xl),
         RecoveryDateSelector(
           selectedDays: _selectedRecoveryDays,
           onDaysChanged: (days) {
@@ -81,10 +78,9 @@ class _TrustedContactSheetState extends State<TrustedContactSheet> {
             });
           },
         ),
-        const SizedBox(height: 20),
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.primary,
-          labelText: l10n.updateTime,
+        const SizedBox(height: Spacing.xl),
+        ButtonComponent(
+          label: l10n.updateTime,
           isDisabled: !_hasChanges,
           onTap: !_hasChanges
               ? null
@@ -96,18 +92,20 @@ class _TrustedContactSheetState extends State<TrustedContactSheet> {
                     ),
                   );
                 },
+          shouldShowSuccessState: false,
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: Spacing.lg),
         Center(
-          child: ButtonWidgetV2(
-            buttonType: ButtonTypeV2.tertiaryCritical,
-            labelText: removeLabel,
+          child: ButtonComponent(
+            variant: ButtonComponentVariant.tertiaryCritical,
+            size: ButtonComponentSize.small,
+            label: removeLabel,
             onTap: () async {
               Navigator.of(context).pop(
                 const TrustedContactResult(action: TrustedContactAction.revoke),
               );
             },
-            shouldSurfaceExecutionStates: false,
+            shouldShowSuccessState: false,
           ),
         ),
       ],

--- a/mobile/apps/photos/lib/emergency/emergency_page.dart
+++ b/mobile/apps/photos/lib/emergency/emergency_page.dart
@@ -1,5 +1,7 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
+import "package:ente_strings/ente_strings.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:photos/core/configuration.dart";
@@ -12,15 +14,6 @@ import "package:photos/emergency/select_contact_page.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/l10n/l10n.dart";
 import "package:photos/services/contacts/contact_identity_resolver.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/common/loading_widget.dart";
-import "package:photos/ui/components/alert_bottom_sheet.dart";
-import "package:photos/ui/components/buttons/button_widget_v2.dart";
-import "package:photos/ui/components/divider_widget.dart";
-import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
-import "package:photos/ui/components/menu_section_title.dart";
-import "package:photos/ui/components/title_bar_title_widget.dart";
-import "package:photos/ui/notification/toast.dart";
 import "package:photos/ui/sharing/user_avator_widget.dart";
 
 class EmergencyPage extends StatefulWidget {
@@ -33,6 +26,9 @@ class EmergencyPage extends StatefulWidget {
 class _EmergencyPageState extends State<EmergencyPage> {
   late int currentUserID;
   EmergencyInfo? info;
+  bool _hasLoadError = false;
+  bool _isFetching = false;
+  Timer? _pollTimer;
 
   @override
   void initState() {
@@ -41,272 +37,258 @@ class _EmergencyPageState extends State<EmergencyPage> {
     Future.delayed(const Duration(seconds: 0), () async {
       unawaited(_fetchData());
     });
+    _pollTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      if (mounted && ModalRoute.of(context)?.isCurrent == true) {
+        unawaited(_fetchData(showError: false));
+      }
+    });
   }
 
-  Future<void> _fetchData() async {
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<bool> _fetchData({
+    bool showError = true,
+    bool waitForFreshResult = false,
+  }) async {
+    if (_isFetching) {
+      if (!waitForFreshResult) {
+        return false;
+      }
+      while (_isFetching) {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        if (!mounted) return false;
+      }
+    }
+    _isFetching = true;
     try {
       final result = await EmergencyContactService.instance.getInfo();
       if (mounted) {
         setState(() {
           info = result;
+          _hasLoadError = false;
         });
       }
+      return true;
     } catch (e) {
-      if (!mounted) return;
-      showShortToast(context, AppLocalizations.of(context).somethingWentWrong);
+      if (!mounted) return false;
+      if (info == null) {
+        setState(() {
+          _hasLoadError = true;
+        });
+      } else if (showError) {
+        await showLegacyErrorSheet(context, error: e);
+      }
+      return false;
+    } finally {
+      _isFetching = false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final l10n = context.l10n;
     final List<EmergencyContact> othersTrustedContacts =
         info?.othersEmergencyContact ?? [];
     final List<EmergencyContact> trustedContacts = info?.contacts ?? [];
 
     return Scaffold(
-      backgroundColor: colorScheme.backgroundColour,
-      appBar: AppBar(
-        backgroundColor: colorScheme.backgroundColour,
-        toolbarHeight: 48,
-        leadingWidth: 48,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_outlined),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
-      body: CustomScrollView(
+      backgroundColor: colors.backgroundBase,
+      body: AppBarComponent(
+        title: l10n.legacy,
+        backgroundColor: colors.backgroundBase,
         slivers: [
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: TitleBarTitleWidget(title: l10n.legacy),
+              child: Text(
+                l10n.legacyPageDesc,
+                style: TextStyles.body.copyWith(color: colors.textLight),
+              ),
             ),
           ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(l10n.legacyPageDesc, style: textTheme.smallMuted),
-            ),
-          ),
-          if (info == null)
-            const SliverFillRemaining(
+          if (info == null && !_hasLoadError)
+            SliverFillRemaining(
               hasScrollBody: false,
-              child: Center(child: EnteLoadingWidget()),
+              child: Center(
+                child: CircularProgressIndicator(color: colors.primary),
+              ),
+            ),
+          if (info == null && _hasLoadError)
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: Padding(
+                padding: const EdgeInsets.all(Spacing.xl),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      AppLocalizations.of(context).somethingWentWrong,
+                      textAlign: TextAlign.center,
+                      style: TextStyles.body.copyWith(color: colors.textLight),
+                    ),
+                    const SizedBox(height: Spacing.lg),
+                    ButtonComponent(
+                      label: AppLocalizations.of(context).retry,
+                      shouldShowSuccessState: false,
+                      onTap: () => _fetchData(waitForFreshResult: true),
+                    ),
+                  ],
+                ),
+              ),
             ),
           if (info != null && info!.recoverSessions.isNotEmpty)
             SliverPadding(
-              padding: const EdgeInsets.only(top: 20, left: 16, right: 16),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  if (index == 0) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 16),
-                      child: _WarningBanner(text: l10n.recoveryWarning),
-                    );
-                  }
-
-                  final listIndex = index - 1;
-                  final recoverSession = info!.recoverSessions[listIndex];
-                  final isLastItem =
-                      listIndex == info!.recoverSessions.length - 1;
-                  final emergencyUser = recoverSession.emergencyContact;
-                  return _buildGroupedMenuItem(
-                    listIndex: listIndex,
-                    isLastItem: isLastItem,
-                    child: MenuItemWidgetNew(
-                      title: resolveDisplayName(emergencyUser),
-                      titleColor: colorScheme.warning500,
-                      leadingIconSize: 24,
-                      leadingIconWidget: UserAvatarWidget(
-                        emergencyUser,
-                        type: AvatarType.medium,
-                        currentUserID: currentUserID,
-                      ),
-                      menuItemColor: colorScheme.fillFaint,
-                      trailingWidget: _buildTrailingWidget(showWarning: false),
-                      borderRadius: 0,
-                      onTap: () async {
-                        await showRejectRecoveryDialog(recoverSession);
-                      },
+              padding: const EdgeInsets.only(
+                top: Spacing.xl,
+                left: Spacing.lg,
+                right: Spacing.lg,
+              ),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  children: [
+                    _WarningBanner(text: l10n.recoveryWarning),
+                    const SizedBox(height: Spacing.lg),
+                    MenuGroupComponent(
+                      showDividers: true,
+                      items: info!.recoverSessions
+                          .map((recoverSession) {
+                            final emergencyUser =
+                                recoverSession.emergencyContact;
+                            return MenuComponent(
+                              title: resolveDisplayName(emergencyUser),
+                              titleColor: colors.warning,
+                              leading: UserAvatarWidget(
+                                emergencyUser,
+                                type: AvatarType.medium,
+                                currentUserID: currentUserID,
+                              ),
+                              trailing: _buildTrailingWidget(
+                                showWarning: false,
+                              ),
+                              onTap: () =>
+                                  showRejectRecoveryDialog(recoverSession),
+                            );
+                          })
+                          .toList(growable: false),
                     ),
-                  );
-                }, childCount: 1 + info!.recoverSessions.length),
+                  ],
+                ),
               ),
             ),
           if (info != null)
             SliverPadding(
-              padding: const EdgeInsets.only(
-                top: 16,
-                left: 16,
-                right: 16,
-                bottom: 8,
+              padding: const EdgeInsets.fromLTRB(
+                Spacing.lg,
+                Spacing.xl,
+                Spacing.lg,
+                Spacing.sm,
               ),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  if (index == 0 && trustedContacts.isNotEmpty) {
-                    return MenuSectionTitle(title: l10n.trustedContacts);
-                  }
-
-                  if (index > 0 && index <= trustedContacts.length) {
-                    final listIndex = index - 1;
-                    final contact = trustedContacts[listIndex];
-                    final isLastItem = listIndex == trustedContacts.length - 1;
-                    final emergencyUser = contact.emergencyContact;
-                    return _buildGroupedMenuItem(
-                      listIndex: listIndex,
-                      isLastItem: isLastItem,
-                      child: MenuItemWidgetNew(
-                        title: resolveDisplayName(emergencyUser),
-                        titleColor: contact.isPendingInvite()
-                            ? colorScheme.warning500
-                            : textTheme.small.color,
-                        leadingIconSize: 24,
-                        leadingIconWidget: UserAvatarWidget(
-                          emergencyUser,
-                          type: AvatarType.medium,
-                          currentUserID: currentUserID,
-                        ),
-                        menuItemColor: colorScheme.fillFaint,
-                        trailingWidget: _buildTrailingWidget(
-                          showWarning: contact.isPendingInvite(),
-                        ),
-                        borderRadius: 0,
-                        onTap: () async {
-                          await showRevokeOrRemoveDialog(context, contact);
-                        },
-                      ),
-                    );
-                  }
-
-                  if (index == (1 + trustedContacts.length)) {
-                    if (trustedContacts.isEmpty) {
-                      return Column(
-                        children: [
-                          SizedBox(
-                            height: 200,
-                            width: 200,
-                            child: Image.asset(
-                              "assets/legacy.png",
-                              width: 200,
-                              height: 200,
-                            ),
-                          ),
-                          Text(
-                            l10n.legacyPageDesc2,
-                            style: textTheme.smallMuted,
-                          ),
-                          const SizedBox(height: 16),
-                          ButtonWidgetV2(
-                            buttonType: ButtonTypeV2.primary,
-                            labelText: l10n.addTrustedContact,
-                            shouldSurfaceExecutionStates: false,
-                            onTap: () async {
-                              final result = await showAddContactSheet(
-                                context,
-                                emergencyInfo: info!,
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (trustedContacts.isNotEmpty) ...[
+                      _SectionTitle(title: l10n.trustedContacts),
+                      const SizedBox(height: Spacing.sm),
+                      MenuGroupComponent(
+                        showDividers: true,
+                        items: trustedContacts
+                            .map((contact) {
+                              final emergencyUser = contact.emergencyContact;
+                              return MenuComponent(
+                                title: resolveDisplayName(emergencyUser),
+                                subtitle: _contactStatusText(contact),
+                                titleColor: contact.isPendingInvite()
+                                    ? colors.caution
+                                    : colors.textBase,
+                                leading: UserAvatarWidget(
+                                  emergencyUser,
+                                  type: AvatarType.medium,
+                                  currentUserID: currentUserID,
+                                ),
+                                trailing: _buildTrailingWidget(
+                                  showWarning: contact.isPendingInvite(),
+                                ),
+                                onTap: () =>
+                                    showRevokeOrRemoveDialog(context, contact),
                               );
-                              if (result == true) {
-                                unawaited(_fetchData());
-                              }
-                            },
-                          ),
-                        ],
-                      );
-                    }
-
-                    return Padding(
-                      padding: const EdgeInsets.only(top: 20),
-                      child: ButtonWidgetV2(
-                        buttonType: ButtonTypeV2.primary,
-                        labelText: l10n.addTrustedContact,
-                        shouldSurfaceExecutionStates: false,
-                        onTap: () async {
-                          final result = await showAddContactSheet(
-                            context,
-                            emergencyInfo: info!,
-                          );
-                          if (result == true) {
-                            unawaited(_fetchData());
-                          }
-                        },
+                            })
+                            .toList(growable: false),
                       ),
-                    );
-                  }
-                  return const SizedBox.shrink();
-                }, childCount: 1 + trustedContacts.length + 1),
+                      const SizedBox(height: Spacing.xl),
+                    ],
+                    if (trustedContacts.isEmpty) ...[
+                      Center(
+                        child: Image.asset(
+                          "assets/legacy.png",
+                          width: 200,
+                          height: 200,
+                        ),
+                      ),
+                      Text(
+                        l10n.legacyPageDesc2,
+                        style: TextStyles.body.copyWith(
+                          color: colors.textLight,
+                        ),
+                      ),
+                      const SizedBox(height: Spacing.lg),
+                    ],
+                    ButtonComponent(
+                      label: l10n.addTrustedContact,
+                      shouldShowSuccessState: false,
+                      onTap: _addTrustedContact,
+                    ),
+                  ],
+                ),
               ),
             ),
           if (info != null && info!.othersEmergencyContact.isNotEmpty)
             SliverPadding(
-              padding: const EdgeInsets.only(top: 0, left: 16, right: 16),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  if (index == 0 && othersTrustedContacts.isNotEmpty) {
-                    return Column(
-                      children: [
-                        const Padding(
-                          padding: EdgeInsets.symmetric(vertical: 8),
-                          child: DividerWidget(dividerType: DividerType.solid),
-                        ),
-                        MenuSectionTitle(title: l10n.legacyAccounts),
-                      ],
-                    );
-                  }
-
-                  if (index > 0 && index <= othersTrustedContacts.length) {
-                    final listIndex = index - 1;
-                    final currentUser = othersTrustedContacts[listIndex];
-                    final isLastItem = index == othersTrustedContacts.length;
-                    final emergencyUser = currentUser.user;
-                    return _buildGroupedMenuItem(
-                      listIndex: listIndex,
-                      isLastItem: isLastItem,
-                      child: MenuItemWidgetNew(
-                        title: resolveDisplayName(emergencyUser),
-                        titleColor: currentUser.isPendingInvite()
-                            ? colorScheme.warning500
-                            : textTheme.small.color,
-                        leadingIconSize: 24,
-                        leadingIconWidget: UserAvatarWidget(
-                          emergencyUser,
-                          type: AvatarType.medium,
-                          currentUserID: currentUserID,
-                        ),
-                        menuItemColor: colorScheme.fillFaint,
-                        trailingWidget: _buildTrailingWidget(
-                          showWarning: currentUser.isPendingInvite(),
-                        ),
-                        borderRadius: 0,
-                        onTap: () async {
-                          if (currentUser.isPendingInvite()) {
-                            await showAcceptOrDeclineDialog(
-                              context,
-                              currentUser,
-                            );
-                          } else {
-                            await Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (BuildContext context) {
-                                  return OtherContactPage(
-                                    contact: currentUser,
-                                    emergencyInfo: info!,
-                                  );
-                                },
+              padding: const EdgeInsets.fromLTRB(
+                Spacing.lg,
+                Spacing.xl,
+                Spacing.lg,
+                Spacing.xxl,
+              ),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const DividerComponent(),
+                    const SizedBox(height: Spacing.lg),
+                    _SectionTitle(title: l10n.legacyAccounts),
+                    const SizedBox(height: Spacing.sm),
+                    MenuGroupComponent(
+                      showDividers: true,
+                      items: othersTrustedContacts
+                          .map((contact) {
+                            final emergencyUser = contact.user;
+                            return MenuComponent(
+                              title: resolveDisplayName(emergencyUser),
+                              subtitle: _legacyAccountStatusText(contact),
+                              titleColor: contact.isPendingInvite()
+                                  ? colors.caution
+                                  : colors.textBase,
+                              leading: UserAvatarWidget(
+                                emergencyUser,
+                                type: AvatarType.medium,
+                                currentUserID: currentUserID,
                               ),
+                              trailing: _buildTrailingWidget(
+                                showWarning: contact.isPendingInvite(),
+                              ),
+                              onTap: () => _openLegacyAccount(contact),
                             );
-                            if (mounted) {
-                              unawaited(_fetchData());
-                            }
-                          }
-                        },
-                      ),
-                    );
-                  }
-                  return const SizedBox.shrink();
-                }, childCount: 1 + othersTrustedContacts.length + 1),
+                          })
+                          .toList(growable: false),
+                    ),
+                  ],
+                ),
               ),
             ),
         ],
@@ -314,41 +296,74 @@ class _EmergencyPageState extends State<EmergencyPage> {
     );
   }
 
-  Widget _buildGroupedMenuItem({
-    required int listIndex,
-    required bool isLastItem,
-    required Widget child,
-  }) {
-    final colorScheme = getEnteColorScheme(context);
-    return Column(
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadius.vertical(
-            top: listIndex == 0 ? const Radius.circular(14) : Radius.zero,
-            bottom: isLastItem ? const Radius.circular(14) : Radius.zero,
-          ),
-          child: child,
-        ),
-        if (!isLastItem)
-          DividerWidget(
-            dividerType: DividerType.menu,
-            bgColor: colorScheme.fillFaint,
-          ),
-      ],
+  String _contactStatusText(EmergencyContact contact) {
+    return contact.isPendingInvite()
+        ? context.strings.trustedContactStatusPending
+        : context.strings.trustedContactStatusAccepted;
+  }
+
+  String _legacyAccountStatusText(EmergencyContact contact) {
+    if (contact.isPendingInvite()) {
+      return context.strings.trustedContactStatusPending;
+    }
+    return switch (_recoverySessionFor(contact)?.status) {
+      "WAITING" => context.l10n.recoveryInitiated,
+      "READY" => context.l10n.recoverAccount,
+      _ => context.strings.trustedContactStatusAccepted,
+    };
+  }
+
+  RecoverySessions? _recoverySessionFor(EmergencyContact contact) {
+    final recoverySessions = info?.othersRecoverySession;
+    if (recoverySessions == null) {
+      return null;
+    }
+    for (final session in recoverySessions) {
+      if (session.user.id == contact.user.id) {
+        return session;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _addTrustedContact() async {
+    final result = await showAddContactSheet(context, emergencyInfo: info!);
+    if (result == true && mounted) {
+      await _fetchData(showError: false, waitForFreshResult: true);
+    }
+  }
+
+  Future<void> _openLegacyAccount(EmergencyContact contact) async {
+    if (contact.isPendingInvite()) {
+      await showAcceptOrDeclineDialog(context, contact);
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) =>
+            OtherContactPage(contact: contact, emergencyInfo: info!),
+      ),
     );
+    if (mounted) {
+      await _fetchData(showError: false, waitForFreshResult: true);
+    }
   }
 
   Widget _buildTrailingWidget({required bool showWarning}) {
-    final colorScheme = getEnteColorScheme(context);
+    final colors = context.componentColors;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         if (showWarning) ...[
           Image.asset("assets/warning-yellow.png", width: 20, height: 20),
-          const SizedBox(width: 6),
+          const SizedBox(width: Spacing.xs),
         ],
-        Icon(Icons.chevron_right, color: colorScheme.strokeMuted),
+        Icon(
+          Icons.chevron_right_rounded,
+          color: colors.textLight,
+          size: IconSizes.medium,
+        ),
       ],
     );
   }
@@ -368,36 +383,40 @@ class _EmergencyPageState extends State<EmergencyPage> {
     if (actionResult.action == TrustedContactAction.revoke) {
       final isPending = contact.isPendingInvite();
       if (!context.mounted) return;
-      final confirmed = await showAlertBottomSheet<bool>(
+      final confirmed = await showLegacyAlertSheet<bool>(
         context,
         title: isPending
             ? context.l10n.cancelInvite
             : context.l10n.removeContact,
-        assetPath: "assets/warning-grey.png",
         message: isPending
             ? context.l10n.cancelInviteDesc
             : context.l10n.removeContactDesc,
-        buttons: [
-          ButtonWidgetV2(
-            buttonType: ButtonTypeV2.critical,
-            labelText: isPending
+        actions: [
+          ButtonComponent(
+            variant: ButtonComponentVariant.critical,
+            label: isPending
                 ? context.l10n.revokeInvite
                 : context.l10n.removeContact,
             onTap: () async => Navigator.of(context).pop(true),
-            shouldSurfaceExecutionStates: false,
+            shouldShowSuccessState: false,
           ),
         ],
       );
 
       if (confirmed == true) {
-        await EmergencyContactService.instance.updateContact(
-          contact,
-          ContactState.userRevokedContact,
-        );
-        info?.contacts.remove(contact);
-        if (mounted) {
-          setState(() {});
-          unawaited(_fetchData());
+        try {
+          await EmergencyContactService.instance.updateContact(
+            contact,
+            ContactState.userRevokedContact,
+          );
+          info?.contacts.remove(contact);
+          if (mounted) {
+            setState(() {});
+            await _fetchData(showError: false, waitForFreshResult: true);
+          }
+        } catch (e) {
+          if (!context.mounted) return;
+          await showLegacyErrorSheet(context, error: e);
         }
       }
       return;
@@ -426,26 +445,21 @@ class _EmergencyPageState extends State<EmergencyPage> {
         }
         if (mounted) {
           setState(() {});
+          await _fetchData(showError: false, waitForFreshResult: true);
         }
       } else {
         if (mounted) {
           if (!context.mounted) return;
-          await showAlertBottomSheet(
+          await showLegacyAlertSheet(
             context,
             title: context.l10n.cannotUpdateRecoveryTime,
             message: context.l10n.cannotUpdateRecoveryTimeMessage,
-            assetPath: "assets/warning-grey.png",
           );
         }
       }
     } catch (e) {
-      if (mounted) {
-        if (!context.mounted) return;
-        showShortToast(
-          context,
-          AppLocalizations.of(context).somethingWentWrong,
-        );
-      }
+      if (!context.mounted) return;
+      await showLegacyErrorSheet(context, error: e);
     }
   }
 
@@ -460,46 +474,43 @@ class _EmergencyPageState extends State<EmergencyPage> {
         context,
       ).legacyInvite(email: contact.user.email),
       buttons: [
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.primary,
-          labelText: AppLocalizations.of(context).acceptTrustInvite,
-          shouldSurfaceExecutionStates: false,
+        ButtonComponent(
+          label: AppLocalizations.of(context).acceptTrustInvite,
+          shouldShowSuccessState: false,
           onTap: () async => Navigator.of(context).pop("accept"),
         ),
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.tertiaryCritical,
-          labelText: AppLocalizations.of(context).declineTrustInvite,
-          shouldSurfaceExecutionStates: false,
+        ButtonComponent(
+          variant: ButtonComponentVariant.tertiaryCritical,
+          label: AppLocalizations.of(context).declineTrustInvite,
+          shouldShowSuccessState: false,
           onTap: () async => Navigator.of(context).pop("decline"),
         ),
       ],
     );
 
-    if (result == "accept") {
-      await EmergencyContactService.instance.updateContact(
-        contact,
-        ContactState.contactAccepted,
-      );
-      final updatedContact = contact.copyWith(
-        state: ContactState.contactAccepted,
-      );
-      info?.othersEmergencyContact.remove(contact);
-      info?.othersEmergencyContact.add(updatedContact);
-      if (mounted) {
-        setState(() {});
-      }
+    final state = switch (result) {
+      "accept" => ContactState.contactAccepted,
+      "decline" => ContactState.contactDenied,
+      _ => null,
+    };
+    if (state == null) {
       return;
     }
-
-    if (result == "decline") {
-      await EmergencyContactService.instance.updateContact(
-        contact,
-        ContactState.contactDenied,
-      );
+    try {
+      await EmergencyContactService.instance.updateContact(contact, state);
       info?.othersEmergencyContact.remove(contact);
+      if (state == ContactState.contactAccepted) {
+        info?.othersEmergencyContact.add(
+          contact.copyWith(state: ContactState.contactAccepted),
+        );
+      }
       if (mounted) {
         setState(() {});
+        await _fetchData(showError: false, waitForFreshResult: true);
       }
+    } catch (e) {
+      if (!context.mounted) return;
+      await showLegacyErrorSheet(context, error: e);
     }
   }
 
@@ -511,36 +522,47 @@ class _EmergencyPageState extends State<EmergencyPage> {
       email: emergencyContactEmail,
       message: context.l10n.recoveryWarningBody(email: emergencyContactEmail),
       buttons: [
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.critical,
-          labelText: context.l10n.rejectRecovery,
-          shouldSurfaceExecutionStates: false,
+        ButtonComponent(
+          variant: ButtonComponentVariant.critical,
+          label: context.l10n.rejectRecovery,
+          shouldShowSuccessState: false,
           onTap: () async => Navigator.of(context).pop(true),
         ),
         if (kDebugMode)
-          ButtonWidgetV2(
-            buttonType: ButtonTypeV2.secondary,
-            labelText: "Approve recovery (to be removed)",
-            shouldSurfaceExecutionStates: false,
+          ButtonComponent(
+            variant: ButtonComponentVariant.secondary,
+            label: "Approve recovery (to be removed)",
+            shouldShowSuccessState: false,
             onTap: () async {
               Navigator.of(context).pop();
-              await EmergencyContactService.instance.approveRecovery(session);
-              if (mounted) {
-                setState(() {});
+              try {
+                await EmergencyContactService.instance.approveRecovery(session);
+                if (mounted) {
+                  await _fetchData(showError: false, waitForFreshResult: true);
+                }
+              } catch (e) {
+                if (!mounted) return;
+                await showLegacyErrorSheet(context, error: e);
               }
-              unawaited(_fetchData());
             },
           ),
       ],
     );
 
     if (confirmed == true) {
-      await EmergencyContactService.instance.rejectRecovery(session);
-      info?.recoverSessions.removeWhere((element) => element.id == session.id);
-      if (mounted) {
-        setState(() {});
+      try {
+        await EmergencyContactService.instance.rejectRecovery(session);
+        info?.recoverSessions.removeWhere(
+          (element) => element.id == session.id,
+        );
+        if (mounted) {
+          setState(() {});
+          await _fetchData(showError: false, waitForFreshResult: true);
+        }
+      } catch (e) {
+        if (!mounted) return;
+        await showLegacyErrorSheet(context, error: e);
       }
-      unawaited(_fetchData());
     }
   }
 }
@@ -552,26 +574,46 @@ class _WarningBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
-
-    return Container(
-      padding: const EdgeInsets.all(16),
+    final colors = context.componentColors;
+    return DecoratedBox(
       decoration: BoxDecoration(
-        color: colorScheme.warning400.withValues(alpha: 0.13),
-        borderRadius: BorderRadius.circular(20),
+        color: colors.fillLight,
+        borderRadius: BorderRadius.circular(Radii.button),
       ),
-      child: Row(
-        children: [
-          Image.asset("assets/emergency-warning.png", width: 32, height: 32),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              text,
-              style: textTheme.bodyBold.copyWith(color: colorScheme.warning400),
+      child: Padding(
+        padding: const EdgeInsets.all(Spacing.lg),
+        child: Row(
+          children: [
+            Image.asset(
+              "assets/emergency-warning.png",
+              width: IconSizes.large,
+              height: IconSizes.large,
             ),
-          ),
-        ],
+            const SizedBox(width: Spacing.md),
+            Expanded(
+              child: Text(
+                text,
+                style: TextStyles.bodyBold.copyWith(color: colors.caution),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: TextStyles.bodyBold.copyWith(
+        color: context.componentColors.textLight,
       ),
     );
   }

--- a/mobile/apps/photos/lib/emergency/emergency_service.dart
+++ b/mobile/apps/photos/lib/emergency/emergency_service.dart
@@ -7,6 +7,7 @@ import "package:ente_crypto/ente_crypto.dart";
 import "package:flutter/cupertino.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/configuration.dart";
+import "package:photos/emergency/components/email_action_sheet.dart";
 import "package:photos/emergency/model.dart";
 import "package:photos/gateways/emergency/emergency_gateway.dart";
 import "package:photos/gateways/users/models/key_attributes.dart";
@@ -15,8 +16,6 @@ import "package:photos/gateways/users/models/srp.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/account/user_service.dart";
-import "package:photos/ui/common/user_dialogs.dart";
-import "package:photos/ui/components/alert_bottom_sheet.dart";
 import "package:photos/utils/email_util.dart";
 import "package:pointycastle/pointycastle.dart";
 import "package:pointycastle/random/fortuna_random.dart";
@@ -48,27 +47,25 @@ class EmergencyContactService {
   }) async {
     if (!isValidEmail(email)) {
       if (context == null || !context.mounted) return false;
-      await showAlertBottomSheet(
+      await showLegacyAlertSheet(
         context,
         title: AppLocalizations.of(context).letsTryThatAgain,
         message: AppLocalizations.of(context).enterValidEmail,
-        assetPath: "assets/warning-grey.png",
       );
       return false;
     } else if (email.trim() == Configuration.instance.getEmail()) {
       if (context == null || !context.mounted) return false;
-      await showAlertBottomSheet(
+      await showLegacyAlertSheet(
         context,
         title: AppLocalizations.of(context).oops,
         message: AppLocalizations.of(context).youCannotShareWithYourself,
-        assetPath: "assets/warning-grey.png",
       );
       return false;
     }
     final String? publicKey = await _userService.getPublicKey(email);
     if (publicKey == null) {
       if (context == null || !context.mounted) return false;
-      await showInviteDialog(context, email);
+      await showLegacyInviteSheet(context, email: email);
       return false;
     }
     final Uint8List recoveryKey = Configuration.instance.getRecoveryKey();

--- a/mobile/apps/photos/lib/emergency/other_contact_page.dart
+++ b/mobile/apps/photos/lib/emergency/other_contact_page.dart
@@ -1,18 +1,18 @@
+import "dart:async";
+
 import "package:collection/collection.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/configuration.dart";
+import "package:photos/emergency/components/email_action_sheet.dart";
 import "package:photos/emergency/emergency_service.dart";
 import "package:photos/emergency/model.dart";
 import "package:photos/emergency/recover_others_account.dart";
 import "package:photos/gateways/users/models/key_attributes.dart";
 import "package:photos/l10n/l10n.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/alert_bottom_sheet.dart";
-import "package:photos/ui/components/buttons/button_widget_v2.dart";
-import "package:photos/ui/components/title_bar_title_widget.dart";
-import "package:photos/utils/dialog_util.dart";
+import "package:photos/ui/settings/components/settings_page_scaffold.dart";
 
 // OtherContactPage is used to start recovery process for other user's account
 // Based on the state of the contact & recovery session, it will show
@@ -37,16 +37,42 @@ class _OtherContactPageState extends State<OtherContactPage> {
   String? waitTill;
   final Logger _logger = Logger("_OtherContactPageState");
   late EmergencyInfo emergencyInfo = widget.emergencyInfo;
+  bool _isFetching = false;
+  Timer? _pollTimer;
 
   @override
   void initState() {
     super.initState();
     recoverySession = widget.emergencyInfo.othersRecoverySession
         .firstWhereOrNull((session) => session.user.email == accountEmail);
-    _fetchData();
+    unawaited(_fetchData(showError: false));
+    _pollTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      if (mounted && ModalRoute.of(context)?.isCurrent == true) {
+        unawaited(_fetchData(showError: false));
+      }
+    });
   }
 
-  Future<void> _fetchData() async {
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<bool> _fetchData({
+    bool showError = true,
+    bool waitForFreshResult = false,
+  }) async {
+    if (_isFetching) {
+      if (!waitForFreshResult) {
+        return false;
+      }
+      while (_isFetching) {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        if (!mounted) return false;
+      }
+    }
+    _isFetching = true;
     try {
       final result = await EmergencyContactService.instance.getInfo();
       if (mounted) {
@@ -56,8 +82,15 @@ class _OtherContactPageState extends State<OtherContactPage> {
           );
         });
       }
+      return true;
     } catch (e) {
       _logger.severe("Error fetching data", e);
+      if (mounted && showError) {
+        await showLegacyErrorSheet(context, error: e);
+      }
+      return false;
+    } finally {
+      _isFetching = false;
     }
   }
 
@@ -69,192 +102,155 @@ class _OtherContactPageState extends State<OtherContactPage> {
       );
       waitTill = getFormattedTime(dateTime, context: context);
     }
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
-    return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 48,
-        leadingWidth: 48,
-        backgroundColor: colorScheme.backgroundColour,
-        leading: GestureDetector(
-          onTap: () {
-            Navigator.pop(context);
-          },
-          child: const Icon(Icons.arrow_back_outlined),
-        ),
-      ),
-      backgroundColor: colorScheme.backgroundColour,
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TitleBarTitleWidget(title: context.l10n.recoverAccount),
-            Text(accountEmail, style: textTheme.smallMuted),
-            const SizedBox(height: 12),
-            if (recoverySession == null)
-              Text(
-                context.l10n.recoverAccountDesc(
-                  email: accountEmail,
-                  days: widget.contact.recoveryNoticeInDays,
-                ),
-                style: textTheme.smallMuted,
-              ),
-            if (recoverySession != null && recoverySession!.status == "READY")
-              Text(
-                context.l10n.recoveryReady(email: accountEmail),
-                style: textTheme.smallMuted,
-              ),
-            if (recoverySession != null && recoverySession!.status == "WAITING")
-              Text(
-                context.l10n.recoverAccountAfter(
-                  email: accountEmail,
-                  time: waitTill!,
-                ),
-                style: textTheme.smallMuted,
-              ),
-            const SizedBox(height: 24),
-            if (recoverySession == null)
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.primary,
-                labelText: context.l10n.startRecovery,
-                isDisabled: widget.contact.isPendingInvite(),
-                shouldSurfaceExecutionStates: false,
-                onTap: widget.contact.isPendingInvite()
-                    ? null
-                    : () async {
-                        final confirmed = await showAlertBottomSheet<bool>(
-                          context,
-                          title: context.l10n.startRecovery,
-                          message: context.l10n.startRecoveryDesc(
-                            email: accountEmail,
-                          ),
-                          assetPath: "assets/warning-grey.png",
-                          buttons: [
-                            ButtonWidgetV2(
-                              buttonType: ButtonTypeV2.primary,
-                              labelText: context.l10n.startRecovery,
-                              onTap: () async =>
-                                  Navigator.of(context).pop(true),
-                              shouldSurfaceExecutionStates: false,
-                            ),
-                          ],
-                        );
-                        if (confirmed != true) {
-                          return;
-                        }
-                        try {
-                          await EmergencyContactService.instance.startRecovery(
-                            widget.contact,
-                          );
-                          if (mounted) {
-                            _fetchData().ignore();
-                            if (!context.mounted) return;
-                            await showAlertBottomSheet(
-                              context,
-                              title: context.l10n.recoveryInitiated,
-                              message: context.l10n.recoveryInitiatedDesc(
-                                days: widget.contact.recoveryNoticeInDays,
-                                email: Configuration.instance.getEmail()!,
-                              ),
-                              assetPath: "assets/warning-grey.png",
-                            );
-                          }
-                        } catch (e) {
-                          if (!context.mounted) return;
-                          showGenericErrorBottomSheet(
-                            context: context,
-                            error: e,
-                          ).ignore();
-                        }
-                      },
-              ),
-            if (recoverySession != null && recoverySession!.status == "READY")
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.primary,
-                labelText: context.l10n.recoverAccount,
-                shouldSurfaceExecutionStates: false,
-                onTap: () async {
-                  try {
-                    final (
-                      String key,
-                      KeyAttributes attributes,
-                    ) = await EmergencyContactService.instance.getRecoveryInfo(
-                      recoverySession!,
-                    );
-                    routeToPage(
-                      context,
-                      RecoverOthersAccount(key, attributes, recoverySession!),
-                    ).ignore();
-                  } catch (e) {
-                    showGenericErrorBottomSheet(
-                      context: context,
-                      error: e,
-                    ).ignore();
-                  }
-                },
-              ),
-            if (recoverySession != null && recoverySession!.status == "WAITING")
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.secondary,
-                labelText: context.l10n.cancelRecovery,
-                shouldSurfaceExecutionStates: false,
-                onTap: () async {
-                  await _showCancelRecoverySheet();
-                },
-              ),
-            if (recoverySession != null &&
-                recoverySession!.status == "READY") ...[
-              const SizedBox(height: 20),
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.tertiaryCritical,
-                labelText: context.l10n.cancelRecovery,
-                shouldSurfaceExecutionStates: false,
-                onTap: () async {
-                  await _showCancelRecoverySheet();
-                },
-              ),
-              const SizedBox(height: 24),
-              Text(
-                context.l10n.orRemoveYourself(email: accountEmail),
-                style: textTheme.smallMuted,
-              ),
-              const SizedBox(height: 12),
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.tertiaryCritical,
-                labelText: context.l10n.removeContact,
-                shouldSurfaceExecutionStates: false,
-                onTap: showRemoveSheet,
-              ),
-            ],
-            if (recoverySession == null ||
-                recoverySession!.status != "READY") ...[
-              const SizedBox(height: 20),
-              ButtonWidgetV2(
-                buttonType: ButtonTypeV2.tertiaryCritical,
-                labelText: context.l10n.removeContact,
-                shouldSurfaceExecutionStates: false,
-                onTap: showRemoveSheet,
-              ),
-            ],
-          ],
-        ),
-      ),
+    final colors = context.componentColors;
+    return SettingsPageScaffold(
+      title: context.l10n.recoverAccount,
+      subtitle: accountEmail,
+      children: [
+        if (recoverySession == null)
+          Text(
+            context.l10n.recoverAccountDesc(
+              email: accountEmail,
+              days: widget.contact.recoveryNoticeInDays,
+            ),
+            style: TextStyles.body.copyWith(color: colors.textLight),
+          ),
+        if (recoverySession != null && recoverySession!.status == "READY")
+          Text(
+            context.l10n.recoveryReady(email: accountEmail),
+            style: TextStyles.body.copyWith(color: colors.textLight),
+          ),
+        if (recoverySession != null && recoverySession!.status == "WAITING")
+          Text(
+            context.l10n.recoverAccountAfter(
+              email: accountEmail,
+              time: waitTill!,
+            ),
+            style: TextStyles.body.copyWith(color: colors.textLight),
+          ),
+        const SizedBox(height: Spacing.xxl),
+        if (recoverySession == null)
+          ButtonComponent(
+            label: context.l10n.startRecovery,
+            isDisabled: widget.contact.isPendingInvite(),
+            shouldShowSuccessState: false,
+            onTap: widget.contact.isPendingInvite() ? null : _startRecovery,
+          ),
+        if (recoverySession != null && recoverySession!.status == "READY")
+          ButtonComponent(
+            label: context.l10n.recoverAccount,
+            shouldShowSuccessState: false,
+            onTap: _recoverAccount,
+          ),
+        if (recoverySession != null && recoverySession!.status == "WAITING")
+          ButtonComponent(
+            variant: ButtonComponentVariant.secondary,
+            label: context.l10n.cancelRecovery,
+            shouldShowSuccessState: false,
+            onTap: _showCancelRecoverySheet,
+          ),
+        if (recoverySession != null && recoverySession!.status == "READY") ...[
+          const SizedBox(height: Spacing.xl),
+          ButtonComponent(
+            variant: ButtonComponentVariant.tertiaryCritical,
+            label: context.l10n.cancelRecovery,
+            shouldShowSuccessState: false,
+            onTap: _showCancelRecoverySheet,
+          ),
+          const SizedBox(height: Spacing.xxl),
+          Text(
+            context.l10n.orRemoveYourself(email: accountEmail),
+            style: TextStyles.body.copyWith(color: colors.textLight),
+          ),
+          const SizedBox(height: Spacing.md),
+          ButtonComponent(
+            variant: ButtonComponentVariant.tertiaryCritical,
+            label: context.l10n.removeContact,
+            shouldShowSuccessState: false,
+            onTap: showRemoveSheet,
+          ),
+        ],
+        if (recoverySession == null || recoverySession!.status != "READY") ...[
+          const SizedBox(height: Spacing.xl),
+          ButtonComponent(
+            variant: ButtonComponentVariant.tertiaryCritical,
+            label: context.l10n.removeContact,
+            shouldShowSuccessState: false,
+            onTap: showRemoveSheet,
+          ),
+        ],
+      ],
     );
   }
 
+  Future<void> _startRecovery() async {
+    final confirmed = await showLegacyAlertSheet<bool>(
+      context,
+      title: context.l10n.startRecovery,
+      message: context.l10n.startRecoveryDesc(email: accountEmail),
+      actions: [
+        ButtonComponent(
+          label: context.l10n.startRecovery,
+          onTap: () async => Navigator.of(context).pop(true),
+          shouldShowSuccessState: false,
+        ),
+      ],
+    );
+    if (confirmed != true) {
+      return;
+    }
+    try {
+      await EmergencyContactService.instance.startRecovery(widget.contact);
+      if (!mounted) return;
+      await _fetchData(showError: false, waitForFreshResult: true);
+      if (!mounted) return;
+      await showLegacyAlertSheet(
+        context,
+        title: context.l10n.recoveryInitiated,
+        message: context.l10n.recoveryInitiatedDesc(
+          days: widget.contact.recoveryNoticeInDays,
+          email: Configuration.instance.getEmail()!,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      await showLegacyErrorSheet(context, error: e);
+    }
+  }
+
+  Future<void> _recoverAccount() async {
+    try {
+      final (
+        String key,
+        KeyAttributes attributes,
+      ) = await EmergencyContactService.instance.getRecoveryInfo(
+        recoverySession!,
+      );
+      if (!mounted) return;
+      await routeToPage(
+        context,
+        RecoverOthersAccount(key, attributes, recoverySession!),
+      );
+      if (mounted) {
+        await _fetchData(showError: false, waitForFreshResult: true);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      await showLegacyErrorSheet(context, error: e);
+    }
+  }
+
   Future<void> _showCancelRecoverySheet() async {
-    final confirmed = await showAlertBottomSheet<bool>(
+    final confirmed = await showLegacyAlertSheet<bool>(
       context,
       title: context.l10n.cancelRecovery,
       message: context.l10n.cancelRecoveryDesc(email: accountEmail),
-      assetPath: "assets/warning-grey.png",
-      buttons: [
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.critical,
-          labelText: context.l10n.cancelRecovery,
+      actions: [
+        ButtonComponent(
+          variant: ButtonComponentVariant.critical,
+          label: context.l10n.cancelRecovery,
           onTap: () async => Navigator.of(context).pop(true),
-          shouldSurfaceExecutionStates: false,
+          shouldShowSuccessState: false,
         ),
       ],
     );
@@ -262,27 +258,28 @@ class _OtherContactPageState extends State<OtherContactPage> {
       try {
         await EmergencyContactService.instance.stopRecovery(recoverySession!);
         if (mounted) {
-          _fetchData().ignore();
+          recoverySession = null;
+          setState(() {});
+          await _fetchData(showError: false, waitForFreshResult: true);
         }
       } catch (e) {
         if (!mounted) return;
-        showGenericErrorBottomSheet(context: context, error: e).ignore();
+        await showLegacyErrorSheet(context, error: e);
       }
     }
   }
 
   Future<void> showRemoveSheet() async {
-    final confirmed = await showAlertBottomSheet<bool>(
+    final confirmed = await showLegacyAlertSheet<bool>(
       context,
       title: context.l10n.removeContact,
       message: context.l10n.removeYourselfDesc(email: accountEmail),
-      assetPath: "assets/warning-grey.png",
-      buttons: [
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.critical,
-          labelText: context.l10n.removeContact,
+      actions: [
+        ButtonComponent(
+          variant: ButtonComponentVariant.critical,
+          label: context.l10n.removeContact,
           onTap: () async => Navigator.of(context).pop(true),
-          shouldSurfaceExecutionStates: false,
+          shouldShowSuccessState: false,
         ),
       ],
     );
@@ -297,7 +294,7 @@ class _OtherContactPageState extends State<OtherContactPage> {
         }
       } catch (e) {
         if (!mounted) return;
-        showGenericErrorBottomSheet(context: context, error: e).ignore();
+        await showLegacyErrorSheet(context, error: e);
       }
     }
   }

--- a/mobile/apps/photos/lib/emergency/recover_others_account.dart
+++ b/mobile/apps/photos/lib/emergency/recover_others_account.dart
@@ -2,23 +2,18 @@ import "dart:async";
 import "dart:convert";
 import "dart:typed_data";
 
+import "package:ente_components/ente_components.dart";
 import "package:ente_crypto/ente_crypto.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:password_strength/password_strength.dart';
+import "package:photos/emergency/components/email_action_sheet.dart";
 import "package:photos/emergency/emergency_service.dart";
 import "package:photos/emergency/model.dart";
 import "package:photos/gateways/users/models/key_attributes.dart";
 import "package:photos/gateways/users/models/set_keys_request.dart";
 import "package:photos/generated/l10n.dart";
-import "package:photos/theme/colors.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/theme/text_style.dart";
-import "package:photos/ui/components/buttons/button_widget_v2.dart";
-import "package:photos/ui/components/models/text_input_type_v2.dart";
-import "package:photos/ui/components/text_input_widget_v2.dart";
-import 'package:photos/ui/notification/toast.dart';
-import 'package:photos/utils/dialog_util.dart';
+import "package:photos/ui/settings/components/settings_page_scaffold.dart";
 
 class RecoverOthersAccount extends StatefulWidget {
   final String recoveryKey;
@@ -50,6 +45,7 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
   bool _passwordsMatch = false;
   bool _isPasswordValid = false;
   bool _showPasswordStrength = false;
+  bool _isProgressSheetOpen = false;
   Timer? _passwordStrengthTimer;
 
   @override
@@ -62,35 +58,22 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
     final title = AppLocalizations.of(context).resetPasswordTitle;
     final isFormValid = _passwordsMatch && _isPasswordValid;
 
-    return Scaffold(
-      resizeToAvoidBottomInset: true,
-      backgroundColor: colorScheme.backgroundColour,
-      appBar: AppBar(
-        elevation: 0,
-        scrolledUnderElevation: 0,
-        backgroundColor: colorScheme.backgroundColour,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          color: colorScheme.content,
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
+    return SettingsPageScaffold(
+      title: title,
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(
+          Spacing.lg,
+          Spacing.sm,
+          Spacing.lg,
+          Spacing.lg,
         ),
-        title: Text(title, style: textTheme.largeBold),
-        centerTitle: true,
-      ),
-      body: _getBody(colorScheme, textTheme),
-      floatingActionButton: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: ButtonWidgetV2(
-          buttonType: ButtonTypeV2.primary,
-          labelText: title,
+        child: ButtonComponent(
+          label: title,
           isDisabled: !isFormValid,
+          shouldShowSuccessState: false,
           onTap: isFormValid
               ? () async {
                   await _updatePassword();
@@ -100,138 +83,125 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
               : null,
         ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      children: [_getBody()],
     );
   }
 
-  Widget _getBody(EnteColorScheme colorScheme, EnteTextTheme textTheme) {
+  Widget _getBody() {
     final email = widget.sessions.user.email;
     String? passwordMessage;
-    TextInputMessageType passwordMessageType = TextInputMessageType.guide;
+    var passwordMessageType = TextInputComponentMessageType.helper;
 
     if (_passwordInInputBox.isNotEmpty && _showPasswordStrength) {
       if (_passwordStrength > kStrongPasswordStrengthThreshold) {
         passwordMessage = AppLocalizations.of(context).strongPassword;
-        passwordMessageType = TextInputMessageType.success;
+        passwordMessageType = TextInputComponentMessageType.success;
       } else if (_passwordStrength <= kMildPasswordStrengthThreshold) {
         passwordMessage = AppLocalizations.of(context).weakStrength;
-        passwordMessageType = TextInputMessageType.alert;
+        passwordMessageType = TextInputComponentMessageType.alert;
       }
     }
 
     String? confirmPasswordMessage;
-    TextInputMessageType confirmPasswordMessageType =
-        TextInputMessageType.guide;
+    var confirmPasswordMessageType = TextInputComponentMessageType.helper;
 
     if (_passwordInInputConfirmationBox.isNotEmpty &&
         _passwordInInputBox.isNotEmpty) {
       if (_passwordsMatch) {
         confirmPasswordMessage = AppLocalizations.of(context).passwordsMatch;
-        confirmPasswordMessageType = TextInputMessageType.success;
+        confirmPasswordMessageType = TextInputComponentMessageType.success;
       } else {
         confirmPasswordMessage = AppLocalizations.of(
           context,
         ).passwordsDontMatch;
-        confirmPasswordMessageType = TextInputMessageType.error;
+        confirmPasswordMessageType = TextInputComponentMessageType.error;
       }
     }
 
-    return SafeArea(
-      child: AutofillGroup(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: ListView(
-            children: [
-              const SizedBox(height: 16),
-              Text(
-                "Enter new password for $email account. You will be able "
-                "to use this password to login into $email account.",
-                style: textTheme.body.copyWith(color: colorScheme.textMuted),
-              ),
-              const SizedBox(height: 24),
-              Visibility(
-                visible: false,
-                child: TextFormField(
-                  autofillHints: const [AutofillHints.email],
-                  autocorrect: false,
-                  keyboardType: TextInputType.emailAddress,
-                  initialValue: email,
-                  textInputAction: TextInputAction.next,
-                ),
-              ),
-              TextInputWidgetV2(
-                label: AppLocalizations.of(context).password,
-                hintText: AppLocalizations.of(context).password,
-                textEditingController: _passwordController1,
-                isPasswordInput: true,
-                isRequired: true,
-                autoCorrect: false,
-                autofillHints: const [AutofillHints.newPassword],
-                message: passwordMessage,
-                messageType: passwordMessageType,
-                onChange: (password) {
-                  if (password != _passwordInInputBox) {
-                    _passwordStrengthTimer?.cancel();
-                    setState(() {
-                      _passwordInInputBox = password;
-                      _passwordStrength = estimatePasswordStrength(password);
-                      _isPasswordValid =
-                          _passwordStrength >= kMildPasswordStrengthThreshold;
-                      _passwordsMatch =
-                          _passwordInInputBox ==
-                          _passwordInInputConfirmationBox;
-                      _showPasswordStrength = false;
-                    });
-                    _passwordStrengthTimer = Timer(
-                      const Duration(seconds: 1),
-                      () {
-                        if (mounted) {
-                          setState(() {
-                            _showPasswordStrength = true;
-                          });
-                        }
-                      },
-                    );
-                  }
-                },
-              ),
-              const SizedBox(height: 16),
-              TextInputWidgetV2(
-                label: AppLocalizations.of(context).confirmPassword,
-                hintText: AppLocalizations.of(context).confirmPassword,
-                textEditingController: _passwordController2,
-                isPasswordInput: true,
-                isRequired: true,
-                autoCorrect: false,
-                autofillHints: const [AutofillHints.newPassword],
-                finishAutofillContextOnEditingComplete: true,
-                message: confirmPasswordMessage,
-                messageType: confirmPasswordMessageType,
-                onChange: (confirmPassword) {
-                  setState(() {
-                    _passwordInInputConfirmationBox = confirmPassword;
-                    if (_passwordInInputBox.isNotEmpty) {
-                      _passwordsMatch =
-                          _passwordInInputBox ==
-                          _passwordInInputConfirmationBox;
-                    }
-                  });
-                },
-              ),
-              const SizedBox(height: 40),
-            ],
+    return AutofillGroup(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "Enter new password for $email account. You will be able "
+            "to use this password to login into $email account.",
+            style: TextStyles.body.copyWith(
+              color: context.componentColors.textLight,
+            ),
           ),
-        ),
+          const SizedBox(height: Spacing.xxl),
+          Visibility(
+            visible: false,
+            child: TextInputComponent(
+              autofillHints: const [AutofillHints.email],
+              autocorrect: false,
+              keyboardType: TextInputType.emailAddress,
+              initialValue: email,
+              textInputAction: TextInputAction.next,
+            ),
+          ),
+          TextInputComponent(
+            label: AppLocalizations.of(context).password,
+            hintText: AppLocalizations.of(context).password,
+            controller: _passwordController1,
+            isPasswordInput: true,
+            isRequired: true,
+            autocorrect: false,
+            autofillHints: const [AutofillHints.newPassword],
+            message: passwordMessage,
+            messageType: passwordMessageType,
+            onChanged: (password) {
+              if (password != _passwordInInputBox) {
+                _passwordStrengthTimer?.cancel();
+                setState(() {
+                  _passwordInInputBox = password;
+                  _passwordStrength = estimatePasswordStrength(password);
+                  _isPasswordValid =
+                      _passwordStrength >= kMildPasswordStrengthThreshold;
+                  _passwordsMatch =
+                      _passwordInInputBox == _passwordInInputConfirmationBox;
+                  _showPasswordStrength = false;
+                });
+                _passwordStrengthTimer = Timer(const Duration(seconds: 1), () {
+                  if (mounted) {
+                    setState(() {
+                      _showPasswordStrength = true;
+                    });
+                  }
+                });
+              }
+            },
+          ),
+          const SizedBox(height: Spacing.lg),
+          TextInputComponent(
+            label: AppLocalizations.of(context).confirmPassword,
+            hintText: AppLocalizations.of(context).confirmPassword,
+            controller: _passwordController2,
+            isPasswordInput: true,
+            isRequired: true,
+            autocorrect: false,
+            autofillHints: const [AutofillHints.newPassword],
+            finishAutofillContextOnEditingComplete: true,
+            message: confirmPasswordMessage,
+            messageType: confirmPasswordMessageType,
+            onChanged: (confirmPassword) {
+              setState(() {
+                _passwordInInputConfirmationBox = confirmPassword;
+                if (_passwordInInputBox.isNotEmpty) {
+                  _passwordsMatch =
+                      _passwordInInputBox == _passwordInInputConfirmationBox;
+                }
+              });
+            },
+          ),
+          const SizedBox(height: Spacing.xxl),
+        ],
       ),
     );
   }
 
   Future<void> _updatePassword() async {
-    final dialog = createProgressDialog(
-      context,
-      AppLocalizations.of(context).generatingEncryptionKeys,
-    );
-    await dialog.show();
+    _showProgressSheet();
     try {
       final String password = _passwordController1.text;
       final KeyAttributes attributes = widget.attributes;
@@ -281,19 +251,74 @@ class _RecoverOthersAccountState extends State<RecoverOthersAccount> {
         setKeyRequest,
         widget.sessions,
       );
-      await dialog.hide();
+      _closeProgressSheet();
       if (!mounted) return;
-      showShortToast(
-        context,
-        AppLocalizations.of(context).passwordChangedSuccessfully,
+      await showBottomSheetComponent<void>(
+        context: context,
+        builder: (_) => BottomSheetComponent(
+          title: AppLocalizations.of(context).passwordChangedSuccessfully,
+          actions: [
+            ButtonComponent(
+              label: AppLocalizations.of(context).ok,
+              dismissModalOnSuccess: true,
+              shouldShowSuccessState: false,
+              onTap: () async {},
+            ),
+          ],
+        ),
       );
       if (!mounted) return;
       Navigator.of(context).pop();
     } catch (e, s) {
       _logger.severe("Failed to recover account", e, s);
-      await dialog.hide();
+      _closeProgressSheet();
       if (!mounted) return;
-      showGenericErrorBottomSheet(context: context, error: e).ignore();
+      await showLegacyErrorSheet(context, error: e);
     }
+  }
+
+  void _showProgressSheet() {
+    _isProgressSheetOpen = true;
+    unawaited(
+      showBottomSheetComponent<void>(
+        context: context,
+        isDismissible: false,
+        enableDrag: false,
+        builder: (_) => BottomSheetComponent(
+          title: AppLocalizations.of(context).generatingEncryptionKeys,
+          showCloseButton: false,
+          content: Row(
+            children: [
+              SizedBox.square(
+                dimension: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: context.componentColors.primary,
+                ),
+              ),
+              const SizedBox(width: Spacing.md),
+              Expanded(
+                child: Text(
+                  AppLocalizations.of(context).pleaseWait,
+                  style: TextStyles.body.copyWith(
+                    color: context.componentColors.textLight,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ).whenComplete(() {
+        _isProgressSheetOpen = false;
+      }),
+    );
+  }
+
+  void _closeProgressSheet() {
+    if (!_isProgressSheetOpen || !mounted) {
+      return;
+    }
+    _isProgressSheetOpen = false;
+    Navigator.of(context).pop();
   }
 }

--- a/mobile/apps/photos/lib/emergency/select_contact_page.dart
+++ b/mobile/apps/photos/lib/emergency/select_contact_page.dart
@@ -1,7 +1,9 @@
 import 'package:email_validator/email_validator.dart';
+import "package:ente_components/ente_components.dart";
 import 'package:flutter/material.dart';
 import "package:logging/logging.dart";
 import 'package:photos/core/configuration.dart';
+import "package:photos/emergency/components/email_action_sheet.dart";
 import "package:photos/emergency/components/recovery_date_selector.dart";
 import "package:photos/emergency/emergency_service.dart";
 import "package:photos/emergency/model.dart";
@@ -11,13 +13,6 @@ import "package:photos/models/api/collection/user.dart";
 import "package:photos/services/account/user_service.dart";
 import 'package:photos/services/collections_service.dart';
 import "package:photos/services/contacts/contact_identity_resolver.dart";
-import 'package:photos/theme/ente_theme.dart';
-import "package:photos/ui/components/alert_bottom_sheet.dart";
-import "package:photos/ui/components/base_bottom_sheet.dart";
-import "package:photos/ui/components/buttons/button_widget_v2.dart";
-import "package:photos/ui/components/divider_widget.dart";
-import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
-import "package:photos/ui/components/text_input_widget_v2.dart";
 import 'package:photos/ui/sharing/user_avator_widget.dart';
 import "package:photos/ui/sharing/verify_identity_dialog.dart";
 
@@ -25,14 +20,13 @@ Future<bool?> showAddContactSheet(
   BuildContext context, {
   required EmergencyInfo emergencyInfo,
 }) {
-  return showBaseBottomSheet<bool>(
-    context,
-    title: context.l10n.addTrustedContact,
-    headerSpacing: 20,
-    padding: const EdgeInsets.all(16),
-    isKeyboardAware: true,
-    backgroundColor: getEnteColorScheme(context).backgroundColour,
-    child: AddContactSheet(emergencyInfo: emergencyInfo),
+  return showBottomSheetComponent<bool>(
+    context: context,
+    builder: (_) => BottomSheetComponent(
+      title: context.l10n.addTrustedContact,
+      isKeyboardAware: true,
+      content: AddContactSheet(emergencyInfo: emergencyInfo),
+    ),
   );
 }
 
@@ -66,8 +60,7 @@ class _AddContactSheetState extends State<AddContactSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = getEnteColorScheme(context);
-    final textTheme = getEnteTextTheme(context);
+    final colors = context.componentColors;
     final List<User> suggestedUsers = _getSuggestedUser();
     final List<String> emailsToAdd = _emailsToAdd;
     final bool canAdd = emailsToAdd.isNotEmpty;
@@ -78,16 +71,16 @@ class _AddContactSheetState extends State<AddContactSheet> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          TextInputWidgetV2(
+          TextInputComponent(
             hintText: AppLocalizations.of(context).enterEmail,
-            textEditingController: _textController,
+            controller: _textController,
             focusNode: textFieldFocusNode,
             keyboardType: TextInputType.emailAddress,
-            autoCorrect: false,
+            autocorrect: false,
             isClearable: true,
             shouldUnfocusOnClearOrSubmit: true,
             autofillHints: const [AutofillHints.email],
-            onChange: (value) {
+            onChanged: (value) {
               _email = value.trim();
               _emailIsValid = EmailValidator.validate(_email);
               setState(() {});
@@ -97,9 +90,9 @@ class _AddContactSheetState extends State<AddContactSheet> {
             const SizedBox(height: 20),
             Text(
               context.l10n.chooseFromAnExistingContact,
-              style: textTheme.bodyMuted,
+              style: TextStyles.body.copyWith(color: colors.textLight),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: Spacing.sm),
             ConstrainedBox(
               constraints: const BoxConstraints(maxHeight: 190),
               child: Scrollbar(
@@ -107,56 +100,54 @@ class _AddContactSheetState extends State<AddContactSheet> {
                 thumbVisibility: suggestedUsers.length > 2,
                 thickness: 4,
                 radius: const Radius.circular(3),
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: colorScheme.fillFaint,
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                  child: ListView.builder(
-                    controller: _scrollController,
-                    shrinkWrap: true,
-                    padding: EdgeInsets.zero,
-                    itemCount: suggestedUsers.length,
-                    itemBuilder: (context, index) {
-                      final user = suggestedUsers[index];
-                      final isSelected = _selectedEmails.contains(user.email);
-                      final isLastItem = index == suggestedUsers.length - 1;
-                      return _buildGroupedSuggestionItem(
-                        listIndex: index,
-                        isLastItem: isLastItem,
-                        child: MenuItemWidgetNew(
-                          title: resolveDisplayName(user),
-                          titleColor: colorScheme.textMuted,
-                          leadingIconWidget: UserAvatarWidget(
-                            user,
-                            type: AvatarType.medium,
-                            currentUserID: Configuration.instance.getUserID()!,
-                          ),
-                          leadingIconSize: 24,
-                          menuItemColor: Colors.transparent,
-                          trailingIcon: isSelected ? Icons.check : null,
-                          trailingIconColor: colorScheme.greenBase,
-                          onTap: () async {
-                            textFieldFocusNode.unfocus();
-                            if (isSelected) {
-                              _selectedEmails.remove(user.email);
-                            } else {
-                              _selectedEmails.add(user.email);
-                            }
-                            setState(() {});
-                          },
-                          borderRadius: 0,
-                        ),
-                      );
-                    },
+                child: SingleChildScrollView(
+                  controller: _scrollController,
+                  child: MenuGroupComponent(
+                    showDividers: true,
+                    items: suggestedUsers
+                        .map((user) {
+                          final isSelected = _selectedEmails.contains(
+                            user.email,
+                          );
+                          return MenuComponent(
+                            title: resolveDisplayName(user),
+                            titleColor: colors.textLight,
+                            leading: UserAvatarWidget(
+                              user,
+                              type: AvatarType.medium,
+                              currentUserID: Configuration.instance
+                                  .getUserID()!,
+                            ),
+                            trailing: isSelected
+                                ? Icon(
+                                    Icons.check_rounded,
+                                    color: colors.primary,
+                                    size: IconSizes.medium,
+                                  )
+                                : null,
+                            onTap: () {
+                              textFieldFocusNode.unfocus();
+                              if (isSelected) {
+                                _selectedEmails.remove(user.email);
+                              } else {
+                                _selectedEmails.add(user.email);
+                              }
+                              setState(() {});
+                            },
+                          );
+                        })
+                        .toList(growable: false),
                   ),
                 ),
               ),
             ),
           ],
-          const SizedBox(height: 20),
-          Text(context.l10n.chooseARecoveryTime, style: textTheme.bodyMuted),
-          const SizedBox(height: 12),
+          const SizedBox(height: Spacing.xl),
+          Text(
+            context.l10n.chooseARecoveryTime,
+            style: TextStyles.body.copyWith(color: colors.textLight),
+          ),
+          const SizedBox(height: Spacing.md),
           RecoveryDateSelector(
             selectedDays: _selectedRecoveryDays,
             onDaysChanged: (days) {
@@ -165,22 +156,21 @@ class _AddContactSheetState extends State<AddContactSheet> {
               });
             },
           ),
-          const SizedBox(height: 20),
-          ButtonWidgetV2(
-            buttonType: ButtonTypeV2.primary,
-            labelText: context.l10n.addTrustedContact,
+          const SizedBox(height: Spacing.xl),
+          ButtonComponent(
+            label: context.l10n.addTrustedContact,
             isDisabled: !canAdd,
             onTap: canAdd ? _onAddContactTap : null,
-            shouldSurfaceExecutionStates: false,
+            shouldShowSuccessState: false,
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: Spacing.md),
           Center(
-            child: ButtonWidgetV2(
-              buttonType: ButtonTypeV2.link,
-              buttonSize: ButtonSizeV2.small,
-              labelText: AppLocalizations.of(context).verifyIDLabel,
+            child: ButtonComponent(
+              variant: ButtonComponentVariant.link,
+              size: ButtonComponentSize.small,
+              label: AppLocalizations.of(context).verifyIDLabel,
               isDisabled: emailForVerification == null,
-              shouldSurfaceExecutionStates: false,
+              shouldShowSuccessState: false,
               onTap: emailForVerification == null
                   ? null
                   : () async {
@@ -227,8 +217,6 @@ class _AddContactSheetState extends State<AddContactSheet> {
         }
         if (success) {
           hasSuccess = true;
-        } else {
-          failures.add(email);
         }
       } catch (e) {
         _logger.severe("Failed to add contact for $email", e);
@@ -239,11 +227,10 @@ class _AddContactSheetState extends State<AddContactSheet> {
     if (hasSuccess && mounted) {
       Navigator.of(context).pop(true);
     } else if (failures.isNotEmpty && mounted) {
-      await showAlertBottomSheet(
+      await showLegacyAlertSheet(
         context,
         title: AppLocalizations.of(context).error,
         message: AppLocalizations.of(context).somethingWentWrong,
-        assetPath: "assets/warning-grey.png",
       );
     }
   }
@@ -263,17 +250,16 @@ class _AddContactSheetState extends State<AddContactSheet> {
             numOfDays: recoveryDays,
           );
 
-    return showAlertBottomSheet<bool>(
+    return showLegacyAlertSheet<bool>(
       context,
       title: l10n.warning,
       message: message,
-      assetPath: "assets/warning-grey.png",
-      buttons: [
-        ButtonWidgetV2(
-          buttonType: ButtonTypeV2.critical,
-          labelText: l10n.proceed,
+      actions: [
+        ButtonComponent(
+          variant: ButtonComponentVariant.critical,
+          label: l10n.proceed,
           onTap: () async => Navigator.of(context).pop(true),
-          shouldSurfaceExecutionStates: false,
+          shouldShowSuccessState: false,
         ),
       ],
     );
@@ -281,21 +267,15 @@ class _AddContactSheetState extends State<AddContactSheet> {
 
   Future<void> _onVerifyTap(String emailToAdd) async {
     if (!_emailsToAdd.contains(emailToAdd)) {
-      await showAlertBottomSheet(
+      await showLegacyAlertSheet(
         context,
         title: AppLocalizations.of(context).invalidEmailAddress,
         message: AppLocalizations.of(context).enterValidEmail,
-        assetPath: "assets/warning-grey.png",
       );
       return;
     }
 
-    await showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return VerifyIdentifyDialog(self: false, email: emailToAdd);
-      },
-    );
+    await showVerifyIdentitySheet(context, self: false, email: emailToAdd);
   }
 
   List<User> _getSuggestedUser() {
@@ -370,29 +350,5 @@ class _AddContactSheetState extends State<AddContactSheet> {
       return emailsToAdd.first;
     }
     return null;
-  }
-
-  Widget _buildGroupedSuggestionItem({
-    required int listIndex,
-    required bool isLastItem,
-    required Widget child,
-  }) {
-    final colorScheme = getEnteColorScheme(context);
-    return Column(
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadius.vertical(
-            top: listIndex == 0 ? const Radius.circular(14) : Radius.zero,
-            bottom: isLastItem ? const Radius.circular(14) : Radius.zero,
-          ),
-          child: child,
-        ),
-        if (!isLastItem)
-          DividerWidget(
-            dividerType: DividerType.menu,
-            bgColor: colorScheme.fillFaint,
-          ),
-      ],
-    );
   }
 }


### PR DESCRIPTION
Refreshes the Photos Legacy flow with ente_components across trusted contacts and account recovery.

Before / After:
<img src="https://github.com/user-attachments/assets/681d10b3-8c85-4fef-8b1b-18faf7cba59b" alt="Legacy before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/348424c6-2cbb-4ef7-814a-1fc0c530ecf0" alt="Legacy after" width="300" height="650">

Tested with Flutter analyze and on the Android emulator.