### PR TITLE
[mobile] Refine library sharing UX

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/flex_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/flex_grid_view.dart
@@ -158,6 +158,10 @@ class _CollectionsFlexiGridViewWidgetState
   }
 
   void _handleCollectionLongPress(Collection collection) {
+    if (widget.selectionCallbacks != null) {
+      unawaited(_toggleAlbumSelection(collection));
+      return;
+    }
     unawaited(
       _togglesSelectionOnTap
           ? _navigateToCollectionPage(collection)

--- a/mobile/apps/photos/lib/ui/family/family_dashboard.dart
+++ b/mobile/apps/photos/lib/ui/family/family_dashboard.dart
@@ -440,7 +440,6 @@ class _MemberAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasPhoto = profilePictureBytes != null || linkedPersonId != null;
     final cachedPixelWidth =
         (AvatarComponentSize.large.dimension *
                 MediaQuery.devicePixelRatioOf(context))
@@ -475,19 +474,17 @@ class _MemberAvatar extends StatelessWidget {
             semanticLabel: displayName,
           );
 
-    if (hasPhoto) {
-      avatar = DecoratedBox(
-        position: DecorationPosition.foreground,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: avatarComponentColorValue(context, avatarColor),
-            width: 2,
-          ),
+    avatar = DecoratedBox(
+      position: DecorationPosition.foreground,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: avatarComponentColorValue(context, avatarColor),
+          width: 2,
         ),
-        child: avatar,
-      );
-    }
+      ),
+      child: avatar,
+    );
 
     if (!member.isAdmin) {
       return avatar;

--- a/mobile/apps/photos/lib/ui/payment/store_subscription_page.dart
+++ b/mobile/apps/photos/lib/ui/payment/store_subscription_page.dart
@@ -405,7 +405,7 @@ class _StoreSubscriptionPageState extends State<StoreSubscriptionPage> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: MenuItemWidgetNew(
             title: _isFreePlanUser()
-                ? AppLocalizations.of(context).familyPlans
+                ? AppLocalizations.of(context).family
                 : AppLocalizations.of(context).manageFamily,
             menuItemColor: colorScheme.fillFaint,
             pressedColor: colorScheme.fillFaintPressed,

--- a/mobile/apps/photos/lib/ui/settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings_page.dart
@@ -346,7 +346,7 @@ class _SettingsBody extends StatelessWidget {
           },
         ),
         _buildMenuItem(
-          title: AppLocalizations.of(context).familyPlans,
+          title: AppLocalizations.of(context).family,
           icon: HugeIcons.strokeRoundedUserMultiple,
           showOnlyLoadingState: true,
           shouldSurfaceExecutionStates: true,

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_controller.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_controller.dart
@@ -19,7 +19,7 @@ class LibrarySharingController extends ChangeNotifier {
   List<Collection> _albums = const [];
   final Map<int, CollectionParticipantRole> _activeRoles = {};
   final Map<int, CollectionParticipantRole> _selectedRoles = {};
-  CollectionParticipantRole _defaultRole = CollectionParticipantRole.admin;
+  CollectionParticipantRole _defaultRole = CollectionParticipantRole.viewer;
   Object? _loadError;
   int _failedCount = 0;
   bool _isLoading = true;

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_page.dart
@@ -251,6 +251,7 @@ class _LibrarySharingPageState extends State<LibrarySharingPage> {
           isSelected: _controller.isSelected,
           toggle: _handleAlbumTap,
         ),
+        enableSelectionMode: true,
         gridTopLeftOverlayBuilder: _roleOverlay,
         topPadding: Spacing.sm,
         bottomPadding: _gridBottomPadding,
@@ -263,7 +264,7 @@ class _LibrarySharingPageState extends State<LibrarySharingPage> {
     return SliverPadding(
       padding: const EdgeInsets.fromLTRB(
         Spacing.lg,
-        Spacing.xl,
+        Spacing.xs,
         Spacing.lg,
         Spacing.md,
       ),

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_sheets.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_sheets.dart
@@ -14,7 +14,7 @@ Future<bool> showEnableLibrarySharingSheet({
   required BuildContext context,
   required String recipientLabel,
 }) async {
-  var selectedRole = CollectionParticipantRole.admin;
+  var selectedRole = CollectionParticipantRole.viewer;
   return await showBottomSheetComponent<bool>(
         context: context,
         builder: (sheetContext) => StatefulBuilder(

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_strings.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_strings.dart
@@ -7,7 +7,7 @@ abstract final class LibrarySharingStrings {
   static String get shareAlbums => pendingTranslation('Share albums');
   static String get internalShareAlbums =>
       pendingTranslation('(i) Share albums');
-  static String get librarySharing => pendingTranslation('Library Sharing');
+  static String get librarySharing => pendingTranslation('Library sharing');
   static String get shareAllYourAlbums =>
       pendingTranslation('Share all your albums');
   static String get enableLibrarySharing =>

--- a/mobile/apps/photos/test/ui/sharing/library_sharing_controller_test.dart
+++ b/mobile/apps/photos/test/ui/sharing/library_sharing_controller_test.dart
@@ -55,7 +55,7 @@ void main() {
     expect(await controller.applySelection(), isFalse);
     expect(controller.selectedAlbums.map((album) => album.id).toSet(), {2});
     expect(controller.failedCount, 1);
-    expect(controller.activeRoleFor(1), CollectionParticipantRole.admin);
+    expect(controller.activeRoleFor(1), CollectionParticipantRole.viewer);
     expect(controller.activeRoleFor(2), isNull);
 
     repository.shareFailures.clear();
@@ -154,14 +154,14 @@ void main() {
     expect(controller.isMutating, isTrue);
     controller.toggleSelection(repository.albums[1]);
     controller.selectAll();
-    controller.setRoleForSelection(CollectionParticipantRole.viewer);
+    controller.setRoleForSelection(CollectionParticipantRole.admin);
 
     expect(controller.selectedAlbums.map((album) => album.id).toSet(), {1});
-    expect(controller.stagedRoleFor(1), CollectionParticipantRole.admin);
+    expect(controller.stagedRoleFor(1), CollectionParticipantRole.viewer);
 
     gate.complete();
     expect(await apply, isTrue);
-    expect(repository.sharedRoles, [CollectionParticipantRole.admin]);
+    expect(repository.sharedRoles, [CollectionParticipantRole.viewer]);
   });
 
   test(
@@ -180,7 +180,7 @@ void main() {
 
       expect(await controller.applySelection(), isTrue);
       expect(controller.selectedAlbums, isEmpty);
-      expect(controller.activeRoleFor(1), CollectionParticipantRole.admin);
+      expect(controller.activeRoleFor(1), CollectionParticipantRole.viewer);
       expect(repository.sharedIDs, [1]);
     },
   );

--- a/mobile/apps/photos/test/ui/sharing/library_sharing_page_test.dart
+++ b/mobile/apps/photos/test/ui/sharing/library_sharing_page_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     expect(find.byType(LibrarySharingSelectionSheet), findsNothing);
     expect(find.text('No albums to share yet'), findsOneWidget);
-    expect(find.text('Library Sharing'), findsOneWidget);
+    expect(find.text('Library sharing'), findsOneWidget);
     expect(find.byType(ToggleSwitchComponent), findsOneWidget);
   });
 
@@ -70,7 +70,7 @@ void main() {
     expect(find.text('Share with'), findsOneWidget);
     expect(find.text('Sharing with'), findsNothing);
     expect(find.text('All your current albums are shared'), findsOneWidget);
-    expect(find.text('Library Sharing'), findsNothing);
+    expect(find.text('Library sharing'), findsNothing);
     expect(find.byType(LibrarySharingSelectionSheet), findsNothing);
     expect(find.byType(ToggleSwitchComponent), findsNothing);
   });
@@ -90,14 +90,14 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Library Sharing'), findsOneWidget);
+    expect(find.text('Library sharing'), findsOneWidget);
     expect(find.text('Share all your albums'), findsOneWidget);
     final toggle = tester.widget<ToggleSwitchComponent>(
       find.byKey(const ValueKey('library-sharing-toggle')),
     );
     expect(toggle.selected, isFalse);
 
-    await tester.tap(find.text('Library Sharing'));
+    await tester.tap(find.text('Library sharing'));
     await tester.pumpAndSettle();
 
     expect(find.text('Enable library sharing?'), findsOneWidget);
@@ -114,7 +114,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Role'), findsOneWidget);
-    expect(find.text('Admin'), findsOneWidget);
+    expect(find.text('Viewer'), findsOneWidget);
 
     await tester.tap(find.text('Enable'));
     await tester.pumpAndSettle();
@@ -147,18 +147,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Library Sharing'), findsOneWidget);
+    expect(find.text('Library sharing'), findsOneWidget);
     expect(find.byType(LibrarySharingSelectionSheet), findsNothing);
 
     controller.enterManageMode();
     controller.selectAll();
     await tester.pumpAndSettle();
-    expect(find.text('Library Sharing'), findsOneWidget);
+    expect(find.text('Library sharing'), findsOneWidget);
     expect(find.byType(LibrarySharingSelectionSheet), findsOneWidget);
 
     controller.clearSelection();
     await tester.pumpAndSettle();
-    expect(find.text('Library Sharing'), findsOneWidget);
+    expect(find.text('Library sharing'), findsOneWidget);
     expect(find.byType(LibrarySharingSelectionSheet), findsNothing);
     expect(find.byTooltip('Share albums'), findsOneWidget);
   });


### PR DESCRIPTION
- Align Family and library-sharing copy, spacing, avatars, and default roles.
- Support selecting albums with a long press.