### PR TITLE
[desktop] Preflight N-API codegen dependencies

### DIFF
--- a/.github/workflows/desktop-lint.yml
+++ b/.github/workflows/desktop-lint.yml
@@ -39,7 +39,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   workspaces: rust
-                  shared-key: ensu-android-photos-desktop
+                  shared-key: photos-desktop-ensu-android
                   save-if: false
 
             # tsc typechecks against the generated rust-bindings/index.d.ts.

--- a/.github/workflows/ensu-android-build.yml
+++ b/.github/workflows/ensu-android-build.yml
@@ -34,7 +34,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   workspaces: rust
-                  shared-key: ensu-android-photos-desktop
+                  shared-key: photos-desktop-ensu-android
                   save-if: false
 
             # cargo codegen native builds the uniffi library for the host, which

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -124,8 +124,8 @@ jobs:
 
             - run: npm run build:space-wasm
 
-    ensu-android-photos-desktop:
-        # For ensu-android-build.yml and desktop-lint.yml.
+    photos-desktop-ensu-android:
+        # For desktop-lint.yml and ensu-android-build.yml.
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -143,7 +143,7 @@ jobs:
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   workspaces: rust
-                  shared-key: ensu-android-photos-desktop
+                  shared-key: photos-desktop-ensu-android
 
             - name: Install Vulkan build dependencies
               run: |

--- a/desktop/changes/rust-ml-indexing.md
+++ b/desktop/changes/rust-ml-indexing.md
@@ -1,0 +1,2 @@
+- Use the shared rust ML code for indexing
+- Enable CoreML on MacOS and WebGPU on Linux and Windows

--- a/rust/apps/codegen/src/main.rs
+++ b/rust/apps/codegen/src/main.rs
@@ -211,6 +211,8 @@ fn generate_frb_package(package_dir: &Path) -> Result<(), DynError> {
 fn generate_napi() -> Result<(), DynError> {
     let rust_root = rust_root()?;
     let desktop_dir = repo_root()?.join("desktop");
+    ensure_napi_codegen_dependencies(&desktop_dir)?;
+
     let out_dir = desktop_dir.join("rust-bindings");
     write_generated_gitignore(&out_dir)?;
 
@@ -248,9 +250,43 @@ fn generate_napi() -> Result<(), DynError> {
             .arg(&type_def_dir)
             .arg(out_dir.join("index.d.ts"))
             .current_dir(&desktop_dir),
-        "failed to render the TypeScript declarations (run npm install in desktop/ first)"
-            .to_owned(),
+        "failed to render the TypeScript declarations".to_owned(),
     )
+}
+
+fn ensure_napi_codegen_dependencies(desktop_dir: &Path) -> Result<(), DynError> {
+    let status = Command::new("node")
+        .arg("-e")
+        .arg("try { require.resolve('@napi-rs/cli') } catch { process.exit(1) }")
+        .current_dir(desktop_dir)
+        .status()
+        .map_err(|error| {
+            format!(
+                concat!(
+                    "N-API codegen requires Node.js and the desktop npm dependencies.\n\n",
+                    "Failed to run Node.js:\n",
+                    "  {}\n\n",
+                    "After installing Node.js, run:\n",
+                    "  (cd \"{}\" && npm ci)"
+                ),
+                error,
+                desktop_dir.display(),
+            )
+        })?;
+
+    if !status.success() {
+        return Err(format!(
+            concat!(
+                "N-API codegen requires the desktop npm dependencies.\n\n",
+                "Run:\n",
+                "  (cd \"{}\" && npm ci)"
+            ),
+            desktop_dir.display(),
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 fn format_frb_bindings(target: FrbTarget) -> Result<(), DynError> {


### PR DESCRIPTION
## Summary

- preflight the desktop N-API codegen dependencies and show actionable setup instructions when Node.js or `@napi-rs/cli` is unavailable
- align the shared Rust cache naming across desktop and Ensu workflows
- add the desktop Rust ML indexing changelog entry

## Impact

N-API declaration generation now fails early with a clear `npm ci` recovery path instead of failing later during rendering. The cache update is naming-only.

## Validation

- `cargo fmt --package codegen -- --check`
- `cargo check --package codegen`
