### PR TITLE
[mob][photos] Fix comment album selection and social overlay updates

### DIFF
--- a/mobile/apps/photos/changes/latest-comment-album.md
+++ b/mobile/apps/photos/changes/latest-comment-album.md
@@ -1,1 +1,0 @@
-- Fixed opening the wrong album when tapping the latest comment on a photo.

--- a/mobile/apps/photos/changes/latest-comment-album.md
+++ b/mobile/apps/photos/changes/latest-comment-album.md
@@ -1,0 +1,1 @@
+- Fixed opening the wrong album when tapping the latest comment on a photo.

--- a/mobile/apps/photos/lib/ui/social/comment_collection_selection.dart
+++ b/mobile/apps/photos/lib/ui/social/comment_collection_selection.dart
@@ -1,0 +1,12 @@
+int resolveInitialCommentsCollectionID({
+  required int requestedCollectionID,
+  required int? draftCollectionID,
+  required bool preferDraftCollection,
+  required bool hasHighlightedComment,
+}) {
+  return preferDraftCollection &&
+          !hasHighlightedComment &&
+          draftCollectionID != null
+      ? draftCollectionID
+      : requestedCollectionID;
+}

--- a/mobile/apps/photos/lib/ui/social/comments_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/comments_screen.dart
@@ -265,7 +265,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       final savedSelectedCollectionID =
           _lastSelectedDraftCollectionIDs[_draftFileKey];
       final nextSelectedCollectionID =
-          _canRestoreDraftCollection &&
+          _shouldPreferDraftCollection &&
               savedSelectedCollectionID != null &&
               sharedCollections.any(
                 (info) => info.collection.id == savedSelectedCollectionID,
@@ -688,7 +688,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
   _CommentDraftFileKey get _draftFileKey =>
       (userID: _currentUserID, fileID: widget.fileID);
 
-  bool get _canRestoreDraftCollection =>
+  bool get _shouldPreferDraftCollection =>
       widget.preferDraftCollection && widget.highlightCommentID == null;
 
   _CommentDraftKey get _draftKey => (

--- a/mobile/apps/photos/lib/ui/social/comments_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/comments_screen.dart
@@ -17,6 +17,7 @@ import 'package:photos/services/social_notification_coordinator.dart';
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/components/buttons/icon_button_widget.dart";
+import "package:photos/ui/social/comment_collection_selection.dart";
 import "package:photos/ui/social/social_actor_contact_navigation.dart";
 import "package:photos/ui/social/widgets/collection_selector_widget.dart";
 import "package:photos/ui/social/widgets/comment_bubble_widget.dart";
@@ -41,6 +42,7 @@ Future<void> showFileCommentsBottomSheet(
   required int collectionID,
   required int fileID,
   String? highlightCommentID,
+  bool preferDraftCollection = true,
   List<Collection>? sharedCollections,
 }) {
   return showModalBottomSheet(
@@ -52,6 +54,7 @@ Future<void> showFileCommentsBottomSheet(
       collectionID: collectionID,
       fileID: fileID,
       highlightCommentID: highlightCommentID,
+      preferDraftCollection: preferDraftCollection,
       sharedCollections: sharedCollections,
     ),
   );
@@ -62,6 +65,7 @@ class _DraggableCommentsSheet extends StatefulWidget {
   final int collectionID;
   final int fileID;
   final String? highlightCommentID;
+  final bool preferDraftCollection;
   final List<Collection>? sharedCollections;
 
   const _DraggableCommentsSheet({
@@ -69,6 +73,7 @@ class _DraggableCommentsSheet extends StatefulWidget {
     required this.collectionID,
     required this.fileID,
     this.highlightCommentID,
+    required this.preferDraftCollection,
     this.sharedCollections,
   });
 
@@ -102,6 +107,7 @@ class _DraggableCommentsSheetState extends State<_DraggableCommentsSheet> {
         collectionID: widget.collectionID,
         fileID: widget.fileID,
         highlightCommentID: widget.highlightCommentID,
+        preferDraftCollection: widget.preferDraftCollection,
         sharedCollections: widget.sharedCollections,
         dragController: scrollController,
         sheetController: sheetController,
@@ -119,6 +125,10 @@ class FileCommentsBottomSheet extends StatefulWidget {
   /// Optional comment ID to scroll to and highlight.
   final String? highlightCommentID;
 
+  /// Whether an unsent draft in another collection may override
+  /// [collectionID] when the sheet opens.
+  final bool preferDraftCollection;
+
   /// Scroll controller for the drag handle (from DraggableScrollableSheet).
   final ScrollController dragController;
 
@@ -130,6 +140,7 @@ class FileCommentsBottomSheet extends StatefulWidget {
     required this.collectionID,
     required this.fileID,
     this.sharedCollections,
+    this.preferDraftCollection = true,
     required this.dragController,
     required this.sheetController,
     this.highlightCommentID,
@@ -183,9 +194,12 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
     _inputFocusNode = FocusNode()..addListener(_onInputFocusChange);
     _scrollController = ScrollController()..addListener(_onScroll);
     _currentUserID = Configuration.instance.getUserID()!;
-    _selectedCollectionID = _canRestoreDraftCollection
-        ? _lastSelectedDraftCollectionIDs[_draftFileKey] ?? widget.collectionID
-        : widget.collectionID;
+    _selectedCollectionID = resolveInitialCommentsCollectionID(
+      requestedCollectionID: widget.collectionID,
+      draftCollectionID: _lastSelectedDraftCollectionIDs[_draftFileKey],
+      preferDraftCollection: widget.preferDraftCollection,
+      hasHighlightedComment: widget.highlightCommentID != null,
+    );
     _highlightedCommentID = widget.highlightCommentID;
     _loadSharedCollections();
   }
@@ -674,7 +688,8 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
   _CommentDraftFileKey get _draftFileKey =>
       (userID: _currentUserID, fileID: widget.fileID);
 
-  bool get _canRestoreDraftCollection => widget.highlightCommentID == null;
+  bool get _canRestoreDraftCollection =>
+      widget.preferDraftCollection && widget.highlightCommentID == null;
 
   _CommentDraftKey get _draftKey => (
     userID: _currentUserID,

--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -361,7 +361,7 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
     });
   }
 
-  Future<void> _openComments({Comment? comment}) async {
+  Future<void> _openComments({int? targetCollectionID}) async {
     final fileID = widget.file.uploadedFileID;
     if (fileID == null) return;
     await _runSheetAndRefresh(() async {
@@ -376,12 +376,12 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
         return;
       }
 
-      Collection? commentCollection;
+      Collection? targetCollection;
       Collection? openingCollection;
       Collection? latestCommentCollection;
       for (final collection in sharedCollections) {
-        if (collection.id == comment?.collectionID) {
-          commentCollection = collection;
+        if (collection.id == targetCollectionID) {
+          targetCollection = collection;
         }
         if (collection.id == widget.openingCollectionID) {
           openingCollection = collection;
@@ -391,7 +391,7 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
         }
       }
       final initialCollection =
-          commentCollection ??
+          targetCollection ??
           latestCommentCollection ??
           openingCollection ??
           sharedCollections.first;
@@ -400,7 +400,7 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
         context,
         collectionID: initialCollection.id,
         fileID: fileID,
-        preferDraftCollection: comment == null,
+        preferDraftCollection: targetCollectionID == null,
         sharedCollections: sharedCollections,
       );
     });
@@ -438,7 +438,8 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
                 MediaQuery.sizeOf(context).width * 0.6,
               ),
               currentUserID: widget.currentUserID!,
-              onTap: () => _openComments(comment: latestComment),
+              onTap: () =>
+                  _openComments(targetCollectionID: latestComment.collectionID),
             ),
           )
         : const SizedBox.shrink();

--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -123,7 +123,18 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
 
     if (fileID == null || currentUserID == null) {
       _clearSocialState();
-      widget.onVisibilityChanged?.call(false);
+      // This path can run synchronously from didUpdateWidget. Defer notifying
+      // the host so a future uploaded-to-local transition cannot mark a
+      // sibling widget dirty while Flutter is still building this overlay.
+      scheduleMicrotask(() {
+        if (!mounted ||
+            refreshID != _latestRefreshID ||
+            widget.file.uploadedFileID != fileID ||
+            widget.currentUserID != currentUserID) {
+          return;
+        }
+        widget.onVisibilityChanged?.call(false);
+      });
       return;
     }
 
@@ -389,6 +400,7 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
         context,
         collectionID: initialCollection.id,
         fileID: fileID,
+        preferDraftCollection: comment == null,
         sharedCollections: sharedCollections,
       );
     });

--- a/mobile/apps/photos/test/ui/social/comments_collection_selection_test.dart
+++ b/mobile/apps/photos/test/ui/social/comments_collection_selection_test.dart
@@ -1,0 +1,42 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ui/social/comment_collection_selection.dart";
+
+void main() {
+  group("initial comments collection", () {
+    test("prefers a collection containing an unsent draft", () {
+      expect(
+        resolveInitialCommentsCollectionID(
+          requestedCollectionID: 10,
+          draftCollectionID: 20,
+          preferDraftCollection: true,
+          hasHighlightedComment: false,
+        ),
+        20,
+      );
+    });
+
+    test("keeps the requested collection for an explicit comment tap", () {
+      expect(
+        resolveInitialCommentsCollectionID(
+          requestedCollectionID: 10,
+          draftCollectionID: 20,
+          preferDraftCollection: false,
+          hasHighlightedComment: false,
+        ),
+        10,
+      );
+    });
+
+    test("keeps the requested collection for a highlighted comment", () {
+      expect(
+        resolveInitialCommentsCollectionID(
+          requestedCollectionID: 10,
+          draftCollectionID: 20,
+          preferDraftCollection: true,
+          hasHighlightedComment: true,
+        ),
+        10,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- keep latest-comment taps in the collection that contains the tapped comment
- preserve draft-collection restoration when opening the general comments sheet
- defer the social-overlay visibility callback to avoid notifying sibling widgets during a future uploaded-to-local transition
- add focused tests for comment collection selection

## Root cause

The comments sheet used the absence of `highlightCommentID` as a proxy for whether an unsent draft could override the requested collection. Removing highlighting from latest-comment taps therefore allowed a draft in another collection to redirect the sheet.

The social overlay's null file/user path also notified its host synchronously. Although Memories currently uses either uploaded or local files rather than mixing them, deferring that notification prevents a future mixed transition from marking a sibling dirty during Flutter's build phase.

## Validation

- `flutter test test/ui/social/comments_collection_selection_test.dart`
- targeted `dart analyze` for the changed Dart files and test
- `dart format`
- `git diff --check`
