### PR TITLE
[mobile][photos] Refresh contacts after album participant changes

### DIFF
--- a/mobile/apps/photos/lib/events/contact_relationships_invalidated_event.dart
+++ b/mobile/apps/photos/lib/events/contact_relationships_invalidated_event.dart
@@ -1,0 +1,3 @@
+import 'package:photos/events/event.dart';
+
+class ContactRelationshipsInvalidatedEvent extends Event {}

--- a/mobile/apps/photos/lib/models/search/search_types.dart
+++ b/mobile/apps/photos/lib/models/search/search_types.dart
@@ -5,6 +5,7 @@ import "package:flutter/material.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/collection_updated_event.dart";
+import "package:photos/events/contact_relationships_invalidated_event.dart";
 import "package:photos/events/contacts_changed_event.dart";
 import "package:photos/events/event.dart";
 import "package:photos/events/location_tag_updated_event.dart";
@@ -306,6 +307,7 @@ extension SectionTypeExtensions on SectionType {
         return [Bus.instance.on<PeopleChangedEvent>()];
       case SectionType.contacts:
         return [
+          Bus.instance.on<ContactRelationshipsInvalidatedEvent>(),
           Bus.instance.on<PeopleChangedEvent>(),
           Bus.instance.on<ContactsChangedEvent>(),
         ];
@@ -328,6 +330,7 @@ extension SectionTypeExtensions on SectionType {
         return [];
       case SectionType.contacts:
         return [
+          Bus.instance.on<ContactRelationshipsInvalidatedEvent>(),
           Bus.instance.on<PeopleChangedEvent>(),
           Bus.instance.on<ContactsChangedEvent>(),
         ];

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -20,6 +20,7 @@ import 'package:photos/db/files_db.dart';
 import 'package:photos/db/social_db.dart';
 import 'package:photos/db/trash_db.dart';
 import 'package:photos/events/collection_updated_event.dart';
+import 'package:photos/events/contact_relationships_invalidated_event.dart';
 import 'package:photos/events/files_updated_event.dart';
 import 'package:photos/events/force_reload_home_gallery_event.dart';
 import 'package:photos/events/local_photos_updated_event.dart';
@@ -206,6 +207,7 @@ class CollectionsService {
     watch.log("${fetchedCollections.length} collection cached refreshed ");
 
     if (fetchedCollections.isNotEmpty) {
+      Bus.instance.fire(ContactRelationshipsInvalidatedEvent());
       Bus.instance.fire(
         CollectionUpdatedEvent(
           null,
@@ -905,6 +907,7 @@ class CollectionsService {
       );
       _collectionIDToCollections[collectionID] =
           _collectionIDToCollections[collectionID]!.copyWith(sharees: sharees);
+      Bus.instance.fire(ContactRelationshipsInvalidatedEvent());
       unawaited(_db.insert([_collectionIDToCollections[collectionID]!]));
       RemoteSyncService.instance.sync(silently: true).ignore();
       return sharees;
@@ -924,6 +927,7 @@ class CollectionsService {
       );
       _collectionIDToCollections[collectionID] =
           _collectionIDToCollections[collectionID]!.copyWith(sharees: sharees);
+      Bus.instance.fire(ContactRelationshipsInvalidatedEvent());
       unawaited(_db.insert([_collectionIDToCollections[collectionID]!]));
       RemoteSyncService.instance.sync(silently: true).ignore();
       return sharees;


### PR DESCRIPTION
- Refresh Contacts after album participants change.
- Batch multi-person share refreshes to avoid repeated scans.