### PR TITLE
[mobile] Center cropped panorama initial view

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/panorama_view_data.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/panorama_view_data.dart
@@ -1,3 +1,5 @@
+import "dart:math" as math;
+
 import "package:flutter/material.dart";
 
 /// View parameters for rendering a (possibly partial) panorama on a sphere,
@@ -36,6 +38,40 @@ class PanoramaViewData {
     if (longitude > 180) longitude -= 360;
     if (longitude < -180) longitude += 360;
     return longitude;
+  }
+
+  /// Initial camera latitude that points at the vertical center of the crop.
+  double get initialLatitude {
+    final double vCenter =
+        (croppedArea.top + croppedArea.height / 2) / fullHeight;
+    return (0.5 - vCenter) * 180;
+  }
+
+  /// Smallest supported zoom that keeps the initial viewport within the crop.
+  double initialZoom(double viewportAspectRatio) {
+    const double halfVerticalFieldOfView = 75 * math.pi / 360;
+    const double maxZoom = 5;
+    final double projectionScale = math.tan(halfVerticalFieldOfView);
+
+    final double halfVerticalCrop =
+        croppedArea.height / fullHeight * math.pi / 2;
+    final double verticalZoom = halfVerticalCrop >= halfVerticalFieldOfView
+        ? 1
+        : projectionScale / math.tan(halfVerticalCrop);
+
+    final double halfHorizontalCrop = croppedArea.width / fullWidth * math.pi;
+    final double halfHorizontalFieldOfView = math.atan(
+      projectionScale * viewportAspectRatio,
+    );
+    final double horizontalZoom =
+        halfHorizontalCrop >= halfHorizontalFieldOfView
+        ? 1
+        : projectionScale * viewportAspectRatio / math.tan(halfHorizontalCrop);
+
+    return math.min(
+      maxZoom,
+      math.max(1, math.max(verticalZoom, horizontalZoom)),
+    );
   }
 
   /// Parses GPano attributes extracted from XMP. Returns null when the

--- a/mobile/apps/photos/lib/ui/viewer/file/panorama_viewer_screen.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/panorama_viewer_screen.dart
@@ -107,30 +107,43 @@ class _PanoramaViewerScreenState extends State<PanoramaViewerScreen> {
   Widget _buildPanorama() {
     return Stack(
       children: [
-        Panorama(
-          onTap: (_, _, _) {
-            setState(() {
-              if (isVisible) {
-                timer?.cancel();
-                SystemChrome.setEnabledSystemUIMode(
-                  SystemUiMode.immersiveSticky,
-                );
-              } else {
-                initTimer();
-              }
-              isVisible = !isVisible;
-            });
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final double initialZoom =
+                viewData?.initialZoom(
+                  constraints.maxWidth / constraints.maxHeight,
+                ) ??
+                1.0;
+            return Panorama(
+              onTap: (_, _, _) {
+                setState(() {
+                  if (isVisible) {
+                    timer?.cancel();
+                    SystemChrome.setEnabledSystemUIMode(
+                      SystemUiMode.immersiveSticky,
+                    );
+                  } else {
+                    initTimer();
+                  }
+                  isVisible = !isVisible;
+                });
+              },
+              latitude: viewData?.initialLatitude ?? 0.0,
+              longitude: viewData?.initialLongitude ?? 0.0,
+              zoom: initialZoom,
+              minZoom: initialZoom,
+              croppedArea:
+                  viewData?.croppedArea ??
+                  const Rect.fromLTWH(0.0, 0.0, 1.0, 1.0),
+              croppedFullWidth: viewData?.fullWidth ?? 1.0,
+              croppedFullHeight: viewData?.fullHeight ?? 1.0,
+              sensorControl: control,
+              background: widget.thumbnail != null
+                  ? Image.memory(widget.thumbnail!)
+                  : null,
+              child: Image.file(widget.file),
+            );
           },
-          longitude: viewData?.initialLongitude ?? 0.0,
-          croppedArea:
-              viewData?.croppedArea ?? const Rect.fromLTWH(0.0, 0.0, 1.0, 1.0),
-          croppedFullWidth: viewData?.fullWidth ?? 1.0,
-          croppedFullHeight: viewData?.fullHeight ?? 1.0,
-          sensorControl: control,
-          background: widget.thumbnail != null
-              ? Image.memory(widget.thumbnail!)
-              : null,
-          child: Image.file(widget.file),
         ),
         Visibility(
           visible: isVisible,
@@ -152,7 +165,7 @@ class _PanoramaViewerScreenState extends State<PanoramaViewerScreen> {
                     color: Colors.white,
                     size: 26,
                   ),
-                  onPressed: () async {
+                  onPressed: () {
                     if (control != SensorControl.none) {
                       control = SensorControl.none;
                     } else {

--- a/mobile/apps/photos/test/ui/viewer/file/panorama_view_data_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/panorama_view_data_test.dart
@@ -41,6 +41,28 @@ void main() {
       expect(uCenter * 360, closeTo(305.8, 0.1));
     });
 
+    test("initial view fits within the cropped area", () {
+      const data = PanoramaViewData(
+        fullWidth: 8762,
+        fullHeight: 4381,
+        croppedArea: Rect.fromLTWH(6183, 1040, 2520, 1664),
+      );
+
+      expect(data.initialLatitude, closeTo(13.09, 0.01));
+      expect(data.initialZoom(1080 / 2115), closeTo(1.13, 0.01));
+      expect(data.initialZoom(2), closeTo(1.21, 0.01));
+    });
+
+    test("caps the initial zoom at the viewer's maximum", () {
+      const data = PanoramaViewData(
+        fullWidth: 4000,
+        fullHeight: 2000,
+        croppedArea: Rect.fromLTWH(1500, 950, 1000, 100),
+      );
+
+      expect(data.initialZoom(0.5), 5);
+    });
+
     test("initial longitude is normalized to [-180, 180]", () {
       const data = PanoramaViewData(
         fullWidth: 1000,

--- a/mobile/apps/photos/test/ui/viewer/file/panorama_viewer_screen_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/panorama_viewer_screen_test.dart
@@ -148,6 +148,9 @@ void main() {
       // degrees maps to longitude 125.81 because the panorama widget's
       // longitude 0 faces the horizontal center), not the empty canvas area.
       expect(pano.longitude, closeTo(125.81, 0.01));
+      expect(pano.latitude, closeTo(13.09, 0.01));
+      expect(pano.zoom, closeTo(1.13, 0.01));
+      expect(pano.minZoom, pano.zoom);
 
       // Let the auto-hide timer fire and dispose the screen.
       await tester.pump(const Duration(seconds: 6));


### PR DESCRIPTION
Center cropped panoramas and apply a crop-fitting minimum zoom to avoid showing the blurred fallback sphere on initial open.