### PR TITLE
[mobile][photos] Defer QR detection until image render

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 import "dart:math";
 
 import 'package:ente_lock_screen/local_authentication_service.dart';
@@ -158,6 +159,7 @@ class _BodyState extends State<_Body> {
   bool swipeLocked = false;
   late final StreamSubscription<GuestViewEvent> _guestViewEventSubscription;
   QrCodeDetectionHelper? _qrHelper;
+  final Map<String, File> _renderedFiles = {};
 
   @override
   void initState() {
@@ -327,10 +329,11 @@ class _BodyState extends State<_Body> {
                     }
                     return ValueListenableBuilder(
                       valueListenable: _qrHelper!.qrDetectionsNotifier,
-                      builder: (context, detections, _) {
+                      builder: (context, result, _) {
+                        final file = _files![selectedIndex];
                         return QrCodeHighlightOverlay(
-                          detections: detections,
-                          file: _files![selectedIndex],
+                          detections: result?.forFile(file) ?? const [],
+                          file: file,
                         );
                       },
                     );
@@ -435,6 +438,12 @@ class _BodyState extends State<_Body> {
             });
           },
           backgroundDecoration: const BoxDecoration(color: Colors.black),
+          onFinalImageLoaded: (localFile) {
+            _renderedFiles[file.tag] = localFile;
+            if (_selectedFile?.tag == file.tag) {
+              _evaluateQrIfEligible(file);
+            }
+          },
           qrDetectionsNotifier: _qrHelper?.qrDetectionsNotifier,
           onTextSelectionStart:
               flagService.ocrOverlayEnabled &&
@@ -482,8 +491,10 @@ class _BodyState extends State<_Body> {
   }
 
   void _evaluateQrIfEligible(EnteFile file) {
-    if (_qrHelper == null || isGuestView || file is TrashFile) return;
-    _qrHelper!.evaluateFile(file);
+    _qrHelper?.evaluateFile(
+      file,
+      isGuestView || file is TrashFile ? null : _renderedFiles[file.tag],
+    );
   }
 
   bool shouldAutoPlay() {

--- a/mobile/apps/photos/lib/ui/viewer/file/file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_widget.dart
@@ -1,9 +1,11 @@
-import "package:ente_qr/ente_qr.dart";
+import "dart:io";
+
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
 import "package:photos/states/detail_page_state.dart";
+import "package:photos/ui/viewer/file/qr_code_detection_helper.dart";
 import "package:photos/ui/viewer/file/video_widget.dart";
 import "package:photos/ui/viewer/file/zoomable_live_image_new.dart";
 
@@ -16,7 +18,8 @@ class FileWidget extends StatelessWidget {
   final bool? autoPlay;
   final bool? isFromMemories;
   final Function({required int memoryDuration})? onFinalFileLoad;
-  final ValueNotifier<List<QrDetection>>? qrDetectionsNotifier;
+  final ValueChanged<File>? onFinalImageLoaded;
+  final ValueNotifier<QrCodeDetectionResult?>? qrDetectionsNotifier;
   final GestureLongPressStartCallback? onTextSelectionStart;
 
   const FileWidget(
@@ -28,6 +31,7 @@ class FileWidget extends StatelessWidget {
     this.backgroundDecoration,
     this.isFromMemories = false,
     this.onFinalFileLoad,
+    this.onFinalImageLoaded,
     this.qrDetectionsNotifier,
     this.onTextSelectionStart,
     super.key,
@@ -49,6 +53,7 @@ class FileWidget extends StatelessWidget {
         isFromMemories: isFromMemories ?? false,
         key: key ?? ValueKey(fileKey),
         onFinalFileLoad: onFinalFileLoad,
+        onFinalImageLoaded: onFinalImageLoaded,
         qrDetectionsNotifier: qrDetectionsNotifier,
         onTextSelectionStart: onTextSelectionStart,
       );

--- a/mobile/apps/photos/lib/ui/viewer/file/qr_code_detection_helper.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/qr_code_detection_helper.dart
@@ -6,27 +6,34 @@ import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
-import "package:photos/module/download/file.dart";
+
+class QrCodeDetectionResult {
+  final String fileTag;
+  final List<QrDetection> detections;
+
+  const QrCodeDetectionResult(this.fileTag, this.detections);
+
+  List<QrDetection> forFile(EnteFile file) =>
+      file.tag == fileTag ? detections : const [];
+}
 
 class QrCodeDetectionHelper {
   static const _debounceDuration = Duration(milliseconds: 500);
   final Logger _logger = Logger("QrCodeDetectionHelper");
   final EnteQr _enteQr = EnteQr();
 
-  final ValueNotifier<List<QrDetection>> qrDetectionsNotifier =
-      ValueNotifier<List<QrDetection>>(const []);
+  final ValueNotifier<QrCodeDetectionResult?> qrDetectionsNotifier =
+      ValueNotifier<QrCodeDetectionResult?>(null);
 
   int _requestId = 0;
   bool _disposed = false;
   Timer? _debounceTimer;
 
-  Future<void> evaluateFile(EnteFile file) async {
+  void evaluateFile(EnteFile file, File? localFile) {
     _debounceTimer?.cancel();
 
-    final bool isEligible = _isFileEligible(file);
     final int requestId = ++_requestId;
-
-    if (!isEligible) {
+    if (!_isFileEligible(file) || localFile == null) {
       _clearDetections();
       return;
     }
@@ -34,22 +41,19 @@ class QrCodeDetectionHelper {
     _clearDetections();
 
     _debounceTimer = Timer(_debounceDuration, () {
-      _scanFile(file, requestId);
+      _scanFile(file, localFile, requestId);
     });
   }
 
-  Future<void> _scanFile(EnteFile file, int requestId) async {
+  Future<void> _scanFile(EnteFile file, File localFile, int requestId) async {
     if (_disposed || requestId != _requestId) return;
 
     try {
       final stopwatch = Stopwatch()..start();
-      final File? localFile = await getFile(file);
-      if (_disposed || requestId != _requestId) return;
-      if (localFile == null || !localFile.existsSync()) {
+      if (!localFile.existsSync()) {
         _clearDetections();
         return;
       }
-      final getFileMs = stopwatch.elapsedMilliseconds;
 
       List<QrDetection> detections = const [];
       try {
@@ -63,15 +67,13 @@ class QrCodeDetectionHelper {
 
       final totalMs = stopwatch.elapsedMilliseconds;
       _logger.info(
-        "QR scan: getFile=${getFileMs}ms, "
-        "detect=${totalMs - getFileMs}ms, "
-        "total=${totalMs}ms, "
+        "QR scan: detect=${totalMs}ms, "
         "found=${detections.length}",
       );
 
       if (_disposed || requestId != _requestId) return;
 
-      qrDetectionsNotifier.value = detections;
+      qrDetectionsNotifier.value = QrCodeDetectionResult(file.tag, detections);
     } catch (error, stackTrace) {
       _logger.severe("QR code detection failed", error, stackTrace);
       if (_disposed || requestId != _requestId) return;
@@ -81,8 +83,8 @@ class QrCodeDetectionHelper {
 
   /// Only notify listeners when the value actually changes.
   void _clearDetections() {
-    if (qrDetectionsNotifier.value.isNotEmpty) {
-      qrDetectionsNotifier.value = const [];
+    if (qrDetectionsNotifier.value != null) {
+      qrDetectionsNotifier.value = null;
     }
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -41,6 +41,7 @@ class ZoomableImage extends StatefulWidget {
   final bool isGuestView;
   final bool isFromMemories;
   final Function({required int memoryDuration})? onFinalFileLoad;
+  final ValueChanged<File>? onFinalImageLoaded;
 
   const ZoomableImage(
     this.photo, {
@@ -52,6 +53,7 @@ class ZoomableImage extends StatefulWidget {
     this.isGuestView = false,
     this.isFromMemories = false,
     this.onFinalFileLoad,
+    this.onFinalImageLoaded,
   });
 
   @override
@@ -604,7 +606,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
         },
       ).then((value) {
         if (mounted && !_loadedFinalImage && !_convertToSupportedFormat) {
-          _updateViewWithFinalImage(imageProvider);
+          _updateViewWithFinalImage(imageProvider, file);
         }
       });
     }
@@ -638,7 +640,10 @@ class _ZoomableImageState extends State<ZoomableImage> {
     );
   }
 
-  Future<void> _updateViewWithFinalImage(ImageProvider imageProvider) async {
+  Future<void> _updateViewWithFinalImage(
+    ImageProvider imageProvider,
+    File file,
+  ) async {
     await _updatePhotoViewController(
       previewImageProvider: _imageProvider,
       finalImageProvider: imageProvider,
@@ -649,6 +654,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
       _logger.info("Final image loaded");
     });
     _notifyReadyOnce();
+    widget.onFinalImageLoaded?.call(file);
   }
 
   Future<void> _updatePhotoViewController({
@@ -751,7 +757,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
       await precacheImage(imageProvider, context);
       if (mounted && !_loadedFinalImage) {
-        await _updateViewWithFinalImage(imageProvider);
+        await _updateViewWithFinalImage(imageProvider, file);
       }
       return true;
     } catch (e) {
@@ -855,7 +861,7 @@ class _ZoomableImageState extends State<ZoomableImage> {
       unawaited(
         precacheImage(imageProvider, context).then((value) {
           if (mounted) {
-            _updateViewWithFinalImage(imageProvider);
+            _updateViewWithFinalImage(imageProvider, file);
           }
         }),
       );

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 import "dart:io";
 
-import "package:ente_qr/ente_qr.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import "package:media_kit/media_kit.dart";
@@ -19,6 +18,7 @@ import "package:photos/src/rust/api/motion_photo_api.dart";
 import "package:photos/states/detail_page_state.dart";
 import 'package:photos/ui/notification/toast.dart';
 import "package:photos/ui/viewer/file/live_image_long_press_router.dart";
+import "package:photos/ui/viewer/file/qr_code_detection_helper.dart";
 import 'package:photos/ui/viewer/file/zoomable_image.dart';
 
 class ZoomableLiveImageNew extends StatefulWidget {
@@ -28,7 +28,8 @@ class ZoomableLiveImageNew extends StatefulWidget {
   final Decoration? backgroundDecoration;
   final bool isFromMemories;
   final Function({required int memoryDuration})? onFinalFileLoad;
-  final ValueNotifier<List<QrDetection>>? qrDetectionsNotifier;
+  final ValueChanged<File>? onFinalImageLoaded;
+  final ValueNotifier<QrCodeDetectionResult?>? qrDetectionsNotifier;
   final GestureLongPressStartCallback? onTextSelectionStart;
 
   const ZoomableLiveImageNew(
@@ -39,6 +40,7 @@ class ZoomableLiveImageNew extends StatefulWidget {
     this.backgroundDecoration,
     this.isFromMemories = false,
     this.onFinalFileLoad,
+    this.onFinalImageLoaded,
     this.qrDetectionsNotifier,
     this.onTextSelectionStart,
   });
@@ -86,7 +88,9 @@ class _ZoomableLiveImageNewState extends State<ZoomableLiveImageNew>
   /// Check if a local position (relative to this widget) falls within any
   /// detected QR code bounding box.
   bool _isPositionInQrRegion(Offset localPosition) {
-    final detections = widget.qrDetectionsNotifier?.value;
+    final detections = widget.qrDetectionsNotifier?.value?.forFile(
+      widget.enteFile,
+    );
     if (detections == null || detections.isEmpty) return false;
     final file = widget.enteFile;
     if (!file.hasDimensions) return false;
@@ -199,6 +203,7 @@ class _ZoomableLiveImageNewState extends State<ZoomableLiveImageNew>
       isGuestView: isGuestView,
       isFromMemories: widget.isFromMemories,
       onFinalFileLoad: widget.onFinalFileLoad,
+      onFinalImageLoaded: widget.onFinalImageLoaded,
     );
 
     final shouldShowVideo =


### PR DESCRIPTION
- Start QR detection only after the full viewer image renders, while retaining the existing swipe debounce.
- Scope detection results to their source file so adjacent pages cannot consume stale QR regions.

Validation: mobile lint workflow (policy checks, Rust codegen/clippy, Dart format, Flutter analyze, workspace tests)