### PR TITLE
Add deep linking for unconfigured home screen widgets

### DIFF
--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EnteAlbumsWidgetProvider.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EnteAlbumsWidgetProvider.kt
@@ -125,6 +125,10 @@ class EnteAlbumsWidgetProvider : HomeWidgetProvider() {
                                                                 View.GONE
                                                         )
                                                         setViewVisibility(
+                                                                R.id.widget_placeholder_title,
+                                                                View.GONE
+                                                        )
+                                                        setViewVisibility(
                                                                 R.id.widget_placeholder_text,
                                                                 View.GONE
                                                         )
@@ -143,10 +147,15 @@ class EnteAlbumsWidgetProvider : HomeWidgetProvider() {
                                                         )
                                                 } else {
                                                         // Open App on Widget Click
+                                                        val deepLinkUri =
+                                                                Uri.parse(
+                                                                        "albumwidget://configure?homeWidget"
+                                                                )
                                                         val pendingIntent =
                                                                 HomeWidgetLaunchIntent.getActivity(
                                                                         context,
-                                                                        MainActivity::class.java
+                                                                        MainActivity::class.java,
+                                                                        deepLinkUri
                                                                 )
                                                         setOnClickPendingIntent(
                                                                 R.id.widget_container,
@@ -173,14 +182,18 @@ class EnteAlbumsWidgetProvider : HomeWidgetProvider() {
                                                                 R.id.widget_overlay,
                                                                 View.GONE
                                                         )
-                                                        setViewVisibility(
-                                                                R.id.widget_placeholder,
-                                                                View.VISIBLE
-                                                        )
-                                                        setViewVisibility(
-                                                                R.id.widget_placeholder_text,
-                                                                View.VISIBLE
-                                                        )
+                                                         setViewVisibility(
+                                                                 R.id.widget_placeholder,
+                                                                 View.VISIBLE
+                                                         )
+                                                         setViewVisibility(
+                                                                 R.id.widget_placeholder_title,
+                                                                 View.VISIBLE
+                                                         )
+                                                         setViewVisibility(
+                                                                 R.id.widget_placeholder_text,
+                                                                 View.VISIBLE
+                                                         )
                                                         setViewVisibility(
                                                                 R.id.widget_placeholder_container,
                                                                 View.VISIBLE

--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EnteMemoryWidgetProvider.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EnteMemoryWidgetProvider.kt
@@ -118,6 +118,10 @@ class EnteMemoryWidgetProvider : HomeWidgetProvider() {
                                                                 View.GONE
                                                         )
                                                         setViewVisibility(
+                                                                R.id.widget_placeholder_title,
+                                                                View.GONE
+                                                        )
+                                                        setViewVisibility(
                                                                 R.id.widget_placeholder_text,
                                                                 View.GONE
                                                         )
@@ -136,10 +140,15 @@ class EnteMemoryWidgetProvider : HomeWidgetProvider() {
                                                         )
                                                 } else {
                                                         // Open App on Widget Click
+                                                        val deepLinkUri =
+                                                                Uri.parse(
+                                                                        "memorywidget://configure?homeWidget"
+                                                                )
                                                         val pendingIntent =
                                                                 HomeWidgetLaunchIntent.getActivity(
                                                                         context,
-                                                                        MainActivity::class.java
+                                                                        MainActivity::class.java,
+                                                                        deepLinkUri
                                                                 )
                                                         setOnClickPendingIntent(
                                                                 R.id.widget_container,
@@ -168,6 +177,10 @@ class EnteMemoryWidgetProvider : HomeWidgetProvider() {
                                                         )
                                                         setViewVisibility(
                                                                 R.id.widget_placeholder,
+                                                                View.VISIBLE
+                                                        )
+                                                        setViewVisibility(
+                                                                R.id.widget_placeholder_title,
                                                                 View.VISIBLE
                                                         )
                                                         setViewVisibility(

--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EntePeopleWidgetProvider.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/EntePeopleWidgetProvider.kt
@@ -124,6 +124,10 @@ class EntePeopleWidgetProvider : HomeWidgetProvider() {
                                                                 View.GONE
                                                         )
                                                         setViewVisibility(
+                                                                R.id.widget_placeholder_title,
+                                                                View.GONE
+                                                        )
+                                                        setViewVisibility(
                                                                 R.id.widget_placeholder_text,
                                                                 View.GONE
                                                         )
@@ -142,10 +146,15 @@ class EntePeopleWidgetProvider : HomeWidgetProvider() {
                                                         )
                                                 } else {
                                                         // Open App on Widget Click
+                                                        val deepLinkUri =
+                                                                Uri.parse(
+                                                                        "peoplewidget://configure?homeWidget"
+                                                                )
                                                         val pendingIntent =
                                                                 HomeWidgetLaunchIntent.getActivity(
                                                                         context,
-                                                                        MainActivity::class.java
+                                                                        MainActivity::class.java,
+                                                                        deepLinkUri
                                                                 )
                                                         setOnClickPendingIntent(
                                                                 R.id.widget_container,
@@ -174,6 +183,10 @@ class EntePeopleWidgetProvider : HomeWidgetProvider() {
                                                         )
                                                         setViewVisibility(
                                                                 R.id.widget_placeholder,
+                                                                View.VISIBLE
+                                                        )
+                                                        setViewVisibility(
+                                                                R.id.widget_placeholder_title,
                                                                 View.VISIBLE
                                                         )
                                                         setViewVisibility(

--- a/mobile/apps/photos/android/app/src/main/res/layout/albums_widget_layout.xml
+++ b/mobile/apps/photos/android/app/src/main/res/layout/albums_widget_layout.xml
@@ -69,16 +69,29 @@
             android:scaleType="fitCenter" />
 
         <TextView
+            android:id="@+id/widget_placeholder_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Albums"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:gravity="center_horizontal"
+            android:textColor="@color/widget_text_color"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
             android:id="@+id/widget_placeholder_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Go to Settings -> Widgets to customise the widget"
+            android:text="Click to customise"
             android:textSize="12sp"
             android:gravity="center_horizontal"
             android:textColor="@color/widget_text_color"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"
-            android:layout_marginTop="12dp"/>
+            android:layout_marginTop="2dp"/>
     </LinearLayout>
 
 </FrameLayout>

--- a/mobile/apps/photos/android/app/src/main/res/layout/memory_widget_layout.xml
+++ b/mobile/apps/photos/android/app/src/main/res/layout/memory_widget_layout.xml
@@ -69,16 +69,29 @@
             android:scaleType="fitCenter" />
 
         <TextView
+            android:id="@+id/widget_placeholder_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Memories"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:gravity="center_horizontal"
+            android:textColor="@color/widget_text_color"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
             android:id="@+id/widget_placeholder_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Go to Settings -> Widgets to customise the widget"
+            android:text="Click to customise"
             android:textSize="12sp"
             android:gravity="center_horizontal"
             android:textColor="@color/widget_text_color"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"
-            android:layout_marginTop="12dp"/>
+            android:layout_marginTop="2dp"/>
     </LinearLayout>
 
 </FrameLayout>

--- a/mobile/apps/photos/android/app/src/main/res/layout/people_widget_layout.xml
+++ b/mobile/apps/photos/android/app/src/main/res/layout/people_widget_layout.xml
@@ -69,16 +69,29 @@
             android:scaleType="fitCenter" />
 
         <TextView
+            android:id="@+id/widget_placeholder_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="People"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:gravity="center_horizontal"
+            android:textColor="@color/widget_text_color"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:layout_marginTop="8dp"/>
+
+        <TextView
             android:id="@+id/widget_placeholder_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Go to Settings -> Widgets to customise the widget"
+            android:text="Click to customise"
             android:textSize="12sp"
             android:gravity="center_horizontal"
             android:textColor="@color/widget_text_color"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"
-            android:layout_marginTop="12dp"/>
+            android:layout_marginTop="2dp"/>
     </LinearLayout>
 
 </FrameLayout>

--- a/mobile/apps/photos/changes/home-widget-customization.md
+++ b/mobile/apps/photos/changes/home-widget-customization.md
@@ -1,0 +1,1 @@
+- Tapping an unconfigured home screen widget now opens its customization screen.

--- a/mobile/apps/photos/ios/EnteAlbumWidget/EnteAlbumWidget.swift
+++ b/mobile/apps/photos/ios/EnteAlbumWidget/EnteAlbumWidget.swift
@@ -198,7 +198,7 @@ struct EnteAlbumWidgetEntryView: View {
                             )
                     }
                 } else if let uiImage = UIImage(named: "AlbumsWidgetDefault") {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 4) {
                         Spacer()
                         Image(uiImage: uiImage)
                             .resizable()
@@ -206,8 +206,15 @@ struct EnteAlbumWidgetEntryView: View {
                             .aspectRatio(contentMode: .fit)
                             .padding(8)
 
-                        Text("Go to Settings -> Widgets to customise the widget")
-                            .font(.custom("Inter", size: 12, relativeTo: .caption))
+                        Text("Albums")
+                            .font(.custom("Inter", size: 14, relativeTo: .caption))
+                            .bold()
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .backwardWidgetAccentable(true)
+
+                        Text("Click to customise")
+                            .font(.custom("Inter", size: 12, relativeTo: .caption2))
                             .foregroundStyle(.white)  // Tint-aware color
                             .multilineTextAlignment(.center)
                             .padding(.bottom, 12)
@@ -224,8 +231,9 @@ struct EnteAlbumWidgetEntryView: View {
             .edgesIgnoringSafeArea(.all)
             .widgetURL(
                 URL(
-                    string:
-                        "albumwidget://message?generatedId=\(entry.generatedId != nil ? String(entry.generatedId!) : "nan")&mainKey=\(entry.mainKey != nil ? entry.mainKey! : "nan")&homeWidget"
+                    string: entry.generatedId != nil
+                        ? "albumwidget://message?generatedId=\(entry.generatedId!)&mainKey=\(entry.mainKey ?? "")&homeWidget"
+                        : "albumwidget://configure?homeWidget"
                 )
             )
         }

--- a/mobile/apps/photos/ios/EnteMemoryWidget/EnteMemoryWidget.swift
+++ b/mobile/apps/photos/ios/EnteMemoryWidget/EnteMemoryWidget.swift
@@ -195,7 +195,7 @@ struct EnteMemoryWidgetEntryView: View {
                             )
                     }
                 } else if let uiImage = UIImage(named: "MemoriesWidgetDefault") {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 4) {
                         Spacer()
                         Image(uiImage: uiImage)
                             .resizable()
@@ -203,8 +203,15 @@ struct EnteMemoryWidgetEntryView: View {
                             .aspectRatio(contentMode: .fit)
                             .padding(8)
 
-                        Text("Go to Settings -> Widgets to customise the widget")
-                            .font(.custom("Inter", size: 12, relativeTo: .caption))
+                        Text("Memories")
+                            .font(.custom("Inter", size: 14, relativeTo: .caption))
+                            .bold()
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .backwardWidgetAccentable(true)
+
+                        Text("Click to customise")
+                            .font(.custom("Inter", size: 12, relativeTo: .caption2))
                             .foregroundStyle(.white)  // Tint-aware color
                             .multilineTextAlignment(.center)
                             .padding(.bottom, 12)
@@ -221,8 +228,9 @@ struct EnteMemoryWidgetEntryView: View {
             .edgesIgnoringSafeArea(.all)
             .widgetURL(
                 URL(
-                    string:
-                        "memorywidget://message?generatedId=\(entry.generatedId != nil ? String(entry.generatedId!) : "nan")&homeWidget"
+                    string: entry.generatedId != nil
+                        ? "memorywidget://message?generatedId=\(entry.generatedId!)&homeWidget"
+                        : "memorywidget://configure?homeWidget"
                 )
             )
         }

--- a/mobile/apps/photos/ios/EntePeopleWidget/EntePeopleWidget.swift
+++ b/mobile/apps/photos/ios/EntePeopleWidget/EntePeopleWidget.swift
@@ -198,7 +198,7 @@ struct EntePeopleWidgetEntryView: View {
                             )
                     }
                 } else if let uiImage = UIImage(named: "PeopleWidgetDefault") {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 4) {
                         Spacer()
                         Image(uiImage: uiImage)
                             .resizable()
@@ -206,8 +206,15 @@ struct EntePeopleWidgetEntryView: View {
                             .aspectRatio(contentMode: .fit)
                             .padding(8)
 
-                        Text("Go to Settings -> Widgets to customise the widget")
-                            .font(.custom("Inter", size: 12, relativeTo: .caption))
+                        Text("People")
+                            .font(.custom("Inter", size: 14, relativeTo: .caption))
+                            .bold()
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .backwardWidgetAccentable(true)
+
+                        Text("Click to customise")
+                            .font(.custom("Inter", size: 12, relativeTo: .caption2))
                             .foregroundStyle(.white)  // Tint-aware color
                             .multilineTextAlignment(.center)
                             .padding(.bottom, 12)
@@ -224,8 +231,9 @@ struct EntePeopleWidgetEntryView: View {
             .edgesIgnoringSafeArea(.all)
             .widgetURL(
                 URL(
-                    string:
-                        "peoplewidget://message?generatedId=\(entry.generatedId != nil ? String(entry.generatedId!) : "nan")&mainKey=\(entry.mainKey != nil ? entry.mainKey! : "nan")&homeWidget"
+                    string: entry.generatedId != nil
+                        ? "peoplewidget://message?generatedId=\(entry.generatedId!)&mainKey=\(entry.mainKey ?? "")&homeWidget"
+                        : "peoplewidget://configure?homeWidget"
                 )
             )
         }

--- a/mobile/apps/photos/ios/Runner/AppDelegate.swift
+++ b/mobile/apps/photos/ios/Runner/AppDelegate.swift
@@ -44,7 +44,7 @@ import workmanager_apple
     // Retrieve the link from parameters
     if let url = AppLinks.shared.getLink(launchOptions: launchOptions) {
       // only accept non-homewidget urls for AppLinks
-      if !url.absoluteString.contains("&homeWidget") {
+      if !url.absoluteString.contains("homeWidget") {
         AppLinks.shared.handleLink(url: url)
         // link is handled, stop propagation
         return true

--- a/mobile/apps/photos/lib/services/home_widget_service.dart
+++ b/mobile/apps/photos/lib/services/home_widget_service.dart
@@ -9,10 +9,16 @@ import 'package:path_provider_foundation/path_provider_foundation.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/module/download/thumbnail.dart';
+import 'package:photos/service_locator.dart';
 import 'package:photos/services/album_home_widget_service.dart';
+import 'package:photos/services/app_navigation_service.dart';
 import 'package:photos/services/memory_home_widget_service.dart';
 import 'package:photos/services/people_home_widget_service.dart';
 import 'package:photos/services/smart_memories_service.dart';
+import 'package:photos/ui/settings/ml/machine_learning_settings_page.dart';
+import 'package:photos/ui/settings/widgets/albums_widget_settings.dart';
+import 'package:photos/ui/settings/widgets/memories_widget_settings.dart';
+import 'package:photos/ui/settings/widgets/people_widget_settings.dart';
 import 'package:synchronized/synchronized.dart';
 
 enum WidgetStatus {
@@ -253,43 +259,74 @@ class HomeWidgetService {
       return;
     }
 
+    _logger.info("Handling widget launch with URI: $uri");
+
     final generatedId = int.tryParse(
       uri.queryParameters[GENERATED_ID_PARAM] ?? "",
     );
-    if (generatedId == null) {
-      _logger.warning("Widget launch failed: Invalid or missing generated ID");
-      return;
-    }
+
+    final bool isConfigureRoute =
+        uri.host == 'configure' || generatedId == null;
 
     // Route to appropriate handler based on widget scheme
     switch (uri.scheme) {
       case MEMORY_WIDGET_SCHEME:
-        await MemoryHomeWidgetService.instance.onLaunchFromWidget(generatedId);
+        if (isConfigureRoute) {
+          _logger.info("Navigating to Memories widget customization screen");
+          await AppNavigationService.instance.pushPage(
+            const MemoriesWidgetSettings(),
+          );
+        } else {
+          await MemoryHomeWidgetService.instance.onLaunchFromWidget(
+            generatedId,
+          );
+        }
         break;
 
       case PEOPLE_WIDGET_SCHEME:
-        final personId = uri.queryParameters[MAIN_KEY_PARAM] ?? "";
-        await PeopleHomeWidgetService.instance.onLaunchFromWidget(
-          generatedId,
-          personId,
-        );
+        if (isConfigureRoute) {
+          _logger.info("Navigating to People widget customization screen");
+          if (!hasGrantedMLConsent) {
+            await AppNavigationService.instance.pushPage(
+              const MachineLearningSettingsPage(),
+              forceCustomPageRoute: true,
+            );
+          } else {
+            await AppNavigationService.instance.pushPage(
+              const PeopleWidgetSettings(),
+            );
+          }
+        } else {
+          final personId = uri.queryParameters[MAIN_KEY_PARAM] ?? "";
+          await PeopleHomeWidgetService.instance.onLaunchFromWidget(
+            generatedId,
+            personId,
+          );
+        }
         break;
 
       case ALBUM_WIDGET_SCHEME:
-        final collectionId = int.tryParse(
-          uri.queryParameters[MAIN_KEY_PARAM] ?? "",
-        );
-        if (collectionId == null) {
-          _logger.warning(
-            "Album widget launch failed: Invalid or missing collection ID",
+        if (isConfigureRoute) {
+          _logger.info("Navigating to Album widget customization screen");
+          await AppNavigationService.instance.pushPage(
+            const AlbumsWidgetSettings(),
           );
-          return;
-        }
+        } else {
+          final collectionId = int.tryParse(
+            uri.queryParameters[MAIN_KEY_PARAM] ?? "",
+          );
+          if (collectionId == null) {
+            _logger.warning(
+              "Album widget launch failed: Invalid or missing collection ID",
+            );
+            return;
+          }
 
-        await AlbumHomeWidgetService.instance.onLaunchFromWidget(
-          generatedId,
-          collectionId,
-        );
+          await AlbumHomeWidgetService.instance.onLaunchFromWidget(
+            generatedId,
+            collectionId,
+          );
+        }
         break;
 
       default:


### PR DESCRIPTION
## **Description**

Previously, tapping an unconfigured home screen **widget simply launched the app's main screen**, requiring users to manually navigate through Settings $\rightarrow$ Widgets to configure them.

This PR enables direct deep-linking for unconfigured widgets (Albums, People, and Memories) on Android and iOS. Tapping an unconfigured widget now lands directly on its respective customization screen in the app, **avoiding back-and-forth navigation and making setup much more convenient for users.**

Also updates the placeholder UI across native Android layouts and iOS WidgetKit views to display the widget title (Albums / People / Memories) and "Click widget to customise" subtext.

> Note: Conditional check for ML enabled when navigating to people widget customise screen is also handled.

## Tests
Tested and verified on devices Realme C67 5G and Realme Pad 2.

## Demo 

https://github.com/user-attachments/assets/d14dbde2-9281-4c58-9c20-63f3d2b275b7

**Top left:** Widget before change
**Bottom right:** Widget after change
