### PR TITLE
docs: update Google Takeout import options

### DIFF
--- a/docs/docs/photos/faq/migration.md
+++ b/docs/docs/photos/faq/migration.md
@@ -169,7 +169,7 @@ Each partner should export their own library via [Google Takeout](/photos/migrat
 
 > [!NOTE]
 >
-> Photos only visible to you through Partner Sharing (not saved to your library) are **not** included in your Takeout. Only the partner who originally took those photos will have them in their export. There is also no built-in filter to remove partner-shared photos from a Takeout import - so duplicates may occur if both partners import and then share entire libraries on Ente.
+> Photos only visible to you through Partner Sharing (not saved to your library) are **not** included in your Takeout. Only the partner who originally took those photos will have them in their export. For partner-shared photos that are present in your Takeout, the desktop importer lets you choose whether to import or skip them. Skip them if the original owner is also importing their library and you want to avoid duplicate copies.
 
 #### 2. Set up sharing on Ente
 
@@ -211,7 +211,9 @@ Once this is done, you can reupload your entire Google Takeout folder again usin
 
 ### Is there a way to remove partner sharing photos when importing via Google Takeout?
 
-There is currently no built-in filter to automatically remove partner-shared photos when importing from Google Takeout.
+Yes. When the desktop app detects a Google Takeout import, use the **Partner-shared photos** option in the import confirmation dialog to include or skip them.
+
+This only applies to partner-shared photos that Google included in your Takeout. Photos that were only visible through Partner Sharing and were never saved to your library are not included in your Takeout.
 
 ## Importing from Apple Photos
 

--- a/docs/docs/photos/migration/from-google-photos/index.md
+++ b/docs/docs/photos/migration/from-google-photos/index.md
@@ -45,7 +45,11 @@ Follow the following steps to recover your data from Google Photos and preserve 
 
         ![Google Takeout Selection](google-photos-6.webp)
 
-10. Choose where to import your photos:
+10. Review the import options shown by the desktop app:
+    - **Favorites**: Keep this enabled to add items marked as favorites in Google Photos to Ente's Favorites album.
+    - **Partner-shared photos**: Choose whether photos saved from Google Photos Partner Sharing should be imported. Skip them if the original owner is also importing their library and you want to avoid duplicate copies.
+
+11. Choose where to import your photos:
 
     **If you selected a folder**, decide whether you want to:
     - **Import to existing album** → Pick one of your current albums, or
@@ -56,7 +60,9 @@ Follow the following steps to recover your data from Google Photos and preserve 
     **If you selected ZIP files directly**:
     - Photos are automatically organized into separate albums based on the folder structure within the ZIPs
 
-11. Wait for the uploads to complete. Ente will parse Google's metadata and preserve everything with your photos, end-to-end encrypted!
+12. Review the photo, video, and album counts, then start the upload. The progress dialog shows completed, skipped, and failed files so you can check the result.
+
+Ente will parse Google's metadata and preserve everything with your photos, end-to-end encrypted!
 
 ---
 


### PR DESCRIPTION
## Summary

- document the Google Takeout options for preserving favorites and skipping partner-shared photos
- explain upload count review and completed/skipped/failed progress reporting
- replace outdated FAQ guidance that said partner-shared photos could not be filtered

## Release

Updates the help docs for `ente-io/photos-desktop` v1.7.27.

## Verification

- `git diff --check`
- Prettier check for the changed documentation files
- Docs build CI
