### PR TITLE
[mob][auth] Add multi-account support with profile switching

### DIFF
--- a/mobile/apps/auth/lib/core/app_wide_preferences.dart
+++ b/mobile/apps/auth/lib/core/app_wide_preferences.dart
@@ -1,0 +1,47 @@
+import 'package:ente_auth/services/auth_theme_preferences.dart';
+import 'package:ente_auth/services/preference_service.dart';
+
+// Preference keys that belong to the app rather than to any one account.
+//
+// They are stored unprefixed, so a logout of the pre-existing (unscoped)
+// profile would otherwise delete them along with that account's keys, silently
+// resetting the surviving profile's theme, language and backup configuration.
+// Configuration.logoutPreservedKeyPrefixes spares everything listed here.
+//
+// Add a key here whenever a new setting is app wide. Account owned settings
+// must NOT be listed: they would then survive a logout and leak into the next
+// session.
+const kAppWidePreferenceKeys = <String>[
+  // Language.
+  localePreferenceKey,
+  // Appearance. ("theme_mode" is a field inside the adaptive blob below, not a
+  // preference key of its own, so it needs no entry here.)
+  AuthThemePreferences.authThemeModeKey,
+  AuthThemePreferences.adaptiveThemePrefKey,
+  // General app preferences.
+  PreferenceService.kHasShownCoachMarkKey,
+  PreferenceService.kLocalTimeOffsetKey,
+  PreferenceService.kShouldShowLargeIconsKey,
+  PreferenceService.kShouldHideCodesKey,
+  PreferenceService.kShouldAutoFocusOnSearchBar,
+  PreferenceService.kShouldMinimizeOnCopy,
+  PreferenceService.kShouldMinimizeToTrayOnClose,
+  PreferenceService.kCompactMode,
+  PreferenceService.kAppInstallTime,
+  PreferenceService.kCodeSortKey,
+  // Local backup destination and schedule. The backup password is account
+  // scoped (Configuration.autoBackupPasswordKey) and deliberately not here.
+  kAutoBackupEnabledKey,
+  kAutoBackupPathKey,
+  kAutoBackupTreeUriKey,
+  kAutoBackupIosBookmarkKey,
+  kLastBackupDayKey,
+];
+
+const localePreferenceKey = 'locale';
+
+const kAutoBackupEnabledKey = 'isAutoBackupEnabled';
+const kAutoBackupPathKey = 'autoBackupPath';
+const kAutoBackupTreeUriKey = 'autoBackupTreeUri';
+const kAutoBackupIosBookmarkKey = 'autoBackupIosBookmark';
+const kLastBackupDayKey = 'lastBackupDay';

--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:ente_account_deletion/account_deletion.dart';
+import 'package:ente_auth/core/app_wide_preferences.dart';
 import 'package:ente_base/models/database.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_crypto_api/ente_crypto_api.dart';
@@ -83,12 +84,15 @@ class Configuration extends BaseConfiguration
   @override
   // The pre-existing profile stores its keys unprefixed, so its logout clears
   // preferences wholesale. These must survive it: other profiles' data, the
-  // profile registry, and the app wide lock screen state.
+  // profile registry, the app wide lock screen state, and every app wide
+  // setting (theme, language, local backup configuration) which is likewise
+  // stored unprefixed and would otherwise be reset for the surviving profile.
   List<String> get logoutPreservedKeyPrefixes => const [
     "acct_",
     "profiles",
     "ls_",
     "should_show_lock_screen",
+    ...kAppWidePreferenceKeys,
   ];
 
   // Only for prefixed scopes: the unprefixed profile's entries are cleared by

--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -34,8 +34,8 @@ class Configuration extends BaseConfiguration
   late FlutterSecureStorage _secureStorage;
 
   @override
-  Future<void> init(List<EnteBaseDatabase> dbs) async {
-    await super.init(dbs);
+  Future<void> init(List<EnteBaseDatabase> dbs, {String scope = ""}) async {
+    await super.init(dbs, scope: scope);
     _preferences = await SharedPreferences.getInstance();
     _secureStorage = const FlutterSecureStorage(
       iOptions: IOSOptions(
@@ -47,13 +47,27 @@ class Configuration extends BaseConfiguration
     await _initOnlineAccount();
   }
 
+  @override
+  Future<void> setScope(String scope) async {
+    if (scope == this.scope) return;
+    _authSecretKey = null;
+    _offlineAuthKey = null;
+    await super.setScope(scope);
+    await _initOfflineAccount();
+    await _initOnlineAccount();
+  }
+
   Future<void> _initOfflineAccount() async {
-    _offlineAuthKey = await _secureStorage.read(key: offlineAuthSecretKey);
+    _offlineAuthKey = await _secureStorage.read(
+      key: scopedKey(offlineAuthSecretKey),
+    );
   }
 
   Future<void> _initOnlineAccount() async {
     if (hasConfiguredAccount()) {
-      _authSecretKey = await _secureStorage.read(key: authSecretKeyKey);
+      _authSecretKey = await _secureStorage.read(
+        key: scopedKey(authSecretKeyKey),
+      );
     }
   }
 
@@ -67,6 +81,33 @@ class Configuration extends BaseConfiguration
   ];
 
   @override
+  // The pre-existing profile stores its keys unprefixed, so its logout clears
+  // preferences wholesale. These must survive it: other profiles' data, the
+  // profile registry, and the app wide lock screen state.
+  List<String> get logoutPreservedKeyPrefixes => const [
+    "acct_",
+    "profiles",
+    "ls_",
+    "should_show_lock_screen",
+  ];
+
+  // Only for prefixed scopes: the unprefixed profile's entries are cleared by
+  // logout() via resetSecureStorage(), which keeps its offline key.
+  Future<void> clearSecureStorageForScope(String scope) async {
+    if (scope.isEmpty) {
+      return;
+    }
+    final keys = {
+      ...secureStorageKeys,
+      offlineAuthSecretKey,
+      autoBackupPasswordKey,
+    };
+    for (final key in keys) {
+      await _secureStorage.delete(key: "$scope$key");
+    }
+  }
+
+  @override
   Future<void> logout({bool autoLogout = false}) async {
     _authSecretKey = null;
     await super.logout();
@@ -74,7 +115,10 @@ class Configuration extends BaseConfiguration
 
   Future<void> setAuthSecretKey(String? authSecretKey) async {
     _authSecretKey = authSecretKey;
-    await _secureStorage.write(key: authSecretKeyKey, value: authSecretKey);
+    await _secureStorage.write(
+      key: scopedKey(authSecretKeyKey),
+      value: authSecretKey,
+    );
   }
 
   Uint8List? getAuthSecretKey() {
@@ -90,32 +134,41 @@ class Configuration extends BaseConfiguration
   }
 
   bool hasOptedForOfflineMode() {
-    return _preferences.getBool(hasOptedForOfflineModeKey) ?? false;
+    return _preferences.getBool(scopedKey(hasOptedForOfflineModeKey)) ?? false;
   }
 
   Future<void> optForOfflineMode() async {
-    if ((await _secureStorage.containsKey(key: offlineAuthSecretKey))) {
-      _offlineAuthKey = await _secureStorage.read(key: offlineAuthSecretKey);
+    final key = scopedKey(offlineAuthSecretKey);
+    if ((await _secureStorage.containsKey(key: key))) {
+      _offlineAuthKey = await _secureStorage.read(key: key);
     } else {
       _offlineAuthKey = CryptoUtil.bin2base64(CryptoUtil.generateKey());
-      await _secureStorage.write(
-        key: offlineAuthSecretKey,
-        value: _offlineAuthKey,
-      );
+      await _secureStorage.write(key: key, value: _offlineAuthKey);
     }
-    await _preferences.setBool(hasOptedForOfflineModeKey, true);
+    await _preferences.setBool(scopedKey(hasOptedForOfflineModeKey), true);
+  }
+
+  // Unlike logout(), which preserves the offline key, this is for a profile
+  // being removed outright.
+  Future<void> clearOfflineAccount() async {
+    _offlineAuthKey = null;
+    await _secureStorage.delete(key: scopedKey(offlineAuthSecretKey));
+    await _preferences.remove(scopedKey(hasOptedForOfflineModeKey));
   }
 
   // Backup password methods
   Future<String?> getBackupPassword() async {
-    return _secureStorage.read(key: autoBackupPasswordKey);
+    return _secureStorage.read(key: scopedKey(autoBackupPasswordKey));
   }
 
   Future<void> setBackupPassword(String password) async {
-    await _secureStorage.write(key: autoBackupPasswordKey, value: password);
+    await _secureStorage.write(
+      key: scopedKey(autoBackupPasswordKey),
+      value: password,
+    );
   }
 
   Future<void> clearBackupPassword() async {
-    await _secureStorage.delete(key: autoBackupPasswordKey);
+    await _secureStorage.delete(key: scopedKey(autoBackupPasswordKey));
   }
 }

--- a/mobile/apps/auth/lib/l10n/arb/app_en.arb
+++ b/mobile/apps/auth/lib/l10n/arb/app_en.arb
@@ -1,5 +1,22 @@
 {
   "account": "Account",
+  "accounts": "Accounts",
+  "addAccount": "Add account",
+  "maxAccountsReached": "You can be signed in to up to {count} accounts",
+  "@maxAccountsReached": {
+    "placeholders": {
+      "count": {
+        "description": "The maximum number of accounts that can be added",
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "offlineVault": "Offline vault",
+  "renameVault": "Rename vault",
+  "vaultNameHint": "Vault name",
+  "switchAccount": "Switch account",
+  "alreadySignedInToAccount": "You are already signed in to this account",
   "unlock": "Unlock",
   "recoveryKey": "Recovery key",
   "counterAppBarTitle": "Counter",

--- a/mobile/apps/auth/lib/locale.dart
+++ b/mobile/apps/auth/lib/locale.dart
@@ -1,3 +1,4 @@
+import 'package:ente_auth/core/app_wide_preferences.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -67,7 +68,7 @@ Locale localResolutionCallBack(
 
 Future<Locale?> getLocale({bool noFallback = false}) async {
   final String? savedValue = (await SharedPreferences.getInstance()).getString(
-    'locale',
+    localePreferenceKey,
   );
   // if savedLocale is not null and is supported by the app, return it
   if (savedValue != null) {
@@ -101,7 +102,7 @@ Future<void> setLocale(Locale locale) async {
     out.write(locale.countryCode);
   }
   await (await SharedPreferences.getInstance()).setString(
-    'locale',
+    localePreferenceKey,
     out.toString(),
   );
 }

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -15,11 +15,13 @@ import 'package:ente_auth/services/billing_service.dart';
 import 'package:ente_auth/services/local_backup_service.dart';
 import 'package:ente_auth/services/notification_service.dart';
 import 'package:ente_auth/services/preference_service.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/services/update_service.dart';
 import 'package:ente_auth/services/window_listener_service.dart';
 import 'package:ente_auth/store/authenticator_db.dart';
 import 'package:ente_auth/store/code_display_store.dart';
 import 'package:ente_auth/store/code_store.dart';
+import 'package:ente_auth/store/offline_authenticator_db.dart';
 import 'package:ente_auth/ui/home_page.dart';
 import 'package:ente_auth/ui/utils/icon_utils.dart';
 import 'package:ente_auth/utils/debug_build_flags.dart';
@@ -176,7 +178,13 @@ Future<void> _init(bool bool, {String? via}) async {
   await PreferenceService.instance.init();
   await CodeStore.instance.init();
   await CodeDisplayStore.instance.init();
-  await Configuration.instance.init([AuthenticatorDB.instance]);
+  await ProfileService.instance.init();
+  final activeScope = ProfileService.instance.activeScope;
+  await AuthenticatorDB.instance.setScope(activeScope);
+  await OfflineAuthenticatorDB.instance.setScope(activeScope);
+  await Configuration.instance.init([
+    AuthenticatorDB.instance,
+  ], scope: activeScope);
   await cleanupPickedImagesOnStartup(logger: _logger);
   await Network.instance.init(Configuration.instance);
   await UserService.instance.init(Configuration.instance, const HomePage());
@@ -189,6 +197,9 @@ Future<void> _init(bool bool, {String? via}) async {
     Configuration.instance,
     hasOptedForOfflineMode: Configuration.instance.hasOptedForOfflineMode(),
     hideAppContentDefault: true,
+    // The lock guards the app, not any one vault.
+    shouldClearAppLockOnSignOut: () =>
+        !ProfileService.instance.hasMultipleProfiles,
   );
   if (shouldAllowAuthScreenCapture) {
     await LockScreenSettings.instance.setHideAppContent(false, persist: false);

--- a/mobile/apps/auth/lib/models/profile.dart
+++ b/mobile/apps/auth/lib/models/profile.dart
@@ -1,0 +1,55 @@
+enum ProfileKind { online, offline }
+
+// A vault the user can switch to. [scope] is the prefix applied to this
+// account's preference and secure storage keys, and to its database filenames.
+// The account that predates multi-account support uses an empty scope.
+class Profile {
+  final String scope;
+  final ProfileKind kind;
+  final int? userID;
+  final String? email;
+  final String? label;
+
+  const Profile({
+    required this.scope,
+    required this.kind,
+    this.userID,
+    this.email,
+    this.label,
+  });
+
+  bool get isOffline => kind == ProfileKind.offline;
+
+  // [offlineFallback] is passed in so this stays free of l10n.
+  String displayName(String offlineFallback) {
+    final named = label?.trim();
+    if (named != null && named.isNotEmpty) return named;
+    return email ?? offlineFallback;
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'scope': scope,
+      'kind': kind.name,
+      'userID': userID,
+      'email': email,
+      'label': label,
+    };
+  }
+
+  static Profile fromMap(Map<String, dynamic> map) {
+    return Profile(
+      scope: map['scope'] as String,
+      kind: ProfileKind.values.firstWhere(
+        (k) => k.name == map['kind'],
+        orElse: () => ProfileKind.online,
+      ),
+      userID: map['userID'] as int?,
+      email: map['email'] as String?,
+      label: map['label'] as String?,
+    );
+  }
+
+  @override
+  String toString() => "Profile(scope: '$scope', kind: ${kind.name})";
+}

--- a/mobile/apps/auth/lib/onboarding/view/onboarding_page.dart
+++ b/mobile/apps/auth/lib/onboarding/view/onboarding_page.dart
@@ -11,6 +11,7 @@ import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/events/trigger_logout_event.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/locale.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/theme/colors.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/account/logout_dialog.dart';
@@ -270,6 +271,9 @@ class _OnboardingPageState extends State<OnboardingPage> {
         result?.action == ButtonAction.first) {
       if (!context.mounted) return;
       await Configuration.instance.optForOfflineMode();
+      // Or this vault can never be reached from the switcher once another
+      // account is added.
+      await ProfileService.instance.ensureActiveProfileRegistered();
       if (!mounted) return;
       unawaited(
         Navigator.of(context).pushReplacement(

--- a/mobile/apps/auth/lib/services/auth_theme_preferences.dart
+++ b/mobile/apps/auth/lib/services/auth_theme_preferences.dart
@@ -6,8 +6,8 @@ import "package:shared_preferences/shared_preferences.dart";
 class AuthThemePreferences {
   AuthThemePreferences._();
 
-  static const _authThemeModeKey = "ente_auth_theme_mode";
-  static const _adaptiveThemePrefKey = "adaptive_theme_preferences";
+  static const authThemeModeKey = "ente_auth_theme_mode";
+  static const adaptiveThemePrefKey = "adaptive_theme_preferences";
   static const _themeModeKey = "theme_mode";
 
   static Future<ThemeMode> getThemeMode() async {
@@ -30,13 +30,13 @@ class AuthThemePreferences {
 
   static Future<ThemeMode?> _getAuthThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return _authThemeModeFromIndex(prefs.getInt(_authThemeModeKey));
+    return _authThemeModeFromIndex(prefs.getInt(authThemeModeKey));
   }
 
   static Future<void> _setAuthThemeMode(ThemeMode themeMode) async {
     final prefs = await SharedPreferences.getInstance();
     // Auth owns this key, so persist Flutter's ThemeMode.index directly.
-    await prefs.setInt(_authThemeModeKey, themeMode.index);
+    await prefs.setInt(authThemeModeKey, themeMode.index);
   }
 
   static Future<ThemeMode?> _getMigratedThemeMode() async {
@@ -44,14 +44,14 @@ class AuthThemePreferences {
     // cached SharedPreferences backend depending on platform/plugin history.
     final prefs = SharedPreferencesAsync();
     return _parseAdaptiveThemeMode(
-          await prefs.getString(_adaptiveThemePrefKey),
+          await prefs.getString(adaptiveThemePrefKey),
         ) ??
         await _getLegacyAdaptiveThemeMode();
   }
 
   static Future<ThemeMode?> _getLegacyAdaptiveThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return _parseAdaptiveThemeMode(prefs.getString(_adaptiveThemePrefKey));
+    return _parseAdaptiveThemeMode(prefs.getString(adaptiveThemePrefKey));
   }
 
   static ThemeMode? _parseAdaptiveThemeMode(String? themeDataString) {

--- a/mobile/apps/auth/lib/services/authenticator_service.dart
+++ b/mobile/apps/auth/lib/services/authenticator_service.dart
@@ -35,9 +35,14 @@ class AuthenticatorService {
   late AuthenticatorGateway _gateway;
   late AuthenticatorDB _db;
   late OfflineAuthenticatorDB _offlineDb;
-  final String _lastEntitySyncTime = "lastEntitySyncTime";
+  // Scoped, so switching profiles does not carry one account's sync cursor
+  // over to another's and silently skip its entities.
+  String get _lastEntitySyncTime => _config.scopedKey("lastEntitySyncTime");
   Future<bool>? _onlineSyncInFlight;
   bool _onlineSyncRerunRequested = false;
+  bool _syncSuspended = false;
+  bool _syncRequestedWhileSuspended = false;
+  StreamSubscription<SignedInEvent>? _signedInSubscription;
 
   AuthenticatorService._privateConstructor();
 
@@ -51,6 +56,8 @@ class AuthenticatorService {
         : AccountMode.online;
   }
 
+  // Safe to call again when the active profile changes; the listener is only
+  // registered once, so switching cannot stack up duplicates.
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
     _db = AuthenticatorDB.instance;
@@ -59,7 +66,7 @@ class AuthenticatorService {
     if (Configuration.instance.hasConfiguredAccount()) {
       unawaited(onlineSync());
     }
-    Bus.instance.on<SignedInEvent>().listen((event) {
+    _signedInSubscription ??= Bus.instance.on<SignedInEvent>().listen((event) {
       unawaited(onlineSync());
     });
   }
@@ -161,7 +168,27 @@ class AuthenticatorService {
     }
   }
 
+  // Blocks new syncs and waits for the one underway to settle. A sync
+  // requested while suspended runs on resume.
+  Future<void> suspendSync() async {
+    _syncSuspended = true;
+    _syncRequestedWhileSuspended = false;
+    await _onlineSyncInFlight;
+  }
+
+  void resumeSync() {
+    _syncSuspended = false;
+    if (_syncRequestedWhileSuspended) {
+      _syncRequestedWhileSuspended = false;
+      unawaited(onlineSync());
+    }
+  }
+
   Future<bool> onlineSync() {
+    if (_syncSuspended) {
+      _syncRequestedWhileSuspended = true;
+      return Future.value(false);
+    }
     final inFlightSync = _onlineSyncInFlight;
     if (inFlightSync != null) {
       _onlineSyncRerunRequested = true;

--- a/mobile/apps/auth/lib/services/local_backup_service.dart
+++ b/mobile/apps/auth/lib/services/local_backup_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:ente_auth/core/app_wide_preferences.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/models/export/ente.dart';
 import 'package:ente_auth/store/code_store.dart';
@@ -22,8 +23,8 @@ class LocalBackupService {
   static final LocalBackupService instance = LocalBackupService._();
 
   static const int _maxBackups = 5;
-  static const _lastBackupDayKey = 'lastBackupDay';
-  static const _iosBookmarkKey = 'autoBackupIosBookmark';
+  static const _lastBackupDayKey = kLastBackupDayKey;
+  static const _iosBookmarkKey = kAutoBackupIosBookmarkKey;
 
   StreamSubscription<SignedOutEvent>? _signedOutSubscription;
 
@@ -282,11 +283,11 @@ class LocalBackupService {
   }
 
   bool _isBackupEnabled(SharedPreferences prefs) =>
-      prefs.getBool('isAutoBackupEnabled') ?? false;
+      prefs.getBool(kAutoBackupEnabledKey) ?? false;
 
   _BackupTarget? _resolveTarget(SharedPreferences prefs) {
-    final path = prefs.getString('autoBackupPath');
-    final treeUri = prefs.getString('autoBackupTreeUri');
+    final path = prefs.getString(kAutoBackupPathKey);
+    final treeUri = prefs.getString(kAutoBackupTreeUriKey);
     final iosBookmark = prefs.getString(_iosBookmarkKey);
 
     if (treeUri != null && treeUri.isNotEmpty) {

--- a/mobile/apps/auth/lib/services/local_backup_service.dart
+++ b/mobile/apps/auth/lib/services/local_backup_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -24,10 +25,16 @@ class LocalBackupService {
   static const _lastBackupDayKey = 'lastBackupDay';
   static const _iosBookmarkKey = 'autoBackupIosBookmark';
 
+  StreamSubscription<SignedOutEvent>? _signedOutSubscription;
+
+  // Safe to call again when the active profile changes; the listener is only
+  // registered once, so switching cannot stack up duplicates.
   Future<void> init({bool hasOptedForOfflineMode = false}) async {
     await _clearBackupPasswordIfFreshInstall(hasOptedForOfflineMode);
 
-    Bus.instance.on<SignedOutEvent>().listen((event) {
+    _signedOutSubscription ??= Bus.instance.on<SignedOutEvent>().listen((
+      event,
+    ) {
       _clearBackupPassword();
     });
   }

--- a/mobile/apps/auth/lib/services/preference_service.dart
+++ b/mobile/apps/auth/lib/services/preference_service.dart
@@ -28,6 +28,7 @@ class PreferenceService {
       "should_minimize_to_tray_on_close";
   static const kCompactMode = "vi.compactMode";
   static const kAppInstallTime = "appInstallTime";
+  static const kCodeSortKey = "codeSortKey";
 
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
@@ -45,12 +46,12 @@ class PreferenceService {
   }
 
   CodeSortKey codeSortKey() {
-    return CodeSortKey.values[_prefs.getInt("codeSortKey") ??
+    return CodeSortKey.values[_prefs.getInt(kCodeSortKey) ??
         CodeSortKey.issuerName.index];
   }
 
   Future<void> setCodeSortKey(CodeSortKey key) async {
-    await _prefs.setInt("codeSortKey", key.index);
+    await _prefs.setInt(kCodeSortKey, key.index);
   }
 
   Future<void> setHasShownCoachMark(bool value) {

--- a/mobile/apps/auth/lib/services/profile_service.dart
+++ b/mobile/apps/auth/lib/services/profile_service.dart
@@ -1,0 +1,425 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:ente_accounts/services/user_service.dart';
+import 'package:ente_auth/core/configuration.dart';
+import 'package:ente_auth/models/profile.dart';
+import 'package:ente_auth/services/authenticator_service.dart';
+import 'package:ente_auth/services/billing_service.dart';
+import 'package:ente_auth/services/local_backup_service.dart';
+import 'package:ente_auth/store/authenticator_db.dart';
+import 'package:ente_auth/store/offline_authenticator_db.dart';
+import 'package:ente_auth/utils/directory_utils.dart';
+import 'package:ente_configuration/base_configuration.dart';
+import 'package:ente_events/event_bus.dart';
+import 'package:ente_events/models/signed_in_event.dart';
+import 'package:ente_network/network.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// The profile list is app wide state, so it is stored under unprefixed keys.
+// Everything an account owns lives under its Profile.scope prefix.
+class ProfileService {
+  static const maxProfiles = 5;
+
+  static const _profilesKey = "profilesV1";
+  static const _activeScopeKey = "profilesActiveScope";
+  static const _nextIdKey = "profilesNextId";
+
+  final _logger = Logger((ProfileService).toString());
+
+  ProfileService._privateConstructor();
+
+  static final ProfileService instance = ProfileService._privateConstructor();
+
+  late SharedPreferences _prefs;
+  List<Profile> _profiles = const [];
+  String _activeScope = "";
+
+  String? _pendingAddReturnScope;
+  StreamSubscription<SignedInEvent>? _pendingAddSubscription;
+  StreamSubscription<SignedInEvent>? _signedInSubscription;
+  bool _rejectedDuplicateAdd = false;
+
+  bool consumeRejectedDuplicateAdd() {
+    final rejected = _rejectedDuplicateAdd;
+    _rejectedDuplicateAdd = false;
+    return rejected;
+  }
+
+  List<Profile> get profiles => List.unmodifiable(_profiles);
+
+  String get activeScope => _activeScope;
+
+  bool get hasMultipleProfiles => _profiles.length > 1;
+
+  bool get canAddProfile => _profiles.length < maxProfiles;
+
+  Profile? get activeProfile =>
+      _profiles.where((profile) => profile.scope == _activeScope).firstOrNull;
+
+  // Must run before Configuration.init(), which needs the active scope.
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    final stored = _prefs.getStringList(_profilesKey);
+    if (stored == null) {
+      await _seedFromLegacyState();
+    } else {
+      _profiles = stored
+          .map((e) => Profile.fromMap(json.decode(e) as Map<String, dynamic>))
+          .toList();
+      _activeScope = _prefs.getString(_activeScopeKey) ?? "";
+      if (_profiles.isEmpty && _hasLegacyAccountData()) {
+        _logger.warning("Unregistered legacy account found, re-seeding");
+        await _seedFromLegacyState();
+      }
+      await _reconcile();
+      if (_profiles.isNotEmpty && activeProfile == null) {
+        _logger.warning(
+          "Active scope '$_activeScope' is unknown, falling back to the first "
+          "profile",
+        );
+        _activeScope = _profiles.first.scope;
+        await _persist();
+      }
+    }
+    // Registers the account for a sign in outside the add flow, in particular
+    // the first sign in on a fresh install.
+    _signedInSubscription ??= Bus.instance.on<SignedInEvent>().listen((event) {
+      unawaited(ensureActiveProfileRegistered());
+    });
+    _logger.info(
+      "Loaded ${_profiles.length} profile(s), active '$_activeScope'",
+    );
+  }
+
+  bool _hasLegacyAccountData() {
+    return _prefs.containsKey(BaseConfiguration.tokenKey) ||
+        (_prefs.getBool(Configuration.hasOptedForOfflineModeKey) ?? false);
+  }
+
+  // Logout paths in shared packages (the lock screen's too-many-attempts
+  // logout, the revoked-session logout) clear an account's data without
+  // knowing about profiles, leaving records for vaults that can't be opened.
+  Future<void> _reconcile() async {
+    bool hasAccountData(Profile profile) {
+      final scope = profile.scope;
+      return _prefs.containsKey("$scope${BaseConfiguration.tokenKey}") ||
+          _prefs.containsKey("$scope${BaseConfiguration.encryptedTokenKey}") ||
+          (_prefs.getBool("$scope${Configuration.hasOptedForOfflineModeKey}") ??
+              false);
+    }
+
+    final dead = _profiles.where((p) => !hasAccountData(p)).toList();
+    if (dead.isEmpty) {
+      return;
+    }
+    _logger.warning("Dropping ${dead.length} profile(s) with no data: $dead");
+    _profiles = _profiles.where(hasAccountData).toList();
+    if (_profiles.isEmpty) {
+      _activeScope = "";
+    } else if (activeProfile == null) {
+      _activeScope = _profiles.first.scope;
+    }
+    await _persist();
+  }
+
+  // No-ops while an add is in flight: registering there would make commitAdd
+  // take its early return and skip the duplicate account check.
+  Future<void> ensureActiveProfileRegistered() async {
+    if (_pendingAddSubscription != null) {
+      return;
+    }
+    final config = Configuration.instance;
+    await registerProfileSnapshot(
+      scope: config.scope,
+      userID: config.getUserID(),
+      email: config.getEmail(),
+      isOnline: config.isLoggedIn(),
+    );
+  }
+
+  // isOnline must come from isLoggedIn(), not hasConfiguredAccount(): during
+  // sign up the signed in event fires before the keys exist, and the stricter
+  // check would misfile the account as an offline vault.
+  Future<void> registerProfileSnapshot({
+    required String scope,
+    int? userID,
+    String? email,
+    required bool isOnline,
+  }) async {
+    final existing = _profiles
+        .where((profile) => profile.scope == scope)
+        .firstOrNull;
+    await upsert(
+      Profile(
+        scope: scope,
+        kind: isOnline ? ProfileKind.online : ProfileKind.offline,
+        userID: userID ?? existing?.userID,
+        email: email ?? existing?.email,
+        label: existing?.label,
+      ),
+    );
+  }
+
+  // The pre-existing account keeps the empty scope, so none of its
+  // preferences, secure storage entries or database files need to move.
+  Future<void> _seedFromLegacyState() async {
+    _activeScope = "";
+    final hasToken = _prefs.containsKey(BaseConfiguration.tokenKey);
+    final hasOfflineVault =
+        _prefs.getBool(Configuration.hasOptedForOfflineModeKey) ?? false;
+    if (hasToken) {
+      _profiles = [
+        Profile(
+          scope: "",
+          kind: ProfileKind.online,
+          userID: _prefs.getInt(BaseConfiguration.userIDKey),
+          email: _prefs.getString(BaseConfiguration.emailKey),
+        ),
+      ];
+    } else if (hasOfflineVault) {
+      _profiles = [const Profile(scope: "", kind: ProfileKind.offline)];
+    } else {
+      _profiles = const [];
+    }
+    await _persist();
+    _logger.info("Seeded profiles from legacy state: $_profiles");
+  }
+
+  Future<void> _persist() async {
+    await _prefs.setStringList(
+      _profilesKey,
+      _profiles.map((profile) => json.encode(profile.toMap())).toList(),
+    );
+    await _prefs.setString(_activeScopeKey, _activeScope);
+  }
+
+  // Ids are never reused, so a removed profile's leftover keys can never be
+  // picked up by a later one.
+  Future<String> _allocateScope() async {
+    final id = (_prefs.getInt(_nextIdKey) ?? 1);
+    await _prefs.setInt(_nextIdKey, id + 1);
+    return "acct_$id.";
+  }
+
+  Profile? profileForUser(int userID) =>
+      _profiles.where((profile) => profile.userID == userID).firstOrNull;
+
+  Future<void> rename(String scope, String label) async {
+    final index = _profiles.indexWhere((profile) => profile.scope == scope);
+    if (index == -1) {
+      _logger.warning("Cannot rename unknown scope '$scope'");
+      return;
+    }
+    final trimmed = label.trim();
+    final updated = [..._profiles];
+    final existing = updated[index];
+    updated[index] = Profile(
+      scope: existing.scope,
+      kind: existing.kind,
+      userID: existing.userID,
+      email: existing.email,
+      label: trimmed.isEmpty ? null : trimmed,
+    );
+    _profiles = updated;
+    await _persist();
+  }
+
+  Future<void> upsert(Profile profile) async {
+    final index = _profiles.indexWhere((other) => other.scope == profile.scope);
+    final updated = [..._profiles];
+    if (index == -1) {
+      updated.add(profile);
+    } else {
+      updated[index] = profile;
+    }
+    _profiles = updated;
+    await _persist();
+  }
+
+  Future<void> switchTo(String scope) async {
+    if (scope == _activeScope) return;
+    _logger.info("Switching to '$scope'");
+    // Persist only once the services point at the new profile, so a failed
+    // switch does not leave the stored scope disagreeing with what is read.
+    await _applyScope(scope);
+    _activeScope = scope;
+    await _persist();
+  }
+
+  // Re-points the account scoped services at [scope]. App wide state (lock
+  // screen, theme, locale, general preferences) is deliberately left alone.
+  Future<void> _applyScope(String scope) async {
+    // Stops a sync from writing the outgoing account's entities into the
+    // incoming account's database.
+    await AuthenticatorService.instance.suspendSync();
+    try {
+      await AuthenticatorDB.instance.setScope(scope);
+      await OfflineAuthenticatorDB.instance.setScope(scope);
+      await Configuration.instance.setScope(scope);
+      // Billing plans are per account, and the endpoint may differ.
+      BillingService.instance.clearCache();
+      await Network.instance.init(Configuration.instance);
+      await AuthenticatorService.instance.init();
+      await LocalBackupService.instance.init(
+        hasOptedForOfflineMode: Configuration.instance.hasOptedForOfflineMode(),
+      );
+      // Process wide, and otherwise only written by the sign in flow, so
+      // without this it keeps showing the previous profile's email.
+      UserService.instance.emailValueNotifier.value = Configuration.instance
+          .getEmail();
+    } finally {
+      AuthenticatorService.instance.resumeSync();
+    }
+  }
+
+  // Returns the scope the sign in flow should run against. The caller must
+  // follow up with commitAdd() or abortAdd(); until then the new scope is
+  // active but unregistered, so an interrupted sign in leaves nothing behind.
+  Future<String> beginAdd() async {
+    if (!canAddProfile) {
+      throw StateError("At most $maxProfiles profiles are supported");
+    }
+    _rejectedDuplicateAdd = false;
+    final scope = await _allocateScope();
+    _logger.info("Beginning add of a profile at '$scope'");
+    _pendingAddReturnScope = _activeScope;
+    await _applyScope(scope);
+    // The sign in flow navigates on its own across several pages, so watch for
+    // it completing rather than awaiting it.
+    await _pendingAddSubscription?.cancel();
+    _pendingAddSubscription = Bus.instance.on<SignedInEvent>().listen((event) {
+      unawaited(_pendingAddSubscription?.cancel());
+      _pendingAddSubscription = null;
+      unawaited(commitAdd(scope));
+    });
+    return scope;
+  }
+
+  // Returns the profile already signed in as this user, if any, in which case
+  // nothing is added and the caller should switch to it instead.
+  Future<Profile?> commitAdd(String scope) async {
+    await _pendingAddSubscription?.cancel();
+    _pendingAddSubscription = null;
+    // Idempotent: the online path commits from the sign in listener and the
+    // offline path from the caller, and both can be live at once. A second
+    // call must not re-run the duplicate check against the profile just added.
+    if (_profiles.any((profile) => profile.scope == scope)) {
+      _pendingAddReturnScope = null;
+      if (_activeScope != scope) {
+        _activeScope = scope;
+        await _persist();
+      }
+      return null;
+    }
+    final config = Configuration.instance;
+    final userID = config.getUserID();
+    final existing = userID == null ? null : profileForUser(userID);
+    if (existing != null) {
+      _logger.info("$existing is already signed in, discarding '$scope'");
+      _rejectedDuplicateAdd = true;
+      await abortAdd(scope);
+      return existing;
+    }
+    await upsert(
+      Profile(
+        scope: scope,
+        kind: config.isLoggedIn() ? ProfileKind.online : ProfileKind.offline,
+        userID: userID,
+        email: config.getEmail(),
+      ),
+    );
+    _pendingAddReturnScope = null;
+    _activeScope = scope;
+    await _persist();
+    return null;
+  }
+
+  Future<void> abortAdd(String scope) async {
+    _logger.info("Aborting add of '$scope'");
+    await _pendingAddSubscription?.cancel();
+    _pendingAddSubscription = null;
+    final returnScope = _pendingAddReturnScope ?? "";
+    _pendingAddReturnScope = null;
+    _profiles = _profiles.where((profile) => profile.scope != scope).toList();
+    _activeScope = returnScope;
+    await _persist();
+    // Re-point everything at the surviving profile before erasing. The
+    // databases are singletons, so deleting first leaves a window where a sync
+    // or a page load reopens the file that was just removed.
+    await _applyScope(returnScope);
+    await discard(scope);
+  }
+
+  // Returns false when that was the last profile, so the caller knows to send
+  // the user back to onboarding.
+  Future<bool> removeActive() async {
+    final scope = _activeScope;
+    // From the profile record, not the configuration: a logout has usually
+    // cleared the token by now, so hasConfiguredAccount() would report every
+    // profile as an offline one.
+    if (activeProfile?.isOffline ?? false) {
+      await Configuration.instance.clearOfflineAccount();
+    }
+    _profiles = _profiles.where((profile) => profile.scope != scope).toList();
+    _activeScope = _profiles.isEmpty ? "" : _profiles.first.scope;
+    await _persist();
+    // Re-point before erasing; see the note in abortAdd.
+    await _applyScope(_activeScope);
+    await discard(scope);
+    return _profiles.isNotEmpty;
+  }
+
+  // Erases the preferences, keychain entries and database files [scope] owns.
+  // Callers must already have made a different profile active.
+  Future<void> discard(String scope) async {
+    if (_profiles.any((profile) => profile.scope == scope)) {
+      _profiles = _profiles.where((profile) => profile.scope != scope).toList();
+      await _persist();
+    }
+    if (scope.isEmpty) {
+      // Its keys carry no prefix, so there is nothing safe to match on.
+      // Configuration.logout() already clears them wholesale.
+      _logger.info("Skipping key cleanup for the legacy scope");
+      return;
+    }
+    for (final key in _prefs.getKeys().where((key) => key.startsWith(scope))) {
+      await _prefs.remove(key);
+    }
+    await Configuration.instance.clearSecureStorageForScope(scope);
+    await _deleteDatabases(scope);
+  }
+
+  Future<void> _deleteDatabases(String scope) async {
+    final names = [
+      AuthenticatorDB.databaseNameForScope(scope),
+      OfflineAuthenticatorDB.databaseNameForScope(scope),
+    ];
+    for (final name in names) {
+      try {
+        final String path;
+        if (Platform.isWindows || Platform.isLinux) {
+          path = await DirectoryUtils.getDatabasePath(name);
+        } else {
+          final directory = Platform.isMacOS
+              ? await getApplicationSupportDirectory()
+              : await getApplicationDocumentsDirectory();
+          path = p.join(directory.path, name);
+        }
+        for (final suffix in const ["", "-wal", "-shm"]) {
+          final file = File("$path$suffix");
+          if (await file.exists()) {
+            await file.delete();
+          }
+        }
+      } catch (e, s) {
+        _logger.severe("Failed to delete database $name", e, s);
+      }
+    }
+  }
+}

--- a/mobile/apps/auth/lib/store/authenticator_db.dart
+++ b/mobile/apps/auth/lib/store/authenticator_db.dart
@@ -12,7 +12,6 @@ import 'package:sqflite/sqflite.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 class AuthenticatorDB extends EnteBaseDatabase {
-  static const _databaseName = "ente.authenticator.db";
   static const _databaseVersion = 1;
 
   static const entityTable = 'entities';
@@ -21,6 +20,27 @@ class AuthenticatorDB extends EnteBaseDatabase {
   static final AuthenticatorDB instance = AuthenticatorDB._privateConstructor();
 
   static Future<Database>? _dbFuture;
+  static String _scope = "";
+
+  // The empty scope keeps the original name, so existing installs open the
+  // file they always have.
+  static String databaseNameForScope(String scope) =>
+      "ente.${scope}authenticator.db";
+
+  // Closes the open database, so the next access reopens the new scope's file.
+  Future<void> setScope(String scope) async {
+    if (_scope == scope) return;
+    await close();
+    _scope = scope;
+  }
+
+  Future<void> close() async {
+    final dbFuture = _dbFuture;
+    _dbFuture = null;
+    if (dbFuture != null) {
+      await (await dbFuture).close();
+    }
+  }
 
   Future<Database> get database async {
     _dbFuture ??= _initDatabase();
@@ -28,10 +48,11 @@ class AuthenticatorDB extends EnteBaseDatabase {
   }
 
   Future<Database> _initDatabase() async {
+    final String databaseName = databaseNameForScope(_scope);
     if (Platform.isWindows || Platform.isLinux) {
       var databaseFactory = databaseFactoryFfi;
       return await databaseFactory.openDatabase(
-        await DirectoryUtils.getDatabasePath(_databaseName),
+        await DirectoryUtils.getDatabasePath(databaseName),
         options: OpenDatabaseOptions(
           version: _databaseVersion,
           onCreate: _onCreate,
@@ -41,7 +62,7 @@ class AuthenticatorDB extends EnteBaseDatabase {
     final Directory documentsDirectory = Platform.isMacOS
         ? await getApplicationSupportDirectory()
         : await getApplicationDocumentsDirectory();
-    final String path = join(documentsDirectory.path, _databaseName);
+    final String path = join(documentsDirectory.path, databaseName);
     debugPrint(path);
     return await openDatabase(
       path,

--- a/mobile/apps/auth/lib/store/offline_authenticator_db.dart
+++ b/mobile/apps/auth/lib/store/offline_authenticator_db.dart
@@ -10,7 +10,6 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 class OfflineAuthenticatorDB {
-  static const _databaseName = "ente.offline_authenticator.db";
   static const _databaseVersion = 1;
 
   static const entityTable = 'entities';
@@ -20,6 +19,27 @@ class OfflineAuthenticatorDB {
       OfflineAuthenticatorDB._privateConstructor();
 
   static Future<Database>? _dbFuture;
+  static String _scope = "";
+
+  // The empty scope keeps the original name, so existing installs open the
+  // file they always have.
+  static String databaseNameForScope(String scope) =>
+      "ente.${scope}offline_authenticator.db";
+
+  // Closes the open database, so the next access reopens the new scope's file.
+  Future<void> setScope(String scope) async {
+    if (_scope == scope) return;
+    await close();
+    _scope = scope;
+  }
+
+  Future<void> close() async {
+    final dbFuture = _dbFuture;
+    _dbFuture = null;
+    if (dbFuture != null) {
+      await (await dbFuture).close();
+    }
+  }
 
   Future<Database> get database async {
     _dbFuture ??= _initDatabase();
@@ -27,10 +47,11 @@ class OfflineAuthenticatorDB {
   }
 
   Future<Database> _initDatabase() async {
+    final String databaseName = databaseNameForScope(_scope);
     if (Platform.isWindows || Platform.isLinux) {
       var databaseFactory = databaseFactoryFfi;
       return await databaseFactory.openDatabase(
-        await DirectoryUtils.getDatabasePath(_databaseName),
+        await DirectoryUtils.getDatabasePath(databaseName),
         options: OpenDatabaseOptions(
           version: _databaseVersion,
           onCreate: _onCreate,
@@ -40,7 +61,7 @@ class OfflineAuthenticatorDB {
     final Directory documentsDirectory = Platform.isMacOS
         ? await getApplicationSupportDirectory()
         : await getApplicationDocumentsDirectory();
-    final String path = join(documentsDirectory.path, _databaseName);
+    final String path = join(documentsDirectory.path, databaseName);
     debugPrint(path);
     return await openDatabase(
       path,

--- a/mobile/apps/auth/lib/ui/account/logout_dialog.dart
+++ b/mobile/apps/auth/lib/ui/account/logout_dialog.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/store/authenticator_db.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:flutter/material.dart';
@@ -51,8 +54,14 @@ Future<void> autoLogoutAlert(BuildContext context) async {
 }
 
 Future<void> _logout(BuildContext context, AppLocalizations l10n) async {
+  final navigator = Navigator.of(context, rootNavigator: true);
   final dialog = createProgressDialog(context, l10n.loggingOut);
   await dialog.show();
   await Configuration.instance.logout();
+  // '/' then lands on the next profile's home, or onboarding if none remain.
+  await ProfileService.instance.removeActive();
+  // Hide before navigating: the always-false predicate below would otherwise
+  // take the dialog's route with it.
   await dialog.hide();
+  unawaited(navigator.pushNamedAndRemoveUntil('/', (route) => false));
 }

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -18,8 +18,10 @@ import 'package:ente_auth/onboarding/view/setup_enter_secret_key_page.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
 import 'package:ente_auth/services/local_backup_service.dart';
 import 'package:ente_auth/services/preference_service.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/store/code_display_store.dart';
 import 'package:ente_auth/store/code_store.dart';
+import 'package:ente_auth/theme/colors.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/account/logout_dialog.dart';
 import 'package:ente_auth/ui/code_error_widget.dart';
@@ -1443,6 +1445,29 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Widget _buildTitle(EnteColorScheme colorScheme) {
+    final profileService = ProfileService.instance;
+    if (!profileService.hasMultipleProfiles) {
+      return const AuthLogoWidget(height: 18);
+    }
+    final profile = profileService.activeProfile;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const AuthLogoWidget(height: 18),
+        const SizedBox(height: 2),
+        Text(
+          profile?.displayName(context.l10n.offlineVault) ??
+              context.l10n.offlineVault,
+          style: getEnteTextTheme(
+            context,
+          ).miniMuted.copyWith(color: colorScheme.textMuted),
+          overflow: TextOverflow.ellipsis,
+        ),
+      ],
+    );
+  }
+
   PreferredSizeWidget _buildStandardAppBar(
     AppLocalizations l10n,
     bool isDesktop,
@@ -1466,7 +1491,7 @@ class _HomePageState extends State<HomePage> {
         },
       ),
       title: !_showSearchBox
-          ? const AuthLogoWidget(height: 18)
+          ? _buildTitle(colorScheme)
           : AndroidTextInputAutofocus(
               enabled: _autoFocusSearch,
               focusNode: searchBoxFocusNode,

--- a/mobile/apps/auth/lib/ui/settings/account_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/account_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:ente_accounts/pages/change_email_dialog.dart';
 import 'package:ente_accounts/pages/password_entry_page.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/ui/components/recovery_key_sheet.dart';
 import 'package:ente_auth/ui/home_page.dart';
 import 'package:ente_auth/ui/settings/components/auth_settings_item.dart';
@@ -126,10 +127,13 @@ class AccountSettingsPage extends StatelessWidget {
     final deleted = await Navigator.of(
       context,
     ).push<bool>(MaterialPageRoute(builder: (_) => const DeleteAccountPage()));
-    if (deleted == true && context.mounted) {
-      unawaited(
-        Navigator.of(context).pushNamedAndRemoveUntil('/', (_) => false),
-      );
-    }
+    if (deleted != true) return;
+    // The deletion cleared this account's data but left its profile registered,
+    // so drop it before navigating: removeActive() re-points everything at the
+    // surviving profile and erases what this scope owned. Without it '/' would
+    // evaluate against the emptied scope and show onboarding.
+    await ProfileService.instance.removeActive();
+    if (!context.mounted) return;
+    unawaited(Navigator.of(context).pushNamedAndRemoveUntil('/', (_) => false));
   }
 }

--- a/mobile/apps/auth/lib/ui/settings/account_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/account_settings_page.dart
@@ -8,7 +8,9 @@ import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/ui/components/recovery_key_sheet.dart';
 import 'package:ente_auth/ui/home_page.dart';
 import 'package:ente_auth/ui/settings/components/auth_settings_item.dart';
+import 'package:ente_auth/ui/settings/components/auth_settings_navigation.dart';
 import 'package:ente_auth/ui/settings/components/auth_settings_page_scaffold.dart';
+import 'package:ente_auth/ui/settings/profiles_settings_page.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
 import 'package:ente_components/ente_components.dart';
 import 'package:ente_crypto_api/ente_crypto_api.dart';
@@ -17,7 +19,11 @@ import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 class AccountSettingsPage extends StatelessWidget {
-  const AccountSettingsPage({super.key});
+  const AccountSettingsPage({super.key, required this.hasAccount});
+
+  // An offline vault has no account behind it, so the items below the switcher
+  // would be meaningless and reading its recovery key would throw.
+  final bool hasAccount;
 
   @override
   Widget build(BuildContext context) {
@@ -26,29 +32,39 @@ class AccountSettingsPage extends StatelessWidget {
       title: l10n.account,
       children: [
         AuthSettingsItem(
-          title: l10n.changeEmail,
-          icon: HugeIcons.strokeRoundedMailEdit01,
-          onTap: () => _changeEmail(context),
+          title: l10n.switchAccount,
+          icon: HugeIcons.strokeRoundedUserSwitch,
+          semanticsIdentifier: 'auth_settings_switch_account',
+          onTap: () =>
+              pushAuthSettingsPage(context, const ProfilesSettingsPage()),
         ),
-        const SizedBox(height: Spacing.sm),
-        AuthSettingsItem(
-          title: l10n.changePassword,
-          icon: HugeIcons.strokeRoundedLockPassword,
-          onTap: () => _changePassword(context),
-        ),
-        const SizedBox(height: Spacing.sm),
-        AuthSettingsItem(
-          title: l10n.recoveryKey,
-          icon: HugeIcons.strokeRoundedKey01,
-          onTap: () => _showRecoveryKey(context),
-        ),
-        const SizedBox(height: Spacing.sm),
-        AuthSettingsItem(
-          title: l10n.deleteAccount,
-          icon: HugeIcons.strokeRoundedDelete02,
-          isDestructive: true,
-          onTap: () => _deleteAccount(context),
-        ),
+        if (hasAccount) ...[
+          const SizedBox(height: Spacing.sm),
+          AuthSettingsItem(
+            title: l10n.changeEmail,
+            icon: HugeIcons.strokeRoundedMailEdit01,
+            onTap: () => _changeEmail(context),
+          ),
+          const SizedBox(height: Spacing.sm),
+          AuthSettingsItem(
+            title: l10n.changePassword,
+            icon: HugeIcons.strokeRoundedLockPassword,
+            onTap: () => _changePassword(context),
+          ),
+          const SizedBox(height: Spacing.sm),
+          AuthSettingsItem(
+            title: l10n.recoveryKey,
+            icon: HugeIcons.strokeRoundedKey01,
+            onTap: () => _showRecoveryKey(context),
+          ),
+          const SizedBox(height: Spacing.sm),
+          AuthSettingsItem(
+            title: l10n.deleteAccount,
+            icon: HugeIcons.strokeRoundedDelete02,
+            isDestructive: true,
+            onTap: () => _deleteAccount(context),
+          ),
+        ],
       ],
     );
   }

--- a/mobile/apps/auth/lib/ui/settings/data/local_backup/local_backup_experience.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/local_backup/local_backup_experience.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ente_auth/core/app_wide_preferences.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/services/local_backup_service.dart';
@@ -72,8 +73,8 @@ class LocalBackupExperienceController {
 
 class _LocalBackupExperienceState extends State<LocalBackupExperience> {
   static const _locationConfiguredKey = 'hasConfiguredBackupLocation';
-  static const _treeUriKey = 'autoBackupTreeUri';
-  static const _iosBookmarkKey = 'autoBackupIosBookmark';
+  static const _treeUriKey = kAutoBackupTreeUriKey;
+  static const _iosBookmarkKey = kAutoBackupIosBookmarkKey;
   final _logger = Logger('LocalBackupExperience');
 
   bool _isBackupEnabled = false;
@@ -100,11 +101,11 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
 
   Future<void> _loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
-    final storedPath = prefs.getString('autoBackupPath');
+    final storedPath = prefs.getString(kAutoBackupPathKey);
     final storedTreeUri = prefs.getString(_treeUriKey);
     if (!mounted) return;
     setState(() {
-      _isBackupEnabled = prefs.getBool('isAutoBackupEnabled') ?? false;
+      _isBackupEnabled = prefs.getBool(kAutoBackupEnabledKey) ?? false;
       _backupPath = storedPath;
       _backupTreeUri = storedTreeUri;
       _hasLoaded = true;
@@ -120,7 +121,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
         }
       } else {
         final prefs = await SharedPreferences.getInstance();
-        await prefs.setBool('isAutoBackupEnabled', false);
+        await prefs.setBool(kAutoBackupEnabledKey, false);
         if (!mounted) return;
         setState(() {
           _isBackupEnabled = false;
@@ -149,7 +150,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
     }
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('isAutoBackupEnabled', true);
+    await prefs.setBool(kAutoBackupEnabledKey, true);
     if (!mounted) return false;
     setState(() {
       _isBackupEnabled = true;
@@ -193,7 +194,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
             _showSnackBar(context.l10n.selectFolderToContinue);
           }
           // Clear the path and prompt user to re-select
-          await prefs.remove('autoBackupPath');
+          await prefs.remove(kAutoBackupPathKey);
           if (mounted) {
             setState(() {
               _backupPath = null;
@@ -401,7 +402,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
       return false;
     }
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('autoBackupPath');
+    await prefs.remove(kAutoBackupPathKey);
     await prefs.remove(_treeUriKey);
     await prefs.remove(_iosBookmarkKey);
     await prefs.remove(_locationConfiguredKey);
@@ -821,7 +822,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
         await dirUtils.stopAccess(pickedDir);
       }
 
-      await prefs.setString('autoBackupPath', path);
+      await prefs.setString(kAutoBackupPathKey, path);
       await prefs.setString(_iosBookmarkKey, bookmark);
       await prefs.remove(_treeUriKey);
       await prefs.setBool(_locationConfiguredKey, true);
@@ -860,7 +861,7 @@ class _LocalBackupExperienceState extends State<LocalBackupExperience> {
         } else {
           // Non-iOS: just save the path directly
           await Directory(target).create(recursive: true);
-          await prefs.setString('autoBackupPath', target);
+          await prefs.setString(kAutoBackupPathKey, target);
           await prefs.remove(_treeUriKey);
           await prefs.setBool(_locationConfiguredKey, true);
           if (!mounted) return false;

--- a/mobile/apps/auth/lib/ui/settings/profiles_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/profiles_settings_page.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:ente_auth/core/configuration.dart';
+import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/models/profile.dart';
+import 'package:ente_auth/onboarding/view/onboarding_page.dart';
+import 'package:ente_auth/services/profile_service.dart';
+import 'package:ente_auth/theme/ente_theme.dart';
+import 'package:ente_auth/ui/home_page.dart';
+import 'package:ente_auth/ui/settings/components/auth_settings_item.dart';
+import 'package:ente_auth/ui/settings/components/auth_settings_page_scaffold.dart';
+import 'package:ente_auth/utils/dialog_util.dart';
+import 'package:ente_components/ente_components.dart';
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:logging/logging.dart';
+
+class ProfilesSettingsPage extends StatefulWidget {
+  const ProfilesSettingsPage({super.key});
+
+  @override
+  State<ProfilesSettingsPage> createState() => _ProfilesSettingsPageState();
+}
+
+class _ProfilesSettingsPageState extends State<ProfilesSettingsPage> {
+  final _logger = Logger('ProfilesSettingsPage');
+  bool _isBusy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final service = ProfileService.instance;
+    final contents = <Widget>[];
+
+    for (final profile in service.profiles) {
+      final isActive = profile.scope == service.activeScope;
+      contents.addAll([
+        AuthSettingsItem(
+          title: profile.displayName(l10n.offlineVault),
+          icon: profile.isOffline
+              ? HugeIcons.strokeRoundedCloudOff
+              : HugeIcons.strokeRoundedUser,
+          showChevron: false,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isActive)
+                Icon(
+                  Icons.check,
+                  color: context.componentColors.primary,
+                  size: IconSizes.medium,
+                ),
+              // Offline vaults have no email to tell them apart.
+              if (profile.isOffline)
+                IconButton(
+                  icon: const HugeIcon(icon: HugeIcons.strokeRoundedEdit02),
+                  iconSize: IconSizes.small,
+                  tooltip: l10n.renameVault,
+                  onPressed: _isBusy ? null : () => _rename(profile),
+                ),
+            ],
+          ),
+          onTap: isActive ? null : () => _switchTo(profile),
+        ),
+        const SizedBox(height: Spacing.sm),
+      ]);
+    }
+
+    final canAdd = service.canAddProfile;
+    contents.addAll([
+      const SizedBox(height: Spacing.md),
+      AuthSettingsItem(
+        title: l10n.addAccount,
+        icon: HugeIcons.strokeRoundedUserAdd01,
+        semanticsIdentifier: 'auth_settings_add_account',
+        // A null onTap is what marks the row disabled.
+        showChevron: canAdd,
+        onTap: (canAdd && !_isBusy) ? _addAccount : null,
+      ),
+      if (!canAdd) ...[
+        const SizedBox(height: Spacing.sm),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Spacing.md),
+          child: Text(
+            l10n.maxAccountsReached(ProfileService.maxProfiles),
+            style: getEnteTextTheme(context).miniMuted,
+          ),
+        ),
+      ],
+    ]);
+
+    return AuthSettingsPageScaffold(title: l10n.accounts, children: contents);
+  }
+
+  Future<void> _switchTo(Profile profile) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+    final dialog = createProgressDialog(context, context.l10n.pleaseWait);
+    await dialog.show();
+    try {
+      await ProfileService.instance.switchTo(profile.scope);
+    } catch (e, s) {
+      _logger.severe("Failed to switch to $profile", e, s);
+      await dialog.hide();
+      if (mounted) {
+        setState(() => _isBusy = false);
+        await showGenericErrorDialog(context: context, error: e);
+      }
+      return;
+    }
+    await dialog.hide();
+    if (!mounted) return;
+    // Every page below holds the previous vault's codes.
+    await Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const HomePage()),
+      (route) => false,
+    );
+  }
+
+  Future<void> _rename(Profile profile) async {
+    final l10n = context.l10n;
+    await showTextInputDialog(
+      context,
+      title: l10n.renameVault,
+      submitButtonLabel: l10n.save,
+      hintText: l10n.vaultNameHint,
+      initialValue: profile.label ?? "",
+      maxLength: 50,
+      textCapitalization: TextCapitalization.words,
+      onSubmit: (String name) async {
+        await ProfileService.instance.rename(profile.scope, name);
+        if (mounted) setState(() {});
+      },
+    );
+  }
+
+  Future<void> _addAccount() async {
+    setState(() => _isBusy = true);
+    final navigator = Navigator.of(context, rootNavigator: true);
+    final service = ProfileService.instance;
+    final scope = await service.beginAdd();
+    if (!mounted) return;
+    // The sign in flow navigates to the home page itself once it completes,
+    // and ProfileService commits the new profile when it sees the sign in.
+    final signedIn = await Navigator.of(
+      context,
+    ).push<bool>(MaterialPageRoute(builder: (_) => const OnboardingPage()));
+    // Consumed before the mounted check: a successful sign in resets the
+    // navigation stack and unmounts this page, but a rejected duplicate still
+    // has to be reported.
+    if (service.consumeRejectedDuplicateAdd()) {
+      if (mounted) setState(() => _isBusy = false);
+      if (!navigator.mounted) return;
+      // The root navigator outlives this page, which the sign in flow has
+      // usually unmounted by now.
+      // ignore: use_build_context_synchronously
+      final l10n = navigator.context.l10n;
+      await showErrorDialog(
+        // ignore: use_build_context_synchronously
+        navigator.context,
+        l10n.accounts,
+        l10n.alreadySignedInToAccount,
+      );
+      if (mounted) setState(() {});
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _isBusy = false);
+    final config = Configuration.instance;
+    // An offline vault is a completed add even though nobody signed in, so it
+    // must not fall through to the abort below.
+    final wentOffline =
+        !config.hasConfiguredAccount() && config.hasOptedForOfflineMode();
+    if (signedIn == true || config.hasConfiguredAccount() || wentOffline) {
+      await service.commitAdd(scope);
+      if (wentOffline) {
+        // The offline flow only pushes over this page, unlike the sign in flow
+        // which resets the stack.
+        unawaited(navigator.pushNamedAndRemoveUntil('/', (route) => false));
+      }
+      return;
+    }
+    // The user backed out; drop the half configured scope.
+    await service.abortAdd(scope);
+    if (mounted) setState(() {});
+  }
+}

--- a/mobile/apps/auth/lib/ui/settings/profiles_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/profiles_settings_page.dart
@@ -139,7 +139,13 @@ class _ProfilesSettingsPageState extends State<ProfilesSettingsPage> {
     final navigator = Navigator.of(context, rootNavigator: true);
     final service = ProfileService.instance;
     final scope = await service.beginAdd();
-    if (!mounted) return;
+    if (!mounted) {
+      // Disposed while beginAdd() was re-pointing the databases. Nothing has
+      // signed in, so hand the scope back rather than leaving the app on a
+      // blank, unregistered vault.
+      await service.abortAdd(scope);
+      return;
+    }
     // The sign in flow navigates to the home page itself once it completes,
     // and ProfileService commits the new profile when it sees the sign in.
     final signedIn = await Navigator.of(
@@ -164,14 +170,31 @@ class _ProfilesSettingsPageState extends State<ProfilesSettingsPage> {
       if (mounted) setState(() {});
       return;
     }
-    if (!mounted) return;
-    setState(() => _isBusy = false);
+    if (mounted) setState(() => _isBusy = false);
+    // Deliberately not gated on mounted: a successful sign in unmounts this
+    // page, and skipping the decision below would leave the allocated scope
+    // neither committed nor rolled back.
+    await _finishAdd(scope, signedIn: signedIn == true, navigator: navigator);
+  }
+
+  // Commits the scope [beginAdd] allocated, or hands it back if the user never
+  // completed the sign in. The navigator is passed in because this runs after
+  // the sign in flow may have unmounted the page.
+  Future<void> _finishAdd(
+    String scope, {
+    required bool signedIn,
+    required NavigatorState navigator,
+  }) async {
+    final service = ProfileService.instance;
+    // The sign in listener inside beginAdd() may have committed already, in
+    // which case aborting here would delete the account that was just added.
+    if (service.profiles.any((profile) => profile.scope == scope)) return;
     final config = Configuration.instance;
     // An offline vault is a completed add even though nobody signed in, so it
     // must not fall through to the abort below.
     final wentOffline =
         !config.hasConfiguredAccount() && config.hasOptedForOfflineMode();
-    if (signedIn == true || config.hasConfiguredAccount() || wentOffline) {
+    if (signedIn || config.hasConfiguredAccount() || wentOffline) {
       await service.commitAdd(scope);
       if (wentOffline) {
         // The offline flow only pushes over this page, unlike the sign in flow

--- a/mobile/apps/auth/lib/ui/settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings_page.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:ente_accounts/services/user_service.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/models/profile.dart';
 import 'package:ente_auth/onboarding/view/onboarding_page.dart';
+import 'package:ente_auth/services/profile_service.dart';
 import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/settings/about_settings_page.dart';
@@ -31,6 +34,31 @@ import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+// The active profile is the source of truth, as it is for the home app bar.
+// [email] comes from a process wide notifier the sign in flow writes as soon
+// as an address is typed, so on its own it can show an address that was never
+// signed in to.
+String? settingsSubtitle({
+  required Profile? profile,
+  required String? email,
+  required bool hasLoggedIn,
+  required String offlineFallback,
+}) {
+  if (profile != null) {
+    return profile.displayName(offlineFallback);
+  }
+  return hasLoggedIn ? email : null;
+}
+
+// Any registered profile is enough. An offline-only user is not logged in but
+// still needs this row to reach the switcher and add an account.
+bool showAccountSection({
+  required bool hasLoggedIn,
+  required int profileCount,
+}) {
+  return hasLoggedIn || profileCount > 0;
+}
+
 class SettingsPage extends StatelessWidget {
   const SettingsPage({
     super.key,
@@ -52,7 +80,12 @@ class SettingsPage extends StatelessWidget {
       builder: (context, email, _) => _buildSettings(
         context,
         hasLoggedIn: hasLoggedIn,
-        email: hasLoggedIn ? email : null,
+        email: settingsSubtitle(
+          profile: ProfileService.instance.activeProfile,
+          email: email,
+          hasLoggedIn: hasLoggedIn,
+          offlineFallback: context.l10n.offlineVault,
+        ),
       ),
     );
   }
@@ -64,18 +97,27 @@ class SettingsPage extends StatelessWidget {
   }) {
     final l10n = context.l10n;
     final contents = <Widget>[];
-    if (hasLoggedIn) {
+    final showAccount = showAccountSection(
+      hasLoggedIn: hasLoggedIn,
+      profileCount: ProfileService.instance.profiles.length,
+    );
+    if (showAccount) {
       contents.add(
         AuthSettingsItem(
           title: l10n.account,
           icon: HugeIcons.strokeRoundedUser,
           semanticsIdentifier: 'auth_settings_account',
-          onTap: () =>
-              pushAuthSettingsPage(context, const AccountSettingsPage()),
+          onTap: () => pushAuthSettingsPage(
+            context,
+            AccountSettingsPage(
+              hasAccount: Configuration.instance.hasConfiguredAccount(),
+            ),
+          ),
         ),
       );
       contents.add(const SizedBox(height: Spacing.sm));
-    } else {
+    }
+    if (!hasLoggedIn) {
       contents.add(
         BannerComponent(
           title: l10n.signInToBackup,
@@ -251,6 +293,8 @@ class SettingsPage extends StatelessWidget {
 
   Future<void> _logout(BuildContext context) {
     final l10n = context.l10n;
+    // Captured up front: the logout tears down this page and its drawer.
+    final navigator = Navigator.of(context, rootNavigator: true);
     return showChoiceActionSheet(
       context,
       title: l10n.logout,
@@ -258,7 +302,13 @@ class SettingsPage extends StatelessWidget {
       firstButtonLabel: l10n.yesLogout,
       secondButtonLabel: l10n.cancel,
       isCritical: true,
-      firstButtonOnTap: () => UserService.instance.logout(context),
+      firstButtonOnTap: () async {
+        // Navigation is ours: only once the profile record is gone does '/'
+        // resolve to the next profile's home, or to onboarding if none remain.
+        await UserService.instance.logout(context, navigate: false);
+        await ProfileService.instance.removeActive();
+        unawaited(navigator.pushNamedAndRemoveUntil('/', (route) => false));
+      },
     );
   }
 }

--- a/mobile/apps/auth/test/core/logout_preserved_keys_test.dart
+++ b/mobile/apps/auth/test/core/logout_preserved_keys_test.dart
@@ -1,0 +1,43 @@
+import 'package:ente_auth/core/configuration.dart';
+import 'package:ente_configuration/base_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('keysToClearOnLogout', () {
+    test('clears everything when no prefixes are preserved', () {
+      final keys = {"token", "email", "acct_1.token", "profilesV1"};
+
+      expect(BaseConfiguration.keysToClearOnLogout(keys, const []), keys);
+    });
+
+    test('spares preserved prefixes and clears the rest', () {
+      final keys = {
+        "token",
+        "email",
+        "endpoint",
+        "acct_1.token",
+        "acct_1.email",
+        "acct_2.has_opted_for_offline_mode",
+        "profilesV1",
+        "profilesActiveScope",
+        "profilesNextId",
+        "ls_is_app_lock_set",
+        "should_show_lock_screen",
+      };
+
+      final cleared = BaseConfiguration.keysToClearOnLogout(
+        keys,
+        Configuration.instance.logoutPreservedKeyPrefixes,
+      );
+
+      expect(cleared, {"token", "email", "endpoint"});
+    });
+  });
+
+  test('auth preserves other profiles, the registry and the app lock', () {
+    expect(
+      Configuration.instance.logoutPreservedKeyPrefixes,
+      containsAll(["acct_", "profiles", "ls_", "should_show_lock_screen"]),
+    );
+  });
+}

--- a/mobile/apps/auth/test/core/logout_preserved_keys_test.dart
+++ b/mobile/apps/auth/test/core/logout_preserved_keys_test.dart
@@ -1,3 +1,4 @@
+import 'package:ente_auth/core/app_wide_preferences.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -39,5 +40,59 @@ void main() {
       Configuration.instance.logoutPreservedKeyPrefixes,
       containsAll(["acct_", "profiles", "ls_", "should_show_lock_screen"]),
     );
+  });
+
+  group('app wide settings', () {
+    // The legacy profile's keys carry no prefix, so its logout clears by
+    // exclusion. Anything app wide left off the list is silently reset for
+    // whichever profile survives the logout.
+    test('every app wide key survives a legacy logout', () {
+      final cleared = BaseConfiguration.keysToClearOnLogout(
+        kAppWidePreferenceKeys.toSet(),
+        Configuration.instance.logoutPreservedKeyPrefixes,
+      );
+
+      expect(cleared, isEmpty);
+    });
+
+    test('covers theme, language and local backup', () {
+      // Spelled out so that renaming a constant without updating the list
+      // fails here rather than in the field.
+      expect(
+        kAppWidePreferenceKeys,
+        containsAll([
+          'locale',
+          'ente_auth_theme_mode',
+          'adaptive_theme_preferences',
+          'isAutoBackupEnabled',
+          'autoBackupPath',
+          'autoBackupTreeUri',
+          'autoBackupIosBookmark',
+          'lastBackupDay',
+          'codeSortKey',
+        ]),
+      );
+    });
+
+    test('account owned keys are still cleared', () {
+      // The mirror of the above: preserving one of these would leak the
+      // previous account's state into the next session.
+      final accountKeys = {
+        BaseConfiguration.tokenKey,
+        BaseConfiguration.encryptedTokenKey,
+        BaseConfiguration.userIDKey,
+        BaseConfiguration.emailKey,
+        BaseConfiguration.keyAttributesKey,
+        Configuration.hasOptedForOfflineModeKey,
+        Configuration.autoBackupPasswordKey,
+      };
+
+      final cleared = BaseConfiguration.keysToClearOnLogout(
+        accountKeys,
+        Configuration.instance.logoutPreservedKeyPrefixes,
+      );
+
+      expect(cleared, accountKeys);
+    });
   });
 }

--- a/mobile/apps/auth/test/core/profile_scope_test.dart
+++ b/mobile/apps/auth/test/core/profile_scope_test.dart
@@ -1,0 +1,409 @@
+import 'dart:convert';
+
+import 'package:ente_auth/core/configuration.dart';
+import 'package:ente_auth/models/profile.dart';
+import 'package:ente_auth/services/profile_service.dart';
+import 'package:ente_auth/store/authenticator_db.dart';
+import 'package:ente_auth/store/offline_authenticator_db.dart';
+import 'package:ente_configuration/base_configuration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('key scoping', () {
+    test('the legacy scope leaves keys untouched', () {
+      final config = Configuration.instance;
+
+      expect(config.scope, isEmpty);
+      expect(config.scopedKey(BaseConfiguration.tokenKey), "token");
+      expect(
+        config.scopedKey(Configuration.authSecretKeyKey),
+        "auth_secret_key",
+      );
+    });
+  });
+
+  group('database naming', () {
+    test('the legacy scope keeps the original filenames', () {
+      expect(AuthenticatorDB.databaseNameForScope(""), "ente.authenticator.db");
+      expect(
+        OfflineAuthenticatorDB.databaseNameForScope(""),
+        "ente.offline_authenticator.db",
+      );
+    });
+
+    test('each profile gets its own database files', () {
+      expect(
+        AuthenticatorDB.databaseNameForScope("acct_1."),
+        "ente.acct_1.authenticator.db",
+      );
+      expect(
+        OfflineAuthenticatorDB.databaseNameForScope("acct_1."),
+        "ente.acct_1.offline_authenticator.db",
+      );
+      expect(
+        AuthenticatorDB.databaseNameForScope("acct_1."),
+        isNot(AuthenticatorDB.databaseNameForScope("acct_2.")),
+      );
+    });
+  });
+
+  group('seeding the profile list', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    test('a fresh install starts with no profiles', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.profiles, isEmpty);
+      expect(ProfileService.instance.activeScope, isEmpty);
+      expect(ProfileService.instance.hasMultipleProfiles, isFalse);
+    });
+
+    test('an existing account becomes the legacy profile', () async {
+      SharedPreferences.setMockInitialValues({
+        BaseConfiguration.tokenKey: "a-token",
+        BaseConfiguration.userIDKey: 7,
+        BaseConfiguration.emailKey: "someone@example.org",
+      });
+
+      await ProfileService.instance.init();
+
+      final profiles = ProfileService.instance.profiles;
+      expect(profiles, hasLength(1));
+      expect(profiles.single.scope, isEmpty);
+      expect(profiles.single.kind, ProfileKind.online);
+      expect(profiles.single.userID, 7);
+      expect(profiles.single.email, "someone@example.org");
+      expect(ProfileService.instance.activeScope, isEmpty);
+    });
+
+    test('an existing offline vault becomes the legacy profile', () async {
+      SharedPreferences.setMockInitialValues({
+        Configuration.hasOptedForOfflineModeKey: true,
+      });
+
+      await ProfileService.instance.init();
+
+      final profiles = ProfileService.instance.profiles;
+      expect(profiles, hasLength(1));
+      expect(profiles.single.scope, isEmpty);
+      expect(profiles.single.kind, ProfileKind.offline);
+    });
+
+    test('an empty list with an unregistered account is healed', () async {
+      // A sign in that predates profile registration (or a registry lost to
+      // an older bug) must resurface as a profile — otherwise the account
+      // becomes unreachable the moment another one is added.
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": <String>[],
+        "profilesActiveScope": "",
+        BaseConfiguration.tokenKey: "a-token",
+        BaseConfiguration.userIDKey: 7,
+        BaseConfiguration.emailKey: "someone@example.org",
+      });
+      await ProfileService.instance.init();
+
+      final profiles = ProfileService.instance.profiles;
+      expect(profiles, hasLength(1));
+      expect(profiles.single.scope, isEmpty);
+      expect(profiles.single.kind, ProfileKind.online);
+      expect(profiles.single.userID, 7);
+    });
+
+    test('an empty list with an unregistered offline vault is healed', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": <String>[],
+        "profilesActiveScope": "",
+        Configuration.hasOptedForOfflineModeKey: true,
+      });
+      await ProfileService.instance.init();
+
+      final profiles = ProfileService.instance.profiles;
+      expect(profiles, hasLength(1));
+      expect(profiles.single.kind, ProfileKind.offline);
+    });
+
+    test('an empty list with no account data stays empty', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": <String>[],
+        "profilesActiveScope": "",
+      });
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.profiles, isEmpty);
+    });
+
+    test('an unknown active scope falls back to the first profile', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": [
+          json.encode(
+            const Profile(scope: "acct_1.", kind: ProfileKind.online).toMap(),
+          ),
+        ],
+        "profilesActiveScope": "acct_9.",
+        "acct_1.token": "a-token",
+      });
+
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.activeScope, "acct_1.");
+      expect(ProfileService.instance.activeProfile, isNotNull);
+    });
+  });
+
+  group('reconciliation', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    test('drops profiles whose account data is gone', () async {
+      // Logouts that live in shared packages (revoked session, too many
+      // unlock attempts) clear the account's data without knowing about
+      // profiles; the leftover record would be a vault that can never open.
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": [
+          json.encode(
+            const Profile(
+              scope: "acct_1.",
+              kind: ProfileKind.online,
+              userID: 1,
+            ).toMap(),
+          ),
+          json.encode(
+            const Profile(
+              scope: "acct_2.",
+              kind: ProfileKind.online,
+              userID: 2,
+            ).toMap(),
+          ),
+        ],
+        "profilesActiveScope": "acct_1.",
+        "acct_2.token": "a-token",
+      });
+
+      await ProfileService.instance.init();
+
+      final profiles = ProfileService.instance.profiles;
+      expect(profiles, hasLength(1));
+      expect(profiles.single.scope, "acct_2.");
+      expect(ProfileService.instance.activeScope, "acct_2.");
+    });
+
+    test('keeps offline vaults and encrypted-token accounts', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": [
+          json.encode(
+            const Profile(scope: "acct_1.", kind: ProfileKind.offline).toMap(),
+          ),
+          json.encode(
+            const Profile(scope: "acct_2.", kind: ProfileKind.online).toMap(),
+          ),
+        ],
+        "profilesActiveScope": "acct_1.",
+        "acct_1.${Configuration.hasOptedForOfflineModeKey}": true,
+        "acct_2.${BaseConfiguration.encryptedTokenKey}": "encrypted",
+      });
+
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.profiles, hasLength(2));
+      expect(ProfileService.instance.activeScope, "acct_1.");
+    });
+  });
+
+  group('registering the active profile', () {
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": <String>[],
+        "profilesActiveScope": "",
+      });
+      await ProfileService.instance.init();
+    });
+
+    test('creates a record for a first sign in', () async {
+      await ProfileService.instance.registerProfileSnapshot(
+        scope: "",
+        userID: 7,
+        email: "someone@example.org",
+        isOnline: true,
+      );
+
+      final profile = ProfileService.instance.profiles.single;
+      expect(profile.scope, isEmpty);
+      expect(profile.kind, ProfileKind.online);
+      expect(profile.userID, 7);
+      expect(profile.email, "someone@example.org");
+    });
+
+    test('is idempotent and preserves the label', () async {
+      await ProfileService.instance.registerProfileSnapshot(
+        scope: "acct_1.",
+        isOnline: false,
+      );
+      await ProfileService.instance.rename("acct_1.", "Work laptop");
+
+      await ProfileService.instance.registerProfileSnapshot(
+        scope: "acct_1.",
+        userID: 3,
+        email: "someone@example.org",
+        isOnline: true,
+      );
+
+      final profile = ProfileService.instance.profiles.single;
+      expect(ProfileService.instance.profiles, hasLength(1));
+      expect(profile.label, "Work laptop");
+      expect(profile.kind, ProfileKind.online);
+      expect(profile.userID, 3);
+    });
+  });
+
+  group('the profile cap', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    test('allows adding until the maximum is reached', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": List.generate(
+          ProfileService.maxProfiles - 1,
+          (i) => json.encode(
+            Profile(scope: "acct_$i.", kind: ProfileKind.online).toMap(),
+          ),
+        ),
+        "profilesActiveScope": "acct_0.",
+        for (var i = 0; i < ProfileService.maxProfiles - 1; i++)
+          "acct_$i.token": "token-$i",
+      });
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.canAddProfile, isTrue);
+    });
+
+    test('refuses to begin an add once full', () async {
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": List.generate(
+          ProfileService.maxProfiles,
+          (i) => json.encode(
+            Profile(scope: "acct_$i.", kind: ProfileKind.online).toMap(),
+          ),
+        ),
+        "profilesActiveScope": "acct_0.",
+        for (var i = 0; i < ProfileService.maxProfiles; i++)
+          "acct_$i.token": "token-$i",
+      });
+      await ProfileService.instance.init();
+
+      expect(ProfileService.instance.canAddProfile, isFalse);
+      expect(ProfileService.instance.beginAdd(), throwsStateError);
+      // The rejected attempt must not have consumed a scope or a profile slot.
+      expect(
+        ProfileService.instance.profiles,
+        hasLength(ProfileService.maxProfiles),
+      );
+    });
+  });
+
+  group('committing an add', () {
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({
+        "profilesV1": <String>[],
+        "profilesActiveScope": "",
+      });
+      await ProfileService.instance.init();
+    });
+
+    test('renaming a vault persists and can be cleared', () async {
+      await ProfileService.instance.upsert(
+        const Profile(scope: "acct_1.", kind: ProfileKind.offline),
+      );
+
+      await ProfileService.instance.rename("acct_1.", "  Work laptop  ");
+      expect(ProfileService.instance.profiles.single.label, "Work laptop");
+
+      await ProfileService.instance.rename("acct_1.", "   ");
+      expect(ProfileService.instance.profiles.single.label, isNull);
+    });
+
+    test('is idempotent for the same scope', () async {
+      // The online path commits from the sign in listener and the offline path
+      // commits from the caller. A second call must not re-run duplicate
+      // detection and discard the vault it just registered.
+      await ProfileService.instance.upsert(
+        const Profile(scope: "acct_1.", kind: ProfileKind.offline),
+      );
+
+      final result = await ProfileService.instance.commitAdd("acct_1.");
+
+      expect(result, isNull);
+      expect(ProfileService.instance.profiles, hasLength(1));
+      expect(ProfileService.instance.profiles.single.scope, "acct_1.");
+      expect(ProfileService.instance.activeScope, "acct_1.");
+    });
+  });
+
+  group('Profile', () {
+    test('survives a serialization round trip', () {
+      const profile = Profile(
+        scope: "acct_1.",
+        kind: ProfileKind.online,
+        userID: 42,
+        email: "someone@example.org",
+      );
+
+      final restored = Profile.fromMap(profile.toMap());
+
+      expect(restored.scope, profile.scope);
+      expect(restored.kind, profile.kind);
+      expect(restored.userID, profile.userID);
+      expect(restored.email, profile.email);
+    });
+
+    test('falls back through label, email, then the offline name', () {
+      const named = Profile(
+        scope: "acct_1.",
+        kind: ProfileKind.offline,
+        label: "Work laptop",
+      );
+      const online = Profile(
+        scope: "acct_2.",
+        kind: ProfileKind.online,
+        email: "someone@example.org",
+      );
+      const bare = Profile(scope: "acct_3.", kind: ProfileKind.offline);
+      const blank = Profile(
+        scope: "acct_4.",
+        kind: ProfileKind.offline,
+        label: "   ",
+      );
+
+      expect(named.displayName("Offline vault"), "Work laptop");
+      expect(online.displayName("Offline vault"), "someone@example.org");
+      expect(bare.displayName("Offline vault"), "Offline vault");
+      expect(blank.displayName("Offline vault"), "Offline vault");
+    });
+
+    test('a label survives a serialization round trip', () {
+      const profile = Profile(
+        scope: "acct_1.",
+        kind: ProfileKind.offline,
+        label: "Work laptop",
+      );
+
+      expect(Profile.fromMap(profile.toMap()).label, "Work laptop");
+    });
+
+    test('the kind survives a round trip', () {
+      const online = Profile(scope: "", kind: ProfileKind.online);
+      const offline = Profile(scope: "acct_1.", kind: ProfileKind.offline);
+
+      expect(online.isOffline, isFalse);
+      expect(offline.isOffline, isTrue);
+    });
+  });
+}

--- a/mobile/apps/auth/test/ui/settings/switch_account_tile_test.dart
+++ b/mobile/apps/auth/test/ui/settings/switch_account_tile_test.dart
@@ -1,0 +1,138 @@
+import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/services/profile_service.dart';
+import 'package:ente_auth/ui/settings/account_settings_page.dart';
+import 'package:ente_auth/ui/settings/profiles_settings_page.dart';
+import 'package:ente_components/ente_components.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({
+      "profilesV1": [
+        '{"scope":"","kind":"online","userID":1,"email":"first@example.org"}',
+      ],
+      "profilesActiveScope": "",
+      // Reconciliation drops profiles whose account data is missing, so each
+      // seeded profile needs its (scoped) token to survive init.
+      "token": "a-token",
+    });
+    await ProfileService.instance.init();
+  });
+
+  testWidgets('the account page opens the switcher', (tester) async {
+    await _pumpAccountPage(tester);
+
+    await tester.tap(find.text('Switch account'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ProfilesSettingsPage), findsOneWidget);
+  });
+
+  testWidgets('the switcher row keeps working after going back', (
+    tester,
+  ) async {
+    await _pumpAccountPage(tester);
+
+    // The original symptom was intermittency, so a single successful tap
+    // proves nothing.
+    for (var attempt = 0; attempt < 5; attempt++) {
+      await tester.tap(find.text('Switch account'));
+      await tester.pumpAndSettle();
+      expect(
+        find.byType(ProfilesSettingsPage),
+        findsOneWidget,
+        reason: 'row did not open the switcher on attempt ${attempt + 1}',
+      );
+
+      // Popped directly: the settings scaffold uses a custom back button, so
+      // tester.pageBack() cannot find one.
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pumpAndSettle();
+      expect(find.byType(ProfilesSettingsPage), findsNothing);
+    }
+  });
+
+  testWidgets('an offline vault can still reach the switcher', (tester) async {
+    // Regression: with the account actions hidden for a vault that is not
+    // signed in, the switcher must still be there — it is the only way back
+    // off an offline vault.
+    await _pumpAccountPage(tester, hasAccount: false);
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.switchAccount), findsOneWidget);
+    expect(find.text(l10n.changePassword), findsNothing);
+    expect(find.text(l10n.recoveryKey), findsNothing);
+    expect(find.text(l10n.deleteAccount), findsNothing);
+
+    await tester.tap(find.text(l10n.switchAccount));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ProfilesSettingsPage), findsOneWidget);
+  });
+
+  testWidgets('the add row is disabled once the profile cap is reached', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      "profilesV1": List.generate(
+        ProfileService.maxProfiles,
+        (i) =>
+            '{"scope":"acct_$i.","kind":"online","userID":$i,'
+            '"email":"user$i@example.org"}',
+      ),
+      "profilesActiveScope": "acct_0.",
+      for (var i = 0; i < ProfileService.maxProfiles; i++)
+        "acct_$i.token": "token-$i",
+    });
+    await ProfileService.instance.init();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ComponentTheme.lightTheme(app: ComponentApp.auth),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ProfilesSettingsPage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.addAccount), findsOneWidget);
+    expect(
+      find.text(l10n.maxAccountsReached(ProfileService.maxProfiles)),
+      findsOneWidget,
+    );
+
+    // Disabled rather than merely unstyled: tapping must not start an add.
+    final row = tester.widget<MenuComponent>(
+      find.widgetWithText(MenuComponent, l10n.addAccount),
+    );
+    expect(row.onTap, isNull);
+  });
+
+  testWidgets('the switcher row sits above the account actions', (
+    tester,
+  ) async {
+    await _pumpAccountPage(tester);
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    final switcher = tester.getTopLeft(find.text(l10n.switchAccount));
+    final changeEmail = tester.getTopLeft(find.text(l10n.changeEmail));
+
+    expect(switcher.dy, lessThan(changeEmail.dy));
+  });
+}
+
+Future<void> _pumpAccountPage(WidgetTester tester, {bool hasAccount = true}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      theme: ComponentTheme.lightTheme(app: ComponentApp.auth),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: AccountSettingsPage(hasAccount: hasAccount),
+    ),
+  );
+}

--- a/mobile/apps/auth/test/ui/settings_subtitle_test.dart
+++ b/mobile/apps/auth/test/ui/settings_subtitle_test.dart
@@ -1,0 +1,88 @@
+import 'package:ente_auth/models/profile.dart';
+import 'package:ente_auth/ui/settings_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The settings header used to read straight from UserService's process wide
+// email notifier, which showed the previous account's email after a switch.
+void main() {
+  const stale = "typed-but-never-signed-in@example.org";
+
+  test('prefers the active profile over the notifier', () {
+    final subtitle = settingsSubtitle(
+      profile: const Profile(
+        scope: "acct_1.",
+        kind: ProfileKind.online,
+        email: "active@example.org",
+      ),
+      email: stale,
+      hasLoggedIn: true,
+      offlineFallback: "Offline vault",
+    );
+
+    expect(subtitle, "active@example.org");
+  });
+
+  test('shows a named vault by its name', () {
+    final subtitle = settingsSubtitle(
+      profile: const Profile(
+        scope: "acct_2.",
+        kind: ProfileKind.offline,
+        label: "Work laptop",
+      ),
+      email: stale,
+      hasLoggedIn: false,
+      offlineFallback: "Offline vault",
+    );
+
+    expect(subtitle, "Work laptop");
+  });
+
+  test('falls back to the generic name for an unnamed offline vault', () {
+    final subtitle = settingsSubtitle(
+      profile: const Profile(scope: "acct_3.", kind: ProfileKind.offline),
+      email: stale,
+      hasLoggedIn: false,
+      offlineFallback: "Offline vault",
+    );
+
+    expect(subtitle, "Offline vault");
+  });
+
+  test('shows nothing when signed out with no profile', () {
+    final subtitle = settingsSubtitle(
+      profile: null,
+      email: stale,
+      hasLoggedIn: false,
+      offlineFallback: "Offline vault",
+    );
+
+    expect(subtitle, isNull);
+  });
+
+  test('uses the notifier only when there is no profile yet', () {
+    final subtitle = settingsSubtitle(
+      profile: null,
+      email: "someone@example.org",
+      hasLoggedIn: true,
+      offlineFallback: "Offline vault",
+    );
+
+    expect(subtitle, "someone@example.org");
+  });
+
+  group('showAccountSection', () {
+    test('shown for a lone offline vault', () {
+      // The switcher lives behind this row; without it an offline-only user
+      // could never add or reach another account.
+      expect(showAccountSection(hasLoggedIn: false, profileCount: 1), isTrue);
+    });
+
+    test('shown when signed in', () {
+      expect(showAccountSection(hasLoggedIn: true, profileCount: 0), isTrue);
+    });
+
+    test('hidden when signed out with no profiles', () {
+      expect(showAccountSection(hasLoggedIn: false, profileCount: 0), isFalse);
+    });
+  });
+}

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -219,14 +219,17 @@ class UserService {
       );
       final userDetails = UserDetails.fromMap(response.data);
       if (shouldCache) {
-        await _preferences.setString(keyUserDetails, userDetails.toJson());
+        await _preferences.setString(
+          _config.scopedKey(keyUserDetails),
+          userDetails.toJson(),
+        );
         if (userDetails.profileData != null) {
           await _preferences.setBool(
-            kIsEmailMFAEnabled,
+            _config.scopedKey(kIsEmailMFAEnabled),
             userDetails.profileData!.isEmailMFAEnabled,
           );
           await _preferences.setBool(
-            kCanDisableEmailMFA,
+            _config.scopedKey(kCanDisableEmailMFA),
             userDetails.profileData!.canDisableEmailMFA,
           );
         }
@@ -247,8 +250,9 @@ class UserService {
   }
 
   UserDetails? getCachedUserDetails() {
-    if (_preferences.containsKey(keyUserDetails)) {
-      return UserDetails.fromJson(_preferences.getString(keyUserDetails)!);
+    final key = _config.scopedKey(keyUserDetails);
+    if (_preferences.containsKey(key)) {
+      return UserDetails.fromJson(_preferences.getString(key)!);
     }
     return null;
   }
@@ -284,11 +288,16 @@ class UserService {
     }
   }
 
-  Future<void> logout(BuildContext context) async {
+  // Multi-account apps pass navigate: false and handle navigation themselves,
+  // once they know which of the remaining accounts to land on.
+  Future<void> logout(BuildContext context, {bool navigate = true}) async {
     try {
       final response = await _enteDio.post("/users/logout");
       if (response.statusCode == 200) {
-        await _logoutLocally(context.mounted ? context : null);
+        await _logoutLocally(
+          context.mounted ? context : null,
+          navigate: navigate,
+        );
       } else {
         throw Exception("Log out action failed");
       }
@@ -305,7 +314,10 @@ class UserService {
         } else {
           _logger.info("Token already invalid, proceeding with local logout");
         }
-        await _logoutLocally(context.mounted ? context : null);
+        await _logoutLocally(
+          context.mounted ? context : null,
+          navigate: navigate,
+        );
         return;
       }
 
@@ -321,9 +333,11 @@ class UserService {
     }
   }
 
-  Future<void> _logoutLocally(BuildContext? context) async {
+  Future<void> _logoutLocally(BuildContext? context, {
+    bool navigate = true,
+  }) async {
     await _config.logout();
-    if (context == null || !context.mounted) {
+    if (!navigate || context == null || !context.mounted) {
       return;
     }
     unawaited(
@@ -1154,17 +1168,20 @@ class UserService {
   }
 
   bool? canDisableEmailMFA() {
-    return _preferences.getBool(kCanDisableEmailMFA);
+    return _preferences.getBool(_config.scopedKey(kCanDisableEmailMFA));
   }
 
   bool hasEmailMFAEnabled() {
-    return _preferences.getBool(kIsEmailMFAEnabled) ?? false;
+    return _preferences.getBool(_config.scopedKey(kIsEmailMFAEnabled)) ?? false;
   }
 
   Future<void> updateEmailMFA(bool isEnabled) async {
     try {
       await _enteDio.put("/users/email-mfa", data: {"isEnabled": isEnabled});
-      await _preferences.setBool(kIsEmailMFAEnabled, isEnabled);
+      await _preferences.setBool(
+        _config.scopedKey(kIsEmailMFAEnabled),
+        isEnabled,
+      );
     } catch (e) {
       _logger.severe("Failed to update email mfa", e);
       rethrow;
@@ -1172,10 +1189,10 @@ class UserService {
   }
 
   Future<void> setRefSource(String refSource) async {
-    await _preferences.setString(kReferralSource, refSource);
+    await _preferences.setString(_config.scopedKey(kReferralSource), refSource);
   }
 
   String _getRefSource() {
-    return _preferences.getString(kReferralSource) ?? "";
+    return _preferences.getString(_config.scopedKey(kReferralSource)) ?? "";
   }
 }

--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -54,12 +54,51 @@ abstract class BaseConfiguration {
 
   String? _volatilePassword;
 
+  // Prefix applied to every account scoped preference and secure storage key.
+  // The default empty scope leaves keys unprefixed, which is how
+  // single-account apps continue to read and write their data.
+  String _scope = "";
+
   EnteAppIdentity get appIdentity;
 
   List<String> get secureStorageKeys;
 
-  Future<void> init(List<EnteBaseDatabase> dbs) async {
+  // Preference key prefixes that survive an unscoped logout. Empty by
+  // default, which wipes every preference as it always has.
+  List<String> get logoutPreservedKeyPrefixes => const [];
+
+  static Set<String> keysToClearOnLogout(
+    Set<String> keys,
+    List<String> preservedPrefixes,
+  ) {
+    if (preservedPrefixes.isEmpty) {
+      return keys;
+    }
+    return keys
+        .where((key) => !preservedPrefixes.any(key.startsWith))
+        .toSet();
+  }
+
+  String get scope => _scope;
+
+  String scopedKey(String key) => _scope.isEmpty ? key : "$_scope$key";
+
+  // Callers must tear down anything holding the previous account's data
+  // (databases, caches) before switching.
+  Future<void> setScope(String scope) async {
+    if (_scope == scope) return;
+    _logger.info("Switching scope from '$_scope' to '$scope'");
+    _scope = scope;
+    _key = null;
+    _secretKey = null;
+    _cachedToken = null;
+    _volatilePassword = null;
+    await _setupKeys();
+  }
+
+  Future<void> init(List<EnteBaseDatabase> dbs, {String scope = ""}) async {
     _databases = dbs;
+    _scope = scope;
     _tempDocumentsDirPath =
         "${p.join((await getTemporaryDirectory()).path, "temp")}${p.separator}";
     _preferences = await SharedPreferences.getInstance();
@@ -77,7 +116,7 @@ abstract class BaseConfiguration {
 
   Future<void> logout({bool autoLogout = false}) async {
     await _clearTempFolderOnLogout();
-    await _preferences.clear();
+    await _clearPreferences();
     await resetSecureStorage();
     for (final db in _databases) {
       await db.clearTable();
@@ -86,6 +125,29 @@ abstract class BaseConfiguration {
     _cachedToken = null;
     _secretKey = null;
     Bus.instance.fire(SignedOutEvent());
+  }
+
+  // With a scope only that account's keys are touched, so that other accounts
+  // and app wide preferences survive the logout.
+  Future<void> _clearPreferences() async {
+    if (_scope.isEmpty) {
+      final preserved = logoutPreservedKeyPrefixes;
+      if (preserved.isEmpty) {
+        await _preferences.clear();
+        return;
+      }
+      for (final key in keysToClearOnLogout(_preferences.getKeys(), preserved)) {
+        await _preferences.remove(key);
+      }
+      return;
+    }
+    final scopedKeys = _preferences
+        .getKeys()
+        .where((key) => key.startsWith(_scope))
+        .toList();
+    for (final key in scopedKeys) {
+      await _preferences.remove(key);
+    }
   }
 
   Future<void> _clearTempFolderOnLogout() async {
@@ -107,7 +169,7 @@ abstract class BaseConfiguration {
       'secureStorageKeys must not be empty. Apps must explicitly define which keys to clear.',
     );
     for (final key in secureStorageKeys.toSet()) {
-      await _secureStorage.delete(key: key);
+      await _secureStorage.delete(key: scopedKey(key));
     }
   }
 
@@ -296,7 +358,8 @@ abstract class BaseConfiguration {
   }
 
   String getHttpEndpoint() {
-    final savedEndpoint = _preferences.getString(endPointKey) ?? endpoint;
+    final savedEndpoint =
+        _preferences.getString(scopedKey(endPointKey)) ?? endpoint;
     if (savedEndpoint == kLegacyProductionEndpoint) {
       return kDefaultProductionEndpoint;
     }
@@ -311,12 +374,12 @@ abstract class BaseConfiguration {
   }
 
   Future<void> setHttpEndpoint(String endpoint) async {
-    await _preferences.setString(endPointKey, endpoint);
+    await _preferences.setString(scopedKey(endPointKey), endpoint);
     Bus.instance.fire(EndpointUpdatedEvent());
   }
 
   String? getToken() {
-    _cachedToken ??= _preferences.getString(tokenKey);
+    _cachedToken ??= _preferences.getString(scopedKey(tokenKey));
     return _cachedToken;
   }
 
@@ -326,40 +389,43 @@ abstract class BaseConfiguration {
 
   Future<void> setToken(String token) async {
     _cachedToken = token;
-    await _preferences.setString(tokenKey, token);
+    await _preferences.setString(scopedKey(tokenKey), token);
     Bus.instance.fire(SignedInEvent());
   }
 
   Future<void> setEncryptedToken(String encryptedToken) async {
-    await _preferences.setString(encryptedTokenKey, encryptedToken);
+    await _preferences.setString(scopedKey(encryptedTokenKey), encryptedToken);
   }
 
   String? getEncryptedToken() {
-    return _preferences.getString(encryptedTokenKey);
+    return _preferences.getString(scopedKey(encryptedTokenKey));
   }
 
   String? getEmail() {
-    return _preferences.getString(emailKey);
+    return _preferences.getString(scopedKey(emailKey));
   }
 
   Future<void> setEmail(String email) async {
-    await _preferences.setString(emailKey, email);
+    await _preferences.setString(scopedKey(emailKey), email);
   }
 
   int? getUserID() {
-    return _preferences.getInt(userIDKey);
+    return _preferences.getInt(scopedKey(userIDKey));
   }
 
   Future<void> setUserID(int userID) async {
-    await _preferences.setInt(userIDKey, userID);
+    await _preferences.setInt(scopedKey(userIDKey), userID);
   }
 
   Future<void> setKeyAttributes(KeyAttributes attributes) async {
-    await _preferences.setString(keyAttributesKey, attributes.toJson());
+    await _preferences.setString(
+      scopedKey(keyAttributesKey),
+      attributes.toJson(),
+    );
   }
 
   KeyAttributes? getKeyAttributes() {
-    final jsonValue = _preferences.getString(keyAttributesKey);
+    final jsonValue = _preferences.getString(scopedKey(keyAttributesKey));
     if (jsonValue == null) {
       return null;
     } else {
@@ -369,12 +435,12 @@ abstract class BaseConfiguration {
 
   Future<void> setKey(String key) async {
     _key = key;
-    await _secureStorage.write(key: keyKey, value: key);
+    await _secureStorage.write(key: scopedKey(keyKey), value: key);
   }
 
   Future<void> setSecretKey(String? secretKey) async {
     _secretKey = secretKey;
-    await _secureStorage.write(key: secretKeyKey, value: secretKey);
+    await _secureStorage.write(key: scopedKey(secretKeyKey), value: secretKey);
   }
 
   Uint8List? getKey() {
@@ -430,16 +496,16 @@ abstract class BaseConfiguration {
 
   Future<void> _setupKeys() async {
     try {
-      if (!_preferences.containsKey(tokenKey)) {
+      if (!_preferences.containsKey(scopedKey(tokenKey))) {
         await resetSecureStorage();
         return;
       }
-      _key = await _secureStorage.read(key: keyKey);
+      _key = await _secureStorage.read(key: scopedKey(keyKey));
       if (_key == null) {
         _logger.warning("No key found in secure storage");
         await logout(autoLogout: true);
       }
-      _secretKey = await _secureStorage.read(key: secretKeyKey);
+      _secretKey = await _secureStorage.read(key: scopedKey(secretKeyKey));
     } catch (e, s) {
       _logger.severe("Configuration init failed", e, s);
       /*
@@ -464,6 +530,7 @@ abstract class BaseConfiguration {
   Future<void> _setupFolders() async {
     final tempDirectory = io.Directory(_tempDocumentsDirPath);
     try {
+      // Unscoped: the temp folder is shared by every account.
       final currentTime = DateTime.now().microsecondsSinceEpoch;
       if (tempDirectory.existsSync() &&
           (_preferences.getInt(lastTempFolderClearTimeKey) ?? 0) <

--- a/mobile/packages/lock_screen/lib/lock_screen_settings.dart
+++ b/mobile/packages/lock_screen/lib/lock_screen_settings.dart
@@ -55,6 +55,7 @@ class LockScreenSettings {
     bool hideAppContentDefault = false,
     String appLogoAsset = 'assets/svg/app-logo.svg',
     double? appLogoHeight,
+    bool Function()? shouldClearAppLockOnSignOut,
   }) async {
     _config = config;
     _useLegacyHashFallback = useLegacyHashFallback;
@@ -73,7 +74,13 @@ class LockScreenSettings {
 
     await _clearLsDataInKeychainIfFreshInstall(hasOptedForOfflineMode);
 
+    // Lets multi-account apps keep the app wide lock while other accounts
+    // remain signed in.
     Bus.instance.on<SignedOutEvent>().listen((event) {
+      if (shouldClearAppLockOnSignOut != null &&
+          !shouldClearAppLockOnSignOut()) {
+        return;
+      }
       removePinAndPassword();
     });
   }

--- a/mobile/packages/network/lib/network.dart
+++ b/mobile/packages/network/lib/network.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -15,7 +16,13 @@ int kConnectTimeout = 15000;
 class Network {
   late Dio _dio;
   late Dio _enteDio;
+  bool _initialized = false;
+  BaseConfiguration? _configuration;
+  StreamSubscription<EndpointUpdatedEvent>? _endpointSubscription;
 
+  // Safe to call again when the active account changes. The Dio instances are
+  // created once and mutated in place, since many services capture them in
+  // final fields at construction.
   Future<void> init(BaseConfiguration configuration) async {
     final bool isMobile = Platform.isAndroid || Platform.isIOS;
     String? ua;
@@ -50,44 +57,53 @@ class Network {
     }
 
     final endpoint = configuration.getHttpEndpoint();
+    _configuration = configuration;
 
-    _dio = Dio(
-      BaseOptions(
-        connectTimeout: Duration(milliseconds: kConnectTimeout),
-        headers: {
-          HttpHeaders.userAgentHeader: isMobile
-              ? ua!
-              : Platform.operatingSystem,
-          'X-Client-Version': version,
-          'X-Client-Package': packageName,
-        },
-      ),
-    );
+    if (!_initialized) {
+      _initialized = true;
+      _dio = Dio(
+        BaseOptions(
+          connectTimeout: Duration(milliseconds: kConnectTimeout),
+          headers: {
+            HttpHeaders.userAgentHeader: isMobile
+                ? ua!
+                : Platform.operatingSystem,
+            'X-Client-Version': version,
+            'X-Client-Package': packageName,
+          },
+        ),
+      );
 
-    _enteDio = Dio(
-      BaseOptions(
-        baseUrl: endpoint,
-        connectTimeout: Duration(milliseconds: kConnectTimeout),
-        headers: {
-          if (isMobile)
-            HttpHeaders.userAgentHeader: ua!
-          else
-            HttpHeaders.userAgentHeader: Platform.operatingSystem,
-          'X-Client-Version': version,
-          'X-Client-Package': packageName,
-        },
-      ),
-    );
+      _enteDio = Dio(
+        BaseOptions(
+          baseUrl: endpoint,
+          connectTimeout: Duration(milliseconds: kConnectTimeout),
+          headers: {
+            if (isMobile)
+              HttpHeaders.userAgentHeader: ua!
+            else
+              HttpHeaders.userAgentHeader: Platform.operatingSystem,
+            'X-Client-Version': version,
+            'X-Client-Package': packageName,
+          },
+        ),
+      );
 
-    _dio.httpClientAdapter = NativeAdapter();
-    _enteDio.httpClientAdapter = NativeAdapter();
+      _dio.httpClientAdapter = NativeAdapter();
+      _enteDio.httpClientAdapter = NativeAdapter();
+    } else {
+      _enteDio.options.baseUrl = endpoint;
+    }
 
     _setupInterceptors(configuration);
 
-    Bus.instance.on<EndpointUpdatedEvent>().listen((event) {
-      final endpoint = configuration.getHttpEndpoint();
-      _enteDio.options.baseUrl = endpoint;
-      _setupInterceptors(configuration);
+    _endpointSubscription ??= Bus.instance.on<EndpointUpdatedEvent>().listen((
+      event,
+    ) {
+      final config = _configuration;
+      if (config == null) return;
+      _enteDio.options.baseUrl = config.getHttpEndpoint();
+      _setupInterceptors(config);
     });
   }
 


### PR DESCRIPTION
## Description

Lets users stay signed in to several Ente Auth vaults at once and switch between them from **Settings → Account**, up to a cap of 5. Both online accounts and offline vaults can be added, and offline vaults can be given a name (they have no email to tell them apart).

### How the isolation works

Each account owns a **scope** — a prefix applied to its preference keys, its secure storage keys, and its database filenames. `BaseConfiguration.scopedKey()` is the single place that applies it.

The account that exists before this change keeps the **empty** scope, so its preferences, keychain entries and `ente.authenticator.db` stay exactly where they are. There is no migration step, and an install that never adds a second account behaves as it does today.

`ProfileService` owns the registry (which vaults exist, which is active) and the switch itself: it suspends syncing, re-points the databases and configuration, rebuilds the per-account caches, then resumes. It also reconciles on startup, dropping records whose account data was cleared by a logout path that cannot know about profiles (the lock screen's too-many-attempts logout, the revoked-session logout).

### What stays app-wide

The lock screen, theme, locale and general preferences are deliberately shared — they guard the app, not any one vault. In particular, logging out of one account no longer removes the PIN protecting the others.

### Shared package changes

`base_configuration`, `user_service`, `network` and `lock_screen` are touched, but the changes are **no-ops for single-account apps**: the scope defaults to empty, `logoutPreservedKeyPrefixes` defaults to empty (preserving the existing wipe-everything logout), and the new `navigate:` and `shouldClearAppLockOnSignOut:` parameters default to current behavior. Photos and Locker are unaffected.

One behavioral note in `network.dart`: `init()` is now safe to call more than once. The `Dio` instances are created once and mutated in place rather than replaced, because services capture them in `final` fields at construction — replacing them would leave those services pointed at the previous account's endpoint.

## Tests

Adds coverage for key scoping and database naming, profile seeding/reconciliation, what survives an unscoped logout, the settings subtitle source of truth, and the switcher's entry point. `flutter analyze` is clean and all 103 tests in `mobile/apps/auth` pass.

## Strings

Adds 8 keys to `app_en.arb` (`accounts`, `addAccount`, `maxAccountsReached`, `offlineVault`, `renameVault`, `vaultNameHint`, `switchAccount`, `alreadySignedInToAccount`). No other locale files were touched.

---

Supersedes #11681, which was closed to drop an unrelated local build script from the branch history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)