### PR TITLE
Avoid stale files in Memory Lane links

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -51,20 +51,22 @@ extension SuperLogRecord on LogRecord {
         final e = error as DioException;
         final String? id = e.requestOptions.headers['x-request-id'] as String?;
         if (id != null) {
-          msg += "\n⤷ id: $id";
+          msg += "\n⤷ id: $id ";
         }
-        msg += "\n⤷ type: ${e.type}";
-        final statusCode = e.response?.statusCode;
-        if (statusCode != null) {
-          msg += "\n⤷ status: $statusCode";
-        } else if (e.response == null) {
-          final message = e.message;
-          if (message != null && message.isNotEmpty) {
-            msg += "\n⤷ message: $message";
+        final responseData = e.response?.data;
+        if (responseData != null) {
+          // Skip logging response data if it exceeds 100KB
+          final contentLength = int.tryParse(
+            e.response?.headers.value('content-length') ?? '',
+          );
+          if (contentLength != null && contentLength > 102400) {
+            msg +=
+                "\n⤷ type: ${e.type}\n⤷ error: [response too large: $contentLength bytes]";
+          } else {
+            msg += "\n⤷ type: ${e.type}\n⤷ error: $responseData";
           }
-          if (e.error != null) {
-            msg += "\n⤷ error: ${e.error}";
-          }
+        } else {
+          msg += "\n⤷ type: ${e.type}\n⤷ error: $error";
         }
       } else {
         msg += "\n⤷ type: ${error.runtimeType}\n⤷ error: $error";

--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -51,22 +51,20 @@ extension SuperLogRecord on LogRecord {
         final e = error as DioException;
         final String? id = e.requestOptions.headers['x-request-id'] as String?;
         if (id != null) {
-          msg += "\n⤷ id: $id ";
+          msg += "\n⤷ id: $id";
         }
-        final responseData = e.response?.data;
-        if (responseData != null) {
-          // Skip logging response data if it exceeds 100KB
-          final contentLength = int.tryParse(
-            e.response?.headers.value('content-length') ?? '',
-          );
-          if (contentLength != null && contentLength > 102400) {
-            msg +=
-                "\n⤷ type: ${e.type}\n⤷ error: [response too large: $contentLength bytes]";
-          } else {
-            msg += "\n⤷ type: ${e.type}\n⤷ error: $responseData";
+        msg += "\n⤷ type: ${e.type}";
+        final statusCode = e.response?.statusCode;
+        if (statusCode != null) {
+          msg += "\n⤷ status: $statusCode";
+        } else if (e.response == null) {
+          final message = e.message;
+          if (message != null && message.isNotEmpty) {
+            msg += "\n⤷ message: $message";
           }
-        } else {
-          msg += "\n⤷ type: ${e.type}\n⤷ error: $error";
+          if (e.error != null) {
+            msg += "\n⤷ error: ${e.error}";
+          }
         }
       } else {
         msg += "\n⤷ type: ${error.runtimeType}\n⤷ error: $error";

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -1552,11 +1552,9 @@ class FilesDB with SqlDbBase {
 
   Future<void> deleteCollection(int collectionID) async {
     final db = await instance.sqliteAsyncDB;
-    unawaited(
-      db.execute('DELETE FROM $filesTable WHERE $columnCollectionID = ?', [
-        collectionID,
-      ]),
-    );
+    await db.execute('DELETE FROM $filesTable WHERE $columnCollectionID = ?', [
+      collectionID,
+    ]);
   }
 
   Future<void> removeFromCollection(int collectionID, List<int> fileIDs) async {

--- a/mobile/apps/photos/lib/services/memory_share_service.dart
+++ b/mobile/apps/photos/lib/services/memory_share_service.dart
@@ -690,6 +690,7 @@ class MemoryShareService {
     final files = await FilesDB.instance.getFilesFromIDs(uniqueFileIDs);
     final activeCollectionIDs = CollectionsService.instance
         .getActiveCollections()
+        .where((collection) => !collection.isHidden())
         .map((collection) => collection.id)
         .toSet();
     final filesByID = <int, EnteFile>{};

--- a/mobile/apps/photos/lib/services/memory_share_service.dart
+++ b/mobile/apps/photos/lib/services/memory_share_service.dart
@@ -21,6 +21,7 @@ import 'package:photos/models/memory_lane/memory_lane_models.dart';
 import 'package:photos/models/metadata/file_magic.dart';
 import 'package:photos/models/ml/face/face.dart';
 import 'package:photos/service_locator.dart' show entityService;
+import 'package:photos/services/collections_service.dart';
 import 'package:photos/utils/face_crop_util.dart';
 import 'package:photos/utils/file_key.dart';
 
@@ -631,56 +632,93 @@ class MemoryShareService {
     String? birthDate,
   }) async {
     try {
-      if (entries.isEmpty) {
-        throw Exception("No uploaded files to share");
-      }
-      final uniqueFileIDs = entries
-          .map((entry) => entry.fileId)
-          .toSet()
-          .toList();
-      final filesByID = await FilesDB.instance.getFileIDToFileFromIDs(
-        uniqueFileIDs,
-      );
-      final laneItems = <_MemoryLaneShareItem>[];
-      final seenUploadedFileIDs = <int>{};
-      for (final entry in entries) {
-        final file = filesByID[entry.fileId];
-        final uploadedFileID = file?.uploadedFileID;
-        if (file == null ||
-            uploadedFileID == null ||
-            !seenUploadedFileIDs.add(uploadedFileID)) {
-          continue;
-        }
-        laneItems.add(_MemoryLaneShareItem(file: file, entry: entry));
-      }
-      if (laneItems.isEmpty) {
-        throw Exception("No uploaded files to share");
-      }
-      final facesByFileID = await _loadLaneFacesByFileID(laneItems);
-      final metadata = _buildMemoryLaneMetadata(
-        laneItems,
+      return await _getOrCreateMemoryLaneLink(
+        entries: entries,
         title: title,
         personId: personId,
         personName: personName,
         birthDate: birthDate,
-        facesByFileID: facesByFileID,
-      );
-      final memoryHash = _getMemoryLaneHash(metadata);
-      final existingShare = await _findMemoryShareByHash(memoryHash);
-      if (existingShare != null &&
-          existingShare.type == MemoryShareType.lane &&
-          Uri.parse(existingShare.url).fragment.isNotEmpty) {
-        return (existingShare.url, existingShare.id);
-      }
-      return _createMemoryLaneLink(
-        laneItems: laneItems,
-        metadata: metadata,
-        memoryHash: memoryHash,
       );
     } catch (e, s) {
       _logger.severe("Failed to create memory lane share link data", e, s);
       rethrow;
     }
+  }
+
+  Future<(String, int)> _getOrCreateMemoryLaneLink({
+    required List<MemoryLaneEntry> entries,
+    required String title,
+    String? personId,
+    String? personName,
+    String? birthDate,
+  }) async {
+    if (entries.isEmpty) {
+      throw Exception("No uploaded files to share");
+    }
+    final laneItems = await _getShareableMemoryLaneItems(entries);
+    if (laneItems.isEmpty) {
+      throw Exception("No uploaded files to share");
+    }
+    final facesByFileID = await _loadLaneFacesByFileID(laneItems);
+    final metadata = _buildMemoryLaneMetadata(
+      laneItems,
+      title: title,
+      personId: personId,
+      personName: personName,
+      birthDate: birthDate,
+      facesByFileID: facesByFileID,
+    );
+    final memoryHash = _getMemoryLaneHash(metadata);
+    final existingShare = await _findMemoryShareByHash(memoryHash);
+    if (existingShare != null &&
+        existingShare.type == MemoryShareType.lane &&
+        Uri.parse(existingShare.url).fragment.isNotEmpty) {
+      return (existingShare.url, existingShare.id);
+    }
+
+    return _createMemoryLaneLink(
+      laneItems: laneItems,
+      metadata: metadata,
+      memoryHash: memoryHash,
+    );
+  }
+
+  Future<List<_MemoryLaneShareItem>> _getShareableMemoryLaneItems(
+    List<MemoryLaneEntry> entries,
+  ) async {
+    final uniqueFileIDs = entries.map((entry) => entry.fileId).toSet().toList();
+    final files = await FilesDB.instance.getFilesFromIDs(uniqueFileIDs);
+    final activeCollectionIDs = CollectionsService.instance
+        .getActiveCollections()
+        .map((collection) => collection.id)
+        .toSet();
+    final filesByID = <int, EnteFile>{};
+    for (final file in files) {
+      final uploadedFileID = file.uploadedFileID;
+      final collectionID = file.collectionID;
+      if (uploadedFileID == null ||
+          collectionID == null ||
+          !activeCollectionIDs.contains(collectionID) ||
+          file.encryptedKey == null ||
+          file.keyDecryptionNonce == null) {
+        continue;
+      }
+      filesByID.putIfAbsent(uploadedFileID, () => file);
+    }
+
+    final laneItems = <_MemoryLaneShareItem>[];
+    final seenUploadedFileIDs = <int>{};
+    for (final entry in entries) {
+      final file = filesByID[entry.fileId];
+      final uploadedFileID = file?.uploadedFileID;
+      if (file == null ||
+          uploadedFileID == null ||
+          !seenUploadedFileIDs.add(uploadedFileID)) {
+        continue;
+      }
+      laneItems.add(_MemoryLaneShareItem(file: file, entry: entry));
+    }
+    return laneItems;
   }
 
   Future<MemoryShare?> _findMemoryShareByHash(String memoryHash) async {

--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -362,15 +362,14 @@ class RemoteSyncService {
 
   Future<void> _syncCollectionDiffDelete(Diff diff, int collectionID) async {
     final fileIDs = diff.deletedFiles.map((f) => f.uploadedFileID!).toList();
+    final collectionFiles = (await _db.getFilesFromIDs(
+      fileIDs,
+    )).where((file) => file.collectionID == collectionID).toList();
     final localDeleteCount = await _db.deleteFilesFromCollection(
       collectionID,
       fileIDs,
     );
     if (localDeleteCount > 0) {
-      final collectionFiles = (await _db.getFileIDToFileFromIDs(
-        fileIDs,
-      )).values.toList();
-      collectionFiles.removeWhere((f) => f.collectionID != collectionID);
       Bus.instance.fire(
         CollectionUpdatedEvent(
           collectionID,


### PR DESCRIPTION
## Summary

- Filter Memory Lane link entries to files in active, non-hidden collections with usable key data.
- Await collection file cleanup before continuing synchronization.
- Preserve deleted file rows when emitting local deletion events.

## Why

Cached Memory Lane timelines can retain file IDs after files or collections are removed. Stale local rows can then be submitted when creating a link, causing the server to reject the complete request. These changes reduce stale candidates and make local deletion synchronization consistent.

## Validation

- `dart format` on the three changed files
- `flutter analyze` on the three changed files