### PR TITLE
[mob][photos] Refresh gallery layout sheet

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/group/group_header_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/group/group_header_widget.dart
@@ -226,9 +226,8 @@ class _GroupHeaderWidgetState extends State<GroupHeaderWidget> {
   }
 
   void _showLayoutSettingsOverflowMenu(BuildContext context) {
-    showModalBottomSheet(
+    components.showBottomSheetComponent<void>(
       context: context,
-      backgroundColor: getEnteColorScheme(context).backgroundElevated,
       builder: (BuildContext context) {
         return const GalleryLayoutSettings();
       },

--- a/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
@@ -55,7 +55,7 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
             onTap: () => _applyLayout(GroupType.day, 3),
           ),
           MenuComponent(
-            title: context.l10n.month,
+            title: context.l10n.month.capitalizeFirst(),
             leading: const Icon(Icons.grid_on_rounded),
             trailing: isMonthLayout
                 ? Icon(Icons.check, color: colors.primary)

--- a/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:photos/core/event_bus.dart";
@@ -7,10 +8,6 @@ import "package:photos/events/force_reload_home_gallery_event.dart";
 import "package:photos/generated/l10n.dart";
 import "package:photos/l10n/l10n.dart";
 import "package:photos/service_locator.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/captioned_text_widget.dart";
-import "package:photos/ui/components/divider_widget.dart";
-import "package:photos/ui/components/menu_item_widget/menu_item_widget.dart";
 import "package:photos/ui/settings/gallery_settings_screen.dart";
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
 
@@ -43,123 +40,64 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Column(
+    final colors = context.componentColors;
+    return BottomSheetComponent(
+      title: context.l10n.layout,
+      content: MenuGroupComponent(
+        items: [
+          MenuComponent(
+            title: context.l10n.day,
+            leading: const Icon(Icons.grid_view_outlined),
+            trailing: isDayLayout
+                ? Icon(Icons.check, color: colors.primary)
+                : null,
+            showOnlyLoadingState: true,
+            onTap: () => _applyLayout(GroupType.day, 3),
+          ),
+          MenuComponent(
+            title: context.l10n.month,
+            leading: const Icon(Icons.grid_on_rounded),
+            trailing: isMonthLayout
+                ? Icon(Icons.check, color: colors.primary)
+                : null,
+            showOnlyLoadingState: true,
+            onTap: () => _applyLayout(GroupType.month, 5),
+          ),
+          MenuComponent(
+            title: AppLocalizations.of(context).custom,
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 12,
-                  ),
-                  child: Align(
-                    child: Text(
-                      context.l10n.layout,
-                      style: textTheme.largeBold,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Column(
-                  children: [
-                    MenuItemWidget(
-                      leadingIcon: Icons.grid_view_outlined,
-                      captionedTextWidget: CaptionedTextWidget(
-                        title: context.l10n.day,
-                      ),
-                      menuItemColor: colorScheme.fillFaint,
-                      alignCaptionedTextToLeft: true,
-                      isBottomBorderRadiusRemoved: true,
-                      showOnlyLoadingState: true,
-                      trailingIcon: isDayLayout ? Icons.check : null,
-                      onTap: () async {
-                        final futures = <Future>[
-                          localSettings.setGalleryGroupType(GroupType.day),
-                          localSettings.setPhotoGridSize(3),
-                        ];
-
-                        await Future.wait(futures);
-                        Bus.instance.fire(
-                          ForceReloadHomeGalleryEvent("Gallery layout changed"),
-                        );
-
-                        if (!context.mounted) return;
-                        Navigator.pop(context);
-                      },
-                    ),
-                    DividerWidget(
-                      dividerType: DividerType.menuNoIcon,
-                      bgColor: getEnteColorScheme(context).fillFaint,
-                    ),
-                    MenuItemWidget(
-                      leadingIcon: Icons.grid_on_rounded,
-                      captionedTextWidget: CaptionedTextWidget(
-                        title: context.l10n.month,
-                      ),
-                      menuItemColor: colorScheme.fillFaint,
-                      alignCaptionedTextToLeft: true,
-                      isTopBorderRadiusRemoved: true,
-                      isBottomBorderRadiusRemoved: true,
-                      showOnlyLoadingState: true,
-                      trailingIcon: isMonthLayout ? Icons.check : null,
-                      onTap: () async {
-                        final futures = <Future>[
-                          localSettings.setGalleryGroupType(GroupType.month),
-                          localSettings.setPhotoGridSize(5),
-                        ];
-
-                        await Future.wait(futures);
-                        Bus.instance.fire(
-                          ForceReloadHomeGalleryEvent("Gallery layout changed"),
-                        );
-
-                        if (!context.mounted) return;
-                        Navigator.pop(context);
-                      },
-                    ),
-                    DividerWidget(
-                      dividerType: DividerType.menuNoIcon,
-                      bgColor: getEnteColorScheme(context).fillFaint,
-                    ),
-                    MenuItemWidget(
-                      captionedTextWidget: CaptionedTextWidget(
-                        title: AppLocalizations.of(context).custom,
-                      ),
-                      menuItemColor: colorScheme.fillFaint,
-                      alignCaptionedTextToLeft: true,
-                      showOnlyLoadingState: true,
-                      isTopBorderRadiusRemoved: true,
-                      leadingIcon: isDayLayout || isMonthLayout
-                          ? null
-                          : Icons.check,
-                      trailingWidget: Icon(
-                        Icons.chevron_right_outlined,
-                        color: colorScheme.strokeBase,
-                      ),
-                      onTap: () =>
-                          routeToPage(
-                            context,
-                            const GallerySettingsScreen(
-                              fromGalleryLayoutSettingsCTA: true,
-                            ),
-                          ).then((_) {
-                            _reloadWithLatestSetting();
-                          }),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
+                if (!isDayLayout && !isMonthLayout) ...[
+                  Icon(Icons.check, color: colors.primary),
+                  const SizedBox(width: 8),
+                ],
+                const Icon(Icons.chevron_right_outlined),
               ],
             ),
-          ],
-        ),
+            onTap: () =>
+                routeToPage(
+                  context,
+                  const GallerySettingsScreen(
+                    fromGalleryLayoutSettingsCTA: true,
+                  ),
+                ).then((_) {
+                  _reloadWithLatestSetting();
+                }),
+          ),
+        ],
       ),
     );
+  }
+
+  Future<void> _applyLayout(GroupType groupType, int gridSize) async {
+    await Future.wait([
+      localSettings.setGalleryGroupType(groupType),
+      localSettings.setPhotoGridSize(gridSize),
+    ]);
+    Bus.instance.fire(ForceReloadHomeGalleryEvent("Gallery layout changed"));
+
+    if (!mounted) return;
+    Navigator.pop(context);
   }
 }


### PR DESCRIPTION
Refreshes the gallery layout picker with the shared bottom sheet, menu group, and menu components.

Before / After:
<img src="https://github.com/user-attachments/assets/ab749f3c-a612-488a-a490-a158ba0d905b" alt="Gallery layout sheet before" width="300" height="650"> <img src="https://github.com/user-attachments/assets/2fb481a1-94b6-44f6-be1a-076b5deea07d" alt="Gallery layout sheet after" width="300" height="650">

Tested with targeted Flutter analyze and on the iOS simulator.