### PR TITLE
[auth] Set tray icon tooltip on Windows

### DIFF
--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -54,7 +54,9 @@ Future<void> initSystemTray() async {
       ? 'assets/icons/auth-icon-monochrome-padded.png'
       : _linuxTrayIconPath();
   await trayManager.setIcon(path, isTemplate: true);
-  await trayManager.setToolTip('Ente Auth');
+  if (Platform.isWindows) {
+    await trayManager.setToolTip("Ente Auth");
+  }
   Menu menu = Menu(
     items: [
       MenuItem(key: 'hide_window', label: 'Hide Window'),

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -54,6 +54,7 @@ Future<void> initSystemTray() async {
       ? 'assets/icons/auth-icon-monochrome-padded.png'
       : _linuxTrayIconPath();
   await trayManager.setIcon(path, isTemplate: true);
+  await trayManager.setToolTip('ente Auth');
   Menu menu = Menu(
     items: [
       MenuItem(key: 'hide_window', label: 'Hide Window'),

--- a/mobile/apps/auth/lib/main.dart
+++ b/mobile/apps/auth/lib/main.dart
@@ -54,7 +54,7 @@ Future<void> initSystemTray() async {
       ? 'assets/icons/auth-icon-monochrome-padded.png'
       : _linuxTrayIconPath();
   await trayManager.setIcon(path, isTemplate: true);
-  await trayManager.setToolTip('ente Auth');
+  await trayManager.setToolTip('Ente Auth');
   Menu menu = Menu(
     items: [
       MenuItem(key: 'hide_window', label: 'Hide Window'),


### PR DESCRIPTION
## Description
Ref #11518

Ente Auth's system tray icon on desktop was showing garbled/unexpected text on hover. `tray_manager` copies an uninitialized native tooltip buffer on Windows when no tooltip is explicitly set via `setToolTip()`, which is why the hover text was garbage rather than a clean fallback.
initSystemTray()` sets up the icon and context menu but never calls setToolTip()`. Setting an explicit tooltip is the correct app-level fix.
