### PR TITLE
Update workflows to skip scheduled runs on forks

### DIFF
--- a/.github/workflows/auth-build.yml
+++ b/.github/workflows/auth-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
     build-metadata:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         outputs:
@@ -84,7 +85,7 @@ jobs:
 
     build-android:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production
@@ -211,7 +212,7 @@ jobs:
 
     build-linux:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-22.04
         environment:
             name: production
@@ -321,7 +322,7 @@ jobs:
 
     build-windows:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         # VS2022 is required until local_auth_windows builds cleanly on VS2026.
         runs-on: windows-2022
         environment:
@@ -486,7 +487,7 @@ jobs:
 
     build-macos:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: macos-15
         environment:
             name: production
@@ -621,7 +622,7 @@ jobs:
 
     build-ios:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: macos-26
         environment:
             name: production
@@ -694,7 +695,7 @@ jobs:
 
     finish-build:
         needs: [build-metadata, build-android, build-linux, build-windows, build-macos, build-ios]
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
     analyze:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         name: Analyze (${{ matrix.language }})
         runs-on: 'ubuntu-latest'
         permissions:

--- a/.github/workflows/ensu-build.yml
+++ b/.github/workflows/ensu-build.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
     build-metadata:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         outputs:
@@ -94,7 +95,7 @@ jobs:
 
     build-desktop:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         environment:
             name: production
         strategy:
@@ -295,7 +296,7 @@ jobs:
 
     build-android:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production
@@ -417,7 +418,7 @@ jobs:
 
     build-ios:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: macos-26
         environment:
             name: production
@@ -479,7 +480,7 @@ jobs:
 
     finish-build:
         needs: [build-metadata, build-desktop, build-android, build-ios]
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/locker-build.yml
+++ b/.github/workflows/locker-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
     build-metadata:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         outputs:
@@ -84,7 +85,7 @@ jobs:
 
     build-android:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production
@@ -212,7 +213,7 @@ jobs:
 
     build-ios:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: macos-26
         environment:
             name: production
@@ -293,7 +294,7 @@ jobs:
 
     finish-build:
         needs: [build-metadata, build-android, build-ios]
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production

--- a/.github/workflows/mobile-crowdin-sync.yml
+++ b/.github/workflows/mobile-crowdin-sync.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
     synchronize-with-crowdin:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         name: "Sync ${{ matrix.app }} with Crowdin"
         runs-on: ubuntu-latest
         strategy:

--- a/.github/workflows/photos-build.yml
+++ b/.github/workflows/photos-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
     build-metadata:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         outputs:
@@ -84,7 +85,7 @@ jobs:
 
     build-android:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production
@@ -215,7 +216,7 @@ jobs:
 
     build-ios:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: macos-26
         environment:
             name: production
@@ -299,7 +300,7 @@ jobs:
 
     finish-build:
         needs: [build-metadata, build-android, build-ios]
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         environment:
             name: production

--- a/.github/workflows/photos-desktop-build.yml
+++ b/.github/workflows/photos-desktop-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
     build-metadata:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         outputs:
@@ -75,7 +76,7 @@ jobs:
 
     build:
         needs: build-metadata
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ${{ matrix.os }}
         environment:
             name: production
@@ -197,7 +198,7 @@ jobs:
 
     finish-build:
         needs: [build-metadata, build]
-        if: needs.build-metadata.outputs.should_build == 'true'
+        if: (github.repository == 'ente-io/ente' || github.event_name != 'schedule') && (needs.build-metadata.outputs.should_build == 'true')
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/server-publish-ghcr.yml
+++ b/.github/workflows/server-publish-ghcr.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
     publish:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
         steps:
             - name: Determine commit from prod museum

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
     stale:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
         steps:
             - name: Close pull requests missing CLA

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
     rust-workspace:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For rust-lint.yml and rust-test.yml.
         runs-on: ubuntu-latest
         defaults:
@@ -67,6 +68,7 @@ jobs:
             - run: cargo install cargo-audit --version 0.22.2 --locked
 
     rust-flutter:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For the cargo steps of mobile-lint.yml.
         runs-on: ubuntu-latest
         defaults:
@@ -96,6 +98,7 @@ jobs:
             - run: cargo clippy -p ente_rust --features flutter --all-targets --locked
 
     rust-wasm:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For web-lint.yml's WASM builds.
         runs-on: ubuntu-latest
         defaults:
@@ -125,6 +128,7 @@ jobs:
             - run: npm run build:space-wasm
 
     ensu-android:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For ensu-android-build.yml.
         runs-on: ubuntu-latest
         steps:
@@ -150,6 +154,7 @@ jobs:
               run: ./gradlew :app:assembleDebug
 
     ensu-ios:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For ensu-ios-build.yml.
         runs-on: macos-26
         steps:
@@ -171,6 +176,7 @@ jobs:
               run: xcodebuild build-for-testing -scheme Ensu -destination 'platform=iOS Simulator,name=iPhone 17'
 
     go-server:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         # For server-lint.yml.
         runs-on: ubuntu-latest
         defaults:

--- a/.github/workflows/web-crowdin-sync.yml
+++ b/.github/workflows/web-crowdin-sync.yml
@@ -32,6 +32,7 @@ permissions:
 
 jobs:
     synchronize-with-crowdin:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
     deploy:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
         environment: production
 

--- a/.github/workflows/web-publish-ghcr.yml
+++ b/.github/workflows/web-publish-ghcr.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
     publish:
+        if: github.repository == 'ente-io/ente' || github.event_name != 'schedule'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout


### PR DESCRIPTION
This commit adds an `if` condition to the jobs in workflows that run on a schedule. This condition ensures that the jobs only run on the main repository (`ente-io/ente`) if triggered by a schedule. Other events, such as `push` or `workflow_dispatch`, will still trigger the jobs on forks. This prevents the workflows from failing and sending notifications to users who have forked the repository.

## Description

ente floods my github notifications with failed jobs, it's clear to me that these might have only been intended to run on the main repo and on the main branch. Although perhaps this is supposed to be considered in what ever is generating `should_build`? So not sure if this is the best solution (it definitely doesn't look complete) but raising awareness.

## Tests

N/A