### PR TITLE
[mob] Use ONNX Runtime r3 packaging release

### DIFF
--- a/.github/workflows/ensu-ios-build.yml
+++ b/.github/workflows/ensu-ios-build.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         paths:
             - "mobile/native/apple/apps/ensu/**"
+            - "mobile/native/apple/packages/EnteOnnxRuntime/**"
             - "rust/apps/codegen/**"
             - "rust/crates/core/**"
             - "rust/crates/ensu/**"

--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -200,7 +200,7 @@ dependencies {
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     // Custom WebGPU/XNNPACK build required by Rust ML, which dynamically
     // loads libonnxruntime.so.
-    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.27.0-r2@aar'
+    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.27.0-r3@aar'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/mobile/apps/photos/android/gradle/verification-metadata.xml
+++ b/mobile/apps/photos/android/gradle/verification-metadata.xml
@@ -20,8 +20,8 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.27.0-r2">
-         <artifact name="onnxruntime-webgpu-android-1.27.0-r2.aar">
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.27.0-r3">
+         <artifact name="onnxruntime-webgpu-android-1.27.0-r3.aar">
             <sha256 value="0752f9b026df55780602cf482d9acddbe662d21383a2530d6e8c3d34a1ca8090"/>
          </artifact>
       </component>

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
     - Flutter
   - ente_screen_cover (0.0.1):
     - Flutter
-  - EnteOnnxRuntime (1.27.0-r2)
+  - EnteOnnxRuntime (1.27.0-r3)
   - ffmpeg_kit_custom (6.0.3)
   - ffmpeg_kit_flutter (6.0.3):
     - ffmpeg_kit_custom
@@ -476,11 +476,11 @@ SPEC CHECKSUMS:
   cupertino_http: 94ac07f5ff090b8effa6c5e2c47871d48ab7c86c
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   ente_cast: a25feb3127397e5fc6aff03a12120916707757d4
-  ente_photos_rust: 380a324fc22445a1281e206726ccddd86582ad28
+  ente_photos_rust: 2db1f31cbe3f13ef0f52909a52b1f885b880a6ec
   ente_qr: 86beaf5d2644705db9b565b32dd8b82c05fb36af
   ente_rust: d0197ebd5460e8f67576579452b073d698404abe
   ente_screen_cover: 6792566774f1c83939f9c1d03ed0a1f1ded45ae4
-  EnteOnnxRuntime: 2b0a46f3b247216f991233074d030ab53c257a3f
+  EnteOnnxRuntime: 6621104c53b3bfced7e51f27e1ef5650678523aa
   ffmpeg_kit_custom: 682b4f2f1ff1f8abae5a92f6c3540f2441d5be99
   ffmpeg_kit_flutter: 915b345acc97d4142e8a9a8549d177ff10f043f5
   file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6

--- a/mobile/apps/photos/rust_builder/ios/ente_photos_rust.podspec
+++ b/mobile/apps/photos/rust_builder/ios/ente_photos_rust.podspec
@@ -41,7 +41,7 @@ A new Flutter FFI plugin project.
         iphonesimulator) ort_slice=ios-arm64-simulator ;;
         *) echo "error: unsupported platform for ONNX Runtime: $PLATFORM_NAME" >&2; exit 1 ;;
       esac
-      export ORT_LIB_PATH="$PODS_ROOT/EnteOnnxRuntime/static-lib/$ort_slice"
+      export ORT_LIB_PATH="$PODS_ROOT/EnteOnnxRuntime/onnxruntime.xcframework/$ort_slice"
       if [ ! -f "$ORT_LIB_PATH/libonnxruntime.a" ]; then
         echo "error: $ORT_LIB_PATH/libonnxruntime.a is missing; run 'pod install'" >&2
         exit 1

--- a/mobile/native/android/apps/ensu/gradle/verification-metadata.xml
+++ b/mobile/native/android/apps/ensu/gradle/verification-metadata.xml
@@ -20,8 +20,8 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.27.0-r2">
-         <artifact name="onnxruntime-webgpu-android-1.27.0-r2.aar">
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.27.0-r3">
+         <artifact name="onnxruntime-webgpu-android-1.27.0-r3.aar">
             <sha256 value="0752f9b026df55780602cf482d9acddbe662d21383a2530d6e8c3d34a1ca8090"/>
          </artifact>
       </component>

--- a/mobile/native/android/apps/ensu/rust/build.gradle.kts
+++ b/mobile/native/android/apps/ensu/rust/build.gradle.kts
@@ -134,5 +134,5 @@ dependencies {
     // Custom WebGPU/XNNPACK build; the Rust runtime dynamically loads its
     // libonnxruntime.so. Resolved from the Ivy repository declared in
     // settings.gradle.kts and SHA-256 pinned in gradle/verification-metadata.xml.
-    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.27.0-r2@aar")
+    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.27.0-r3@aar")
 }

--- a/mobile/native/apple/packages/EnteOnnxRuntime/Package.swift
+++ b/mobile/native/apple/packages/EnteOnnxRuntime/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.9
 
-// Ente's pinned custom ONNX Runtime static XCFramework for iOS (CoreML and
-// CPU; device and ARM64 Simulator). SPM downloads the release ZIP, verifies
+// Ente's pinned custom ONNX Runtime static-library XCFramework for iOS
+// (CoreML and CPU; device and ARM64 Simulator). SPM downloads the release ZIP, verifies
 // its checksum (a plain SHA-256 of the archive, published in the release's
 // SHA256SUMS asset), and links the correct slice into the app.
 //
 // The Rust side (ente-ensu's iOS `ort-sys` dependency) is built with
 // "disable-linking" so that it neither downloads nor bundles any other ONNX
-// Runtime; the symbols resolve against this framework at app link time.
+// Runtime; the symbols resolve against this static library at app link time.
 //
 // See mobile/native/onnxruntime/README.md for the release bump checklist.
 import PackageDescription
@@ -20,8 +20,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "onnxruntime",
-            url: "https://github.com/laurens-pilot/ort-packaging/releases/download/ort-1.27.0-r2/onnxruntime-coreml-ios-1.27.0-r2.zip",
-            checksum: "87f27a8d899ff9dbea29a0eac99e08d58a854b0d58542cc131de16f029bb8d5f"
+            url: "https://github.com/laurens-pilot/ort-packaging/releases/download/ort-1.27.0-r3/onnxruntime-coreml-ios-1.27.0-r3.zip",
+            checksum: "b8c450fe29c6517789b6a31e909c0469fac2aa416b4830f2adc7c4f9b4f33f89"
         )
     ]
 )

--- a/mobile/native/onnxruntime/EnteOnnxRuntime.podspec
+++ b/mobile/native/onnxruntime/EnteOnnxRuntime.podspec
@@ -1,28 +1,29 @@
-# Download vehicle for Ente's pinned custom ONNX Runtime iOS static
-# libraries. CocoaPods downloads the release ZIP at `pod install` time,
+# Download vehicle for Ente's pinned custom ONNX Runtime iOS static-library
+# XCFramework. CocoaPods downloads the release ZIP at `pod install` time,
 # verifies its SHA-256, and caches it. Nothing is compiled or linked here:
 # the ente_photos_rust pod's build phase points the Rust `ort` crate at the
-# pre-thinned static archive for the active platform via ORT_LIB_PATH.
+# XCFramework's static archive for the active platform via ORT_LIB_PATH.
 #
 # See README.md next to this file for the release bump checklist.
 Pod::Spec.new do |s|
   s.name     = 'EnteOnnxRuntime'
-  s.version  = '1.27.0-r2'
-  s.summary  = "Ente's custom prebuilt ONNX Runtime static libraries for iOS."
+  s.version  = '1.27.0-r3'
+  s.summary  = "Ente's custom prebuilt ONNX Runtime static-library XCFramework for iOS."
   s.homepage = 'https://github.com/laurens-pilot/ort-packaging'
   s.authors  = { 'Ente' => 'engineering@ente.io' }
   s.license  = { :type => 'MIT', :file => 'ONNXRUNTIME-LICENSE' }
   s.source   = {
-    :http   => 'https://github.com/laurens-pilot/ort-packaging/releases/download/ort-1.27.0-r2/onnxruntime-coreml-ios-1.27.0-r2.zip',
-    :sha256 => '87f27a8d899ff9dbea29a0eac99e08d58a854b0d58542cc131de16f029bb8d5f',
+    :http   => 'https://github.com/laurens-pilot/ort-packaging/releases/download/ort-1.27.0-r3/onnxruntime-coreml-ios-1.27.0-r3.zip',
+    :sha256 => 'b8c450fe29c6517789b6a31e909c0469fac2aa416b4830f2adc7c4f9b4f33f89',
   }
 
   s.platform = :ios, '15.1'
 
-  # Keep only the pre-thinned per-slice static archives; the XCFramework in
-  # the ZIP is not used (the Rust build consumes the .a files directly).
+  # Keep the XCFramework as downloaded, but do not declare it as a vendored
+  # framework. CocoaPods is only the download/checksum vehicle; the Rust build
+  # consumes the selected .a slice directly and links it into its staticlib.
   s.preserve_paths = \
-    'static-lib/**/*',
+    'onnxruntime.xcframework/**/*',
     'ONNXRUNTIME-LICENSE',
     'ThirdPartyNotices.txt'
 end

--- a/mobile/native/onnxruntime/README.md
+++ b/mobile/native/onnxruntime/README.md
@@ -1,10 +1,10 @@
 # Custom ONNX Runtime binaries
 
-The mobile apps use Ente's pinned custom ONNX Runtime 1.27.0 packaging builds
-from the ort-packaging repository:
+The mobile apps use Ente's pinned custom ONNX Runtime 1.27.0 packaging build
+(`ort-1.27.0-r3` from the ort-packaging repository):
 
-- Android (`ort-1.27.0-r2`): WebGPU, XNNPACK, and CPU; ARM64, ARMv7, and x86_64
-- iOS (`ort-1.27.0-r3`): CoreML and CPU; iOS 15.1+ device and ARM64 Simulator
+- Android: WebGPU, XNNPACK, and CPU; ARM64, ARMv7, and x86_64
+- iOS: CoreML and CPU; iOS 15.1+ device and ARM64 Simulator
 
 Each platform's own package manager downloads and checksum-verifies the
 binaries; there are no custom download scripts.

--- a/mobile/native/onnxruntime/README.md
+++ b/mobile/native/onnxruntime/README.md
@@ -1,10 +1,10 @@
 # Custom ONNX Runtime binaries
 
-The mobile apps use Ente's pinned custom ONNX Runtime 1.27.0 packaging build
-(`ort-1.27.0-r2` from the ort-packaging repository):
+The mobile apps use Ente's pinned custom ONNX Runtime 1.27.0 packaging builds
+from the ort-packaging repository:
 
-- Android: WebGPU, XNNPACK, and CPU; ARM64, ARMv7, and x86_64
-- iOS: CoreML and CPU; iOS 15.1+ device and ARM64 Simulator
+- Android (`ort-1.27.0-r2`): WebGPU, XNNPACK, and CPU; ARM64, ARMv7, and x86_64
+- iOS (`ort-1.27.0-r3`): CoreML and CPU; iOS 15.1+ device and ARM64 Simulator
 
 Each platform's own package manager downloads and checksum-verifies the
 binaries; there are no custom download scripts.
@@ -16,15 +16,17 @@ binaries; there are no custom download scripts.
 - **iOS (photos)**: the release ZIP is downloaded by CocoaPods as the local
   `EnteOnnxRuntime` pod (`EnteOnnxRuntime.podspec` in this directory), which
   pins its SHA-256. The `ente_photos_rust` pod's build phase exports
-  `ORT_LIB_PATH` pointing at the pre-thinned static archive for the active
-  platform slice, which the Rust `ort` crate links statically.
-- **iOS (ensu)**: the Ensu Xcode project links the static XCFramework from
+  `ORT_LIB_PATH` pointing at the static archive inside the XCFramework's active
+  platform slice, which the Rust `ort` crate links statically. The podspec uses
+  `preserve_paths`, not `vendored_frameworks`, so CocoaPods does not also link
+  or embed the XCFramework.
+- **iOS (ensu)**: the Ensu Xcode project links the static-library XCFramework from
   the same ZIP through Swift Package Manager
   (`mobile/native/apple/packages/EnteOnnxRuntime/Package.swift`, a binary
   target with a pinned checksum). The Rust side builds `ort-sys` with
   `disable-linking` on iOS (see `rust/crates/ensu/Cargo.toml`), so cargo
   neither downloads nor bundles any other ONNX Runtime; symbols resolve
-  against the SPM framework at app link time. Note: because of this, build
+  against the SPM static library at app link time. Note: because of this, build
   `ente-ensu-uniffi` for iOS with `--crate-type staticlib` (as the app's
   `build-rust.sh` does); the cdylib crate type cannot link on iOS since
   nothing provides ONNX Runtime at cargo link time.
@@ -34,21 +36,26 @@ Desktop ONNX Runtime packaging is intentionally unchanged.
 ## Bumping the pinned release
 
 Update the release tag, version, and SHA-256 digests (published as the
-`SHA256SUMS` release asset) in each of:
+`SHA256SUMS` release asset) for the platform being bumped.
+
+For iOS:
 
 1. `EnteOnnxRuntime.podspec` (this directory): `s.version`, `:http` URL, and
    `:sha256`; then run `pod install` in `mobile/apps/photos/ios`.
-2. `mobile/apps/photos/android/app/build.gradle`: the
-   `io.ente.onnxruntime:onnxruntime-webgpu-android` dependency version.
-3. `mobile/apps/photos/android/gradle/verification-metadata.xml`: the
-   component version, artifact file name, and SHA-256.
-4. `mobile/native/android/apps/ensu/rust/build.gradle.kts`: the dependency
-   version.
-5. `mobile/native/android/apps/ensu/gradle/verification-metadata.xml`: same
-   as 3.
-6. `mobile/native/apple/packages/EnteOnnxRuntime/Package.swift`: the binary
+2. `mobile/native/apple/packages/EnteOnnxRuntime/Package.swift`: the binary
    target URL and checksum (the checksum is the plain SHA-256 of the iOS
    ZIP, identical to the one used in 1).
+
+For Android:
+
+1. `mobile/apps/photos/android/app/build.gradle`: the
+   `io.ente.onnxruntime:onnxruntime-webgpu-android` dependency version.
+2. `mobile/apps/photos/android/gradle/verification-metadata.xml`: the
+   component version, artifact file name, and SHA-256.
+3. `mobile/native/android/apps/ensu/rust/build.gradle.kts`: the dependency
+   version.
+4. `mobile/native/android/apps/ensu/gradle/verification-metadata.xml`: the
+   same component, artifact, and SHA-256 updates as 2.
 
 ## WebGPU rollout status
 
@@ -66,7 +73,7 @@ invocations against an iOS target (for example `cargo check`), run
 `pod install` in `mobile/apps/photos/ios` once, then export it manually:
 
 ```sh
-ORT_LIB_PATH="$PWD/mobile/apps/photos/ios/Pods/EnteOnnxRuntime/static-lib/ios-arm64" \
+ORT_LIB_PATH="$PWD/mobile/apps/photos/ios/Pods/EnteOnnxRuntime/onnxruntime.xcframework/ios-arm64" \
 IPHONEOS_DEPLOYMENT_TARGET=15.1 \
 cargo check -p ente-photos --target aarch64-apple-ios
 ```


### PR DESCRIPTION
## Summary

- pin Ensu and Photos on iOS and Android to ort-1.27.0-r3
- consume the static archive directly from the XCFramework in Photos without declaring a vendored framework
- let SwiftPM statically link the same XCFramework in Ensu
- keep the Android machine code unchanged: the r3 AAR is byte-for-byte identical to r2 and retains the same SHA-256 pin
- document one unified mobile packaging release and trigger the Ensu iOS build when its ONNX Runtime Swift package changes

Release: https://github.com/laurens-pilot/ort-packaging/releases/tag/ort-1.27.0-r3

## Validation

- r3 release workflow and all published SHA-256 checks passed
- Ensu unsigned Release/device archive succeeded; no ONNX framework or dynamic dependency in the app
- Photos ONNX/Rust Release/device target succeeded with ONNX/CoreML symbols present
- Photos full unsigned Release/device archive succeeded; no ONNX framework or dynamic dependency in the app
- Photos and Ensu Android Release dependency resolution selected r3 and passed Gradle verification with the unchanged AAR checksum
- both podspecs parse, Swift package dumps, actionlint and git diff checks pass