### PR TITLE
[mobile][photos] Stop reporting expected upload lock contention

### DIFF
--- a/mobile/apps/photos/lib/db/upload_locks_db.dart
+++ b/mobile/apps/photos/lib/db/upload_locks_db.dart
@@ -174,17 +174,27 @@ class UploadLocksDB {
     await db.delete(_streamQueueTable.table);
   }
 
-  Future<void> acquireLock(String id, String owner, int time) async {
+  Future<bool> tryAcquireLock(String id, String owner, int time) async {
     final db = await database;
     final row = <String, dynamic>{};
     row[_uploadLocksTable.columnID] = id;
     row[_uploadLocksTable.columnOwner] = owner;
     row[_uploadLocksTable.columnTime] = time;
-    await db.insert(
-      _uploadLocksTable.table,
-      row,
-      conflictAlgorithm: ConflictAlgorithm.fail,
-    );
+    try {
+      await db.insert(
+        _uploadLocksTable.table,
+        row,
+        conflictAlgorithm: ConflictAlgorithm.fail,
+      );
+      return true;
+    } on DatabaseException catch (e) {
+      final lockIDColumn =
+          '${_uploadLocksTable.table}.${_uploadLocksTable.columnID}';
+      if (e.isUniqueConstraintError(lockIDColumn)) {
+        return false;
+      }
+      rethrow;
+    }
   }
 
   Future<String> getLockData(String id) async {

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -379,20 +379,29 @@ class FileUploader {
     final String lockKey = file.localID!;
     bool isMultipartUpload = false;
 
+    late final bool acquiredLock;
     try {
-      await _uploadLocks.acquireLock(
+      acquiredLock = await _uploadLocks.tryAcquireLock(
         lockKey,
         _processType.toString(),
         DateTime.now().microsecondsSinceEpoch,
       );
     } catch (e, s) {
-      final lockInfo = await _uploadLocks.getLockData(lockKey);
-      _logger.warning(
-        "Upload lock acquisition failed for ${file.tag}: "
+      _logger.severe(
+        "Upload lock database failure for ${file.tag}: "
         "targetCollectionID=$collectionID, requestOwner=$_processType, "
-        "forcedUpload=$forcedUpload, lock=$lockInfo",
+        "forcedUpload=$forcedUpload",
         e,
         s,
+      );
+      rethrow;
+    }
+    if (!acquiredLock) {
+      final lockInfo = await _uploadLocks.getLockData(lockKey);
+      _logger.warning(
+        "Upload already active for ${file.tag}: "
+        "targetCollectionID=$collectionID, requestOwner=$_processType, "
+        "forcedUpload=$forcedUpload, lock=$lockInfo",
       );
       throw LockAlreadyAcquiredError();
     }


### PR DESCRIPTION
- Treat upload-lock primary-key conflicts as expected contention instead of sending an exception to Sentry.
- Preserve reporting and propagation for unexpected upload-lock database failures.

Validation: mobile lint workflow checks (policy scripts, cargo codegen, both Flutter Rust clippy targets, pub get, full format check, full analyzer, and workspace tests).