### PR TITLE
[mob][photos] Clear cache on logout 

### DIFF
--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -27,6 +27,7 @@ import "package:photos/db/gallery_downloads_db.dart";
 import "package:photos/db/memories_db.dart";
 import "package:photos/db/memory_shares_db.dart";
 import "package:photos/db/ml/db.dart";
+import "package:photos/db/social_db.dart";
 import 'package:photos/db/trash_db.dart';
 import 'package:photos/db/upload_locks_db.dart';
 import "package:photos/events/app_mode_changed_event.dart";
@@ -234,6 +235,7 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
     await UploadLocksDB.instance.clearTable();
     await TrashDB.instance.clearTable();
     await ContactsDatabase().clearTable();
+    await SocialDB.instance.clearAllData();
 
     // Clear all in-memory caches
     ThumbnailInMemoryLruCache.clearAll();

--- a/mobile/apps/photos/lib/services/favorites_service.dart
+++ b/mobile/apps/photos/lib/services/favorites_service.dart
@@ -82,6 +82,9 @@ class FavoritesService {
 
   void clearCache() {
     _cachedFavoritesCollectionID = null;
+    _cachedFavUploadedIDs.clear();
+    _cachedFavFileHases.clear();
+    _cachedPendingLocalIDs.clear();
   }
 
   bool isFavoriteCache(EnteFile file, {bool checkOnlyAlbum = false}) {

--- a/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/device/device_folders_vertical_grid_view.dart
@@ -5,6 +5,7 @@ import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/db/device_files_db.dart';
 import 'package:photos/db/files_db.dart';
@@ -105,6 +106,7 @@ class DeviceFolderVerticalGridSliver extends StatefulWidget {
 class _DeviceFolderVerticalGridViewBodyState
     extends State<DeviceFolderVerticalGridSliver> {
   static List<DeviceCollection>? _cachedDeviceCollections;
+  static int? _cachedUserID;
 
   StreamSubscription<BackupFoldersUpdatedEvent>? _backupFoldersUpdatedEvent;
   StreamSubscription<LocalPhotosUpdatedEvent>? _localFilesSubscription;
@@ -144,10 +146,12 @@ class _DeviceFolderVerticalGridViewBodyState
   }
 
   Future<List<DeviceCollection>> _loadDeviceCollections() async {
+    final userID = Configuration.instance.getUserID();
     final deviceCollections = await FilesDB.instance.getDeviceCollections(
       includeCoverThumbnail: true,
     );
     _cachedDeviceCollections = deviceCollections;
+    _cachedUserID = userID;
     return deviceCollections;
   }
 
@@ -180,7 +184,9 @@ class _DeviceFolderVerticalGridViewBodyState
 
     return FutureBuilder<List<DeviceCollection>>(
       future: _deviceCollectionsFuture,
-      initialData: _cachedDeviceCollections,
+      initialData: _cachedUserID == Configuration.instance.getUserID()
+          ? _cachedDeviceCollections
+          : null,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           List<DeviceCollection> deviceCollections = snapshot.data!.toList();


### PR DESCRIPTION
## Description

- `SocialDB` (`ente.social.db`) was never cleared on logout — `clearAllData()` existed but had no callers. Now invoked from the DB-clear block in `logout()`.

- `FavoritesService.clearCache()` only reset the collection ID and left `_cachedFavUploadedIDs`, `_cachedFavFileHases`, `_cachedPendingLocalIDs` populated. Since `isFavoriteCache()` matches non-owned files by hash, account B could see favorite indicators derived from account A's data. Now clears all four fields.

- The widget's static cache is now stamped with the userID it was loaded for, and `initialData` only serves it back to the same user. The userID is captured *before* the DB query, so a query that straddles logout stamps the old user and can never be served to the new one.

