### PR TITLE
Fix rare mobile SRP signup failures

### DIFF
--- a/mobile/apps/photos/lib/emergency/emergency_service.dart
+++ b/mobile/apps/photos/lib/emergency/emergency_service.dart
@@ -235,7 +235,7 @@ class EmergencyContactService {
         srpUserID: username,
         srpSalt: base64Encode(salt),
         srpVerifier: base64Encode(SRP6Util.encodeBigInt(v)),
-        srpA: base64Encode(SRP6Util.encodeBigInt(A!)),
+        srpA: base64Encode(SRP6Util.getPadded(A!, 512)),
         isUpdate: false,
       );
       final setupSRPResponse = await _gateway.initPasswordChange(
@@ -252,7 +252,7 @@ class EmergencyContactService {
       await _gateway.changePassword(
         recoveryID: recoverySessions.id,
         setupID: setupSRPResponse.setupID,
-        srpM1: base64Encode(SRP6Util.encodeBigInt(clientM!)),
+        srpM1: base64Encode(SRP6Util.getPadded(clientM!, 32)),
         updatedKeyAttr: setKeysRequest.toMap(),
       );
     } catch (e, s) {

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -590,7 +590,7 @@ class UserService {
         srpUserID: username,
         srpSalt: base64Encode(salt),
         srpVerifier: base64Encode(SRP6Util.encodeBigInt(v)),
-        srpA: base64Encode(SRP6Util.encodeBigInt(A!)),
+        srpA: base64Encode(SRP6Util.getPadded(A!, 512)),
         isUpdate: false,
       );
       final setupSRPResponse = await _gateway.setupSrp(request);
@@ -603,12 +603,12 @@ class UserService {
       if (setKeysRequest == null) {
         await _gateway.completeSrp(
           setupID: setupSRPResponse.setupID,
-          srpM1: base64Encode(SRP6Util.encodeBigInt(clientM!)),
+          srpM1: base64Encode(SRP6Util.getPadded(clientM!, 32)),
         );
       } else {
         await _gateway.updateSrp(
           setupID: setupSRPResponse.setupID,
-          srpM1: base64Encode(SRP6Util.encodeBigInt(clientM!)),
+          srpM1: base64Encode(SRP6Util.getPadded(clientM!, 32)),
           updatedKeyAttr: setKeysRequest.toMap(),
           logOutOtherDevices: logOutOtherDevices,
         );

--- a/mobile/packages/accounts/lib/services/user_service.dart
+++ b/mobile/packages/accounts/lib/services/user_service.dart
@@ -655,7 +655,7 @@ class UserService {
         srpUserID: username,
         srpSalt: base64Encode(salt),
         srpVerifier: base64Encode(SRP6Util.encodeBigInt(v)),
-        srpA: base64Encode(SRP6Util.encodeBigInt(A!)),
+        srpA: base64Encode(SRP6Util.getPadded(A!, 512)),
         isUpdate: false,
       );
       final response = await _enteDio.post(
@@ -678,7 +678,7 @@ class UserService {
             "/users/srp/complete",
             data: {
               'setupID': setupSRPResponse.setupID,
-              'srpM1': base64Encode(SRP6Util.encodeBigInt(clientM!)),
+              'srpM1': base64Encode(SRP6Util.getPadded(clientM!, 32)),
             },
           );
         } else {
@@ -686,7 +686,7 @@ class UserService {
             "/users/srp/update",
             data: {
               'setupID': setupSRPResponse.setupID,
-              'srpM1': base64Encode(SRP6Util.encodeBigInt(clientM!)),
+              'srpM1': base64Encode(SRP6Util.getPadded(clientM!, 32)),
               'updatedKeyAttr': setKeysRequest.toMap(),
               'logOutOtherDevices': logOutOtherDevices,
             },

--- a/mobile/packages/legacy/lib/services/emergency_service.dart
+++ b/mobile/packages/legacy/lib/services/emergency_service.dart
@@ -279,7 +279,7 @@ class EmergencyContactService {
         srpUserID: username,
         srpSalt: base64Encode(salt),
         srpVerifier: base64Encode(SRP6Util.encodeBigInt(v)),
-        srpA: base64Encode(SRP6Util.encodeBigInt(A!)),
+        srpA: base64Encode(SRP6Util.getPadded(A!, 512)),
         isUpdate: false,
       );
       final response = await _enteDio.post(
@@ -308,7 +308,7 @@ class EmergencyContactService {
             "recoveryID": recoverySessions.id,
             'updateSrpAndKeysRequest': {
               'setupID': setupSRPResponse.setupID,
-              'srpM1': base64Encode(SRP6Util.encodeBigInt(clientM!)),
+              'srpM1': base64Encode(SRP6Util.getPadded(clientM!, 32)),
               'updatedKeyAttr': setKeysRequest.toMap(),
             },
           },


### PR DESCRIPTION
## Summary

- Pad mobile SRP public values to 512 bytes.
- Pad SRP proof values to 32 bytes.
- Apply the fix to signup, password updates, and emergency recovery.

## Why

Minimal BigInt encoding drops leading zero bytes. Roughly 1 in 256 generated SRP values begin with a zero byte, producing a 511-byte `srpA` that the server rejects with HTTP 400. Fixed-width encoding matches the server contract and the existing login flow.

## Validation

- `dart format` on all four edited files
- Targeted `flutter analyze --no-pub` on all four edited files
- Audit confirms no remaining unpadded mobile `srpA` or `srpM1` transmissions