### PR TITLE
[mob][photos] Handle invalid asset dates with fallbacks instead of throwing

### DIFF
--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -122,26 +122,6 @@ class EncSizeMismatchError implements Exception {
   String toString() => "EncSizeMismatchError: $message";
 }
 
-class InvalidDateTimeError implements Exception {
-  final String assetId;
-  final String? assetTitle;
-  final String field;
-  final String originalError;
-
-  InvalidDateTimeError({
-    required this.assetId,
-    this.assetTitle,
-    required this.field,
-    required this.originalError,
-  });
-
-  @override
-  String toString() {
-    return 'InvalidDateTimeError: $field is invalid for asset '
-        '(id: $assetId, title: ${assetTitle ?? "unknown"}) - $originalError';
-  }
-}
-
 class BadMD5DigestError implements Exception {
   final String message;
   BadMD5DigestError(this.message);

--- a/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
+++ b/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart";
@@ -13,6 +15,15 @@ const _minDateTimeSecondsSinceEpoch = -_maxDateTimeSecondsSinceEpoch;
 
 typedef AssetDateTimes = ({int creationTime, int modificationTime});
 
+/// Compares at the whole-second precision provided by photo_manager.
+bool isAssetAtOrAfterSyncCutoff(AssetDateTimes dateTimes, int cutoffTime) {
+  final latestAssetTimeSecond =
+      max(dateTimes.creationTime, dateTimes.modificationTime) ~/
+      Duration.microsecondsPerSecond;
+  final cutoffTimeSecond = cutoffTime ~/ Duration.microsecondsPerSecond;
+  return latestAssetTimeSecond >= cutoffTimeSecond;
+}
+
 AssetDateTimes resolveAssetDateTimes(AssetEntity asset) {
   final uploadTime = DateTime.now().toUtc().microsecondsSinceEpoch;
   final creationTime = _validMicrosecondsSinceEpoch(asset.createDateSecond);
@@ -27,9 +38,17 @@ AssetDateTimes resolveAssetDateTimes(AssetEntity asset) {
     return (creationTime: uploadTime, modificationTime: uploadTime);
   }
   if (creationTime == null) {
-    _logger.info("Asset creation time is invalid; using modification time");
+    _logger.info(
+      "Asset creation time is invalid; resolving from modification time",
+    );
+    final resolvedCreationTime = _resolveCreationTime(
+      asset,
+      modificationTime!,
+      modificationTime,
+      uploadTime,
+    );
     return (
-      creationTime: modificationTime!,
+      creationTime: resolvedCreationTime,
       modificationTime: modificationTime,
     );
   }

--- a/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
+++ b/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
@@ -16,10 +16,15 @@ const _minDateTimeSecondsSinceEpoch = -_maxDateTimeSecondsSinceEpoch;
 typedef AssetDateTimes = ({int creationTime, int modificationTime});
 
 /// Compares at the whole-second precision provided by photo_manager.
-bool isAssetAtOrAfterSyncCutoff(AssetDateTimes dateTimes, int cutoffTime) {
-  final latestAssetTimeSecond =
-      max(dateTimes.creationTime, dateTimes.modificationTime) ~/
-      Duration.microsecondsPerSecond;
+///
+/// Uses the raw asset timestamps, counting invalid ones as epoch, so that
+/// assets with broken dates are picked up during first import (cutoff 0) but
+/// not re-flagged as updated on every incremental sync.
+bool isAssetAtOrAfterSyncCutoff(AssetEntity asset, int cutoffTime) {
+  final latestAssetTimeSecond = max(
+    _validSecondsSinceEpoch(asset.createDateSecond) ?? 0,
+    _validSecondsSinceEpoch(asset.modifiedDateSecond) ?? 0,
+  );
   final cutoffTimeSecond = cutoffTime ~/ Duration.microsecondsPerSecond;
   return latestAssetTimeSecond >= cutoffTimeSecond;
 }
@@ -31,49 +36,25 @@ AssetDateTimes resolveAssetDateTimes(AssetEntity asset) {
     asset.modifiedDateSecond,
   );
 
-  if (creationTime == null && modificationTime == null) {
+  if (creationTime == null || modificationTime == null) {
     _logger.warning(
-      "Asset creation and modification times are invalid; using upload time",
-    );
-    return (creationTime: uploadTime, modificationTime: uploadTime);
-  }
-  if (creationTime == null) {
-    _logger.info(
-      "Asset creation time is invalid; resolving from modification time",
-    );
-    final resolvedCreationTime = _resolveCreationTime(
-      asset,
-      modificationTime!,
-      modificationTime,
-      uploadTime,
-    );
-    return (
-      creationTime: resolvedCreationTime,
-      modificationTime: modificationTime,
-    );
-  }
-  if (modificationTime == null) {
-    _logger.info("Asset modification time is invalid; using creation time");
-    final resolvedCreationTime = _resolveCreationTime(
-      asset,
-      creationTime,
-      creationTime,
-      uploadTime,
-    );
-    return (
-      creationTime: resolvedCreationTime,
-      modificationTime: resolvedCreationTime,
+      "LocalID: ${asset.id} has invalid raw date(s) "
+      "(createDateSecond: ${asset.createDateSecond}, "
+      "modifiedDateSecond: ${asset.modifiedDateSecond}); using fallbacks",
     );
   }
 
+  // A missing creation time is treated as pre-1981 so the filename and
+  // modification-time fallbacks in _resolveCreationTime apply to it.
+  final resolvedCreationTime = _resolveCreationTime(
+    asset,
+    creationTime ?? 0,
+    modificationTime ?? 0,
+    uploadTime,
+  );
   return (
-    creationTime: _resolveCreationTime(
-      asset,
-      creationTime,
-      modificationTime,
-      uploadTime,
-    ),
-    modificationTime: modificationTime,
+    creationTime: resolvedCreationTime,
+    modificationTime: modificationTime ?? resolvedCreationTime,
   );
 }
 
@@ -89,7 +70,7 @@ int _resolveCreationTime(
     // filesystem creation time. Embedded metadata may replace this on upload.
     if (modificationTime >= jan011981Time && modificationTime < creationTime) {
       _logger.info(
-        "Asset modification time is less than creation time. "
+        "LocalID: ${asset.id} modification time is less than creation time. "
         "Using modification time as creation time",
       );
       resolvedCreationTime = modificationTime;
@@ -110,11 +91,19 @@ int _resolveCreationTime(
   }
 }
 
-int? _validMicrosecondsSinceEpoch(int? secondsSinceEpoch) {
+int? _validSecondsSinceEpoch(int? secondsSinceEpoch) {
   if (secondsSinceEpoch == null ||
       secondsSinceEpoch < _minDateTimeSecondsSinceEpoch ||
       secondsSinceEpoch > _maxDateTimeSecondsSinceEpoch) {
     return null;
   }
-  return secondsSinceEpoch * Duration.microsecondsPerSecond;
+  return secondsSinceEpoch;
+}
+
+int? _validMicrosecondsSinceEpoch(int? secondsSinceEpoch) {
+  final validSeconds = _validSecondsSinceEpoch(secondsSinceEpoch);
+  if (validSeconds == null) {
+    return null;
+  }
+  return validSeconds * Duration.microsecondsPerSecond;
 }

--- a/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
+++ b/mobile/apps/photos/lib/module/metadata/asset_date_times.dart
@@ -1,0 +1,101 @@
+import "package:ente_pure_utils/ente_pure_utils.dart";
+import "package:logging/logging.dart";
+import "package:path/path.dart";
+import "package:photo_manager/photo_manager.dart";
+import "package:photos/core/constants.dart";
+
+final _logger = Logger("AssetDateTimes");
+
+// Dart DateTime accepts +/- 8.64e15 milliseconds; photo_manager exposes
+// timestamps as whole seconds.
+const _maxDateTimeSecondsSinceEpoch = 8640000000000;
+const _minDateTimeSecondsSinceEpoch = -_maxDateTimeSecondsSinceEpoch;
+
+typedef AssetDateTimes = ({int creationTime, int modificationTime});
+
+AssetDateTimes resolveAssetDateTimes(AssetEntity asset) {
+  final uploadTime = DateTime.now().toUtc().microsecondsSinceEpoch;
+  final creationTime = _validMicrosecondsSinceEpoch(asset.createDateSecond);
+  final modificationTime = _validMicrosecondsSinceEpoch(
+    asset.modifiedDateSecond,
+  );
+
+  if (creationTime == null && modificationTime == null) {
+    _logger.warning(
+      "Asset creation and modification times are invalid; using upload time",
+    );
+    return (creationTime: uploadTime, modificationTime: uploadTime);
+  }
+  if (creationTime == null) {
+    _logger.info("Asset creation time is invalid; using modification time");
+    return (
+      creationTime: modificationTime!,
+      modificationTime: modificationTime,
+    );
+  }
+  if (modificationTime == null) {
+    _logger.info("Asset modification time is invalid; using creation time");
+    final resolvedCreationTime = _resolveCreationTime(
+      asset,
+      creationTime,
+      creationTime,
+      uploadTime,
+    );
+    return (
+      creationTime: resolvedCreationTime,
+      modificationTime: resolvedCreationTime,
+    );
+  }
+
+  return (
+    creationTime: _resolveCreationTime(
+      asset,
+      creationTime,
+      modificationTime,
+      uploadTime,
+    ),
+    modificationTime: modificationTime,
+  );
+}
+
+int _resolveCreationTime(
+  AssetEntity asset,
+  int creationTime,
+  int modificationTime,
+  int uploadTime,
+) {
+  var resolvedCreationTime = creationTime;
+  if (creationTime >= jan011981Time) {
+    // Copied files can retain an older modification time while gaining a new
+    // filesystem creation time. Embedded metadata may replace this on upload.
+    if (modificationTime >= jan011981Time && modificationTime < creationTime) {
+      _logger.info(
+        "Asset modification time is less than creation time. "
+        "Using modification time as creation time",
+      );
+      resolvedCreationTime = modificationTime;
+    }
+    return resolvedCreationTime;
+  }
+
+  resolvedCreationTime = modificationTime >= jan011981Time
+      ? modificationTime
+      : uploadTime;
+  try {
+    final parsedDateTime = parseDateTimeFromFileNameV2(
+      basenameWithoutExtension(asset.title ?? ""),
+    );
+    return parsedDateTime?.microsecondsSinceEpoch ?? resolvedCreationTime;
+  } catch (_) {
+    return resolvedCreationTime;
+  }
+}
+
+int? _validMicrosecondsSinceEpoch(int? secondsSinceEpoch) {
+  if (secondsSinceEpoch == null ||
+      secondsSinceEpoch < _minDateTimeSecondsSinceEpoch ||
+      secondsSinceEpoch > _maxDateTimeSecondsSinceEpoch) {
+    return null;
+  }
+  return secondsSinceEpoch * Duration.microsecondsPerSecond;
+}

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -8,12 +8,8 @@ import "package:photos/models/location/location.dart";
 import "package:photos/module/metadata/asset_date_times.dart";
 import "package:photos/module/metadata/exif.dart";
 
-EnteFile fileFromAsset(
-  String deviceFolder,
-  AssetEntity asset, {
-  AssetDateTimes? dateTimes,
-}) {
-  final resolvedDateTimes = dateTimes ?? resolveAssetDateTimes(asset);
+EnteFile fileFromAsset(String deviceFolder, AssetEntity asset) {
+  final resolvedDateTimes = resolveAssetDateTimes(asset);
   return EnteFile()
     ..localID = asset.id
     ..title = asset.title

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -1,31 +1,27 @@
 import "dart:io";
 
 import "package:ente_pure_utils/ente_pure_utils.dart";
-import "package:logging/logging.dart";
-import "package:path/path.dart";
 import "package:photo_manager/photo_manager.dart";
-import "package:photos/core/constants.dart";
-import "package:photos/core/errors.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/location/location.dart";
+import "package:photos/module/metadata/asset_date_times.dart";
 import "package:photos/module/metadata/exif.dart";
 
-final _logger = Logger("LocalFileMetadata");
-
-EnteFile fileFromAsset(String deviceFolder, AssetEntity asset) {
+EnteFile fileFromAsset(
+  String deviceFolder,
+  AssetEntity asset, {
+  AssetDateTimes? dateTimes,
+}) {
+  final resolvedDateTimes = dateTimes ?? resolveAssetDateTimes(asset);
   return EnteFile()
     ..localID = asset.id
     ..title = asset.title
     ..deviceFolder = deviceFolder
     ..location = Location(latitude: asset.latitude, longitude: asset.longitude)
     ..fileType = fileTypeFromAsset(asset)
-    ..creationTime = _creationTimeFromAsset(asset)
-    ..modificationTime = _microsecondsSinceEpoch(
-      asset.modifiedDateTime,
-      asset,
-      "modificationTime",
-    )
+    ..creationTime = resolvedDateTimes.creationTime
+    ..modificationTime = resolvedDateTimes.modificationTime
     ..fileSubType = asset.subtype
     ..metadataVersion = -1;
 }
@@ -58,59 +54,5 @@ void applyCreationTimeMetadata(EnteFile file, ParsedExifDateTime? exifTime) {
         file.creationTime = timeFromFileName.microsecondsSinceEpoch;
       }
     }
-  }
-}
-
-int _creationTimeFromAsset(AssetEntity asset) {
-  var creationTime = _microsecondsSinceEpoch(
-    asset.createDateTime,
-    asset,
-    "createDateTime",
-  );
-  final modificationTime = _microsecondsSinceEpoch(
-    asset.modifiedDateTime,
-    asset,
-    "modificationTime",
-  );
-  if (creationTime >= jan011981Time) {
-    // Copied files can retain an older modification time while gaining a new
-    // filesystem creation time. Embedded metadata may replace this on upload.
-    if (modificationTime >= jan011981Time && modificationTime < creationTime) {
-      _logger.info(
-        "LocalID: ${asset.id} modification time is less than creation time. "
-        "Using modification time as creation time",
-      );
-      creationTime = modificationTime;
-    }
-    return creationTime;
-  }
-
-  creationTime = modificationTime >= jan011981Time
-      ? modificationTime
-      : DateTime.now().toUtc().microsecondsSinceEpoch;
-  try {
-    final parsedDateTime = parseDateTimeFromFileNameV2(
-      basenameWithoutExtension(asset.title ?? ""),
-    );
-    return parsedDateTime?.microsecondsSinceEpoch ?? creationTime;
-  } catch (_) {
-    return creationTime;
-  }
-}
-
-int _microsecondsSinceEpoch(
-  DateTime dateTime,
-  AssetEntity asset,
-  String field,
-) {
-  try {
-    return dateTime.microsecondsSinceEpoch;
-  } on RangeError catch (e) {
-    throw InvalidDateTimeError(
-      assetId: asset.id,
-      assetTitle: asset.title,
-      field: field,
-      originalError: e.message ?? e.toString(),
-    );
   }
 }

--- a/mobile/apps/photos/lib/services/sync/import/local_assets.dart
+++ b/mobile/apps/photos/lib/services/sync/import/local_assets.dart
@@ -4,10 +4,10 @@ import 'dart:math';
 import 'package:computer/computer.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:photos/core/errors.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/local_import_progress.dart';
 import 'package:photos/models/file/file.dart';
+import "package:photos/module/metadata/asset_date_times.dart";
 import "package:photos/module/metadata/local_file.dart";
 import "package:photos/services/sync/import/model.dart";
 import 'package:tuple/tuple.dart';
@@ -202,25 +202,6 @@ Future<List<AssetEntity>> _getAllAssetLists(AssetPathEntity pathEntity) async {
   return result;
 }
 
-/// Safely extracts millisecondsSinceEpoch from DateTime, throwing InvalidDateTimeError if invalid
-int _safeGetMilliseconds(
-  DateTime dateTime,
-  String assetId,
-  String? assetTitle,
-  String label,
-) {
-  try {
-    return dateTime.millisecondsSinceEpoch;
-  } on RangeError catch (e) {
-    throw InvalidDateTimeError(
-      assetId: assetId,
-      assetTitle: assetTitle,
-      field: label,
-      originalError: e.message ?? e.toString(),
-    );
-  }
-}
-
 // Runs in a worker isolate because a device folder can contain thousands of
 // assets and this loop constructs metadata for the full folder. Re-benchmark
 // large imports before moving this work onto the UI isolate.
@@ -235,23 +216,12 @@ Tuple2<Set<String>, List<EnteFile>> _getLocalIDsAndFilesFromAssets(
   final Set<String> localIDs = {};
   for (AssetEntity entity in assetList) {
     localIDs.add(entity.id);
-    final createMs = _safeGetMilliseconds(
-      entity.createDateTime,
-      entity.id,
-      entity.title,
-      'createDateTime',
-    );
-    final modifiedMs = _safeGetMilliseconds(
-      entity.modifiedDateTime,
-      entity.id,
-      entity.title,
-      'modifiedDateTime',
-    );
+    final dateTimes = resolveAssetDateTimes(entity);
     final bool assetCreatedOrUpdatedAfterGivenTime =
-        max(createMs, modifiedMs) >= (fromTime ~/ 1000);
+        max(dateTimes.creationTime, dateTimes.modificationTime) >= fromTime;
     if (!alreadySeenLocalIDs.contains(entity.id) &&
         assetCreatedOrUpdatedAfterGivenTime) {
-      final file = fileFromAsset(pathEntity.name, entity);
+      final file = fileFromAsset(pathEntity.name, entity, dateTimes: dateTimes);
       files.add(file);
     }
   }

--- a/mobile/apps/photos/lib/services/sync/import/local_assets.dart
+++ b/mobile/apps/photos/lib/services/sync/import/local_assets.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 
 import 'package:computer/computer.dart';
 import 'package:logging/logging.dart';
@@ -210,15 +209,17 @@ Tuple2<Set<String>, List<EnteFile>> _getLocalIDsAndFilesFromAssets(
 ) {
   final pathEntity = args["pathEntity"] as AssetPathEntity;
   final assetList = args["assetList"];
-  final fromTime = args["fromTime"];
+  final fromTime = args["fromTime"] as int;
   final alreadySeenLocalIDs = args["alreadySeenLocalIDs"] as Set<String>;
   final List<EnteFile> files = [];
   final Set<String> localIDs = {};
   for (AssetEntity entity in assetList) {
     localIDs.add(entity.id);
     final dateTimes = resolveAssetDateTimes(entity);
-    final bool assetCreatedOrUpdatedAfterGivenTime =
-        max(dateTimes.creationTime, dateTimes.modificationTime) >= fromTime;
+    final bool assetCreatedOrUpdatedAfterGivenTime = isAssetAtOrAfterSyncCutoff(
+      dateTimes,
+      fromTime,
+    );
     if (!alreadySeenLocalIDs.contains(entity.id) &&
         assetCreatedOrUpdatedAfterGivenTime) {
       final file = fileFromAsset(pathEntity.name, entity, dateTimes: dateTimes);

--- a/mobile/apps/photos/lib/services/sync/import/local_assets.dart
+++ b/mobile/apps/photos/lib/services/sync/import/local_assets.dart
@@ -215,14 +215,13 @@ Tuple2<Set<String>, List<EnteFile>> _getLocalIDsAndFilesFromAssets(
   final Set<String> localIDs = {};
   for (AssetEntity entity in assetList) {
     localIDs.add(entity.id);
-    final dateTimes = resolveAssetDateTimes(entity);
     final bool assetCreatedOrUpdatedAfterGivenTime = isAssetAtOrAfterSyncCutoff(
-      dateTimes,
+      entity,
       fromTime,
     );
     if (!alreadySeenLocalIDs.contains(entity.id) &&
         assetCreatedOrUpdatedAfterGivenTime) {
-      final file = fileFromAsset(pathEntity.name, entity, dateTimes: dateTimes);
+      final file = fileFromAsset(pathEntity.name, entity);
       files.add(file);
     }
   }


### PR DESCRIPTION
## Description

Assets with out-of-range creation/modification timestamps previously threw `InvalidDateTimeError` during import, aborting processing. This PR replaces the throw with graceful fallbacks:

- New `asset_date_times.dart` centralizes date resolution. Invalid raw timestamps are validated against Dart's `DateTime` range and fall back to filename-parsed date, modification time, or upload time (existing pre-1981 precedence preserved).
- Sync cutoff check now compares raw asset seconds against the cutoff, treating invalid dates as epoch, so broken assets are imported once (cutoff 0) but not re-flagged on every incremental sync.
- Removed the now-unused `InvalidDateTimeError`.