### PR TITLE
Use Node-API 10 for Photos desktop binding

### DIFF
--- a/rust/bindings/napi/photos/Cargo.toml
+++ b/rust/bindings/napi/photos/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 # usearch requires a newer GCC than napi-cli provides.
 ente-assets.workspace = true
 ente-photos.workspace = true
-napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt"] }
+napi = { version = "3", default-features = false, features = ["napi10", "tokio_rt"] }
 napi-derive = "3"
 ort = { workspace = true, features = ["load-dynamic"] }
 


### PR DESCRIPTION
## Summary

- Target Node-API 10 for the Photos desktop Rust binding.
- Align the native addon with Electron 42's bundled Node 24 runtime.

## Testing

- `cargo check --locked -p ente_photos_napi`
