### PR TITLE
[mob][photos] Refresh widget settings

### DIFF
--- a/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
@@ -14,8 +14,6 @@ import "package:photos/settings/local_settings.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/collections/flex_grid_view.dart";
 import "package:photos/ui/common/loading_widget.dart";
-import "package:photos/ui/components/buttons/button_widget.dart";
-import "package:photos/ui/components/models/button_type.dart";
 
 class AlbumsWidgetSettings extends StatefulWidget {
   const AlbumsWidgetSettings({super.key});
@@ -98,10 +96,8 @@ class _AlbumsWidgetSettingsState extends State<AlbumsWidgetSettings> {
               child: ListenableBuilder(
                 listenable: _selectedAlbums,
                 builder: (context, _) {
-                  return ButtonWidget(
-                    buttonType: ButtonType.primary,
-                    buttonSize: ButtonSize.large,
-                    labelText: AppLocalizations.of(context).save,
+                  return ButtonComponent(
+                    label: AppLocalizations.of(context).save,
                     shouldSurfaceExecutionStates: false,
                     onTap: _selectedAlbums.albums.isNotEmpty
                         ? () async {

--- a/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/albums_widget_settings.dart
@@ -1,3 +1,4 @@
+import "package:ente_components/ente_components.dart";
 import "package:flutter/foundation.dart";
 import 'package:flutter/material.dart';
 import "package:photos/generated/l10n.dart";
@@ -14,12 +15,7 @@ import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/collections/flex_grid_view.dart";
 import "package:photos/ui/common/loading_widget.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
-import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
 import "package:photos/ui/components/models/button_type.dart";
-import 'package:photos/ui/components/title_bar_title_widget.dart';
-import 'package:photos/ui/components/title_bar_widget.dart';
-import "package:photos/ui/components/toggle_switch_widget.dart";
 
 class AlbumsWidgetSettings extends StatefulWidget {
   const AlbumsWidgetSettings({super.key});
@@ -127,31 +123,13 @@ class _AlbumsWidgetSettingsState extends State<AlbumsWidgetSettings> {
       body: Scrollbar(
         interactive: true,
         controller: _scrollController,
-        child: CustomScrollView(
+        child: AppBarComponent(
+          title: AppLocalizations.of(context).albums,
+          subtitle: hasInstalledAny
+              ? AppLocalizations.of(context).albumsWidgetDesc
+              : context.l10n.addAlbumWidgetPrompt,
           controller: _scrollController,
-          primary: false,
           slivers: <Widget>[
-            TitleBarWidget(
-              backgroundColor: colorScheme.backgroundColour,
-              flexibleSpaceTitle: TitleBarTitleWidget(
-                title: AppLocalizations.of(context).albums,
-              ),
-              expandedHeight: MediaQuery.textScalerOf(context).scale(136),
-              flexibleSpaceCaption: hasInstalledAny
-                  ? AppLocalizations.of(context).albumsWidgetDesc
-                  : context.l10n.addAlbumWidgetPrompt,
-              actionIcons: [
-                IconButtonWidget(
-                  icon: Icons.close_outlined,
-                  iconButtonType: IconButtonType.secondary,
-                  onTap: () {
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                    Navigator.pop(context);
-                  },
-                ),
-              ],
-            ),
             if (!hasInstalledAny)
               SliverToBoxAdapter(
                 child: Padding(
@@ -175,17 +153,16 @@ class _AlbumsWidgetSettingsState extends State<AlbumsWidgetSettings> {
               if (kDebugMode)
                 SliverToBoxAdapter(
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(6, 18, 6, 8),
-                    child: MenuItemWidgetNew(
+                    padding: const EdgeInsets.fromLTRB(16, 18, 16, 8),
+                    child: MenuComponent(
                       title: AppLocalizations.of(context).showTextOnWidget,
-                      trailingWidget: ToggleSwitchWidget(
-                        value: () => _showText,
-                        onChanged: () async {
-                          final next = !_showText;
-                          setState(() => _showText = next);
+                      trailing: ToggleSwitchComponent(
+                        selected: _showText,
+                        onChanged: (showText) async {
+                          setState(() => _showText = showText);
                           await localSettings.setWidgetTextHidden(
                             WidgetHideTextFlag.album,
-                            !next,
+                            !showText,
                           );
                           await HomeWidgetService.instance.updateWidget(
                             androidClass:

--- a/mobile/apps/photos/lib/ui/settings/widgets/memories_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/memories_widget_settings.dart
@@ -1,3 +1,4 @@
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import 'package:flutter/material.dart';
@@ -9,13 +10,6 @@ import "package:photos/services/home_widget_service.dart";
 import "package:photos/services/memory_home_widget_service.dart";
 import "package:photos/settings/local_settings.dart";
 import 'package:photos/theme/ente_theme.dart';
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
-import "package:photos/ui/components/captioned_text_widget.dart";
-import "package:photos/ui/components/menu_item_widget/menu_item_widget.dart";
-import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
-import 'package:photos/ui/components/title_bar_title_widget.dart';
-import 'package:photos/ui/components/title_bar_widget.dart';
-import "package:photos/ui/components/toggle_switch_widget.dart";
 
 class MemoriesWidgetSettings extends StatefulWidget {
   const MemoriesWidgetSettings({super.key});
@@ -107,30 +101,12 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
 
     return Scaffold(
       backgroundColor: colorScheme.backgroundColour,
-      body: CustomScrollView(
-        primary: false,
+      body: AppBarComponent(
+        title: AppLocalizations.of(context).memories,
+        subtitle: hasInstalledAny
+            ? AppLocalizations.of(context).memoriesWidgetDesc
+            : context.l10n.addMemoriesWidgetPrompt,
         slivers: <Widget>[
-          TitleBarWidget(
-            backgroundColor: colorScheme.backgroundColour,
-            flexibleSpaceTitle: TitleBarTitleWidget(
-              title: AppLocalizations.of(context).memories,
-            ),
-            expandedHeight: MediaQuery.textScalerOf(context).scale(136),
-            flexibleSpaceCaption: hasInstalledAny
-                ? AppLocalizations.of(context).memoriesWidgetDesc
-                : context.l10n.addMemoriesWidgetPrompt,
-            actionIcons: [
-              IconButtonWidget(
-                icon: Icons.close_outlined,
-                iconButtonType: IconButtonType.secondary,
-                onTap: () {
-                  Navigator.pop(context);
-                  Navigator.pop(context);
-                  Navigator.pop(context);
-                },
-              ),
-            ],
-          ),
           if (!hasInstalledAny)
             SliverToBoxAdapter(
               child: Padding(
@@ -154,23 +130,22 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
             SliverList(
               delegate: SliverChildBuilderDelegate((context, index) {
                 return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       const SizedBox(height: 18),
                       if (kDebugMode) ...[
-                        MenuItemWidgetNew(
+                        MenuComponent(
                           title: AppLocalizations.of(context).showTextOnWidget,
-                          trailingWidget: ToggleSwitchWidget(
-                            value: () => _showText,
-                            onChanged: () async {
-                              final next = !_showText;
-                              setState(() => _showText = next);
+                          trailing: ToggleSwitchComponent(
+                            selected: _showText,
+                            onChanged: (showText) async {
+                              setState(() => _showText = showText);
                               await localSettings.setWidgetTextHidden(
                                 WidgetHideTextFlag.memory,
-                                !next,
+                                !showText,
                               );
                               await HomeWidgetService.instance.updateWidget(
                                 androidClass:
@@ -183,86 +158,72 @@ class _MemoriesWidgetSettingsState extends State<MemoriesWidgetSettings> {
                         ),
                         const SizedBox(height: 8),
                       ],
-                      MenuItemWidget(
-                        captionedTextWidget: CaptionedTextWidget(
-                          title: AppLocalizations.of(context).pastYearsMemories,
-                        ),
-                        leadingIconWidget: SvgPicture.asset(
-                          "assets/icons/past-year-memory-icon.svg",
-                          colorFilter: ColorFilter.mode(
-                            colorScheme.textBase,
-                            BlendMode.srcIn,
-                          ),
-                        ),
-                        menuItemColor: colorScheme.fillFaint,
-                        trailingWidget: ToggleSwitchWidget(
-                          value: () => isYearlyMemoriesEnabled ?? true,
-                          onChanged: () async {
-                            setState(() {
-                              isYearlyMemoriesEnabled =
-                                  !isYearlyMemoriesEnabled!;
-                            });
-                            updateVariables().ignore();
-                          },
-                        ),
-                        singleBorderRadius: 8,
-                        isGestureDetectorDisabled: true,
-                      ),
-                      const SizedBox(height: 4),
-                      MenuItemWidget(
-                        captionedTextWidget: CaptionedTextWidget(
-                          title: AppLocalizations.of(context).onThisDayMemories,
-                        ),
-                        leadingIconWidget: SvgPicture.asset(
-                          "assets/icons/memories-widget-icon.svg",
-                          colorFilter: ColorFilter.mode(
-                            colorScheme.textBase,
-                            BlendMode.srcIn,
-                          ),
-                        ),
-                        menuItemColor: colorScheme.fillFaint,
-                        trailingWidget: ToggleSwitchWidget(
-                          value: () => isOnThisDayMemoriesEnabled!,
-                          onChanged: () async {
-                            setState(() {
-                              isOnThisDayMemoriesEnabled =
-                                  !isOnThisDayMemoriesEnabled!;
-                            });
-                            updateVariables().ignore();
-                          },
-                        ),
-                        singleBorderRadius: 8,
-                        isGestureDetectorDisabled: true,
-                      ),
-                      if (isMLEnabled) ...[
-                        const SizedBox(height: 4),
-                        MenuItemWidget(
-                          captionedTextWidget: CaptionedTextWidget(
-                            title: AppLocalizations.of(context).smartMemories,
-                          ),
-                          leadingIconWidget: SvgPicture.asset(
-                            "assets/icons/smart-memory-icon.svg",
-                            colorFilter: ColorFilter.mode(
-                              colorScheme.textBase,
-                              BlendMode.srcIn,
+                      MenuGroupComponent(
+                        items: [
+                          MenuComponent(
+                            title: AppLocalizations.of(
+                              context,
+                            ).pastYearsMemories,
+                            leading: SvgPicture.asset(
+                              "assets/icons/past-year-memory-icon.svg",
+                              colorFilter: ColorFilter.mode(
+                                colorScheme.textBase,
+                                BlendMode.srcIn,
+                              ),
+                            ),
+                            trailing: ToggleSwitchComponent(
+                              selected: isYearlyMemoriesEnabled ?? true,
+                              onChanged: (selected) {
+                                setState(
+                                  () => isYearlyMemoriesEnabled = selected,
+                                );
+                                updateVariables().ignore();
+                              },
                             ),
                           ),
-                          menuItemColor: colorScheme.fillFaint,
-                          trailingWidget: ToggleSwitchWidget(
-                            value: () => isSmartMemoriesEnabled!,
-                            onChanged: () async {
-                              setState(() {
-                                isSmartMemoriesEnabled =
-                                    !isSmartMemoriesEnabled!;
-                              });
-
-                              updateVariables().ignore();
-                            },
+                          MenuComponent(
+                            title: AppLocalizations.of(
+                              context,
+                            ).onThisDayMemories,
+                            leading: SvgPicture.asset(
+                              "assets/icons/memories-widget-icon.svg",
+                              colorFilter: ColorFilter.mode(
+                                colorScheme.textBase,
+                                BlendMode.srcIn,
+                              ),
+                            ),
+                            trailing: ToggleSwitchComponent(
+                              selected: isOnThisDayMemoriesEnabled!,
+                              onChanged: (selected) {
+                                setState(
+                                  () => isOnThisDayMemoriesEnabled = selected,
+                                );
+                                updateVariables().ignore();
+                              },
+                            ),
                           ),
-                          singleBorderRadius: 8,
-                          isGestureDetectorDisabled: true,
-                        ),
-                      ],
+                          if (isMLEnabled)
+                            MenuComponent(
+                              title: AppLocalizations.of(context).smartMemories,
+                              leading: SvgPicture.asset(
+                                "assets/icons/smart-memory-icon.svg",
+                                colorFilter: ColorFilter.mode(
+                                  colorScheme.textBase,
+                                  BlendMode.srcIn,
+                                ),
+                              ),
+                              trailing: ToggleSwitchComponent(
+                                selected: isSmartMemoriesEnabled!,
+                                onChanged: (selected) {
+                                  setState(
+                                    () => isSmartMemoriesEnabled = selected,
+                                  );
+                                  updateVariables().ignore();
+                                },
+                              ),
+                            ),
+                        ],
+                      ),
                     ],
                   ),
                 );

--- a/mobile/apps/photos/lib/ui/settings/widgets/people_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/people_widget_settings.dart
@@ -11,8 +11,6 @@ import "package:photos/services/home_widget_service.dart";
 import "package:photos/services/people_home_widget_service.dart";
 import "package:photos/settings/local_settings.dart";
 import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/buttons/button_widget.dart";
-import "package:photos/ui/components/models/button_type.dart";
 import "package:photos/ui/viewer/search/result/people_section_all_page.dart";
 
 class PeopleWidgetSettings extends StatefulWidget {
@@ -73,10 +71,8 @@ class _PeopleWidgetSettingsState extends State<PeopleWidgetSettings> {
                         )
                       : _selectedPeople.personIds.isNotEmpty;
 
-                  return ButtonWidget(
-                    buttonType: ButtonType.primary,
-                    buttonSize: ButtonSize.large,
-                    labelText: AppLocalizations.of(context).save,
+                  return ButtonComponent(
+                    label: AppLocalizations.of(context).save,
                     shouldSurfaceExecutionStates: false,
                     isDisabled: !areIdsChanged,
                     onTap: areIdsChanged

--- a/mobile/apps/photos/lib/ui/settings/widgets/people_widget_settings.dart
+++ b/mobile/apps/photos/lib/ui/settings/widgets/people_widget_settings.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
 import "package:flutter/foundation.dart";
 import 'package:flutter/material.dart';
 import "package:photos/generated/l10n.dart";
@@ -11,12 +12,7 @@ import "package:photos/services/people_home_widget_service.dart";
 import "package:photos/settings/local_settings.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
-import 'package:photos/ui/components/buttons/icon_button_widget.dart';
-import "package:photos/ui/components/menu_item_widget/menu_item_widget_new.dart";
 import "package:photos/ui/components/models/button_type.dart";
-import 'package:photos/ui/components/title_bar_title_widget.dart';
-import 'package:photos/ui/components/title_bar_widget.dart';
-import "package:photos/ui/components/toggle_switch_widget.dart";
 import "package:photos/ui/viewer/search/result/people_section_all_page.dart";
 
 class PeopleWidgetSettings extends StatefulWidget {
@@ -99,30 +95,12 @@ class _PeopleWidgetSettingsState extends State<PeopleWidgetSettings> {
               ),
             )
           : null,
-      body: CustomScrollView(
-        primary: false,
+      body: AppBarComponent(
+        title: AppLocalizations.of(context).people,
+        subtitle: hasInstalledAny
+            ? AppLocalizations.of(context).peopleWidgetDesc
+            : context.l10n.addPeopleWidgetPrompt,
         slivers: <Widget>[
-          TitleBarWidget(
-            backgroundColor: colorScheme.backgroundColour,
-            flexibleSpaceTitle: TitleBarTitleWidget(
-              title: AppLocalizations.of(context).people,
-            ),
-            expandedHeight: MediaQuery.textScalerOf(context).scale(136),
-            flexibleSpaceCaption: hasInstalledAny
-                ? AppLocalizations.of(context).peopleWidgetDesc
-                : context.l10n.addPeopleWidgetPrompt,
-            actionIcons: [
-              IconButtonWidget(
-                icon: Icons.close_outlined,
-                iconButtonType: IconButtonType.secondary,
-                onTap: () {
-                  Navigator.pop(context);
-                  Navigator.pop(context);
-                  Navigator.pop(context);
-                },
-              ),
-            ],
-          ),
           if (!hasInstalledAny)
             SliverToBoxAdapter(
               child: Padding(
@@ -143,17 +121,16 @@ class _PeopleWidgetSettingsState extends State<PeopleWidgetSettings> {
             if (kDebugMode)
               SliverToBoxAdapter(
                 child: Padding(
-                  padding: const EdgeInsets.fromLTRB(6, 18, 6, 8),
-                  child: MenuItemWidgetNew(
+                  padding: const EdgeInsets.fromLTRB(16, 18, 16, 8),
+                  child: MenuComponent(
                     title: AppLocalizations.of(context).showTextOnWidget,
-                    trailingWidget: ToggleSwitchWidget(
-                      value: () => _showText,
-                      onChanged: () async {
-                        final next = !_showText;
-                        setState(() => _showText = next);
+                    trailing: ToggleSwitchComponent(
+                      selected: _showText,
+                      onChanged: (showText) async {
+                        setState(() => _showText = showText);
                         await localSettings.setWidgetTextHidden(
                           WidgetHideTextFlag.people,
-                          !next,
+                          !showText,
                         );
                         await HomeWidgetService.instance.updateWidget(
                           androidClass:


### PR DESCRIPTION
Refreshes the Photos People, Albums, and Memories widget settings with the current app bar, menu, toggle, and button components.

Before / After:
<img src="https://github.com/user-attachments/assets/a37d1074-5071-4480-a167-cf4aef38f656" alt="People before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/fbe5488e-f024-4a40-847a-7e16815dab09" alt="People after" width="300" height="650">

<img src="https://github.com/user-attachments/assets/8213a283-0788-4680-9d15-ffff121d8272" alt="Albums before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/d8f5334d-89bf-45e7-baca-f5383edc9c33" alt="Albums after" width="300" height="650">

<img src="https://github.com/user-attachments/assets/17f8590f-a059-4280-9639-c04a412cda6c" alt="Memories before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/be3d82cf-6eb7-4ed8-a97c-71d785585e24" alt="Memories after" width="300" height="650">

Tested with Flutter analyze and on the iOS simulator.