### PR TITLE
[mobile][auth] Validate imported OTP parameters

### DIFF
--- a/mobile/apps/auth/changes/import-error-handling.md
+++ b/mobile/apps/auth/changes/import-error-handling.md
@@ -1,0 +1,1 @@
+- Improved error handling for malformed authenticator app imports.

--- a/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/aegis_import.dart
@@ -115,8 +115,9 @@ Future<int?> _processAegisExportFile(
         }
       }
     }
-    Code code = Code.fromOTPAuthUrl(
-      buildImportOtpUri(
+    Code code = parseImportOtpCode(
+      item,
+      () => buildImportOtpUri(
         kind: kind,
         issuer: issuer,
         account: account,

--- a/mobile/apps/auth/lib/ui/settings/data/import/andotp_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/andotp_import.dart
@@ -144,6 +144,7 @@ Future<int?> _processAndOTPFile(
       parsedCodes.add(code);
     } catch (e, s) {
       _logger.warning('Failed to parse andOTP entry: $displayName', e, s);
+      throwImportEntryParseError(item, e);
     }
   }
 

--- a/mobile/apps/auth/lib/ui/settings/data/import/import_flow.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/import_flow.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/services/authenticator_service.dart';
 import 'package:ente_auth/store/code_store.dart';
+import 'package:ente_auth/ui/components/buttons/button_widget.dart';
 import 'package:ente_auth/ui/settings/data/import/import_instruction_sheet.dart';
 import 'package:ente_auth/ui/settings/data/import/import_success.dart';
 import 'package:ente_auth/utils/dialog_util.dart';
@@ -14,6 +16,37 @@ import 'package:logging/logging.dart';
 
 typedef ImportFileProcessor =
     Future<int?> Function(String path, ProgressDialog progressDialog);
+
+const _maxImportedOtpDigits = 10;
+
+class ImportEntryParseException implements Exception {
+  final Object? entry;
+  final Object error;
+
+  const ImportEntryParseException({required this.entry, required this.error});
+
+  String get errorText => error.toString();
+
+  String get entryText {
+    final failedEntry = entry;
+    if (failedEntry is String) return failedEntry;
+    try {
+      return const JsonEncoder.withIndent('  ').convert(failedEntry);
+    } catch (_) {
+      return failedEntry.toString();
+    }
+  }
+
+  String get details => 'Error: $errorText\n\nEntry:\n$entryText';
+
+  @override
+  String toString() => 'Could not parse import entry: $errorText';
+}
+
+Never throwImportEntryParseError(Object? entry, Object error) {
+  if (error is ImportEntryParseException) throw error;
+  throw ImportEntryParseException(entry: entry, error: error);
+}
 
 Future<void> showFileImportInstruction({
   required BuildContext context,
@@ -76,13 +109,37 @@ Future<void> pickAndProcessImportFile({
     logger.severe(logMessage, error, stackTrace);
     await progressDialog.hide();
     if (!context.mounted) return;
-    await showErrorDialog(
-      context,
-      context.l10n.sorry,
-      errorMessage?.call(context, error) ??
-          '${context.l10n.importFailureDesc}\n Error: $error',
-    );
+    final message =
+        errorMessage?.call(context, error) ??
+        '${context.l10n.importFailureDesc}\n Error: $error';
+    if (error is ImportEntryParseException) {
+      await _showImportEntryParseError(context, error, message);
+    } else {
+      await showErrorDialog(context, context.l10n.sorry, message);
+    }
   }
+}
+
+Future<void> _showImportEntryParseError(
+  BuildContext context,
+  ImportEntryParseException error,
+  String message,
+) async {
+  final result = await showChoiceDialog(
+    context,
+    title: context.l10n.sorry,
+    body: message,
+    firstButtonLabel: 'View entry',
+    secondButtonLabel: context.l10n.ok,
+  );
+  if (result?.action != ButtonAction.first || !context.mounted) return;
+
+  await showErrorDialog(
+    context,
+    'Failed import entry',
+    error.details,
+    showContactSupport: false,
+  );
 }
 
 Future<String?> promptForImportPassword(
@@ -102,6 +159,14 @@ Future<String?> promptForImportPassword(
   return password;
 }
 
+Code parseImportOtpCode(Object? entry, String Function() buildUri) {
+  try {
+    return Code.fromOTPAuthUrl(buildUri());
+  } catch (error) {
+    throwImportEntryParseError(entry, error);
+  }
+}
+
 String buildImportOtpUri({
   required String kind,
   required Object issuer,
@@ -114,13 +179,45 @@ String buildImportOtpUri({
   bool allowSteam = true,
 }) {
   final normalizedKind = kind.toLowerCase();
+  final normalizedDigits = _normalizeImportedOtpDigits(digits);
   if (normalizedKind == 'totp' || (allowSteam && normalizedKind == 'steam')) {
-    return 'otpauth://$normalizedKind/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$digits&period=$period';
+    final normalizedPeriod = _normalizeImportedOtpPeriod(period);
+    return 'otpauth://$normalizedKind/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$normalizedDigits&period=$normalizedPeriod';
   }
   if (normalizedKind == 'hotp') {
-    return 'otpauth://hotp/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$digits&counter=$counter';
+    final normalizedCounter = _normalizeImportedOtpCounter(counter);
+    return 'otpauth://hotp/$issuer:$account?secret=$secret&issuer=$issuer&algorithm=$algorithm&digits=$normalizedDigits&counter=$normalizedCounter';
   }
   throw FormatException('Invalid OTP type: $kind');
+}
+
+int _normalizeImportedOtpDigits(Object? digits) {
+  final parsedDigits = _parseImportedOtpInt(digits);
+  if (parsedDigits == null || parsedDigits == 0) return Code.defaultDigits;
+  if (parsedDigits < 0 || parsedDigits > _maxImportedOtpDigits) {
+    throw FormatException('Invalid OTP digits: $parsedDigits');
+  }
+  return parsedDigits;
+}
+
+int _normalizeImportedOtpPeriod(Object? period) {
+  final parsedPeriod = _parseImportedOtpInt(period);
+  if (parsedPeriod == null || parsedPeriod <= 0) return Code.defaultPeriod;
+  return parsedPeriod;
+}
+
+int _normalizeImportedOtpCounter(Object? counter) {
+  final parsedCounter = _parseImportedOtpInt(counter);
+  if (parsedCounter == null) return 0;
+  if (parsedCounter < 0) {
+    throw FormatException('Invalid HOTP counter: $parsedCounter');
+  }
+  return parsedCounter;
+}
+
+int? _parseImportedOtpInt(Object? value) {
+  if (value is int) return value;
+  return int.tryParse(value?.toString() ?? '');
 }
 
 Future<int> saveImportedCodes(Iterable<Code> codes) async {

--- a/mobile/apps/auth/lib/ui/settings/data/import/otp_auth_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/otp_auth_import.dart
@@ -69,6 +69,12 @@ Future<int?> _processOtpAuthFile(
       );
       continue;
     }
+    if (result['status'] == 'entry_error') {
+      throw ImportEntryParseException(
+        entry: result['entry'],
+        error: result['error']!,
+      );
+    }
 
     final codes = (result['otpUris'] as List).cast<String>().map(
       Code.fromOTPAuthUrl,
@@ -89,5 +95,11 @@ Map<String, Object> _parseOtpAuthExport(Map<String, Object> params) {
     };
   } on IncorrectOtpAuthPasswordException {
     return {'status': 'incorrect_password'};
+  } on ImportEntryParseException catch (error) {
+    return {
+      'status': 'entry_error',
+      'entry': error.entryText,
+      'error': error.errorText,
+    };
   }
 }

--- a/mobile/apps/auth/lib/ui/settings/data/import/otp_auth_import_parser.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/otp_auth_import_parser.dart
@@ -55,7 +55,8 @@ List<Code> parseOtpAuthExport(Uint8List fileBytes, {required String password}) {
     try {
       codes.add(_accountToCode(_asMap(account)));
     } catch (error, stackTrace) {
-      _logger.warning('Skipping unsupported OTP Auth entry', error, stackTrace);
+      _logger.warning('Failed to parse OTP Auth entry', error, stackTrace);
+      throwImportEntryParseError(account, error);
     }
   }
   return codes;
@@ -115,8 +116,8 @@ Code _accountToCode(Map<String, Object?> account) {
       account: Uri.encodeComponent(label),
       secret: secret,
       algorithm: algorithm.name.toUpperCase(),
-      digits: digits == 0 ? Code.defaultDigits : digits,
-      period: period == 0 ? Code.defaultPeriod : period,
+      digits: digits,
+      period: period,
       counter: counter,
     ),
   );

--- a/mobile/apps/auth/lib/ui/settings/data/import/raivo_plain_text_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/raivo_plain_text_import.dart
@@ -56,8 +56,9 @@ Future<int?> _processRaivoExportFile(BuildContext context, String path) async {
     var counter = item['counter'];
 
     parsedCodes.add(
-      Code.fromOTPAuthUrl(
-        buildImportOtpUri(
+      parseImportOtpCode(
+        item,
+        () => buildImportOtpUri(
           kind: kind,
           issuer: issuer,
           account: account,

--- a/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
@@ -117,8 +117,9 @@ Future<int?> _process2FasExportFile(
     var digits = item['otp']['digits'];
     var counter = item['otp']['counter'];
 
-    Code code = Code.fromOTPAuthUrl(
-      buildImportOtpUri(
+    Code code = parseImportOtpCode(
+      item,
+      () => buildImportOtpUri(
         kind: kind,
         issuer: issuer,
         account: account,

--- a/mobile/apps/auth/test/ui/settings/data/import/import_flow_test.dart
+++ b/mobile/apps/auth/test/ui/settings/data/import/import_flow_test.dart
@@ -1,0 +1,109 @@
+import 'package:ente_auth/models/code.dart';
+import 'package:ente_auth/ui/settings/data/import/import_flow.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildImportOtpUri', () {
+    test('normalizes missing and sentinel OTP parameters', () {
+      final totpUri = buildImportOtpUri(
+        kind: 'totp',
+        issuer: 'Example',
+        account: 'alice@example.com',
+        secret: 'ASKZNWOU6SVYAMVS',
+        algorithm: 'SHA1',
+        digits: 0,
+        period: 0,
+      );
+
+      final totpCode = Code.fromOTPAuthUrl(totpUri);
+      expect(totpCode.digits, Code.defaultDigits);
+      expect(totpCode.period, Code.defaultPeriod);
+
+      final hotpUri = buildImportOtpUri(
+        kind: 'hotp',
+        issuer: 'Example',
+        account: 'alice@example.com',
+        secret: 'ASKZNWOU6SVYAMVS',
+        algorithm: 'SHA1',
+        digits: '0',
+        counter: null,
+      );
+
+      final hotpCode = Code.fromOTPAuthUrl(hotpUri);
+      expect(hotpCode.digits, Code.defaultDigits);
+      expect(hotpCode.counter, 0);
+    });
+
+    test('rejects unsafe imported OTP parameters', () {
+      const entry = {'digits': 11};
+      expect(
+        () => parseImportOtpCode(
+          entry,
+          () => buildImportOtpUri(
+            kind: 'totp',
+            issuer: 'Example',
+            account: 'alice@example.com',
+            secret: 'ASKZNWOU6SVYAMVS',
+            algorithm: 'SHA1',
+            digits: 11,
+            period: 30,
+          ),
+        ),
+        throwsA(
+          isA<ImportEntryParseException>().having(
+            (error) => error.entry,
+            'entry',
+            same(entry),
+          ),
+        ),
+      );
+      expect(
+        () => buildImportOtpUri(
+          kind: 'hotp',
+          issuer: 'Example',
+          account: 'alice@example.com',
+          secret: 'ASKZNWOU6SVYAMVS',
+          algorithm: 'SHA1',
+          digits: 6,
+          counter: -1,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('keeps compatible nonstandard positive periods', () {
+      final uri = buildImportOtpUri(
+        kind: 'totp',
+        issuer: 'Example',
+        account: 'alice@example.com',
+        secret: 'ASKZNWOU6SVYAMVS',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 300,
+      );
+
+      expect(Code.fromOTPAuthUrl(uri).period, 300);
+    });
+
+    test('formats failed entry details separately from summary error', () {
+      const exception = ImportEntryParseException(
+        entry: {'issuer': 'Example', 'digits': 11},
+        error: FormatException('Invalid OTP digits: 11'),
+      );
+
+      expect(exception.toString(), contains('Invalid OTP digits: 11'));
+      expect(exception.toString(), isNot(contains('issuer')));
+      expect(exception.details, contains('Invalid OTP digits: 11'));
+      expect(exception.details, contains('"digits": 11'));
+    });
+
+    test('keeps preformatted failed entry details readable', () {
+      const exception = ImportEntryParseException(
+        entry: '{\n  "digits": 11\n}',
+        error: FormatException('Invalid OTP digits: 11'),
+      );
+
+      expect(exception.entryText, '{\n  "digits": 11\n}');
+    });
+  });
+}


### PR DESCRIPTION
- Validate imported OTP parameters before saving codes.
- Surface malformed entries so users can identify the failed backup item.