### PR TITLE
[server] Use latest activity for inactive users

### DIFF
--- a/server/pkg/repo/user.go
+++ b/server/pkg/repo/user.go
@@ -164,10 +164,9 @@ func (repo *UserRepository) GetAll(sinceTime int64, tillTime int64) ([]ente.User
 }
 
 // GetActiveUsersByLastActivityBefore returns active users whose effective last
-// activity is older than or equal to beforeTime. Effective activity uses latest
-// token activity when present, otherwise falls back to max(users.creation_time,
-// authenticator_entity.updated_at, collections.updation_time). Paging is done
-// by user_id.
+// activity is older than or equal to beforeTime. Effective activity is the
+// latest of token activity, users.creation_time, authenticator_entity.updated_at,
+// and collections.updation_time. Paging is done by user_id.
 func (repo *UserRepository) GetActiveUsersByLastActivityBefore(beforeTime int64, afterUserID int64, limit int) ([]UserInactivityCandidate, error) {
 	rows, err := repo.DB.Query(`
 		SELECT
@@ -176,13 +175,11 @@ func (repo *UserRepository) GetActiveUsersByLastActivityBefore(beforeTime int64,
 		FROM (
 			SELECT
 				u.user_id,
-				COALESCE(
-					t.last_token_activity,
-					GREATEST(
-						u.creation_time,
-						COALESCE(a.last_auth_activity, 0),
-						COALESCE(c.last_collection_activity, 0)
-					)
+				GREATEST(
+					u.creation_time,
+					COALESCE(t.last_token_activity, 0),
+					COALESCE(a.last_auth_activity, 0),
+					COALESCE(c.last_collection_activity, 0)
 				) AS last_activity
 			FROM users u
 			LEFT JOIN LATERAL (
@@ -238,13 +235,11 @@ func (repo *UserRepository) GetLatestActivity(userID int64) (int64, bool, error)
 	var lastActivity int64
 	err := repo.DB.QueryRow(`
 		SELECT
-			COALESCE(
-				t.last_token_activity,
-				GREATEST(
-					u.creation_time,
-					COALESCE(a.last_auth_activity, 0),
-					COALESCE(c.last_collection_activity, 0)
-				)
+			GREATEST(
+				u.creation_time,
+				COALESCE(t.last_token_activity, 0),
+				COALESCE(a.last_auth_activity, 0),
+				COALESCE(c.last_collection_activity, 0)
 			) AS last_activity
 		FROM users u
 		LEFT JOIN LATERAL (

--- a/server/pkg/repo/user_inactivity_test.go
+++ b/server/pkg/repo/user_inactivity_test.go
@@ -1,0 +1,75 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+)
+
+func TestUserInactivityUsesLatestActivityAcrossSources(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() {
+		testutil.ResetTables(t, db)
+	})
+
+	beforeTime := int64(1_000_000)
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "active-user@ente.com",
+		CreationTime: beforeTime - 300,
+	})
+
+	_, err := db.Exec(
+		`INSERT INTO tokens(user_id, token, creation_time, last_used_at, app)
+		 VALUES($1, $2, $3, $4, $5)`,
+		userID,
+		"stale-token",
+		beforeTime-200,
+		beforeTime-100,
+		ente.Photos,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert stale token: %v", err)
+	}
+
+	lastCollectionActivity := beforeTime + 100
+	_, err = db.Exec(
+		`INSERT INTO collections(owner_id, encrypted_key, key_decryption_nonce, name, type, attributes, updation_time, app)
+		 VALUES($1, $2, $3, $4, $5, $6::jsonb, $7, $8)`,
+		userID,
+		"encrypted-key",
+		"key-nonce",
+		"Recent collection",
+		"album",
+		"{}",
+		lastCollectionActivity,
+		ente.Photos,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert collection: %v", err)
+	}
+
+	userRepo := &UserRepository{DB: db}
+	lastActivity, found, err := userRepo.GetLatestActivity(userID)
+	if err != nil {
+		t.Fatalf("failed to get latest activity: %v", err)
+	}
+	if !found {
+		t.Fatal("expected active user to be found")
+	}
+	if lastActivity != lastCollectionActivity {
+		t.Fatalf("unexpected latest activity: got %d want %d", lastActivity, lastCollectionActivity)
+	}
+
+	candidates, err := userRepo.GetActiveUsersByLastActivityBefore(beforeTime, 0, 10)
+	if err != nil {
+		t.Fatalf("failed to get inactive candidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("expected recent collection activity to exclude user, got %+v", candidates)
+	}
+}


### PR DESCRIPTION
- Use the newest token, Auth, collection, or account-creation timestamp.
- Prevent stale tokens from overriding newer activity.