### PR TITLE
fix(auth): re-arm privacy screen cover on app backgrounding

### DIFF
--- a/mobile/packages/lock_screen/lib/ui/app_lock.dart
+++ b/mobile/packages/lock_screen/lib/ui/app_lock.dart
@@ -106,6 +106,15 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
       return;
     }
 
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive) {
+      if (LockScreenSettings.instance.getShouldHideAppContent()) {
+        unawaited(
+          LockScreenSettings.instance.setHideAppContent(true, persist: false),
+        );
+      }
+    }
+
     if (state == AppLifecycleState.paused &&
         (!this._isLocked && this._didUnlockForAppLaunch)) {
       this._backgroundedAt = DateTime.now().millisecondsSinceEpoch;

--- a/mobile/packages/lock_screen/lib/ui/lock_screen.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen.dart
@@ -349,7 +349,10 @@ class _LockScreenState extends State<LockScreen> with WidgetsBindingObserver {
       _isShowingLockScreen = false;
       if (result) {
         lastAuthenticatingTime = DateTime.now().millisecondsSinceEpoch;
-        AppLock.of(context)?.didUnlock();
+        final appLock = AppLock.of(context);
+        await LockScreenSettings.instance
+            .setHideAppContent(false, persist: false);
+        appLock?.didUnlock();
         await _lockscreenSetting.setInvalidAttemptCount(0);
         setState(() {
           lockedTimeInSeconds = 15;


### PR DESCRIPTION
## Description
Fixes #4749

Ente Auth's privacy screen cover (`EnteScreenCover`) currently gets set once at app startup or when the user manually toggles "Hide app content" — nothing re-arms it during the app's normal lock/unlock/background lifecycle. A prior PR (#9884) tried disabling it right after successful Face ID unlock to fix the ~1s delay before codes appear, but never re-enabled it afterward — so after the first unlock, the app-switcher privacy blur stopped working entirely. That PR was closed for this reason.

This PR fixes the underlying delay while avoiding that regression, by re-arming the cover on the app's own lifecycle transitions instead of leaving it in whatever state the last toggle left it in.

## Changes
- `lock_screen.dart`: on successful authentication in `_showLockScreen()`,calls `LockScreenSettings.instance.setHideAppContent(false, persist: false)` before `AppLock.didUnlock()`, so codes appear instantly.
- `app_lock.dart`: in `didChangeAppLifecycleState()`, re-arms the cover via `setHideAppContent(true, persist: false)` whenever the app transitions to `paused`/`inactive` (if `getShouldHideAppContent()` is true), so the app-switcher blur is restored before any screenshot can  be taken.
- `persist: false` is used throughout, so the user's stored "Hide app content" preference is never modified — only the live cover state istoggled.


## Testing
- [x] `flutter analyze` passes with no issues on
      `mobile/packages/lock_screen` and `mobile/apps/auth`
      (Flutter 3.38.10 / Dart 3.10.9, matching CI)
- [x] Existing test suite passes (`flutter test` in
      `mobile/packages/lock_screen`, all 16 tests green)
- [ ] Manual verification on iOS device/simulator: instant unlock, no
      delay
- [ ] Manual verification on iOS device/simulator: app-switcher privacy
      blur restored after backgrounding

I don't currently have access to a Mac for iOS device/simulator testing, so the two manual checks above are unverified on my end. Happy to test if someone can point me to CI results, or if a maintainer wants to verify directly given this touches security-sensitive behavior.