### PR TITLE
[mobile][photos] Filter unreliable face suggestions

### DIFF
--- a/mobile/apps/photos/lib/db/ml/base.dart
+++ b/mobile/apps/photos/lib/db/ml/base.dart
@@ -15,6 +15,8 @@ abstract class IMLDataDB<T> {
   Future<Map<int, int>> faceIndexedFileIds({int minimumMlVersion});
   Future<int> getFaceIndexedFileCount({int minimumMlVersion});
   Future<Map<String, int>> clusterIdToFaceCount();
+  Future<Set<String>> getBadFaceSingletonClusterIDs();
+  Future<Set<String>> getClustersWithThreeOrMoreNotPersonFeedback();
   Future<Set<String>> getPersonIgnoredClusters(String personID);
   Future<Map<String, Set<String>>> getPersonToRejectedSuggestions();
   Future<Set<String>> getPersonClusterIDs(String personID);

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -513,16 +513,18 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
       GROUP BY fc.$clusterIDColumn
       HAVING COUNT(*) = 1
       ''');
-    return rows
-        .where(
-          (row) => isBadFaceForClustering(
-            faceScore: row[faceScore] as double,
-            blurValue: row[faceBlur] as double,
-            isSideways: (row[isSideways] as int) == 1,
-          ),
-        )
-        .map((row) => row[clusterIDColumn] as String)
-        .toSet();
+    final badClusterIDs = <String>{};
+    for (final row in rows) {
+      final badFace = isBadFaceForClustering(
+        faceScore: row[faceScore] as double,
+        blurValue: row[faceBlur] as double,
+        isSideways: (row[isSideways] as int) == 1,
+      );
+      if (badFace) {
+        badClusterIDs.add(row[clusterIDColumn] as String);
+      }
+    }
+    return badClusterIDs;
   }
 
   @override
@@ -532,7 +534,7 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
       SELECT $clusterIDColumn
       FROM $notPersonFeedback
       GROUP BY $clusterIDColumn
-      HAVING COUNT(DISTINCT $personIdColumn) >= 3
+      HAVING COUNT(*) >= 3
       ''');
     return rows.map((row) => row[clusterIDColumn] as String).toSet();
   }

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -503,6 +503,41 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
   }
 
   @override
+  Future<Set<String>> getBadFaceSingletonClusterIDs() async {
+    final db = await asyncDB;
+    final rows = await db.getAll('''
+      SELECT fc.$clusterIDColumn, f.$faceScore, f.$faceBlur, f.$isSideways
+      FROM $faceClustersTable fc
+      INNER JOIN $facesTable f
+        ON fc.$faceIDColumn = f.$faceIDColumn
+      GROUP BY fc.$clusterIDColumn
+      HAVING COUNT(*) = 1
+      ''');
+    return rows
+        .where(
+          (row) => isBadFaceForClustering(
+            faceScore: row[faceScore] as double,
+            blurValue: row[faceBlur] as double,
+            isSideways: (row[isSideways] as int) == 1,
+          ),
+        )
+        .map((row) => row[clusterIDColumn] as String)
+        .toSet();
+  }
+
+  @override
+  Future<Set<String>> getClustersWithThreeOrMoreNotPersonFeedback() async {
+    final db = await asyncDB;
+    final rows = await db.getAll('''
+      SELECT $clusterIDColumn
+      FROM $notPersonFeedback
+      GROUP BY $clusterIDColumn
+      HAVING COUNT(DISTINCT $personIdColumn) >= 3
+      ''');
+    return rows.map((row) => row[clusterIDColumn] as String).toSet();
+  }
+
+  @override
   Future<Set<String>> getPersonIgnoredClusters(String personID) async {
     final db = await asyncDB;
     // find out clusterIds that are assigned to other persons using the clusters table

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart
@@ -352,12 +352,11 @@ ClusteringResult runLinearClustering(Map args) {
         faceID: face.faceID,
         faceScore: face.faceScore,
         blurValue: face.blurValue,
-        badFace:
-            face.faceScore < kMinimumQualityFaceScore ||
-            face.blurValue < kLaplacianSoftThreshold ||
-            (face.blurValue < kLaplacianVerySoftThreshold &&
-                face.faceScore < kMediumQualityFaceScore) ||
-            face.isSideways,
+        badFace: isBadFaceForClustering(
+          faceScore: face.faceScore,
+          blurValue: face.blurValue,
+          isSideways: face.isSideways,
+        ),
         vEmbedding: Vector.fromList(
           EVector.fromBuffer(face.embeddingBytes).values,
           dtype: DType.float32,

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart
@@ -17,6 +17,17 @@ const kMinimumQualityFaceScore = 0.80;
 const kMediumQualityFaceScore = 0.85;
 const kHighQualityFaceScore = 0.90;
 
+bool isBadFaceForClustering({
+  required double faceScore,
+  required double blurValue,
+  required bool isSideways,
+}) =>
+    faceScore < kMinimumQualityFaceScore ||
+    blurValue < kLaplacianSoftThreshold ||
+    (blurValue < kLaplacianVerySoftThreshold &&
+        faceScore < kMediumQualityFaceScore) ||
+    isSideways;
+
 /// The minimum cluster size for displaying a cluster in the UI by default
 const kMinimumClusterSizeSearchResult = 10;
 

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
@@ -68,6 +68,14 @@ class ClusterFeedbackService<T> {
     lastViewedClusterID = '';
   }
 
+  Future<Set<String>> _getExcludedSuggestionClusterIDs() async {
+    final excludedClusterIDs = await mlDataDB.getBadFaceSingletonClusterIDs();
+    excludedClusterIDs.addAll(
+      await mlDataDB.getClustersWithThreeOrMoreNotPersonFeedback(),
+    );
+    return excludedClusterIDs;
+  }
+
   /// Returns a list of cluster suggestions for a person.
   Future<List<ClusterSuggestion>> getSuggestionForPerson(
     PersonEntity person, {
@@ -392,18 +400,23 @@ class ClusterFeedbackService<T> {
       final personToClusterIDsFuture = mlDataDB.getPersonToClusterIDs();
       final personToRejectedSuggestionsFuture = mlDataDB
           .getPersonToRejectedSuggestions();
+      final excludedSuggestionClusterIDsFuture =
+          _getExcludedSuggestionClusterIDs();
       final canUseVectorDbFuture =
           _canUseClusterCentroidVectorDbForSuggestions();
       await Future.wait<Object?>([
         allClusterIdsToCountMapFuture,
         personToClusterIDsFuture,
         personToRejectedSuggestionsFuture,
+        excludedSuggestionClusterIDsFuture,
         canUseVectorDbFuture,
       ], eagerError: false);
       final allClusterIdsToCountMap = await allClusterIdsToCountMapFuture;
       final personToClusterIDs = await personToClusterIDsFuture;
       final personToRejectedSuggestions =
           await personToRejectedSuggestionsFuture;
+      final excludedSuggestionClusterIDs =
+          await excludedSuggestionClusterIDsFuture;
       final canUseVectorDb = await canUseVectorDbFuture;
       if (!canUseVectorDb) {
         _logger.info(
@@ -414,6 +427,7 @@ class ClusterFeedbackService<T> {
           allClusterIdsToCountMap,
           personToClusterIDs,
           personToRejectedSuggestions,
+          excludedSuggestionClusterIDs,
         );
       }
 
@@ -446,9 +460,10 @@ class ClusterFeedbackService<T> {
       for (final clusters in personToClusterIDs.values) {
         assignedClustersToAnyPerson.addAll(clusters);
       }
-      final ignoredClustersForAverages = assignedClustersToAnyPerson.difference(
-        selectedPersonClusters,
-      );
+      final ignoredClustersForAverages = <String>{
+        ...assignedClustersToAnyPerson,
+        ...excludedSuggestionClusterIDs,
+      }.difference(selectedPersonClusters);
 
       final clusterAvg = await _getUpdateClusterAvg(
         allClusterIdsToCountMap,
@@ -513,6 +528,7 @@ class ClusterFeedbackService<T> {
           allClusterIdsToCountMap,
           personToClusterIDs,
           personToRejectedSuggestions,
+          excludedSuggestionClusterIDs,
         );
       }
 
@@ -575,7 +591,8 @@ class ClusterFeedbackService<T> {
         final ignored = <String>{}
           ..addAll(assignedClustersToAnyPerson)
           ..removeAll(entry.value)
-          ..addAll(personToRejectedSuggestions[entry.key] ?? const <String>{});
+          ..addAll(personToRejectedSuggestions[entry.key] ?? const <String>{})
+          ..addAll(excludedSuggestionClusterIDs);
         personIDToIgnoredClusters[entry.key] = ignored;
       }
 
@@ -1104,6 +1121,7 @@ class ClusterFeedbackService<T> {
     Map<String, int> allClusterIdsToCountMap,
     Map<String, Set<String>> personToClusterIDs,
     Map<String, Set<String>> personToRejectedSuggestions,
+    Set<String> excludedSuggestionClusterIDs,
   ) async {
     final personIdToBiggestCluster = <String, String>{};
     final biggestClusterToPersonID = <String, String>{};
@@ -1141,13 +1159,17 @@ class ClusterFeedbackService<T> {
       return [];
     }
     final allPersonClusters = biggestClusterToPersonID.keys.toSet();
-    final allOtherPersonClustersToIgnore = <String>{};
+    final allOtherPersonClustersToIgnore = <String>{
+      ...excludedSuggestionClusterIDs,
+    };
     for (final ignoredClusters in personIdToOtherPersonClusterIDs.values) {
       allOtherPersonClustersToIgnore.addAll(ignoredClusters);
     }
+    final ignoredClustersForAverages = allOtherPersonClustersToIgnore
+        .difference(allPersonClusters);
     final clusterAvg = await _getUpdateClusterAvg(
       allClusterIdsToCountMap,
-      allOtherPersonClustersToIgnore,
+      ignoredClustersForAverages,
       minClusterSize: kMinimumClusterSizeSearchResult,
     );
 
@@ -1526,10 +1548,14 @@ class ClusterFeedbackService<T> {
     // Get all the cluster data
     final allClusterIdsToCountMap = await mlDataDB.clusterIdToFaceCount();
     final ignoredClusters = await mlDataDB.getPersonIgnoredClusters(p.remoteID);
+    ignoredClusters.addAll(await _getExcludedSuggestionClusterIDs());
     final personClusters = await mlDataDB.getPersonClusterIDs(p.remoteID);
     if (personClusters.isEmpty) {
       return [];
     }
+    final ignoredClustersForAverages = ignoredClusters.difference(
+      personClusters,
+    );
     final personFaceIDs = await mlDataDB.getFaceIDsForPerson(p.remoteID);
     final personFileIDs = personFaceIDs.map(getFileIdFromFaceId<int>).toSet();
     w?.log(
@@ -1551,7 +1577,7 @@ class ClusterFeedbackService<T> {
           min(minimumSize, kMinimumClusterSizeSearchResult)) {
         clusterAvgBigClusters = await _getUpdateClusterAvg(
           allClusterIdsToCountMap,
-          ignoredClusters,
+          ignoredClustersForAverages,
           minClusterSize: minimumSize,
         );
         w?.log(

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
@@ -69,11 +69,11 @@ class ClusterFeedbackService<T> {
   }
 
   Future<Set<String>> _getExcludedSuggestionClusterIDs() async {
-    final excludedClusterIDs = await mlDataDB.getBadFaceSingletonClusterIDs();
-    excludedClusterIDs.addAll(
-      await mlDataDB.getClustersWithThreeOrMoreNotPersonFeedback(),
-    );
-    return excludedClusterIDs;
+    final results = await Future.wait([
+      mlDataDB.getBadFaceSingletonClusterIDs(),
+      mlDataDB.getClustersWithThreeOrMoreNotPersonFeedback(),
+    ]);
+    return results[0].union(results[1]);
   }
 
   /// Returns a list of cluster suggestions for a person.


### PR DESCRIPTION
## Summary

- Exclude singleton clusters from suggestions when their only face matches the existing bad-face criteria.
- Exclude clusters from suggestions with at least three “No” feedback entries before candidate ranking.

## Why

Low-quality and repeatedly rejected clusters could consume bounded candidate slots, producing irrelevant suggestions while hiding valid lower-ranked matches.

## Impact

People suggestions should be more relevant without changing clustering thresholds or suggestion UI behavior.

## Validation

- `dart format` on the five changed files
- `flutter analyze` on the five changed files
