### PR TITLE
docs: document shared memory controls

### DIFF
--- a/docs/docs/photos/features/search-and-discovery/index.md
+++ b/docs/docs/photos/features/search-and-discovery/index.md
@@ -119,6 +119,12 @@ After enabling, the app will download and index your photos locally. This is fas
 
 Ente automatically creates collections of photos from past years on the same date, helping you rediscover memories.
 
+To share items from a memory on mobile:
+
+1. Open the memory and tap the share action.
+2. Select the photos and videos you want to include. You can use **Select all**, or tap the selected count to clear the selection.
+3. Tap **Share memory** to create a link containing only the selected items. To send the selected original files instead, tap **Share items**.
+
 ### Memory Lane
 
 Memory Lane creates a timeline for a person using photos of them from different years. When a person's timeline is ready, Ente shows a **Memory lane** banner on their page so you can open it and, on supported platforms, share it as a public link.

--- a/docs/docs/photos/features/search-and-discovery/memory-lane.md
+++ b/docs/docs/photos/features/search-and-discovery/memory-lane.md
@@ -44,10 +44,11 @@ You can share a Memory Lane as a public link so others can view that person's ti
 
 1. Open a person's **Memory lane**.
 2. Tap the share action.
-3. Create or copy the link.
-4. Share the link with anyone you want.
+3. Select the photos and videos you want to include. You can use **Select all**, or tap the selected count to clear the selection.
+4. Tap **Share memory** to create the link. To send the selected original files instead, tap **Share items**.
+5. Share the link with anyone you want.
 
-Recipients can open the link without an Ente account.
+Recipients can open the link without an Ente account. The link contains only the items you selected.
 
 ## What recipients see
 
@@ -55,7 +56,7 @@ A shared Memory Lane opens as a public, browser-based viewer with the same timel
 
 Recipients can:
 
-- view the timeline in order
+- view the selected items in order
 - play through the lane presentation
 - open the shared link without signing in
 

--- a/docs/docs/photos/features/search-and-discovery/memory-lane.md
+++ b/docs/docs/photos/features/search-and-discovery/memory-lane.md
@@ -44,11 +44,10 @@ You can share a Memory Lane as a public link so others can view that person's ti
 
 1. Open a person's **Memory lane**.
 2. Tap the share action.
-3. Select the photos and videos you want to include. You can use **Select all**, or tap the selected count to clear the selection.
-4. Tap **Share memory** to create the link. To send the selected original files instead, tap **Share items**.
-5. Share the link with anyone you want.
+3. Create or copy the link.
+4. Share the link with anyone you want.
 
-Recipients can open the link without an Ente account. The link contains only the items you selected.
+Recipients can open the link without an Ente account.
 
 ## What recipients see
 
@@ -56,7 +55,7 @@ A shared Memory Lane opens as a public, browser-based viewer with the same timel
 
 Recipients can:
 
-- view the selected items in order
+- view the timeline in order
 - play through the lane presentation
 - open the shared link without signing in
 

--- a/docs/docs/photos/features/sharing-and-collaboration/comments-and-likes.md
+++ b/docs/docs/photos/features/sharing-and-collaboration/comments-and-likes.md
@@ -14,6 +14,7 @@ Ente lets you comment on and like shared photos and videos. Whether you're colla
 Comments and likes are available on:
 
 - **Shared albums**: Albums you've shared with other Ente users or that have been shared with you
+- **Shared memories on mobile**: While viewing a memory made from photos or videos in a shared album, you can comment and react without leaving the memory viewer
 - **Public links**: Albums shared via public links, including collect links
 - **Both authenticated and anonymous users**: Ente users can comment with their account, while public link visitors can comment anonymously
 


### PR DESCRIPTION
## Summary

- document choosing which photos and videos are included in a shared Memory Lane link
- distinguish sharing a memory link from sending the selected original items
- clarify that comments and reactions are available while viewing shared memories on mobile

## Context

Ente Photos mobile v1.3.59 added selectable memory-link sharing and comments/reactions on shared memories. The changelog listed both features, but the relevant feature guides did not yet explain them.

## Validation

- `git diff --check`
- Docs lint/build could not run in this checkout because dependencies are not installed (`prettier: not found`).
