### PR TITLE
[mobile][photos] adjust SVG icon sizing in video editor bottom bar

### DIFF
--- a/mobile/apps/photos/changes/video-editor-bottom-bar-icons.md
+++ b/mobile/apps/photos/changes/video-editor-bottom-bar-icons.md
@@ -1,0 +1,1 @@
+- Adjusted SVG icon sizing in the video editor bottom bar for better visiblity. (@r4khul)

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/circular_icon_button.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/circular_icon_button.dart
@@ -41,8 +41,8 @@ class CircularIconButton extends StatelessWidget {
     } else if (svgPath != null) {
       iconContent = SvgPicture.asset(
         svgPath!,
-        width: 12,
-        height: 12,
+        width: size * 0.68,
+        height: size * 0.68,
         fit: BoxFit.scaleDown,
         colorFilter: ColorFilter.mode(colors.iconColor, BlendMode.srcIn),
       );


### PR DESCRIPTION
## Description

### Issue: Bottom bar icons were barely visible in video editor

The editor bottom bar icons looked way too tiny and faint on screen because the source SVG assets have ~50% internal margins (`24px` artwork sitting inside a `41px` canvas).

* **Fix**: Scaled `CircularIconButton` to `size * 0.68` (40.8px). This forces the inner SVG artwork to render at an actual `24px` visual weight, matching `HugeIcon` and system defaults.

**Visuals:**

<img width="2639" height="745" alt="image" src="https://github.com/user-attachments/assets/67575d0b-d46b-4721-b3f7-17f3e41b44a8" />


## Tests
Tested & verified on physical devices - realme C67 5G & realme Pad 2.