### PR TITLE
[mobile][photos] Refine shared avatar and selection components

### DIFF
--- a/mobile/apps/photos/lib/ui/family/family_dashboard.dart
+++ b/mobile/apps/photos/lib/ui/family/family_dashboard.dart
@@ -416,11 +416,12 @@ class _MemberAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hasPhoto = profilePictureBytes != null || linkedPersonId != null;
     final cachedPixelWidth =
         (AvatarComponentSize.large.dimension *
                 MediaQuery.devicePixelRatioOf(context))
             .round();
-    final avatar = profilePictureBytes != null
+    Widget avatar = profilePictureBytes != null
         ? AvatarComponent.image(
             image: ResizeImage(
               MemoryImage(profilePictureBytes!),
@@ -444,11 +445,25 @@ class _MemberAvatar extends StatelessWidget {
             ),
           )
         : AvatarComponent(
-            initials: _initials(displayName),
+            initials: avatarInitials(displayName),
             color: avatarColor,
             size: AvatarComponentSize.large,
             semanticLabel: displayName,
           );
+
+    if (hasPhoto) {
+      avatar = DecoratedBox(
+        position: DecorationPosition.foreground,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: avatarComponentColorValue(context, avatarColor),
+            width: 2,
+          ),
+        ),
+        child: avatar,
+      );
+    }
 
     if (!member.isAdmin) {
       return avatar;
@@ -475,19 +490,4 @@ class _MemberAvatar extends StatelessWidget {
       ],
     );
   }
-}
-
-String _initials(String value) {
-  final words = value
-      .trim()
-      .split(RegExp(r'\s+'))
-      .where((word) => word.isNotEmpty)
-      .toList();
-  if (words.isEmpty) {
-    return '?';
-  }
-  if (words.length == 1) {
-    return words.first.substring(0, 1);
-  }
-  return '${words.first.substring(0, 1)}${words.last.substring(0, 1)}';
 }

--- a/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memory_share_sheet.dart
@@ -1,6 +1,5 @@
 import "dart:math" as math;
 
-import "package:ente_components/components/chip_surface.dart";
 import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
@@ -115,7 +114,7 @@ class _MemoryShareSelectionSheetState
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: Spacing.xl),
-                  child: _buildSelectionControls(context, l10n),
+                  child: _buildSelectionControls(l10n),
                 ),
                 const SizedBox(height: Spacing.lg),
                 Expanded(child: _buildGrid()),
@@ -162,74 +161,33 @@ class _MemoryShareSelectionSheetState
     );
   }
 
-  Widget _buildSelectionControls(BuildContext context, AppLocalizations l10n) {
+  Widget _buildSelectionControls(AppLocalizations l10n) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        _buildSelectionChip(
+        SelectionSummaryChipComponent(
           key: const ValueKey("memory-share-select-all"),
           label: l10n.selectAll,
-          icon: HugeIcons.strokeRoundedTick02,
+          icon: const HugeIcon(
+            icon: HugeIcons.strokeRoundedTick02,
+            size: IconSizes.small,
+          ),
           semanticLabel: l10n.selectAll,
-          selected: _areAllSelected,
+          isSelected: _areAllSelected,
           onTap: _areAllSelected ? null : _selectAll,
         ),
-        _buildSelectionChip(
+        SelectionSummaryChipComponent(
           key: const ValueKey("memory-share-selected-count"),
           label: l10n.selectedPhotos(count: _selectedFiles.files.length),
-          icon: HugeIcons.strokeRoundedCancel01,
+          icon: const HugeIcon(
+            icon: HugeIcons.strokeRoundedCancel01,
+            size: IconSizes.small,
+          ),
           semanticLabel: l10n.clearSelection,
-          selected: _hasSelection,
+          isSelected: _hasSelection,
           onTap: _hasSelection ? _clearSelection : null,
         ),
       ],
-    );
-  }
-
-  Widget _buildSelectionChip({
-    required Key key,
-    required String label,
-    required List<List<dynamic>> icon,
-    required String semanticLabel,
-    required bool selected,
-    required VoidCallback? onTap,
-  }) {
-    final colors = context.componentColors;
-    final foreground = onTap == null ? colors.textLighter : colors.textBase;
-    return ChipSurface(
-      key: key,
-      surfaceKey: ValueKey("$key-surface"),
-      enabled: onTap != null,
-      selected: selected,
-      semanticLabel: semanticLabel,
-      minWidth: 104,
-      minHeight: 36,
-      padding: const EdgeInsets.fromLTRB(Spacing.sm, 8, Spacing.md, 8),
-      background: colors.fillLight,
-      borderRadius: BorderRadius.circular(100),
-      onTap: onTap,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            width: 66,
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: TextStyles.mini.copyWith(color: foreground),
-            ),
-          ),
-          const SizedBox(width: Spacing.xs),
-          ChipIconSlot(
-            color: foreground,
-            size: 12,
-            slotSize: 14,
-            child: HugeIcon(icon: icon),
-          ),
-        ],
-      ),
     );
   }
 

--- a/mobile/apps/photos/lib/ui/sharing/user_avator_widget.dart
+++ b/mobile/apps/photos/lib/ui/sharing/user_avator_widget.dart
@@ -184,14 +184,14 @@ class _UserAvatarWidgetState extends State<UserAvatarWidget> {
                         }
                       },
                     )
-                  : _FirstLetterCircularAvatar(
+                  : _InitialsCircularAvatar(
                       user: widget.user,
                       type: widget.type,
                       fallbackIdentity: widget.fallbackIdentity,
                     ),
             ),
           )
-        : _FirstLetterCircularAvatar(
+        : _InitialsCircularAvatar(
             user: widget.user,
             type: widget.type,
             fallbackIdentity: widget.fallbackIdentity,
@@ -199,11 +199,11 @@ class _UserAvatarWidgetState extends State<UserAvatarWidget> {
   }
 }
 
-class _FirstLetterCircularAvatar extends StatelessWidget {
+class _InitialsCircularAvatar extends StatelessWidget {
   final User user;
   final AvatarType type;
   final AvatarIdentity? fallbackIdentity;
-  const _FirstLetterCircularAvatar({
+  const _InitialsCircularAvatar({
     required this.user,
     required this.type,
     required this.fallbackIdentity,
@@ -222,7 +222,7 @@ class _FirstLetterCircularAvatar extends StatelessWidget {
       child: CircleAvatar(
         backgroundColor: avatarBackgroundColor(context, identity),
         child: Text(
-          identity.initial,
+          identity.initials,
           // fixed color
           style: textStyle.copyWith(color: Colors.white),
         ),
@@ -269,9 +269,9 @@ double getAvatarSize(AvatarType type) {
   }
 }
 
-class FirstLetterUserAvatar extends StatelessWidget {
+class UserInitialsAvatar extends StatelessWidget {
   final User user;
-  const FirstLetterUserAvatar(this.user, {super.key});
+  const UserInitialsAvatar(this.user, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -280,7 +280,7 @@ class FirstLetterUserAvatar extends StatelessWidget {
       color: avatarBackgroundColor(context, identity),
       child: Center(
         child: Text(
-          identity.initial,
+          identity.initials,
           style: getEnteTextTheme(context).small.copyWith(color: Colors.white),
         ),
       ),

--- a/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
@@ -36,7 +36,7 @@ class AddedByWidget extends StatelessWidget {
     }
     final colors = context.componentColors;
     final avatar = AvatarComponent(
-      initials: identity.initial,
+      initials: identity.initials,
       color: avatarComponentColorForAvatarIdentity(identity),
       size: AvatarComponentSize.defaultSize,
     );

--- a/mobile/apps/photos/lib/ui/viewer/people/person_face_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/person_face_widget.dart
@@ -576,7 +576,7 @@ class _EmptyPersonThumbnail extends StatelessWidget {
                       ? shortestSide * 0.42
                       : textTheme.h2.fontSize ?? 24;
                   return Text(
-                    identity!.initial,
+                    identity!.initials,
                     style: textTheme.h2Bold.copyWith(
                       color: Colors.white,
                       fontSize: fontSize,

--- a/mobile/apps/photos/lib/ui/viewer/search/contact_avatar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/contact_avatar_widget.dart
@@ -100,7 +100,7 @@ class _ContactAvatarWidgetState extends State<ContactAvatarWidget> {
             },
           );
         }
-        return FirstLetterUserAvatar(_fallbackUser());
+        return UserInitialsAvatar(_fallbackUser());
       },
     );
     return SizedBox(

--- a/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/result/edit_contact_page.dart
@@ -258,7 +258,7 @@ class _EditContactPageState extends State<EditContactPage> {
       backgroundColor: avatarBackgroundColor(context, identity),
       child: Center(
         child: Text(
-          identity.initial,
+          identity.initials,
           style: textTheme.h1Bold.copyWith(
             fontSize: 38.25,
             height: 47.813 / 38.25,

--- a/mobile/apps/photos/lib/utils/avatar_util.dart
+++ b/mobile/apps/photos/lib/utils/avatar_util.dart
@@ -56,10 +56,7 @@ class AvatarIdentity {
   final String key;
   final AvatarIdentityRole role;
 
-  String get initial {
-    final trimmed = label.trim();
-    return trimmed.isEmpty ? " " : trimmed.characters.first.toUpperCase();
-  }
+  String get initials => avatarInitials(label);
 }
 
 String avatarIdentityKey({

--- a/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
+++ b/mobile/apps/photos/test/ui/family/family_dashboard_test.dart
@@ -242,6 +242,7 @@ void main() {
       final savedMemberAvatar = avatars.singleWhere(
         (avatar) => avatar.semanticLabel == 'Saved member',
       );
+      expect(savedMemberAvatar.initials, 'SM');
       expect(
         savedMemberAvatar.color,
         avatarComponentColorForIdentity(
@@ -302,6 +303,26 @@ void main() {
       find.byType(PersonFaceWidget),
     );
     expect(personAvatar.personId, 'person-42');
+    final ringFinder = find.ancestor(
+      of: find.byType(PersonFaceWidget),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is DecoratedBox &&
+            widget.position == DecorationPosition.foreground &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration as BoxDecoration).shape == BoxShape.circle,
+      ),
+    );
+    expect(ringFinder, findsOneWidget);
+    final ring = tester.widget<DecoratedBox>(ringFinder);
+    final border = (ring.decoration as BoxDecoration).border! as Border;
+    expect(
+      border.top.color,
+      avatarComponentColorValue(
+        tester.element(find.byType(PersonFaceWidget)),
+        familyMemberAvatarComponentColor(member),
+      ),
+    );
 
     await tester.tap(find.byType(MenuComponent));
     expect(selectedDisplayName, 'Current person');

--- a/mobile/packages/ente_components/lib/components/app_bar_component.dart
+++ b/mobile/packages/ente_components/lib/components/app_bar_component.dart
@@ -60,6 +60,8 @@ class AppBarComponent extends StatefulWidget {
 
   final String title;
   final HeaderAppBarTitleBuilder? titleBuilder;
+
+  /// Vertical space reserved for [titleBuilder] in both header states.
   final double? titleBuilderHeight;
   final VoidCallback? onTitleTap;
   final VoidCallback? onTitleDoubleTap;
@@ -830,7 +832,7 @@ _HeaderAppBarMetrics _resolveHeaderAppBarMetrics(
     ),
   );
   final expandedTextBlockHeight =
-      expandedTitleLineHeight +
+      (titleBuilderHeight ?? expandedTitleLineHeight) +
       (subtitle == null ? 0 : _subtitleGap + subtitleHeight);
   final effectiveExpandedHeight = _maxDouble(
     expandedHeight ?? defaultExpandedHeight,

--- a/mobile/packages/ente_components/lib/components/avatar_component.dart
+++ b/mobile/packages/ente_components/lib/components/avatar_component.dart
@@ -127,6 +127,16 @@ const List<AvatarComponentColor> avatarComponentIdentityPalette = [
   AvatarComponentColor.cyan,
 ];
 
+String avatarInitials(String name) {
+  final words = name.trim().split(RegExp(r'\s+'));
+  if (words.first.isEmpty) return '?';
+
+  final initial = words.first.toUpperCase().characters.first;
+  return words.length == 1
+      ? initial
+      : '$initial${words.last.toUpperCase().characters.first}';
+}
+
 /// A stable FNV-1a seed for identity colors across processes and platforms.
 int avatarSeedForIdentity(String identityKey) {
   var hash = 0x811c9dc5;
@@ -278,11 +288,10 @@ class AvatarComponent extends StatelessWidget {
       );
     }
 
-    final text = initials.trim().isEmpty ? '?' : initials.trim().toUpperCase();
     return FittedBox(
       fit: BoxFit.scaleDown,
       child: Text(
-        text,
+        _displayInitials,
         maxLines: 1,
         textAlign: TextAlign.center,
         style: size.textStyle.copyWith(
@@ -306,7 +315,12 @@ class AvatarComponent extends StatelessWidget {
     if (image != null) return 'AvatarComponent image';
     if (icon != null) return 'Add avatar';
     if (initials.trim().isEmpty) return 'AvatarComponent';
-    return 'AvatarComponent $initials';
+    return 'AvatarComponent $_displayInitials';
+  }
+
+  String get _displayInitials {
+    final normalized = initials.trim().toUpperCase();
+    return normalized.isEmpty ? '?' : normalized.characters.take(2).join();
   }
 }
 

--- a/mobile/packages/ente_components/lib/components/buttons/button_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/button_component.dart
@@ -23,13 +23,7 @@ enum ButtonComponentVariant {
 
 enum ButtonComponentSize { small, large }
 
-enum ButtonComponentDensity {
-  regular,
-
-  /// Opt-in 48px Button Large treatment used by the Memory sharing sheet.
-  /// Source: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-312441&m=dev
-  compact,
-}
+enum ButtonComponentDensity { regular, compact }
 
 /// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=2207-41578&m=dev
 /// Section: Buttons / Button Small

--- a/mobile/packages/ente_components/lib/components/selection_summary_chip_component.dart
+++ b/mobile/packages/ente_components/lib/components/selection_summary_chip_component.dart
@@ -1,0 +1,81 @@
+import 'package:ente_components/components/chip_surface.dart';
+import 'package:ente_components/theme/spacing.dart';
+import 'package:ente_components/theme/text_styles.dart';
+import 'package:ente_components/theme/theme.dart';
+import 'package:flutter/material.dart';
+
+/// Compact selection action used to select or clear a group of items.
+///
+/// This is separate from a filter chip: it represents an action and
+/// keeps the same neutral surface when enabled or disabled.
+/// Sources:
+/// https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=18629-313326&m=dev
+/// https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=15782-102259&m=dev
+class SelectionSummaryChipComponent extends StatelessWidget {
+  const SelectionSummaryChipComponent({
+    required this.label,
+    required this.icon,
+    required this.semanticLabel,
+    this.onTap,
+    this.isSelected = false,
+    super.key,
+  });
+
+  final String label;
+  final Widget icon;
+  final String semanticLabel;
+  final VoidCallback? onTap;
+  final bool isSelected;
+
+  static const double width = 104;
+  static const double minHeight = 36;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    final enabled = onTap != null;
+    final foreground = enabled ? colors.textBase : colors.textLighter;
+
+    return SizedBox(
+      width: width,
+      child: ChipSurface(
+        surfaceKey: const ValueKey('selection-summary-chip-surface'),
+        enabled: enabled,
+        selected: isSelected,
+        semanticLabel: semanticLabel,
+        minHeight: minHeight,
+        padding: const EdgeInsets.fromLTRB(
+          Spacing.sm,
+          Spacing.sm,
+          Spacing.md,
+          Spacing.sm,
+        ),
+        background: colors.fillLight,
+        borderRadius: BorderRadius.circular(100),
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 66,
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: TextStyles.mini.copyWith(color: foreground),
+              ),
+            ),
+            const SizedBox(width: Spacing.xs),
+            ChipIconSlot(
+              color: foreground,
+              size: 12,
+              slotSize: 14,
+              child: icon,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -15,6 +15,7 @@ export 'components/selection_controls/checkbox_component.dart';
 export 'components/selection_controls/labeled_control_component.dart';
 export 'components/selection_controls/radio_component.dart';
 export 'components/selection_controls/toggle_switch_component.dart';
+export 'components/selection_summary_chip_component.dart';
 export 'components/slider_component.dart';
 export 'components/stepper_component.dart';
 export 'components/tag_chip_component.dart';

--- a/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
+++ b/mobile/packages/ente_components/test/components/app_surface_widgets_test.dart
@@ -819,6 +819,37 @@ void main() {
     },
   );
 
+  testWidgets('SliverAppBarComponent reserves custom title height', (
+    tester,
+  ) async {
+    const customTitleKey = ValueKey('custom-title');
+    const firstItemKey = ValueKey('first-item');
+
+    await pumpComponent(
+      tester,
+      CustomScrollView(
+        slivers: [
+          SliverAppBarComponent(
+            title: 'Custom title',
+            titleBuilderHeight: 80,
+            titleBuilder: (_, _) =>
+                const SizedBox(key: customTitleKey, height: 80),
+          ),
+          const SliverToBoxAdapter(
+            child: SizedBox(key: firstItemKey, height: 80),
+          ),
+        ],
+      ),
+      width: 390,
+      height: 600,
+    );
+
+    expect(
+      tester.getBottomLeft(find.byKey(customTitleKey)).dy,
+      lessThanOrEqualTo(tester.getTopLeft(find.byKey(firstItemKey)).dy),
+    );
+  });
+
   testWidgets('AppBarComponent lets short content stick collapsed', (
     tester,
   ) async {

--- a/mobile/packages/ente_components/test/components/avatar_test.dart
+++ b/mobile/packages/ente_components/test/components/avatar_test.dart
@@ -30,6 +30,16 @@ void main() {
     ]);
   });
 
+  test(
+    'avatar initials use the first and last words with a two-letter cap',
+    () {
+      expect(avatarInitials('Sachin Jain'), 'SJ');
+      expect(avatarInitials('Sachin Kumar Jain'), 'SJ');
+      expect(avatarInitials('Sachin'), 'S');
+      expect(avatarInitials('  '), '?');
+    },
+  );
+
   testWidgets('AvatarComponent renders the Figma sizes', (tester) async {
     await tester.pumpWidget(
       _wrap(
@@ -98,6 +108,21 @@ void main() {
       expect((cyanAvatar.decoration as BoxDecoration).color, avatarCyan);
     },
   );
+
+  testWidgets('AvatarComponent renders at most two supplied initials', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(_wrap(const AvatarComponent(initials: 'SJK')));
+
+    expect(find.text('SJ'), findsOneWidget);
+    expect(find.text('SJK'), findsNothing);
+    expect(
+      tester.getSemantics(find.byType(AvatarComponent)).label,
+      contains('AvatarComponent SJ'),
+    );
+    semantics.dispose();
+  });
 }
 
 Widget _wrap(Widget child) {

--- a/mobile/packages/ente_components/test/components/button_test.dart
+++ b/mobile/packages/ente_components/test/components/button_test.dart
@@ -491,6 +491,49 @@ void main() {
     expect(tester.getSize(find.byType(AnimatedContainer)).height, 52);
   });
 
+  testWidgets("Tertiary critical buttons retain the standard typography", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        ButtonComponent(
+          label: "Remove access",
+          variant: ButtonComponentVariant.tertiaryCritical,
+          size: ButtonComponentSize.small,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    final style = tester.widget<Text>(find.text("Remove access")).style!;
+    expect(style.fontFamily, TextStyles.bodyBold.fontFamily);
+    expect(style.fontSize, 14);
+    expect(style.height, 20 / 14);
+    expect(style.fontWeight, TextStyles.bodyBold.fontWeight);
+    expect(style.decoration, TextDecoration.underline);
+    expect(style.color, ColorTokens.light.warning);
+  });
+
+  testWidgets("Compact tertiary critical buttons use Body Link typography", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        ButtonComponent(
+          label: "Remove access",
+          variant: ButtonComponentVariant.tertiaryCritical,
+          density: ButtonComponentDensity.compact,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    final style = tester.widget<Text>(find.text("Remove access")).style!;
+    expect(style.fontFamily, TextStyles.body.fontFamily);
+    expect(style.fontWeight, TextStyles.body.fontWeight);
+    expect(style.decoration, TextDecoration.underline);
+  });
+
   testWidgets("Secondary button states follow Figma fill and text tokens", (
     tester,
   ) async {

--- a/mobile/packages/ente_components/test/components/selection_controls_test.dart
+++ b/mobile/packages/ente_components/test/components/selection_controls_test.dart
@@ -360,6 +360,49 @@ void main() {
     );
   });
 
+  testWidgets("SelectionSummaryChipComponent invokes only enabled actions", (
+    tester,
+  ) async {
+    var tapCount = 0;
+    await tester.pumpWidget(
+      _wrap(
+        SelectionSummaryChipComponent(
+          label: "Select all",
+          semanticLabel: "Select all",
+          icon: const HugeIcon(
+            icon: HugeIcons.strokeRoundedTick02,
+            size: IconSizes.small,
+          ),
+          onTap: () => tapCount += 1,
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey("selection-summary-chip-surface")),
+    );
+    expect(tapCount, 1);
+
+    await tester.pumpWidget(
+      _wrap(
+        const SelectionSummaryChipComponent(
+          label: "Select all",
+          semanticLabel: "Select all",
+          icon: HugeIcon(
+            icon: HugeIcons.strokeRoundedTick02,
+            size: IconSizes.small,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey("selection-summary-chip-surface")),
+    );
+    expect(tapCount, 1);
+    final label = tester.widget<Text>(find.text("Select all"));
+    expect(label.style?.color, ColorTokens.light.textLighter);
+  });
+
   testWidgets("FilterChipComponent keeps avatar fixed by default", (
     tester,
   ) async {


### PR DESCRIPTION
- Use consistent initials and identity styling for avatars.
- Reuse selection controls in Memories and honor custom app-bar title heights.