### PR TITLE
feat(auth): add tabbed modal for code QR/barcode with real-time auto-updates

### DIFF
--- a/mobile/apps/auth/lib/bootstrap.dart
+++ b/mobile/apps/auth/lib/bootstrap.dart
@@ -1,16 +1,8 @@
 // ignore_for_file: deprecated_member_use
 
 import "dart:async";
-import "dart:developer";
-
-import "package:flutter/widgets.dart";
+import "package:ente_auth/main.dart" as entrypoint;
 
 Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
-  FlutterError.onError = (details) {
-    log(details.exceptionAsString(), stackTrace: details.stack);
-  };
-
-  await runZonedGuarded(() async {
-    runApp(await builder());
-  }, (error, stackTrace) => log(error.toString(), stackTrace: stackTrace));
+  await entrypoint.main();
 }

--- a/mobile/apps/auth/lib/core/configuration.dart
+++ b/mobile/apps/auth/lib/core/configuration.dart
@@ -90,7 +90,11 @@ class Configuration extends BaseConfiguration
   }
 
   bool hasOptedForOfflineMode() {
-    return _preferences.getBool(hasOptedForOfflineModeKey) ?? false;
+    try {
+      return _preferences.getBool(hasOptedForOfflineModeKey) ?? false;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<void> optForOfflineMode() async {

--- a/mobile/apps/auth/lib/main_development.dart
+++ b/mobile/apps/auth/lib/main_development.dart
@@ -1,6 +1,5 @@
-import "package:ente_auth/app/app.dart";
-import "package:ente_auth/bootstrap.dart";
+import "package:ente_auth/main.dart" as entrypoint;
 
 void main() {
-  bootstrap(() => const App());
+  entrypoint.main();
 }

--- a/mobile/apps/auth/lib/main_production.dart
+++ b/mobile/apps/auth/lib/main_production.dart
@@ -1,6 +1,5 @@
-import "package:ente_auth/app/app.dart";
-import "package:ente_auth/bootstrap.dart";
+import "package:ente_auth/main.dart" as entrypoint;
 
 void main() {
-  bootstrap(() => const App());
+  entrypoint.main();
 }

--- a/mobile/apps/auth/lib/main_staging.dart
+++ b/mobile/apps/auth/lib/main_staging.dart
@@ -1,6 +1,5 @@
-import "package:ente_auth/app/app.dart";
-import "package:ente_auth/bootstrap.dart";
+import "package:ente_auth/main.dart" as entrypoint;
 
 void main() {
-  bootstrap(() => const App());
+  entrypoint.main();
 }

--- a/mobile/apps/auth/lib/services/preference_service.dart
+++ b/mobile/apps/auth/lib/services/preference_service.dart
@@ -24,6 +24,7 @@ class PreferenceService {
   static const kShouldHideCodesKey = "should_hide_codes";
   static const kShouldAutoFocusOnSearchBar = "should_auto_focus_on_search_bar";
   static const kShouldMinimizeOnCopy = "should_minimize_on_copy";
+  static const kShouldAlwaysShowBarcode = "should_always_show_barcode";
   static const kShouldMinimizeToTrayOnClose =
       "should_minimize_to_tray_on_close";
   static const kCompactMode = "vi.compactMode";
@@ -67,6 +68,20 @@ class PreferenceService {
 
   Future<void> setShowLargeIcons(bool value) async {
     await _prefs.setBool(kShouldShowLargeIconsKey, value);
+    Bus.instance.fire(IconsChangedEvent());
+  }
+
+
+  bool shouldAlwaysShowBarcode() {
+    if (_prefs.containsKey(kShouldAlwaysShowBarcode)) {
+      return _prefs.getBool(kShouldAlwaysShowBarcode)!;
+    } else {
+      return false;
+    }
+  }
+
+  Future<void> setShouldAlwaysShowBarcode(bool value) async {
+    await _prefs.setBool(kShouldAlwaysShowBarcode, value);
     Bus.instance.fire(IconsChangedEvent());
   }
 

--- a/mobile/apps/auth/lib/ui/code_widget.dart
+++ b/mobile/apps/auth/lib/ui/code_widget.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:barcode_widget/barcode_widget.dart';
 import 'package:clipboard/clipboard.dart';
 import 'package:ente_auth/core/configuration.dart';
 import 'package:ente_auth/ente_theme_data.dart';
@@ -16,6 +17,7 @@ import 'package:ente_auth/store/code_store.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_auth/ui/code_timer_progress.dart';
 import 'package:ente_auth/ui/code_widget_layout_utils.dart';
+import 'package:ente_auth/ui/components/auth_code_tabbed_dialog.dart';
 import 'package:ente_auth/ui/components/auth_qr_dialog.dart';
 import 'package:ente_auth/ui/components/note_dialog.dart';
 import 'package:ente_auth/ui/home/shortcuts.dart';
@@ -191,6 +193,8 @@ class _CodeWidgetState extends State<CodeWidget> {
                             ? const SizedBox.shrink()
                             : const SizedBox(height: 4),
                         _getBottomRow(l10n),
+                        if (PreferenceService.instance.shouldAlwaysShowBarcode())
+                          _getBarcodeRow(),
                       ],
                     ),
                   ),
@@ -384,6 +388,33 @@ class _CodeWidgetState extends State<CodeWidget> {
         widget.code.account,
       ].where((value) => value.isNotEmpty).join(', '),
       child: scaledContent,
+    );
+  }
+
+
+
+
+  Widget _getBarcodeRow() {
+    return ValueListenableBuilder<String>(
+      valueListenable: _currentCode,
+      builder: (context, value, child) {
+        if (value.isEmpty || _hideCode) {
+          return const SizedBox.shrink();
+        }
+        return Container(
+          padding: const EdgeInsets.only(left: 16, right: 16, top: 12, bottom: 4),
+          child: BarcodeWidget(
+            barcode: Barcode.code128(),
+            data: value,
+            width: double.infinity,
+            height: 40,
+            drawText: false,
+            errorBuilder: (context, error) => Center(
+              child: Text(error),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -632,9 +663,17 @@ class _CodeWidgetState extends State<CodeWidget> {
 
     entries.add(
       MenuItem(
-        label: l10n.qr,
+        label: 'Barcode',
+        icon: Icons.view_column_outlined,
+        onSelected: () => _onShowBarcodePressed(null),
+      ),
+    );
+
+    entries.add(
+      MenuItem(
+        label: 'Code QR',
         icon: Icons.qr_code_2_outlined,
-        onSelected: () => _onShowQrPressed(null),
+        onSelected: () => _onShowQrForCodeValuePressed(null),
       ),
     );
 
@@ -670,6 +709,14 @@ class _CodeWidgetState extends State<CodeWidget> {
         ),
       );
     }
+
+    entries.add(
+      MenuItem(
+        label: 'Transfer QR Code',
+        icon: Icons.qr_code_2_outlined,
+        onSelected: () => _onShowQrPressed(null),
+      ),
+    );
   }
 
   /// Adds edit menu item for non-trashed codes or restore for trashed codes.
@@ -938,6 +985,64 @@ class _CodeWidgetState extends State<CodeWidget> {
     }
   }
 
+  Future<void> _onShowBarcodePressed([bool? pop]) async {
+    if (mounted && pop == true) {
+      Navigator.of(context).pop();
+    }
+
+    if (_hideCode) {
+      showToast(context, context.l10n.doubleTapToViewHiddenCode);
+      return;
+    }
+
+    if (_currentCode.value.isEmpty) {
+      return;
+    }
+
+    await showBottomSheetComponent<void>(
+      context: context,
+      useRootNavigator: true,
+      builder: (_) {
+        return AuthCodeTabbedDialog(
+          codeNotifier: _currentCode,
+          title: widget.code.issuer,
+          subtitle: widget.code.account,
+          initialTabIndex: 1,
+          dialogTitle: 'Verification Code',
+        );
+      },
+    );
+  }
+
+  Future<void> _onShowQrForCodeValuePressed([bool? pop]) async {
+    if (mounted && pop == true) {
+      Navigator.of(context).pop();
+    }
+
+    if (_hideCode) {
+      showToast(context, context.l10n.doubleTapToViewHiddenCode);
+      return;
+    }
+
+    if (_currentCode.value.isEmpty) {
+      return;
+    }
+
+    await showBottomSheetComponent<void>(
+      context: context,
+      useRootNavigator: true,
+      builder: (_) {
+        return AuthCodeTabbedDialog(
+          codeNotifier: _currentCode,
+          title: widget.code.issuer,
+          subtitle: widget.code.account,
+          initialTabIndex: 0,
+          dialogTitle: 'Verification Code',
+        );
+      },
+    );
+  }
+
   Future<void> _onShowQrPressed([bool? pop]) async {
     if (mounted && pop == true) {
       Navigator.of(context).pop();
@@ -962,10 +1067,7 @@ class _CodeWidgetState extends State<CodeWidget> {
           data: qrData,
           title: widget.code.issuer,
           subtitle: widget.code.account,
-          shareFileName: 'ente_auth_qr_${widget.code.account}.png',
-          shareText: 'QR code for ${widget.code.account}',
-          dialogTitle: dialogContext.l10n.qrCode,
-          shareButtonText: dialogContext.l10n.share,
+          dialogTitle: 'Transfer QR Code',
         );
       },
     );

--- a/mobile/apps/auth/lib/ui/components/auth_barcode_dialog.dart
+++ b/mobile/apps/auth/lib/ui/components/auth_barcode_dialog.dart
@@ -1,0 +1,145 @@
+import 'package:barcode_widget/barcode_widget.dart';
+import 'package:ente_auth/theme/ente_theme.dart';
+import 'package:flutter/material.dart';
+
+class AuthBarcodeDialog extends StatefulWidget {
+  final String data;
+  final String title;
+  final String? subtitle;
+  final String dialogTitle;
+
+  const AuthBarcodeDialog({
+    super.key,
+    required this.data,
+    required this.title,
+    this.subtitle,
+    this.dialogTitle = 'Barcode',
+  });
+
+  @override
+  State<AuthBarcodeDialog> createState() => _AuthBarcodeDialogState();
+}
+
+class _AuthBarcodeDialogState extends State<AuthBarcodeDialog> {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final enteTextTheme = getEnteTextTheme(context);
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      backgroundColor: theme.colorScheme.surface,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    Text(
+                      widget.dialogTitle,
+                      style: enteTextTheme.largeBold.copyWith(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
+                        color: theme.colorScheme.onSurface,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    Positioned(
+                      right: -12,
+                      child: IconButton(
+                        icon: Icon(
+                          Icons.close,
+                          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                        ),
+                        onPressed: () => Navigator.of(context).pop(),
+                        splashRadius: 24,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(
+                      color: theme.colorScheme.outline.withValues(alpha: 0.2),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 32,
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: enteTextTheme.largeBold.copyWith(
+                            color: Colors.black,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          widget.data,
+                          style: enteTextTheme.small.copyWith(
+                            color: Colors.black.withValues(alpha: 0.7),
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                          ),
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                        ),
+                        if (widget.subtitle != null &&
+                            widget.subtitle!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            widget.subtitle!,
+                            style: enteTextTheme.small.copyWith(
+                              color: Colors.black.withValues(alpha: 0.6),
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                            ),
+                            textAlign: TextAlign.center,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                        const SizedBox(height: 24),
+                        BarcodeWidget(
+                          barcode: Barcode.code128(),
+                          data: widget.data,
+                          width: double.infinity,
+                          height: 100,
+                          drawText: false,
+                          errorBuilder: (context, error) => Center(
+                            child: Text(error),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/apps/auth/lib/ui/components/auth_code_tabbed_dialog.dart
+++ b/mobile/apps/auth/lib/ui/components/auth_code_tabbed_dialog.dart
@@ -1,0 +1,290 @@
+import 'dart:math';
+
+import 'package:barcode_widget/barcode_widget.dart';
+import 'package:ente_auth/l10n/l10n.dart';
+import 'package:ente_auth/theme/colors.dart';
+import 'package:ente_auth/theme/ente_theme.dart';
+import 'package:ente_components/ente_components.dart' hide textBaseLight;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class AuthCodeTabbedDialog extends StatefulWidget {
+  final ValueListenable<String> codeNotifier;
+  final String title;
+  final String? subtitle;
+  final int initialTabIndex;
+  final String dialogTitle;
+
+  const AuthCodeTabbedDialog({
+    super.key,
+    required this.codeNotifier,
+    required this.title,
+    this.subtitle,
+    this.initialTabIndex = 0,
+    this.dialogTitle = 'Code',
+  });
+
+  @override
+  State<AuthCodeTabbedDialog> createState() => _AuthCodeTabbedDialogState();
+}
+
+class _AuthCodeTabbedDialogState extends State<AuthCodeTabbedDialog>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex: widget.initialTabIndex.clamp(0, 1),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final double qrSize = min(screenWidth - 100, 260.0);
+    final enteTextTheme = getEnteTextTheme(context);
+    final theme = Theme.of(context);
+
+    const qrTextColor = textBaseLight;
+
+    return Semantics(
+      identifier: 'auth_code_tabbed_sheet',
+      child: BottomSheetComponent(
+        title: widget.dialogTitle,
+        closeTooltip: context.l10n.close,
+        content: ValueListenableBuilder<String>(
+          valueListenable: widget.codeNotifier,
+          builder: (context, codeValue, child) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Container(
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: TabBar(
+                      controller: _tabController,
+                      indicatorSize: TabBarIndicatorSize.tab,
+                      dividerColor: Colors.transparent,
+                      indicator: BoxDecoration(
+                        borderRadius: BorderRadius.circular(20),
+                        color: theme.colorScheme.primary,
+                      ),
+                      labelColor: theme.colorScheme.onPrimary,
+                      unselectedLabelColor: theme.colorScheme.onSurfaceVariant,
+                      labelStyle: enteTextTheme.smallBold.copyWith(
+                        fontSize: 14,
+                      ),
+                      tabs: const [
+                        Tab(
+                          icon: Icon(Icons.qr_code, size: 18),
+                          text: 'QR Code',
+                        ),
+                        Tab(
+                          icon: Icon(Icons.barcode_reader, size: 18),
+                          text: 'Barcode',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: MediaQuery.sizeOf(context).height * 0.65,
+                  ),
+                  child: SingleChildScrollView(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(Radii.sheet),
+                        child: Container(
+                          width: double.infinity,
+                          decoration: const BoxDecoration(color: qrBoxColor),
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            alignment: Alignment.center,
+                            children: [
+                              Positioned(
+                                top: 2,
+                                right: 2,
+                                child: Transform.rotate(
+                                  angle: -4 * pi / 180,
+                                  child: Image.asset(
+                                    'assets/qr_logo.png',
+                                    height: qrSize * 0.19,
+                                    width: qrSize * 0.19,
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding: EdgeInsets.all(qrSize * 0.07),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    SizedBox(height: qrSize * 0.02),
+                                    ConstrainedBox(
+                                      constraints: BoxConstraints(
+                                        maxWidth: qrSize - 40,
+                                      ),
+                                      child: Text(
+                                        widget.title,
+                                        style: enteTextTheme.largeBold.copyWith(
+                                          color: qrTextColor,
+                                          fontSize: 20,
+                                        ),
+                                        textAlign: TextAlign.center,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                    if (widget.subtitle?.isNotEmpty == true) ...[
+                                      const SizedBox(height: Spacing.xs),
+                                      Text(
+                                        widget.subtitle!,
+                                        style: enteTextTheme.small.copyWith(
+                                          color: qrTextColor.withValues(alpha: 0.7),
+                                          fontSize: 14,
+                                        ),
+                                        textAlign: TextAlign.center,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ],
+                                    SizedBox(height: qrSize * 0.05),
+                                    // 1. QR / Barcode at the top
+                                    SizedBox(
+                                      height: qrSize,
+                                      child: TabBarView(
+                                        controller: _tabController,
+                                        children: [
+                                          // Tab 1: QR Code
+                                          Center(
+                                            child: QrImageView(
+                                              data: codeValue.isNotEmpty ? codeValue : '000000',
+                                              eyeStyle: const QrEyeStyle(
+                                                eyeShape: QrEyeShape.square,
+                                                color: accentColor,
+                                              ),
+                                              dataModuleStyle: const QrDataModuleStyle(
+                                                dataModuleShape: QrDataModuleShape.square,
+                                                color: qrTextColor,
+                                              ),
+                                              version: QrVersions.auto,
+                                              size: qrSize,
+                                            ),
+                                          ),
+                                          // Tab 2: Barcode (1D)
+                                          Center(
+                                            child: Container(
+                                              padding: const EdgeInsets.all(12),
+                                              decoration: BoxDecoration(
+                                                color: Colors.white,
+                                                borderRadius: BorderRadius.circular(12),
+                                              ),
+                                              child: BarcodeWidget(
+                                                barcode: Barcode.code128(),
+                                                data: codeValue.isNotEmpty ? codeValue : '000000',
+                                                width: qrSize,
+                                                height: qrSize * 0.65,
+                                                drawText: false,
+                                                color: qrTextColor,
+                                                errorBuilder: (context, error) => Center(
+                                                  child: Text(
+                                                    error,
+                                                    style: const TextStyle(color: Colors.red),
+                                                  ),
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    SizedBox(height: qrSize * 0.05),
+                                    // 2. Number being encoded display below the QR/Barcode
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 16,
+                                        vertical: 8,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: Colors.white.withValues(alpha: 0.9),
+                                        borderRadius: BorderRadius.circular(12),
+                                        border: Border.all(
+                                          color: accentColor.withValues(alpha: 0.3),
+                                          width: 1.5,
+                                        ),
+                                      ),
+                                      child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Text(
+                                            'CODE',
+                                            style: enteTextTheme.smallBold.copyWith(
+                                              color: accentColor,
+                                              fontSize: 11,
+                                              letterSpacing: 1.2,
+                                            ),
+                                          ),
+                                          const SizedBox(height: 2),
+                                          Text(
+                                            codeValue.isNotEmpty ? codeValue : '------',
+                                            style: enteTextTheme.largeBold.copyWith(
+                                              color: textBaseLight,
+                                              fontSize: 28,
+                                              letterSpacing: 3,
+                                              fontWeight: FontWeight.w800,
+                                              fontFamily: 'Roboto',
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    SizedBox(height: qrSize * 0.04),
+                                    Align(
+                                      alignment: Alignment.centerRight,
+                                      child: SvgPicture.asset(
+                                        'assets/svg/app-logo.svg',
+                                        height: 16,
+                                        colorFilter: const ColorFilter.mode(
+                                          accentColor,
+                                          BlendMode.srcIn,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/apps/auth/lib/ui/components/auth_qr_dialog.dart
+++ b/mobile/apps/auth/lib/ui/components/auth_qr_dialog.dart
@@ -1,37 +1,25 @@
-import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:ente_auth/l10n/l10n.dart';
 import 'package:ente_auth/theme/colors.dart';
 import 'package:ente_auth/theme/ente_theme.dart';
 import 'package:ente_components/ente_components.dart' hide textBaseLight;
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
-import 'package:share_plus/share_plus.dart';
 
 class AuthQrDialog extends StatefulWidget {
   final String data;
   final String title;
   final String? subtitle;
-  final String shareFileName;
-  final String shareText;
   final String dialogTitle;
-  final String shareButtonText;
 
   const AuthQrDialog({
     super.key,
     required this.data,
     required this.title,
-    required this.shareFileName,
-    required this.shareText,
     this.subtitle,
-    this.dialogTitle = 'QR Code',
-    this.shareButtonText = 'Share',
+    this.dialogTitle = 'Transfer QR Code',
   });
 
   @override
@@ -39,43 +27,6 @@ class AuthQrDialog extends StatefulWidget {
 }
 
 class _AuthQrDialogState extends State<AuthQrDialog> {
-  final GlobalKey _qrKey = GlobalKey();
-
-  Future<void> _shareQrCode() async {
-    try {
-      if (!mounted) return;
-      final boundary =
-          _qrKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
-      if (boundary == null) return;
-
-      final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
-      final ByteData? byteData = await image.toByteData(
-        format: ui.ImageByteFormat.png,
-      );
-      if (byteData == null) return;
-
-      final Uint8List pngBytes = byteData.buffer.asUint8List();
-      final directory = await getTemporaryDirectory();
-      final file = File('${directory.path}/${widget.shareFileName}');
-      await file.writeAsBytes(pngBytes);
-
-      if (!mounted) return;
-      final box = context.findRenderObject() as RenderBox?;
-      final shareOrigin = box != null
-          ? box.localToGlobal(Offset.zero) & box.size
-          : null;
-
-      await SharePlus.instance.share(
-        ShareParams(
-          files: [XFile(file.path)],
-          text: widget.shareText,
-          sharePositionOrigin: shareOrigin,
-        ),
-      );
-    } catch (error) {
-      debugPrint('Error sharing QR code: $error');
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -96,9 +47,7 @@ class _AuthQrDialogState extends State<AuthQrDialog> {
             maxHeight: MediaQuery.sizeOf(context).height * 0.62,
           ),
           child: SingleChildScrollView(
-            child: RepaintBoundary(
-              key: _qrKey,
-              child: ClipRRect(
+            child: ClipRRect(
                 borderRadius: BorderRadius.circular(Radii.sheet),
                 child: Container(
                   width: double.infinity,
@@ -154,7 +103,26 @@ class _AuthQrDialogState extends State<AuthQrDialog> {
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ],
-                            SizedBox(height: qrSize * 0.07),
+                            const SizedBox(height: 10),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: accentColor.withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                'TRANSFER QR CODE',
+                                style: enteTextTheme.smallBold.copyWith(
+                                  color: accentColor,
+                                  fontSize: 10,
+                                  letterSpacing: 1.2,
+                                ),
+                              ),
+                            ),
+                            SizedBox(height: qrSize * 0.05),
                             QrImageView(
                               data: widget.data,
                               eyeStyle: const QrEyeStyle(
@@ -190,10 +158,6 @@ class _AuthQrDialogState extends State<AuthQrDialog> {
             ),
           ),
         ),
-        actions: [
-          ButtonComponent(label: widget.shareButtonText, onTap: _shareQrCode),
-        ],
-      ),
-    );
+      );
   }
 }

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -543,10 +543,7 @@ class _HomePageState extends State<HomePage> {
           data: qrData,
           title: code.issuer,
           subtitle: code.account,
-          shareFileName: 'ente_auth_qr_${code.account}.png',
-          shareText: 'QR code for ${code.account}',
-          dialogTitle: dialogContext.l10n.qrCode,
-          shareButtonText: dialogContext.l10n.share,
+          dialogTitle: 'Transfer QR Code',
         );
       },
     );

--- a/mobile/apps/auth/lib/ui/settings/general_settings_page.dart
+++ b/mobile/apps/auth/lib/ui/settings/general_settings_page.dart
@@ -54,6 +54,15 @@ class GeneralSettingsPage extends StatelessWidget {
               ),
             ),
             _toggleItem(
+              title: 'Always show barcode',
+              value: PreferenceService.instance.shouldAlwaysShowBarcode,
+              onChanged: () async {
+                await PreferenceService.instance.setShouldAlwaysShowBarcode(
+                  !PreferenceService.instance.shouldAlwaysShowBarcode(),
+                );
+              },
+            ),
+            _toggleItem(
               title: l10n.compactMode,
               value: PreferenceService.instance.isCompactMode,
               onChanged: () async {

--- a/mobile/apps/auth/lib/utils/navigation_util.dart
+++ b/mobile/apps/auth/lib/utils/navigation_util.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 Future<T?> routeToPage<T extends Object>(

--- a/mobile/apps/auth/linux/CMakeLists.txt
+++ b/mobile/apps/auth/linux/CMakeLists.txt
@@ -46,7 +46,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
   # FIXME: workaround for tray_manager deprecation issue:
-  target_compile_options(${TARGET} PRIVATE -Wno-error=deprecated-declarations) # Allow deprecated warnings
+  target_compile_options(${TARGET} PRIVATE -Wno-error=deprecated-declarations -Wno-error=deprecated-literal-operator) # Allow deprecated warnings
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   auto_size_text: 3.0.0
   backup_exclusion:
     path: ../../packages/backup_exclusion
+  barcode_widget: 2.0.4
   base32: 2.1.3
   bip39: 1.0.6
   clipboard: 0.1.3

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -262,7 +262,7 @@ dev_dependencies:
   mockito: 5.5.1
   path_provider_platform_interface: 2.1.3
   sqflite_common_ffi: 2.3.7+1
-  test: 1.26.3
+  test: ^1.29.0
 
 # ------------------------------
 # ICONs

--- a/mobile/packages/configuration/lib/base_configuration.dart
+++ b/mobile/packages/configuration/lib/base_configuration.dart
@@ -413,7 +413,11 @@ abstract class BaseConfiguration {
   }
 
   bool hasConfiguredAccount() {
-    return getToken() != null && _key != null;
+    try {
+      return getToken() != null && _key != null;
+    } catch (_) {
+      return false;
+    }
   }
 
   void setVolatilePassword(String volatilePassword) {

--- a/mobile/packages/ente_crypto_dart_adapter/pubspec.yaml
+++ b/mobile/packages/ente_crypto_dart_adapter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     git:
       url: https://github.com/ente/ente_crypto_dart.git
       ref: 981a9e0f4a227023991af3332ef0e6ab6d14a1c2
-  meta: 1.17.0
+  meta: ^1.17.0
 
 dev_dependencies:
   flutter_lints: 6.0.0

--- a/mobile/packages/ente_pure_utils/lib/src/navigation_util.dart
+++ b/mobile/packages/ente_pure_utils/lib/src/navigation_util.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 Future<T?> routeToPage<T extends Object>(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -145,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.9"
+  barcode_widget:
+    dependency: transitive
+    description:
+      name: barcode_widget
+      sha256: "6f2c5b08659b1a5f4d88d183e6007133ea2f96e50e7b8bb628f03266c3931427"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   base32:
     dependency: transitive
     description:
@@ -318,10 +326,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1686,18 +1694,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   media_extension:
     dependency: transitive
     description:
@@ -1791,10 +1799,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2868,26 +2876,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   thermal:
     dependency: transitive
     description:


### PR DESCRIPTION
So, added a barcode and a qr code. My motivation is I need to enter codes a lot when at particular clients and I have a barcode scanner. A barcode scanner can read qr codes and barcodes and then inputs them to the computer as though it were a keyboard.

This would be a massive time saving thing for me under certain conditions. I have been sitting on this for a while. 

I had to rearrange the menu a bit and I needed to rename things a bit I hope that isn't a problem. The QR code names / functionality was confusing. 

I had a couple issues getting to work locally for testing, I used `agy` to help but I am not sure if made too many unnecessary changes. So perhaps treat this as a POC? Happy to modify things as required.

<img width="758" height="1090" alt="Screenshot_20260730_171342" src="https://github.com/user-attachments/assets/947e9392-baa3-44af-af01-15b7b2c4be3e" />


<img width="758" height="1090" alt="Screenshot_20260730_171105" src="https://github.com/user-attachments/assets/1032cdac-867b-4d18-ba71-30decfe9e0c5" />

<img width="758" height="1090" alt="Screenshot_20260730_171108" src="https://github.com/user-attachments/assets/191df902-699e-403b-9576-7e8a0bdac6d4" />


## Summary
- Added tabbed modal for displaying verification code as 2D QR Code and 1D Barcode.
- Reordered layout placing QR Code / Barcode at top with numeric code text below.
- Auto-updates QR Code, Barcode, and number in real-time as TOTP code refreshes.
- Distinctly titled and formatted Transfer QR Code vs. Verification Code.