### PR TITLE
[mobile][photos] Deduplicate album sorting

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -417,6 +417,53 @@ class CollectionsService {
     return _collectionIDToNewestFileTime!;
   }
 
+  Future<void> sortCollectionsByAlbumPreferences(
+    List<Collection> collections, {
+    AlbumSortKey? sortKey,
+    AlbumSortDirection? sortDirection,
+  }) async {
+    if (collections.length < 2) {
+      return;
+    }
+    final comparator = await _albumPreferenceComparator(
+      sortKey: sortKey,
+      sortDirection: sortDirection,
+    );
+    collections.sort(comparator);
+  }
+
+  Future<Comparator<Collection>> _albumPreferenceComparator({
+    AlbumSortKey? sortKey,
+    AlbumSortDirection? sortDirection,
+  }) async {
+    final effectiveSortKey = sortKey ?? localSettings.albumSortKey();
+    final effectiveSortDirection =
+        sortDirection ?? localSettings.albumSortDirection();
+    final newestPhotoTimeByCollectionID =
+        effectiveSortKey == AlbumSortKey.newestPhoto
+        ? await getCollectionIDToNewestFileTime()
+        : const <int, int>{};
+
+    return (Collection first, Collection second) {
+      final comparison = switch (effectiveSortKey) {
+        AlbumSortKey.albumName => compareAsciiLowerCaseNatural(
+          first.displayName,
+          second.displayName,
+        ),
+        AlbumSortKey.newestPhoto =>
+          (newestPhotoTimeByCollectionID[second.id] ?? -intMaxValue).compareTo(
+            newestPhotoTimeByCollectionID[first.id] ?? -intMaxValue,
+          ),
+        AlbumSortKey.lastUpdated => second.updationTime.compareTo(
+          first.updationTime,
+        ),
+      };
+      return effectiveSortDirection == AlbumSortDirection.ascending
+          ? comparison
+          : -comparison;
+    };
+  }
+
   Future<EnteFile?> getCover(Collection c) async {
     final int localSyncTime = getCollectionSyncTime(c.id);
     final String coverKey = '${c.id}_${localSyncTime}_${c.updationTime}';
@@ -578,9 +625,6 @@ class CollectionsService {
   }
 
   Future<SharedCollections> getSharedCollections() async {
-    final AlbumSortKey sortKey = localSettings.albumSortKey();
-    final AlbumSortDirection sortDirection = localSettings.albumSortDirection();
-
     final List<Collection> outgoing = [];
     final List<Collection> incoming = [];
     final List<Collection> quickLinks = [];
@@ -600,11 +644,7 @@ class CollectionsService {
       }
     }
 
-    late Map<int, int> collectionIDToNewestPhotoTime;
-    if (sortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
+    final comparator = await _albumPreferenceComparator();
 
     // Sort incoming collections, then separate pinned from rest
     incoming.sort((first, second) {
@@ -613,47 +653,10 @@ class CollectionsService {
       final secondPinned = second.hasShareePinned();
       if (firstPinned && !secondPinned) return -1;
       if (!firstPinned && secondPinned) return 1;
-
-      int comparison;
-      if (sortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (sortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return sortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
+      return comparator(first, second);
     });
 
-    outgoing.sort((first, second) {
-      int comparison;
-      if (sortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (sortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return sortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
-    });
+    outgoing.sort(comparator);
 
     return SharedCollections(outgoing, incoming, quickLinks);
   }
@@ -673,36 +676,10 @@ class CollectionsService {
   }
 
   Future<List<Collection>> getCollectionForOnEnteSection() async {
-    final AlbumSortKey sortKey = localSettings.albumSortKey();
-    final AlbumSortDirection sortDirection = localSettings.albumSortDirection();
     final List<Collection> collections = CollectionsService.instance
         .getCollectionsForUI();
     final bool hasFavorites = FavoritesService.instance.hasFavorites();
-    late Map<int, int> collectionIDToNewestPhotoTime;
-    if (sortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
-    collections.sort((first, second) {
-      int comparison;
-      if (sortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (sortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return sortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
-    });
+    await sortCollectionsByAlbumPreferences(collections);
     final List<Collection> favorites = [];
     final List<Collection> pinned = [];
     final List<Collection> rest = [];
@@ -729,37 +706,11 @@ class CollectionsService {
   }
 
   Future<List<Collection>> getCollectionForWidgetSelection() async {
-    final AlbumSortKey sortKey = localSettings.albumSortKey();
-    final AlbumSortDirection sortDirection = localSettings.albumSortDirection();
     const bool includeShared = true;
     final List<Collection> collections = CollectionsService.instance
         .getCollectionsForUI(includedShared: includeShared);
     final bool hasFavorites = FavoritesService.instance.hasFavorites();
-    late Map<int, int> collectionIDToNewestPhotoTime;
-    if (sortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
-    collections.sort((first, second) {
-      int comparison;
-      if (sortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (sortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return sortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
-    });
+    await sortCollectionsByAlbumPreferences(collections);
     final List<Collection> favorites = [];
     final List<Collection> pinned = [];
     final List<Collection> rest = [];
@@ -786,36 +737,10 @@ class CollectionsService {
   }
 
   Future<List<Collection>> getCollectionsForRituals() async {
-    final AlbumSortKey sortKey = localSettings.albumSortKey();
-    final AlbumSortDirection sortDirection = localSettings.albumSortDirection();
     final List<Collection> collections = CollectionsService.instance
         .getCollectionsForUI();
     final bool hasFavorites = FavoritesService.instance.hasFavorites();
-    late Map<int, int> collectionIDToNewestPhotoTime;
-    if (sortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
-    collections.sort((first, second) {
-      int comparison;
-      if (sortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (sortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return sortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
-    });
+    await sortCollectionsByAlbumPreferences(collections);
     final List<Collection> favorites = [];
     final List<Collection> pinned = [];
     final List<Collection> rest = [];

--- a/mobile/apps/photos/lib/ui/collections/collection_list_page.dart
+++ b/mobile/apps/photos/lib/ui/collections/collection_list_page.dart
@@ -1,10 +1,8 @@
 import "dart:async";
 
-import "package:collection/collection.dart";
 import "package:ente_components/ente_components.dart";
 import 'package:flutter/material.dart';
 import "package:hugeicons/hugeicons.dart";
-import "package:photos/core/constants.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/album_sort_order_change_event.dart";
 import "package:photos/events/collection_updated_event.dart";
@@ -295,48 +293,14 @@ class _CollectionListPageState extends State<CollectionListPage> {
     }
     if (widget.sectionType == UISectionType.archivedCollections ||
         widget.sectionType == UISectionType.hiddenCollections) {
-      await _sortCollectionsByCurrentPreferences(collections!);
+      await CollectionsService.instance.sortCollectionsByAlbumPreferences(
+        collections!,
+        sortKey: sortKey,
+        sortDirection: albumSortDirection,
+      );
     }
     if (mounted) {
       setState(() {});
     }
-  }
-
-  Future<void> _sortCollectionsByCurrentPreferences(
-    List<Collection> collectionsToSort,
-  ) async {
-    if (collectionsToSort.length < 2) {
-      return;
-    }
-
-    final currentSortKey = sortKey;
-    final currentSortDirection = albumSortDirection;
-
-    Map<int, int>? collectionIDToNewestPhotoTime;
-    if (currentSortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
-
-    collectionsToSort.sort((first, second) {
-      int comparison;
-      if (currentSortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (currentSortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime?[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime?[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return currentSortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
-    });
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/gallery/hidden_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/hidden_page.dart
@@ -4,7 +4,6 @@ import "package:collection/collection.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:photos/core/configuration.dart";
-import "package:photos/core/constants.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/events/album_sort_order_change_event.dart";
@@ -14,10 +13,8 @@ import "package:photos/generated/l10n.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/gallery_type.dart";
 import "package:photos/models/selected_files.dart";
-import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
 import "package:photos/services/hidden_service.dart";
-import "package:photos/settings/local_settings.dart";
 import "package:photos/ui/collections/album/horizontal_list.dart";
 import "package:photos/ui/collections/collection_list_page.dart";
 import "package:photos/ui/common/loading_widget.dart";
@@ -104,7 +101,7 @@ class _HiddenPageState extends State<HiddenPage> {
     final hiddenCollectionsExcludingDefault = hiddenCollections
         .where((c) => c.id != defaultHiddenCollection.id)
         .toList();
-    await _sortCollectionsByCurrentPreferences(
+    await CollectionsService.instance.sortCollectionsByAlbumPreferences(
       hiddenCollectionsExcludingDefault,
     );
     if (!mounted) {
@@ -115,43 +112,6 @@ class _HiddenPageState extends State<HiddenPage> {
         ..clear()
         ..addAll(hiddenCollectionsExcludingDefault);
       _defaultHiddenCollectionId = defaultHiddenCollection.id;
-    });
-  }
-
-  Future<void> _sortCollectionsByCurrentPreferences(
-    List<Collection> collectionsToSort,
-  ) async {
-    if (collectionsToSort.length < 2) {
-      return;
-    }
-    final currentSortKey = localSettings.albumSortKey();
-    final currentSortDirection = localSettings.albumSortDirection();
-
-    Map<int, int>? collectionIDToNewestPhotoTime;
-    if (currentSortKey == AlbumSortKey.newestPhoto) {
-      collectionIDToNewestPhotoTime = await CollectionsService.instance
-          .getCollectionIDToNewestFileTime();
-    }
-
-    collectionsToSort.sort((first, second) {
-      int comparison;
-      if (currentSortKey == AlbumSortKey.albumName) {
-        comparison = compareAsciiLowerCaseNatural(
-          first.displayName,
-          second.displayName,
-        );
-      } else if (currentSortKey == AlbumSortKey.newestPhoto) {
-        comparison =
-            (collectionIDToNewestPhotoTime?[second.id] ?? -1 * intMaxValue)
-                .compareTo(
-                  collectionIDToNewestPhotoTime?[first.id] ?? -1 * intMaxValue,
-                );
-      } else {
-        comparison = second.updationTime.compareTo(first.updationTime);
-      }
-      return currentSortDirection == AlbumSortDirection.ascending
-          ? comparison
-          : -comparison;
     });
   }
 


### PR DESCRIPTION
- Centralize collection ordering by album sort preferences.
- Reuse it across shared, hidden, widget, ritual, and album list flows.