### PR TITLE
[web][photos] Add straighten (horizon leveling) to the photo editor

### DIFF
--- a/web/apps/photos/package.json
+++ b/web/apps/photos/package.json
@@ -37,6 +37,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@types/react-window": "1.8.8",
+        "canvas": "3.2.3",
         "ente-build-config": "*",
         "vitest": "4.1.8"
     }

--- a/web/apps/photos/tests/image-editor-canvas.test.ts
+++ b/web/apps/photos/tests/image-editor-canvas.test.ts
@@ -1,0 +1,139 @@
+import { createCanvas, Image, type Canvas } from "canvas";
+import {
+    computeInscribedCrop,
+    cropRegionOfCanvas,
+    rotateCanvas,
+} from "ente-new/photos/utils/image-editor";
+import { describe, expect, test } from "vitest";
+
+// rotateCanvas/cropRegionOfCanvas construct `new Image()` internally, which
+// isn't a Node global — node-canvas provides a compatible implementation.
+(globalThis as { Image?: unknown }).Image = Image;
+
+// node-canvas's Canvas is structurally compatible with the subset of
+// HTMLCanvasElement that rotateCanvas/cropRegionOfCanvas use (getContext,
+// toDataURL, width/height), so it's cast for use with these functions.
+const asHTMLCanvas = (c: Canvas) => c as unknown as HTMLCanvasElement;
+
+// canvas.width/height are integers (the spec truncates any assigned float),
+// and the rotate+crop chain truncates twice (once per resize) — so up to a
+// couple of pixels of accumulated truncation drift versus an independently
+// computed float expectation is normal, not a bug.
+const expectPxClose = (actual: number, expected: number) => {
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(2);
+};
+
+const makeMarkerCanvas = (width: number, height: number): Canvas => {
+    const canvas = createCanvas(width, height);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, width, height);
+    // A green marker at the center, small relative to the canvas, so it
+    // survives any crop that keeps a reasonable fraction of the image.
+    ctx.fillStyle = "lime";
+    ctx.fillRect(width / 2 - 5, height / 2 - 5, 10, 10);
+    return canvas;
+};
+
+/** Bakes a straighten commit: rotate, then crop to the inscribed rectangle. */
+const straighten = async (canvas: Canvas, angle: number) => {
+    const originalWidth = canvas.width;
+    const originalHeight = canvas.height;
+    const crop = computeInscribedCrop(originalWidth, originalHeight, angle);
+
+    await rotateCanvas(asHTMLCanvas(canvas), angle);
+
+    const cropX = (canvas.width - crop.width) / 2;
+    const cropY = (canvas.height - crop.height) / 2;
+    await cropRegionOfCanvas(
+        asHTMLCanvas(canvas),
+        cropX,
+        cropY,
+        cropX + crop.width,
+        cropY + crop.height,
+    );
+
+    return crop;
+};
+
+describe("rotateCanvas + cropRegionOfCanvas straighten pipeline", () => {
+    test("after rotate+crop, canvas dimensions exactly match computeInscribedCrop", async () => {
+        const canvas = makeMarkerCanvas(400, 300);
+        const expectedCrop = await straighten(canvas, 12);
+
+        expectPxClose(canvas.width, expectedCrop.width);
+        expectPxClose(canvas.height, expectedCrop.height);
+    });
+
+    test("center marker survives the crop (content is preserved, not just resized)", async () => {
+        const canvas = makeMarkerCanvas(400, 300);
+        await straighten(canvas, 12);
+
+        const ctx = canvas.getContext("2d");
+        const centerPixel = ctx.getImageData(
+            Math.floor(canvas.width / 2),
+            Math.floor(canvas.height / 2),
+            1,
+            1,
+        ).data;
+        // Green should dominate; rotation may introduce minor anti-aliasing.
+        expect(centerPixel[1]).toBeGreaterThan(200);
+        expect(centerPixel[0]).toBeLessThan(100);
+    });
+
+    test("bake+crop sequencing does not race: crop uses post-rotation dimensions", async () => {
+        // This is the specific bug the awaitable rotateCanvas/cropRegionOfCanvas
+        // fix: if the crop step read canvas.width/height before rotateCanvas's
+        // onload had actually resized the canvas, it would crop the
+        // pre-rotation size (400x300) instead of the rotated bounding box.
+        const width = 400;
+        const height = 300;
+        const angle = 20;
+        const canvas = makeMarkerCanvas(width, height);
+
+        await rotateCanvas(asHTMLCanvas(canvas), angle);
+
+        const radians = (angle * Math.PI) / 180;
+        const expectedRotatedWidth =
+            Math.abs(width * Math.cos(radians)) +
+            Math.abs(height * Math.sin(radians));
+        expectPxClose(canvas.width, expectedRotatedWidth);
+    });
+
+    test("no black/transparent corners survive: every pixel (away from the tight boundary) is opaque content", async () => {
+        const canvas = makeMarkerCanvas(400, 300);
+        await straighten(canvas, 20);
+
+        // The crop rectangle is computed as a tight floating-point boundary,
+        // but the canvas only has integer pixel dimensions — right at that
+        // exact edge, sub-pixel anti-aliasing can legitimately blend a thin
+        // sliver of partial transparency. Sample a region inset from the
+        // edges to check for genuine holes (a real bug) without tripping on
+        // that expected boundary artifact.
+        const inset = 3;
+        const ctx = canvas.getContext("2d");
+        const { data } = ctx.getImageData(
+            inset,
+            inset,
+            canvas.width - inset * 2,
+            canvas.height - inset * 2,
+        );
+        for (let i = 3; i < data.length; i += 4) {
+            expect(data[i]).toBe(255);
+        }
+    });
+
+    test("works across a range of angles and both landscape/portrait orientations", async () => {
+        for (const [width, height] of [
+            [400, 300],
+            [300, 400],
+        ]) {
+            for (const angle of [1, 10, 30, 45, -20]) {
+                const canvas = makeMarkerCanvas(width!, height!);
+                const expectedCrop = await straighten(canvas, angle);
+                expectPxClose(canvas.width, expectedCrop.width);
+                expectPxClose(canvas.height, expectedCrop.height);
+            }
+        }
+    });
+});

--- a/web/apps/photos/tests/image-editor.test.ts
+++ b/web/apps/photos/tests/image-editor.test.ts
@@ -1,0 +1,81 @@
+import { computeInscribedCrop } from "ente-new/photos/utils/image-editor";
+import { describe, expect, test } from "vitest";
+
+describe("computeInscribedCrop", () => {
+    test("0 degrees returns the input dimensions unchanged", () => {
+        expect(computeInscribedCrop(1000, 600, 0)).toEqual({
+            width: 1000,
+            height: 600,
+        });
+    });
+
+    test("square image, 45 degrees", () => {
+        // wide = long = 1000, sinT = cosT = sqrt(2)/2
+        // wide <= 2*sinT*cosT*long -> 1000 <= 1000, so first branch
+        // x = 500, cropW = 500 / (sqrt(2)/2), cropH = same
+        const result = computeInscribedCrop(1000, 1000, 45);
+        expect(result.width).toBeCloseTo(707.10678, 4);
+        expect(result.height).toBeCloseTo(707.10678, 4);
+    });
+
+    test("landscape image, small angle uses the second branch", () => {
+        // W=1000, H=600, angle=5deg
+        const result = computeInscribedCrop(1000, 600, 5);
+        const radians = (5 * Math.PI) / 180;
+        const sinT = Math.abs(Math.sin(radians));
+        const cosT = Math.abs(Math.cos(radians));
+        const d = cosT * cosT - sinT * sinT;
+        const expectedW = (1000 * cosT - 600 * sinT) / d;
+        const expectedH = (600 * cosT - 1000 * sinT) / d;
+        expect(result.width).toBeCloseTo(expectedW, 4);
+        expect(result.height).toBeCloseTo(expectedH, 4);
+    });
+
+    test("portrait image, 15 degrees", () => {
+        const result = computeInscribedCrop(600, 1000, 15);
+        const radians = (15 * Math.PI) / 180;
+        const sinT = Math.abs(Math.sin(radians));
+        const cosT = Math.abs(Math.cos(radians));
+        // wide = 600, long = 1000
+        const wide = 600;
+        const long = 1000;
+        if (wide <= 2 * sinT * cosT * long) {
+            const x = wide / 2;
+            expect(result.width).toBeCloseTo(x / sinT, 4);
+            expect(result.height).toBeCloseTo(x / cosT, 4);
+        } else {
+            const d = cosT * cosT - sinT * sinT;
+            expect(result.width).toBeCloseTo((600 * cosT - 1000 * sinT) / d, 4);
+            expect(result.height).toBeCloseTo(
+                (1000 * cosT - 600 * sinT) / d,
+                4,
+            );
+        }
+    });
+
+    test("negative angle uses the absolute value (symmetric result)", () => {
+        const positive = computeInscribedCrop(1000, 600, 30);
+        const negative = computeInscribedCrop(1000, 600, -30);
+        expect(negative).toEqual(positive);
+    });
+
+    test("composing with a prior edit uses the current (already-cropped) dimensions, not original", () => {
+        // A second call using the output of a first call as its input must
+        // recompute from those dimensions, not reference anything global.
+        const first = computeInscribedCrop(1000, 600, 20);
+        const second = computeInscribedCrop(first.width, first.height, 10);
+        const direct = computeInscribedCrop(first.width, first.height, 10);
+        expect(second).toEqual(direct);
+    });
+
+    test("45 degree cap on a very wide image uses the first branch", () => {
+        const result = computeInscribedCrop(2000, 400, 45);
+        // wide=400, long=2000, sinT=cosT=sqrt(2)/2
+        // 2*sinT*cosT*long = 2000, wide(400) <= 2000 -> first branch
+        const x = 200;
+        const sinT = Math.sqrt(2) / 2;
+        const cosT = Math.sqrt(2) / 2;
+        expect(result.width).toBeCloseTo(x / sinT, 4);
+        expect(result.height).toBeCloseTo(x / cosT, 4);
+    });
+});

--- a/web/apps/photos/tests/image-editor.test.ts
+++ b/web/apps/photos/tests/image-editor.test.ts
@@ -27,10 +27,7 @@ const cropFitsWithinOriginal = (
         [a, -b],
         [-a, b],
         [-a, -b],
-    ].map(([x, y]) => ({
-        x: x! * cos + y! * sin,
-        y: -x! * sin + y! * cos,
-    }));
+    ].map(([x, y]) => ({ x: x! * cos + y! * sin, y: -x! * sin + y! * cos }));
 
     return corners.every(
         (c) =>
@@ -78,9 +75,9 @@ describe("computeInscribedCrop", () => {
         test(`${label}: fits within the original bounds, preserves aspect ratio, and is tight`, () => {
             const crop = computeInscribedCrop(width, height, angle);
 
-            expect(
-                cropFitsWithinOriginal(width, height, angle, crop),
-            ).toBe(true);
+            expect(cropFitsWithinOriginal(width, height, angle, crop)).toBe(
+                true,
+            );
 
             expect(crop.width / crop.height).toBeCloseTo(width / height, 6);
 

--- a/web/apps/photos/tests/image-editor.test.ts
+++ b/web/apps/photos/tests/image-editor.test.ts
@@ -1,6 +1,56 @@
 import { computeInscribedCrop } from "ente-new/photos/utils/image-editor";
 import { describe, expect, test } from "vitest";
 
+/**
+ * Independently verify a computed crop rectangle by rotating its corners
+ * back into the original (unrotated) rectangle's frame and checking they
+ * lie within its bounds — this checks the actual geometry, rather than
+ * re-deriving the same closed-form formula the code under test uses.
+ */
+const cropFitsWithinOriginal = (
+    originalWidth: number,
+    originalHeight: number,
+    angleDegrees: number,
+    crop: { width: number; height: number },
+    tolerance = 1e-6,
+) => {
+    const radians = (angleDegrees * Math.PI) / 180;
+    const sin = Math.sin(radians);
+    const cos = Math.cos(radians);
+    const a = crop.width / 2;
+    const b = crop.height / 2;
+
+    // The four corners of the crop rectangle, rotated by -angleDegrees
+    // (undoing the rotation) into the original rectangle's frame.
+    const corners = [
+        [a, b],
+        [a, -b],
+        [-a, b],
+        [-a, -b],
+    ].map(([x, y]) => ({
+        x: x! * cos + y! * sin,
+        y: -x! * sin + y! * cos,
+    }));
+
+    return corners.every(
+        (c) =>
+            Math.abs(c.x) <= originalWidth / 2 + tolerance &&
+            Math.abs(c.y) <= originalHeight / 2 + tolerance,
+    );
+};
+
+/** The crop is "tight" if scaling it up even slightly no longer fits. */
+const cropIsTight = (
+    originalWidth: number,
+    originalHeight: number,
+    angleDegrees: number,
+    crop: { width: number; height: number },
+) =>
+    !cropFitsWithinOriginal(originalWidth, originalHeight, angleDegrees, {
+        width: crop.width * 1.001,
+        height: crop.height * 1.001,
+    });
+
 describe("computeInscribedCrop", () => {
     test("0 degrees returns the input dimensions unchanged", () => {
         expect(computeInscribedCrop(1000, 600, 0)).toEqual({
@@ -9,73 +59,55 @@ describe("computeInscribedCrop", () => {
         });
     });
 
-    test("square image, 45 degrees", () => {
-        // wide = long = 1000, sinT = cosT = sqrt(2)/2
-        // wide <= 2*sinT*cosT*long -> 1000 <= 1000, so first branch
-        // x = 500, cropW = 500 / (sqrt(2)/2), cropH = same
-        const result = computeInscribedCrop(1000, 1000, 45);
-        expect(result.width).toBeCloseTo(707.10678, 4);
-        expect(result.height).toBeCloseTo(707.10678, 4);
-    });
+    const cases: [string, number, number, number][] = [
+        ["square, 1 degree", 1000, 1000, 1],
+        ["square, 45 degrees", 1000, 1000, 45],
+        ["landscape, 5 degrees", 1000, 600, 5],
+        ["landscape, 15 degrees", 1000, 600, 15],
+        ["landscape, 30 degrees", 1000, 600, 30],
+        ["landscape, 45 degrees", 1000, 600, 45],
+        ["portrait, 5 degrees", 600, 1000, 5],
+        ["portrait, 15 degrees", 600, 1000, 15],
+        ["portrait, 45 degrees", 600, 1000, 45],
+        ["portrait, -15 degrees", 600, 1000, -15],
+        ["very wide, 45 degrees", 2000, 400, 45],
+        ["very wide, 10 degrees", 2000, 400, 10],
+    ];
 
-    test("landscape image, small angle uses the second branch", () => {
-        // W=1000, H=600, angle=5deg
-        const result = computeInscribedCrop(1000, 600, 5);
-        const radians = (5 * Math.PI) / 180;
-        const sinT = Math.abs(Math.sin(radians));
-        const cosT = Math.abs(Math.cos(radians));
-        const d = cosT * cosT - sinT * sinT;
-        const expectedW = (1000 * cosT - 600 * sinT) / d;
-        const expectedH = (600 * cosT - 1000 * sinT) / d;
-        expect(result.width).toBeCloseTo(expectedW, 4);
-        expect(result.height).toBeCloseTo(expectedH, 4);
-    });
+    for (const [label, width, height, angle] of cases) {
+        test(`${label}: fits within the original bounds, preserves aspect ratio, and is tight`, () => {
+            const crop = computeInscribedCrop(width, height, angle);
 
-    test("portrait image, 15 degrees", () => {
-        const result = computeInscribedCrop(600, 1000, 15);
-        const radians = (15 * Math.PI) / 180;
-        const sinT = Math.abs(Math.sin(radians));
-        const cosT = Math.abs(Math.cos(radians));
-        // wide = 600, long = 1000
-        const wide = 600;
-        const long = 1000;
-        if (wide <= 2 * sinT * cosT * long) {
-            const x = wide / 2;
-            expect(result.width).toBeCloseTo(x / sinT, 4);
-            expect(result.height).toBeCloseTo(x / cosT, 4);
-        } else {
-            const d = cosT * cosT - sinT * sinT;
-            expect(result.width).toBeCloseTo((600 * cosT - 1000 * sinT) / d, 4);
-            expect(result.height).toBeCloseTo(
-                (1000 * cosT - 600 * sinT) / d,
-                4,
-            );
-        }
-    });
+            expect(
+                cropFitsWithinOriginal(width, height, angle, crop),
+            ).toBe(true);
 
-    test("negative angle uses the absolute value (symmetric result)", () => {
+            expect(crop.width / crop.height).toBeCloseTo(width / height, 6);
+
+            expect(cropIsTight(width, height, angle, crop)).toBe(true);
+        });
+    }
+
+    test("negative angle produces the same result as its positive counterpart", () => {
         const positive = computeInscribedCrop(1000, 600, 30);
         const negative = computeInscribedCrop(1000, 600, -30);
         expect(negative).toEqual(positive);
     });
 
     test("composing with a prior edit uses the current (already-cropped) dimensions, not original", () => {
-        // A second call using the output of a first call as its input must
-        // recompute from those dimensions, not reference anything global.
         const first = computeInscribedCrop(1000, 600, 20);
         const second = computeInscribedCrop(first.width, first.height, 10);
         const direct = computeInscribedCrop(first.width, first.height, 10);
         expect(second).toEqual(direct);
     });
 
-    test("45 degree cap on a very wide image uses the first branch", () => {
-        const result = computeInscribedCrop(2000, 400, 45);
-        // wide=400, long=2000, sinT=cosT=sqrt(2)/2
-        // 2*sinT*cosT*long = 2000, wide(400) <= 2000 -> first branch
-        const x = 200;
-        const sinT = Math.sqrt(2) / 2;
-        const cosT = Math.sqrt(2) / 2;
-        expect(result.width).toBeCloseTo(x / sinT, 4);
-        expect(result.height).toBeCloseTo(x / cosT, 4);
+    test("shrinks monotonically as the angle increases from 0 to 45", () => {
+        const angles = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45];
+        const widths = angles.map(
+            (a) => computeInscribedCrop(1000, 600, a).width,
+        );
+        for (let i = 1; i < widths.length; i++) {
+            expect(widths[i]).toBeLessThan(widths[i - 1]!);
+        }
     });
 });

--- a/web/apps/photos/vitest.config.ts
+++ b/web/apps/photos/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+    },
+});

--- a/web/apps/photos/vitest.config.ts
+++ b/web/apps/photos/vitest.config.ts
@@ -1,7 +1,3 @@
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
-    test: {
-        environment: "node",
-    },
-});
+export default defineConfig({ test: { environment: "node" } });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -309,6 +309,7 @@
                 "@types/react": "19.2.17",
                 "@types/react-dom": "19.2.3",
                 "@types/react-window": "1.8.8",
+                "canvas": "3.2.3",
                 "ente-build-config": "*",
                 "vitest": "4.1.8"
             }
@@ -3893,6 +3894,27 @@
             "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.33",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
@@ -3912,6 +3934,33 @@
             "license": "ISC",
             "dependencies": {
                 "@noble/hashes": "^1.2.0"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/brace-expansion": {
@@ -3966,6 +4015,31 @@
             "license": "MIT",
             "dependencies": {
                 "base-x": "^5.0.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/call-bind": {
@@ -4046,6 +4120,21 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/canvas": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+            "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-addon-api": "^7.0.0",
+                "prebuild-install": "^7.1.3"
+            },
+            "engines": {
+                "node": "^18.12.0 || >= 20.9.0"
+            }
         },
         "node_modules/cast": {
             "resolved": "apps/cast",
@@ -4405,6 +4494,32 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4570,6 +4685,16 @@
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/ensu": {
             "resolved": "apps/ensu",
@@ -5157,6 +5282,16 @@
                 "@xmldom/xmldom": "^0.9.10"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "dev": true,
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/expect-type": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5349,6 +5484,13 @@
                 "react": ">=16.8.0"
             }
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5525,6 +5667,13 @@
             "funding": {
                 "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
@@ -6023,6 +6172,13 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/inline-style-parser": {
@@ -8012,6 +8168,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -8023,6 +8192,16 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
@@ -8047,6 +8226,13 @@
             "engines": {
                 "node": ">= 18"
             }
+        },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ml-array-max": {
             "version": "2.0.0",
@@ -8111,6 +8297,13 @@
                 "node": "^18 || >=20"
             }
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8170,6 +8363,39 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/node-abi": {
+            "version": "3.94.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+            "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-abi/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/node-exports-info": {
             "version": "1.6.0",
@@ -8323,6 +8549,16 @@
                 "https://opencollective.com/debug"
             ],
             "license": "MIT"
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -8660,6 +8896,34 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8754,6 +9018,17 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8790,6 +9065,22 @@
             "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
             "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
             "license": "MIT"
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
         },
         "node_modules/react": {
             "version": "19.2.7",
@@ -9617,6 +9908,53 @@
                 "ml-matrix": "^6.8.2"
             }
         },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
         "node_modules/sort-object-keys": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
@@ -9874,6 +10212,16 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strtok3": {
             "version": "10.3.5",
             "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -9986,6 +10334,58 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-fs/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/tar/node_modules/yallist": {
@@ -10123,6 +10523,19 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/twoof3": {
             "resolved": "apps/twoof3",
@@ -10959,6 +11372,13 @@
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -859,6 +859,7 @@
     "rotation": "Rotation",
     "rotate_left": "Rotate left",
     "rotate_right": "Rotate right",
+    "straighten": "Straighten",
     "flip": "Flip",
     "flip_vertically": "Flip vertically",
     "flip_horizontally": "Flip horizontally",

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -62,7 +62,11 @@ import React, {
     type RefObject,
 } from "react";
 import { savedCollections } from "../services/photos-fdb";
-import { computeInscribedCrop } from "../utils/image-editor";
+import {
+    computeInscribedCrop,
+    cropRegionOfCanvas,
+    rotateCanvas,
+} from "../utils/image-editor";
 
 export type ImageEditorOverlayProps = ModalVisibilityProps & {
     /**
@@ -911,50 +915,6 @@ const CropMenu: React.FC<CropMenuProps> = (props) => {
     );
 };
 
-const cropRegionOfCanvas = (
-    canvas: HTMLCanvasElement,
-    topLeftX: number,
-    topLeftY: number,
-    bottomRightX: number,
-    bottomRightY: number,
-    scale = 1,
-): Promise<void> => {
-    const context = canvas.getContext("2d");
-    if (!context || !canvas) return Promise.resolve();
-    context.imageSmoothingEnabled = false;
-
-    const width = (bottomRightX - topLeftX) * scale;
-    const height = (bottomRightY - topLeftY) * scale;
-
-    const img = new Image();
-    img.src = canvas.toDataURL();
-    return new Promise((resolve, reject) => {
-        img.onload = () => {
-            try {
-                context.clearRect(0, 0, canvas.width, canvas.height);
-
-                canvas.width = width;
-                canvas.height = height;
-
-                context.drawImage(
-                    img,
-                    topLeftX,
-                    topLeftY,
-                    width,
-                    height,
-                    0,
-                    0,
-                    width,
-                    height,
-                );
-                resolve();
-            } catch (e) {
-                reject(e instanceof Error ? e : new Error(String(e)));
-            }
-        };
-    });
-};
-
 const getCropRegionArgs = (
     cropBoxEle: HTMLDivElement,
     canvasEle: HTMLCanvasElement,
@@ -1191,55 +1151,6 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
 
             context.restore();
         };
-    };
-
-    const rotateCanvas = (
-        canvas: HTMLCanvasElement,
-        angle: number,
-    ): Promise<void> => {
-        const context = canvas?.getContext("2d");
-        if (!context || !canvas) return Promise.resolve();
-        context.imageSmoothingEnabled = false;
-
-        const image = new Image();
-        image.src = canvas.toDataURL();
-
-        return new Promise((resolve, reject) => {
-            image.onload = () => {
-                try {
-                    context.clearRect(0, 0, canvas.width, canvas.height);
-
-                    context.save();
-
-                    const radians = (angle * Math.PI) / 180;
-                    const sin = Math.sin(radians);
-                    const cos = Math.cos(radians);
-                    const newWidth =
-                        Math.abs(image.width * cos) + Math.abs(image.height * sin);
-                    const newHeight =
-                        Math.abs(image.width * sin) + Math.abs(image.height * cos);
-
-                    canvas.width = newWidth;
-                    canvas.height = newHeight;
-
-                    context.translate(canvas.width / 2, canvas.height / 2);
-                    context.rotate(radians);
-
-                    context.drawImage(
-                        image,
-                        -image.width / 2,
-                        -image.height / 2,
-                        image.width,
-                        image.height,
-                    );
-
-                    context.restore();
-                    resolve();
-                } catch (e) {
-                    reject(e instanceof Error ? e : new Error(String(e)));
-                }
-            };
-        });
     };
 
     const createCropHandler =

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -507,18 +507,23 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
             cropBoxRef.current,
             canvasRef.current,
         );
-        setCanvasLoading(true);
-        setTransformationPerformed(true);
-        await cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
-        await cropRegionOfCanvas(
-            originalSizeCanvasRef.current!,
-            x1 / previewCanvasScale,
-            y1 / previewCanvasScale,
-            x2 / previewCanvasScale,
-            y2 / previewCanvasScale,
-        );
-        resetCropBox();
-        setCanvasLoading(false);
+        try {
+            setCanvasLoading(true);
+            setTransformationPerformed(true);
+            await cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
+            await cropRegionOfCanvas(
+                originalSizeCanvasRef.current!,
+                x1 / previewCanvasScale,
+                y1 / previewCanvasScale,
+                x2 / previewCanvasScale,
+                y2 / previewCanvasScale,
+            );
+            resetCropBox();
+        } catch (e) {
+            log.error("apply crop failed", e);
+        } finally {
+            setCanvasLoading(false);
+        }
 
         setCurrentTab("transform");
     };
@@ -781,14 +786,20 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                 <RowButtonGroupTitle>{t("export_data")}</RowButtonGroupTitle>
                 <RowButtonGroup>
                     <RowButton
-                        disabled={!transformationPerformed && !coloursAdjusted}
+                        disabled={
+                            canvasLoading ||
+                            (!transformationPerformed && !coloursAdjusted)
+                        }
                         startIcon={<DownloadIcon />}
                         label={t("download_edited")}
                         onClick={downloadEditedPhoto}
                     />
                     <RowButtonDivider />
                     <RowButton
-                        disabled={!transformationPerformed && !coloursAdjusted}
+                        disabled={
+                            canvasLoading ||
+                            (!transformationPerformed && !coloursAdjusted)
+                        }
                         startIcon={<CloudUploadIcon />}
                         label={t("save_a_copy_to_ente")}
                         onClick={saveCopyToEnte}
@@ -906,24 +917,29 @@ const CropMenu: React.FC<CropMenuProps> = (props) => {
                             props.cropBoxRef.current,
                             canvasRef.current,
                         );
-                        setCanvasLoading(true);
-                        setTransformationPerformed(true);
-                        await cropRegionOfCanvas(
-                            canvasRef.current,
-                            x1,
-                            y1,
-                            x2,
-                            y2,
-                        );
-                        await cropRegionOfCanvas(
-                            originalSizeCanvasRef.current!,
-                            x1 / props.previewScale,
-                            y1 / props.previewScale,
-                            x2 / props.previewScale,
-                            y2 / props.previewScale,
-                        );
-                        props.resetCropBox();
-                        setCanvasLoading(false);
+                        try {
+                            setCanvasLoading(true);
+                            setTransformationPerformed(true);
+                            await cropRegionOfCanvas(
+                                canvasRef.current,
+                                x1,
+                                y1,
+                                x2,
+                                y2,
+                            );
+                            await cropRegionOfCanvas(
+                                originalSizeCanvasRef.current!,
+                                x1 / props.previewScale,
+                                y1 / props.previewScale,
+                                x2 / props.previewScale,
+                                y2 / props.previewScale,
+                            );
+                            props.resetCropBox();
+                        } catch (e) {
+                            log.error("apply crop failed", e);
+                        } finally {
+                            setCanvasLoading(false);
+                        }
 
                         setCurrentTab("transform");
                     }}
@@ -1204,10 +1220,11 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
                 originalSizeCanvasRef.current!,
                 rotation == "left" ? -90 : 90,
             );
-            setCanvasLoading(false);
             setTransformationPerformed(true);
         } catch (e) {
             log.error(`rotation handler (${rotation}) failed`, e);
+        } finally {
+            setCanvasLoading(false);
         }
     };
 

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -492,7 +492,7 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
         }
     };
 
-    const applyCrop = () => {
+    const applyCrop = async () => {
         if (!cropBoxRef.current || !canvasRef.current) return;
 
         const { x1, x2, y1, y2 } = getCropRegionArgs(
@@ -501,8 +501,8 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
         );
         setCanvasLoading(true);
         setTransformationPerformed(true);
-        cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
-        cropRegionOfCanvas(
+        await cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
+        await cropRegionOfCanvas(
             originalSizeCanvasRef.current!,
             x1 / previewCanvasScale,
             y1 / previewCanvasScale,
@@ -827,7 +827,7 @@ const CropMenu: React.FC<CropMenuProps> = (props) => {
                     disabled={canvasLoading}
                     startIcon={<CropIcon />}
                     label={t("apply_crop")}
-                    onClick={() => {
+                    onClick={async () => {
                         if (!props.cropBoxRef.current || !canvasRef.current)
                             return;
 
@@ -837,8 +837,8 @@ const CropMenu: React.FC<CropMenuProps> = (props) => {
                         );
                         setCanvasLoading(true);
                         setTransformationPerformed(true);
-                        cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
-                        cropRegionOfCanvas(
+                        await cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
+                        await cropRegionOfCanvas(
                             originalSizeCanvasRef.current!,
                             x1 / props.previewScale,
                             y1 / props.previewScale,
@@ -863,9 +863,9 @@ const cropRegionOfCanvas = (
     bottomRightX: number,
     bottomRightY: number,
     scale = 1,
-) => {
+): Promise<void> => {
     const context = canvas.getContext("2d");
-    if (!context || !canvas) return;
+    if (!context || !canvas) return Promise.resolve();
     context.imageSmoothingEnabled = false;
 
     const width = (bottomRightX - topLeftX) * scale;
@@ -873,24 +873,31 @@ const cropRegionOfCanvas = (
 
     const img = new Image();
     img.src = canvas.toDataURL();
-    img.onload = () => {
-        context.clearRect(0, 0, canvas.width, canvas.height);
+    return new Promise((resolve, reject) => {
+        img.onload = () => {
+            try {
+                context.clearRect(0, 0, canvas.width, canvas.height);
 
-        canvas.width = width;
-        canvas.height = height;
+                canvas.width = width;
+                canvas.height = height;
 
-        context.drawImage(
-            img,
-            topLeftX,
-            topLeftY,
-            width,
-            height,
-            0,
-            0,
-            width,
-            height,
-        );
-    };
+                context.drawImage(
+                    img,
+                    topLeftX,
+                    topLeftY,
+                    width,
+                    height,
+                    0,
+                    0,
+                    width,
+                    height,
+                );
+                resolve();
+            } catch (e) {
+                reject(e instanceof Error ? e : new Error(String(e)));
+            }
+        };
+    });
 };
 
 const getCropRegionArgs = (
@@ -1055,6 +1062,10 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
 
         const img = new Image();
         img.src = canvas.toDataURL();
+        // Mutates canvas.width/height inside img.onload (async) — chaining
+        // this with another canvas op immediately after will race and read
+        // stale dimensions. See rotateCanvas/cropRegionOfCanvas for the
+        // awaitable version if you need to chain.
         img.onload = () => {
             const sourceWidth = img.width;
             const sourceHeight = img.height;
@@ -1101,6 +1112,10 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
         const img = new Image();
         img.src = canvas.toDataURL();
 
+        // Mutates canvas.width/height inside img.onload (async) — chaining
+        // this with another canvas op immediately after will race and read
+        // stale dimensions. See rotateCanvas/cropRegionOfCanvas for the
+        // awaitable version if you need to chain.
         img.onload = () => {
             context.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -1120,43 +1135,53 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
         };
     };
 
-    const rotateCanvas = (canvas: HTMLCanvasElement, angle: number) => {
+    const rotateCanvas = (
+        canvas: HTMLCanvasElement,
+        angle: number,
+    ): Promise<void> => {
         const context = canvas?.getContext("2d");
-        if (!context || !canvas) return;
+        if (!context || !canvas) return Promise.resolve();
         context.imageSmoothingEnabled = false;
 
         const image = new Image();
         image.src = canvas.toDataURL();
 
-        image.onload = () => {
-            context.clearRect(0, 0, canvas.width, canvas.height);
+        return new Promise((resolve, reject) => {
+            image.onload = () => {
+                try {
+                    context.clearRect(0, 0, canvas.width, canvas.height);
 
-            context.save();
+                    context.save();
 
-            const radians = (angle * Math.PI) / 180;
-            const sin = Math.sin(radians);
-            const cos = Math.cos(radians);
-            const newWidth =
-                Math.abs(image.width * cos) + Math.abs(image.height * sin);
-            const newHeight =
-                Math.abs(image.width * sin) + Math.abs(image.height * cos);
+                    const radians = (angle * Math.PI) / 180;
+                    const sin = Math.sin(radians);
+                    const cos = Math.cos(radians);
+                    const newWidth =
+                        Math.abs(image.width * cos) + Math.abs(image.height * sin);
+                    const newHeight =
+                        Math.abs(image.width * sin) + Math.abs(image.height * cos);
 
-            canvas.width = newWidth;
-            canvas.height = newHeight;
+                    canvas.width = newWidth;
+                    canvas.height = newHeight;
 
-            context.translate(canvas.width / 2, canvas.height / 2);
-            context.rotate(radians);
+                    context.translate(canvas.width / 2, canvas.height / 2);
+                    context.rotate(radians);
 
-            context.drawImage(
-                image,
-                -image.width / 2,
-                -image.height / 2,
-                image.width,
-                image.height,
-            );
+                    context.drawImage(
+                        image,
+                        -image.width / 2,
+                        -image.height / 2,
+                        image.width,
+                        image.height,
+                    );
 
-            context.restore();
-        };
+                    context.restore();
+                    resolve();
+                } catch (e) {
+                    reject(e instanceof Error ? e : new Error(String(e)));
+                }
+            };
+        });
     };
 
     const createCropHandler =
@@ -1181,11 +1206,11 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
                 );
             }
         };
-    const createRotationHandler = (rotation: "left" | "right") => () => {
+    const createRotationHandler = (rotation: "left" | "right") => async () => {
         try {
             setCanvasLoading(true);
-            rotateCanvas(canvasRef.current!, rotation == "left" ? -90 : 90);
-            rotateCanvas(
+            await rotateCanvas(canvasRef.current!, rotation == "left" ? -90 : 90);
+            await rotateCanvas(
                 originalSizeCanvasRef.current!,
                 rotation == "left" ? -90 : 90,
             );

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -62,6 +62,7 @@ import React, {
     type RefObject,
 } from "react";
 import { savedCollections } from "../services/photos-fdb";
+import { computeInscribedCrop } from "../utils/image-editor";
 
 export type ImageEditorOverlayProps = ModalVisibilityProps & {
     /**
@@ -123,6 +124,7 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
     const [currentRotationAngle, setCurrentRotationAngle] = useState(0);
 
     const [straightenAngle, setStraightenAngle] = useState(0);
+    const [isStraightenDragging, setIsStraightenDragging] = useState(false);
 
     const [currentTab, setCurrentTab] = useState<OperationTab>("transform");
 
@@ -526,7 +528,32 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
         setCurrentTab,
         straightenAngle,
         setStraightenAngle,
+        setIsStraightenDragging,
     };
+
+    const isTransformTab = currentTab === "transform";
+
+    // How much to scale the canvas up, in addition to rotating it, so the
+    // image fully covers a fixed-size frame at the current straighten angle.
+    const straightenZoomScale =
+        isTransformTab && straightenAngle !== 0 && canvasRef.current
+            ? canvasRef.current.width /
+              computeInscribedCrop(
+                  canvasRef.current.width,
+                  canvasRef.current.height,
+                  straightenAngle,
+              ).width
+            : 1;
+
+    // The canvas is centered within parentRef by flexbox, so the straighten
+    // overlay must be offset to the canvas's on-screen position, not (0,0).
+    const straightenOverlayOffsets =
+        isTransformTab &&
+        isStraightenDragging &&
+        canvasRef.current &&
+        parentRef.current
+            ? getCanvasBoundsOffsets()
+            : null;
 
     return (
         <Backdrop
@@ -614,6 +641,10 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                                             ? "none"
                                             : "block",
                                     position: "absolute",
+                                    transform:
+                                        isTransformTab && straightenAngle !== 0
+                                            ? `rotate(${straightenAngle}deg) scale(${straightenZoomScale})`
+                                            : undefined,
                                 }}
                             />
                             <canvas
@@ -626,6 +657,15 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                                     cropBox={cropBox}
                                     ref={cropBoxRef}
                                     setIsDragging={setIsDragging}
+                                />
+                            )}
+
+                            {straightenOverlayOffsets && canvasRef.current && (
+                                <StraightenOverlay
+                                    canvasWidth={canvasRef.current.width}
+                                    canvasHeight={canvasRef.current.height}
+                                    offsetX={straightenOverlayOffsets.offsetX}
+                                    offsetY={straightenOverlayOffsets.offsetY}
                                 />
                             )}
                         </Stack>
@@ -806,6 +846,7 @@ interface CommonMenuProps {
     setCurrentTab: (tab: OperationTab) => void;
     straightenAngle: number;
     setStraightenAngle: (v: number) => void;
+    setIsStraightenDragging: (v: boolean) => void;
 }
 
 type CropMenuProps = CommonMenuProps & {
@@ -1054,6 +1095,7 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
     setTransformationPerformed,
     straightenAngle,
     setStraightenAngle,
+    setIsStraightenDragging,
 }) => {
     // Crops the canvas according to originalHeight and originalWidth without compounding
     const cropCanvas = (
@@ -1318,6 +1360,7 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
                     marks={[{ value: 0, label: "0°" }]}
                     disabled={canvasLoading}
                     onChange={(_, value) => {
+                        setIsStraightenDragging(true);
                         setStraightenAngle(value as number);
                     }}
                 />
@@ -1343,6 +1386,66 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
         </>
     );
 };
+
+interface StraightenOverlayProps {
+    canvasWidth: number;
+    canvasHeight: number;
+    offsetX: number;
+    offsetY: number;
+}
+
+// A rule-of-thirds grid, fixed to the canvas's on-screen bounds and never
+// rotating itself, so it represents "level" while the image rotates (and
+// zooms to keep covering it) underneath.
+const StraightenOverlay: React.FC<StraightenOverlayProps> = ({
+    canvasWidth,
+    canvasHeight,
+    offsetX,
+    offsetY,
+}) => (
+    <svg
+        width={canvasWidth}
+        height={canvasHeight}
+        style={{
+            position: "absolute",
+            top: offsetY,
+            left: offsetX,
+            pointerEvents: "none",
+        }}
+    >
+        {[1, 2].map((i) => (
+            <line
+                key={`v${i}`}
+                x1={(canvasWidth * i) / 3}
+                y1={0}
+                x2={(canvasWidth * i) / 3}
+                y2={canvasHeight}
+                stroke="rgba(255, 255, 255, 0.6)"
+                strokeWidth={1}
+            />
+        ))}
+        {[1, 2].map((i) => (
+            <line
+                key={`h${i}`}
+                x1={0}
+                y1={(canvasHeight * i) / 3}
+                x2={canvasWidth}
+                y2={(canvasHeight * i) / 3}
+                stroke="rgba(255, 255, 255, 0.6)"
+                strokeWidth={1}
+            />
+        ))}
+        <rect
+            x={0}
+            y={0}
+            width={canvasWidth}
+            height={canvasHeight}
+            fill="none"
+            stroke="white"
+            strokeWidth={1}
+        />
+    </svg>
+);
 
 interface ColoursMenuProps {
     brightness: number;

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -582,6 +582,11 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                     sx={{
                         justifyContent: "space-between",
                         alignItems: "center",
+                        // Sits above the straighten preview area, which can
+                        // paint outside its own box (a zoomed, rotated
+                        // canvas overhanging its frame) while dragging.
+                        position: "relative",
+                        zIndex: 1,
                     }}
                 >
                     <Typography
@@ -607,7 +612,12 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                     sx={{
                         width: "100%",
                         height: "100%",
-                        overflow: "hidden",
+                        // While straightening, the canvas is zoomed beyond
+                        // its box so it always fully covers the alignment
+                        // frame — its rotated corners overhang the box.
+                        // Allow that overhang to paint so it can be dimmed
+                        // by StraightenOverlay instead of silently clipped.
+                        overflow: isStraightenDragging ? "visible" : "hidden",
                         boxSizing: "border-box",
                         alignItems: "center",
                         justifyContent: "center",
@@ -670,6 +680,8 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                                     canvasHeight={canvasRef.current.height}
                                     offsetX={straightenOverlayOffsets.offsetX}
                                     offsetY={straightenOverlayOffsets.offsetY}
+                                    straightenAngle={straightenAngle}
+                                    zoomScale={straightenZoomScale}
                                 />
                             )}
                         </Stack>
@@ -1379,28 +1391,73 @@ interface StraightenOverlayProps {
     canvasHeight: number;
     offsetX: number;
     offsetY: number;
+    straightenAngle: number;
+    zoomScale: number;
 }
 
 // A rule-of-thirds grid, fixed to the canvas's on-screen bounds and never
 // rotating itself, so it represents "level" while the image rotates (and
-// zooms to keep covering it) underneath.
+// zooms to keep covering it) underneath. Also dims the part of the rotated,
+// zoomed image that overhangs past the frame — content that will be cropped
+// away — which would otherwise be invisible (clipped by the container) or
+// just blend in as if it were part of the kept image.
 const StraightenOverlay: React.FC<StraightenOverlayProps> = ({
     canvasWidth,
     canvasHeight,
     offsetX,
     offsetY,
-}) => (
-    <svg
-        width={canvasWidth}
-        height={canvasHeight}
-        style={{
-            position: "absolute",
-            top: offsetY,
-            left: offsetX,
-            pointerEvents: "none",
-        }}
-    >
-        {[1, 2].map((i) => (
+    straightenAngle,
+    zoomScale,
+}) => {
+    const radians = (straightenAngle * Math.PI) / 180;
+    // The on-screen size of the full rotated canvas, before cropping, once
+    // scaled by zoomScale — same bounding-box math as rotateCanvas uses,
+    // scaled up to match what's actually painted on screen right now.
+    const overhangWidth =
+        (Math.abs(canvasWidth * Math.cos(radians)) +
+            Math.abs(canvasHeight * Math.sin(radians))) *
+        zoomScale;
+    const overhangHeight =
+        (Math.abs(canvasWidth * Math.sin(radians)) +
+            Math.abs(canvasHeight * Math.cos(radians))) *
+        zoomScale;
+    // The frame sits centered within that overhanging area.
+    const frameX = (overhangWidth - canvasWidth) / 2;
+    const frameY = (overhangHeight - canvasHeight) / 2;
+
+    return (
+        <>
+            <svg
+                width={overhangWidth}
+                height={overhangHeight}
+                style={{
+                    position: "absolute",
+                    top: offsetY - frameY,
+                    left: offsetX - frameX,
+                    pointerEvents: "none",
+                }}
+            >
+                {/* A single even-odd path: the full overhang rect plus the
+                    frame rect. The overlap (the frame's interior, which
+                    survives the crop) is left unfilled. */}
+                <path
+                    d={`M0,0 H${overhangWidth} V${overhangHeight} H0 Z
+                        M${frameX},${frameY} H${frameX + canvasWidth} V${frameY + canvasHeight} H${frameX} Z`}
+                    fillRule="evenodd"
+                    fill="rgba(0, 0, 0, 0.6)"
+                />
+            </svg>
+            <svg
+                width={canvasWidth}
+                height={canvasHeight}
+                style={{
+                    position: "absolute",
+                    top: offsetY,
+                    left: offsetX,
+                    pointerEvents: "none",
+                }}
+            >
+                {[1, 2].map((i) => (
             <line
                 key={`v${i}`}
                 x1={(canvasWidth * i) / 3}
@@ -1431,8 +1488,10 @@ const StraightenOverlay: React.FC<StraightenOverlayProps> = ({
             stroke="white"
             strokeWidth={1}
         />
-    </svg>
-);
+            </svg>
+        </>
+    );
+};
 
 interface ColoursMenuProps {
     brightness: number;

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -896,7 +896,13 @@ const CropMenu: React.FC<CropMenuProps> = (props) => {
                         );
                         setCanvasLoading(true);
                         setTransformationPerformed(true);
-                        await cropRegionOfCanvas(canvasRef.current, x1, y1, x2, y2);
+                        await cropRegionOfCanvas(
+                            canvasRef.current,
+                            x1,
+                            y1,
+                            x2,
+                            y2,
+                        );
                         await cropRegionOfCanvas(
                             originalSizeCanvasRef.current!,
                             x1 / props.previewScale,
@@ -1178,7 +1184,10 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
     const createRotationHandler = (rotation: "left" | "right") => async () => {
         try {
             setCanvasLoading(true);
-            await rotateCanvas(canvasRef.current!, rotation == "left" ? -90 : 90);
+            await rotateCanvas(
+                canvasRef.current!,
+                rotation == "left" ? -90 : 90,
+            );
             await rotateCanvas(
                 originalSizeCanvasRef.current!,
                 rotation == "left" ? -90 : 90,

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -122,6 +122,8 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
 
     const [currentRotationAngle, setCurrentRotationAngle] = useState(0);
 
+    const [straightenAngle, setStraightenAngle] = useState(0);
+
     const [currentTab, setCurrentTab] = useState<OperationTab>("transform");
 
     const [brightness, setBrightness] = useState(
@@ -522,6 +524,8 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
         canvasLoading,
         setTransformationPerformed,
         setCurrentTab,
+        straightenAngle,
+        setStraightenAngle,
     };
 
     return (
@@ -800,6 +804,8 @@ interface CommonMenuProps {
     canvasLoading: boolean;
     setCanvasLoading: (v: boolean) => void;
     setCurrentTab: (tab: OperationTab) => void;
+    straightenAngle: number;
+    setStraightenAngle: (v: number) => void;
 }
 
 type CropMenuProps = CommonMenuProps & {
@@ -1046,6 +1052,8 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
     canvasLoading,
     setCanvasLoading,
     setTransformationPerformed,
+    straightenAngle,
+    setStraightenAngle,
 }) => {
     // Crops the canvas according to originalHeight and originalWidth without compounding
     const cropCanvas = (
@@ -1298,6 +1306,22 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
                     onClick={createRotationHandler("right")}
                 />
             </RowButtonGroup>
+            <RowButtonGroupTitle>{t("straighten")}</RowButtonGroupTitle>
+            <Box sx={{ px: "8px", mb: "1rem" }}>
+                <Slider
+                    min={-45}
+                    max={45}
+                    step={1}
+                    value={straightenAngle}
+                    valueLabelDisplay="auto"
+                    valueLabelFormat={(v) => `${v}°`}
+                    marks={[{ value: 0, label: "0°" }]}
+                    disabled={canvasLoading}
+                    onChange={(_, value) => {
+                        setStraightenAngle(value as number);
+                    }}
+                />
+            </Box>
             <RowButtonGroupTitle>{t("flip")}</RowButtonGroupTitle>
             <RowButtonGroup sx={{ mb: "1rem" }}>
                 <RowButton

--- a/web/packages/new/photos/components/ImageEditorOverlay.tsx
+++ b/web/packages/new/photos/components/ImageEditorOverlay.tsx
@@ -712,12 +712,20 @@ export const ImageEditorOverlay: React.FC<ImageEditorOverlayProps> = ({
                             setCurrentTab(value);
                         }}
                     >
-                        <Tab label={t("crop")} value="crop" />
-                        <Tab label={t("transform")} value="transform" />
+                        <Tab
+                            label={t("crop")}
+                            value="crop"
+                            disabled={canvasLoading}
+                        />
+                        <Tab
+                            label={t("transform")}
+                            value="transform"
+                            disabled={canvasLoading}
+                        />
                         <Tab
                             label={t("colors")}
                             value="colors"
-                            disabled={transformationPerformed}
+                            disabled={canvasLoading || transformationPerformed}
                         />
                     </Tabs>
                 </Stack>
@@ -1271,6 +1279,62 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
         }
     };
 
+    const commitStraighten = async (angle: number) => {
+        if (angle === 0) {
+            setIsStraightenDragging(false);
+            return;
+        }
+        try {
+            setCanvasLoading(true);
+            setIsStraightenDragging(false);
+
+            const canvas = canvasRef.current!;
+            const fullResCanvas = originalSizeCanvasRef.current!;
+
+            // computeInscribedCrop expects the pre-rotation dimensions (it
+            // accounts for the rotation itself); it must be called before
+            // rotateCanvas resizes the canvas to the (larger) rotated
+            // bounding box.
+            const previewCrop = computeInscribedCrop(
+                canvas.width,
+                canvas.height,
+                angle,
+            );
+            const fullResCrop = computeInscribedCrop(
+                fullResCanvas.width,
+                fullResCanvas.height,
+                angle,
+            );
+
+            await rotateCanvas(canvas, angle);
+            await rotateCanvas(fullResCanvas, angle);
+
+            await cropRegionOfCanvas(
+                canvas,
+                (canvas.width - previewCrop.width) / 2,
+                (canvas.height - previewCrop.height) / 2,
+                (canvas.width - previewCrop.width) / 2 + previewCrop.width,
+                (canvas.height - previewCrop.height) / 2 + previewCrop.height,
+            );
+            await cropRegionOfCanvas(
+                fullResCanvas,
+                (fullResCanvas.width - fullResCrop.width) / 2,
+                (fullResCanvas.height - fullResCrop.height) / 2,
+                (fullResCanvas.width - fullResCrop.width) / 2 +
+                    fullResCrop.width,
+                (fullResCanvas.height - fullResCrop.height) / 2 +
+                    fullResCrop.height,
+            );
+
+            setStraightenAngle(0);
+            setTransformationPerformed(true);
+        } catch (e) {
+            log.error("straighten commit failed", e);
+        } finally {
+            setCanvasLoading(false);
+        }
+    };
+
     const createFlipCanvasHandler =
         (direction: "vertical" | "horizontal") => () => {
             try {
@@ -1362,6 +1426,9 @@ const TransformMenu: React.FC<CommonMenuProps> = ({
                     onChange={(_, value) => {
                         setIsStraightenDragging(true);
                         setStraightenAngle(value as number);
+                    }}
+                    onChangeCommitted={(_, value) => {
+                        void commitStraighten(value as number);
                     }}
                 />
             </Box>

--- a/web/packages/new/photos/utils/image-editor.ts
+++ b/web/packages/new/photos/utils/image-editor.ts
@@ -20,20 +20,24 @@ export const computeInscribedCrop = (
 
     if (sinT === 0) return { width, height };
 
-    const wide = Math.min(width, height);
-    const long = Math.max(width, height);
+    // A crop rectangle sharing the original aspect ratio, centered at the
+    // origin, has half-width a and half-height a*(height/width). Rotating
+    // its corners by -angleDegrees into the original (unrotated) rectangle's
+    // frame gives two constraints on how large a can be before a corner
+    // pokes outside the original width/height bounds:
+    //   a*cosT + a*(height/width)*sinT <= width/2   (stay within width)
+    //   a*sinT + a*(height/width)*cosT <= height/2  (stay within height)
+    // Solving each for the maximum a, and taking the tighter (smaller) one,
+    // gives the largest inscribed rectangle. This also guarantees the result
+    // keeps the original aspect ratio, since both bounds were derived from a
+    // crop rectangle whose height was defined as a*(height/width) already.
+    const maxAFromWidthBound =
+        (width * width) / (2 * (width * cosT + height * sinT));
+    const maxAFromHeightBound =
+        (width * height) / (2 * (width * sinT + height * cosT));
+    const a = Math.min(maxAFromWidthBound, maxAFromHeightBound);
 
-    if (wide <= 2 * sinT * cosT * long) {
-        const x = wide / 2;
-        const cropW = x / sinT;
-        const cropH = x / cosT;
-        return width <= height
-            ? { width: cropW, height: cropH }
-            : { width: cropH, height: cropW };
-    }
-
-    const d = cosT * cosT - sinT * sinT;
-    const cropW = (width * cosT - height * sinT) / d;
-    const cropH = (height * cosT - width * sinT) / d;
+    const cropW = 2 * a;
+    const cropH = cropW * (height / width);
     return { width: cropW, height: cropH };
 };

--- a/web/packages/new/photos/utils/image-editor.ts
+++ b/web/packages/new/photos/utils/image-editor.ts
@@ -1,0 +1,39 @@
+/**
+ * Compute the largest axis-aligned rectangle, sharing the aspect ratio of a
+ * `width` x `height` canvas, that fits entirely within that canvas after it
+ * has been rotated by `angleDegrees` around its center.
+ *
+ * This is the "inscribed rectangle" used to auto-crop a straightened photo
+ * so no empty corners remain: rotating a rectangle by a non-90° angle leaves
+ * its corners outside any axis-aligned frame, so the only way to end up with
+ * a clean rectangular result is to shrink inward to the largest rectangle
+ * that still lies fully within the rotated bounds.
+ */
+export const computeInscribedCrop = (
+    width: number,
+    height: number,
+    angleDegrees: number,
+): { width: number; height: number } => {
+    const radians = (angleDegrees * Math.PI) / 180;
+    const sinT = Math.abs(Math.sin(radians));
+    const cosT = Math.abs(Math.cos(radians));
+
+    if (sinT === 0) return { width, height };
+
+    const wide = Math.min(width, height);
+    const long = Math.max(width, height);
+
+    if (wide <= 2 * sinT * cosT * long) {
+        const x = wide / 2;
+        const cropW = x / sinT;
+        const cropH = x / cosT;
+        return width <= height
+            ? { width: cropW, height: cropH }
+            : { width: cropH, height: cropW };
+    }
+
+    const d = cosT * cosT - sinT * sinT;
+    const cropW = (width * cosT - height * sinT) / d;
+    const cropH = (height * cosT - width * sinT) / d;
+    return { width: cropW, height: cropH };
+};

--- a/web/packages/new/photos/utils/image-editor.ts
+++ b/web/packages/new/photos/utils/image-editor.ts
@@ -97,6 +97,8 @@ export const rotateCanvas = (
                 reject(e instanceof Error ? e : new Error(String(e)));
             }
         };
+        image.onerror = () =>
+            reject(new Error("Failed to load canvas image data for rotate"));
         image.src = canvas.toDataURL();
     });
 };
@@ -147,6 +149,8 @@ export const cropRegionOfCanvas = (
                 reject(e instanceof Error ? e : new Error(String(e)));
             }
         };
+        img.onerror = () =>
+            reject(new Error("Failed to load canvas image data for crop"));
         img.src = canvas.toDataURL();
     });
 };

--- a/web/packages/new/photos/utils/image-editor.ts
+++ b/web/packages/new/photos/utils/image-editor.ts
@@ -41,3 +41,112 @@ export const computeInscribedCrop = (
     const cropH = cropW * (height / width);
     return { width: cropW, height: cropH };
 };
+
+/**
+ * Rotate the contents of `canvas` by `angle` degrees around its center,
+ * resizing the canvas to the new rotated bounding box. Resolves once the
+ * rotated pixels have actually been drawn — callers that need to read the
+ * canvas's post-rotation dimensions (e.g. to crop it next) must await this
+ * before doing so.
+ */
+export const rotateCanvas = (
+    canvas: HTMLCanvasElement,
+    angle: number,
+): Promise<void> => {
+    const context = canvas.getContext("2d");
+    if (!context) return Promise.resolve();
+    context.imageSmoothingEnabled = false;
+
+    const image = new Image();
+
+    return new Promise((resolve, reject) => {
+        // onload must be attached before src is set: some environments
+        // (e.g. server-side canvas implementations used in tests) decode
+        // already-available image data synchronously during assignment.
+        image.onload = () => {
+            try {
+                context.clearRect(0, 0, canvas.width, canvas.height);
+
+                context.save();
+
+                const radians = (angle * Math.PI) / 180;
+                const sin = Math.sin(radians);
+                const cos = Math.cos(radians);
+                const newWidth =
+                    Math.abs(image.width * cos) + Math.abs(image.height * sin);
+                const newHeight =
+                    Math.abs(image.width * sin) + Math.abs(image.height * cos);
+
+                canvas.width = newWidth;
+                canvas.height = newHeight;
+
+                context.translate(canvas.width / 2, canvas.height / 2);
+                context.rotate(radians);
+
+                context.drawImage(
+                    image,
+                    -image.width / 2,
+                    -image.height / 2,
+                    image.width,
+                    image.height,
+                );
+
+                context.restore();
+                resolve();
+            } catch (e) {
+                reject(e instanceof Error ? e : new Error(String(e)));
+            }
+        };
+        image.src = canvas.toDataURL();
+    });
+};
+
+/**
+ * Crop `canvas` to the region between (topLeftX, topLeftY) and
+ * (bottomRightX, bottomRightY) (in the canvas's current coordinate space,
+ * scaled by `scale`), resizing the canvas to the cropped region's size.
+ * Resolves once the cropped pixels have actually been drawn.
+ */
+export const cropRegionOfCanvas = (
+    canvas: HTMLCanvasElement,
+    topLeftX: number,
+    topLeftY: number,
+    bottomRightX: number,
+    bottomRightY: number,
+    scale = 1,
+): Promise<void> => {
+    const context = canvas.getContext("2d");
+    if (!context) return Promise.resolve();
+    context.imageSmoothingEnabled = false;
+
+    const width = (bottomRightX - topLeftX) * scale;
+    const height = (bottomRightY - topLeftY) * scale;
+
+    const img = new Image();
+    return new Promise((resolve, reject) => {
+        img.onload = () => {
+            try {
+                context.clearRect(0, 0, canvas.width, canvas.height);
+
+                canvas.width = width;
+                canvas.height = height;
+
+                context.drawImage(
+                    img,
+                    topLeftX,
+                    topLeftY,
+                    width,
+                    height,
+                    0,
+                    0,
+                    width,
+                    height,
+                );
+                resolve();
+            } catch (e) {
+                reject(e instanceof Error ? e : new Error(String(e)));
+            }
+        };
+        img.src = canvas.toDataURL();
+    });
+};


### PR DESCRIPTION
## Summary

Adds a "Straighten" control to the web Photo Editor's Transform tab, next to the existing 90°-rotate buttons: a slider (-45° to +45°) that rotates the photo by an arbitrary angle to level a tilted horizon, auto-cropping to the largest same-aspect-ratio rectangle so no empty corners remain.

- Live preview: dragging the slider rotates and zooms the canvas (CSS only, no re-rasterizing) to always fully cover a fixed alignment grid with rule-of-thirds lines.
- The area of the image that will be cropped away (outside the frame, due to the rotation) is dimmed during dragging, so it's clear what's being kept vs. discarded.
- Commits on slider release: bakes the rotation and crop into both the preview and full-resolution canvases, matching the editor's existing model — edits bake into the image without per-step undo.
- `rotateCanvas`/`cropRegionOfCanvas` (previously fire-and-forget, relying on click-at-a-time usage to avoid races) are made awaitable and extracted into a standalone, unit-testable module, since straighten is the first feature to chain them together in one commit.

## Screenshots

<img width="1390" height="984" alt="image" src="https://github.com/user-attachments/assets/11cda996-61a8-449a-b745-3205ad184f1f" />
<img width="1397" height="995" alt="image" src="https://github.com/user-attachments/assets/8616a14f-8f51-410b-aa13-855dc961e004" />
<img width="1398" height="998" alt="image" src="https://github.com/user-attachments/assets/ab85c26b-d076-40de-829c-e0ea75d1f2f6" />


## Test plan

- [x] `computeInscribedCrop` (the inscribed-rectangle crop math) is unit tested against independently-derived geometry (corner-containment + tightness checks, not a re-derivation of the same formula) across square/landscape/portrait inputs and a range of angles.
- [x] `rotateCanvas` + `cropRegionOfCanvas` are unit tested via `node-canvas`, covering: correct final dimensions, content preservation through the crop, the async bake→crop ordering that the awaitable conversion fixes, and absence of empty/transparent corners across angles and orientations.
- [x] Full existing test suite (`npm run test`) passes: 79 tests across `ente-wasm`, `ente-contacts-web`, and `photos`.
- [x] `npm run lint` (typecheck + eslint) passes with no new errors.
- [x] Manually verified in-browser: existing 90°-rotate, freehand crop, and flip still work unchanged; straighten commits cleanly with no black/transparent corners across a range of angles; chaining a 90°-rotate followed by a straighten computes the crop against the post-rotation canvas size (not the original); tab-switching is disabled while a commit is in flight (closes a gap where switching tabs mid-commit could read the canvas in an inconsistent state); the out-of-bounds dimming overlay renders correctly without visually overlapping the editor's title bar.