### PR TITLE
Build Linux desktop N-API addon with Zig

### DIFF
--- a/.github/workflows/photos-desktop-build.yml
+++ b/.github/workflows/photos-desktop-build.yml
@@ -88,6 +88,9 @@ jobs:
             RELEASE_TAG: ${{ needs.build-metadata.outputs.release_tag }}
             IS_RC: ${{ startsWith(github.ref_name, 'release/') }}
             RELEASE_BODY: ${{ needs.build-metadata.outputs.release_body }}
+            # Zig 0.14 defaults GNU targets to glibc 2.28.
+            ZIG_VERSION: "0.14.1"
+            CARGO_ZIGBUILD_VERSION: "0.23.0"
 
         defaults:
             run:
@@ -114,6 +117,16 @@ jobs:
               with:
                   workspaces: rust
                   shared-key: rust-desktop
+
+            - name: Setup Zig
+              if: startsWith(matrix.os, 'ubuntu')
+              uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+              with:
+                  version: ${{ env.ZIG_VERSION }}
+
+            - name: Install cargo-zigbuild
+              if: startsWith(matrix.os, 'ubuntu')
+              run: cargo install cargo-zigbuild --version "${CARGO_ZIGBUILD_VERSION}" --locked
 
             - name: Fetch binary dependencies and rebuild native modules
               run: npm run postinstall
@@ -166,10 +179,19 @@ jobs:
 
                   platform=${{ startsWith(matrix.os, 'macos') && 'mac' || startsWith(matrix.os, 'windows') && 'windows' || 'linux' }}
 
+                  case "${RUNNER_OS}" in
+                      Linux)
+                          export ENTE_NAPI_CROSS_COMPILE=1
+                          architectures=(--x64 --arm64)
+                          ;;
+                      macOS) architectures=(--universal) ;;
+                      Windows) architectures=(--x64 --arm64) ;;
+                  esac
+
                   if [ "${IS_RC}" = "true" ]; then
-                      npm exec -- electron-builder --$platform --publish always "-c.releaseInfo.releaseNotes=${RELEASE_BODY}"
+                      npm exec -- electron-builder --$platform "${architectures[@]}" --publish always "-c.releaseInfo.releaseNotes=${RELEASE_BODY}"
                   else
-                      npm exec -- electron-builder --$platform --publish never
+                      npm exec -- electron-builder --$platform "${architectures[@]}" --publish never
                   fi
               env:
                   GH_TOKEN: ${{ steps.nightly_token.outputs.token }}

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -11,9 +11,7 @@ protocols:
     - name: Ente
       schemes: ["ente"]
 win:
-    target:
-        - target: nsis
-          arch: [x64, arm64]
+    target: nsis
     azureSignOptions:
         publisherName: ENTE TECHNOLOGIES, INC.
         endpoint: https://eus.codesigning.azure.net/
@@ -23,22 +21,12 @@ win:
 nsis:
     deleteAppDataOnUninstall: true
 linux:
-    target:
-        - target: AppImage
-          arch: [x64, arm64]
-        - target: deb
-          arch: [x64, arm64]
-        - target: rpm
-          arch: [x64, arm64]
-        - target: pacman
-          arch: [x64, arm64]
+    target: [AppImage, deb, rpm, pacman]
     category: Photography
     icon: ./build/icon.icns
 mac:
     minimumSystemVersion: "13.3"
-    target:
-        target: default
-        arch: [universal]
+    target: default
     category: public.app-category.photography
     hardenedRuntime: true
     mergeASARs: false

--- a/desktop/scripts/napi.js
+++ b/desktop/scripts/napi.js
@@ -82,8 +82,9 @@ const ensureRustTarget = (target, appDir) => {
  *
  * The build always runs so that edits to the Rust sources cannot be missed
  * when packaging; Cargo's incremental compilation makes this cheap when
- * nothing has changed. Linux always uses napi-cli's cross toolchain, including
- * for the host architecture, to keep the addon's glibc requirement at 2.17.
+ * nothing has changed. Linux release CI opts into cargo-zigbuild so its native
+ * dependencies use Zig's modern compiler and glibc 2.28 compatibility
+ * baseline. Local development and packaging use the native toolchain.
  */
 const buildNapiAddon = async (appDir, platform, arch) => {
     if (arch != process.arch)
@@ -105,7 +106,10 @@ const buildNapiAddon = async (appDir, platform, arch) => {
         ...(platform == "linux" || arch != process.arch
             ? [
                   `--target ${rustTriple(platform, arch)}`,
-                  ...(platform == "linux" ? ["--use-napi-cross"] : []),
+                  ...(platform == "linux" &&
+                  process.env.ENTE_NAPI_CROSS_COMPILE == "1"
+                      ? ["--cross-compile"]
+                      : []),
               ]
             : []),
     ].join(" ");


### PR DESCRIPTION
## Summary

- build Linux desktop N-API addons with pinned Zig and `cargo-zigbuild`
- retain a glibc 2.28 compatibility floor for x64 and ARM64 release artifacts
- keep Zig CI-only; local development and packaging use the native host toolchain

## Why

The previous napi-rs cross toolchain uses an obsolete GCC that can no longer compile `ring` reliably. The release workflow now opts into a modern compiler with an older glibc baseline, while the architecture matrix is passed explicitly by CI so normal developer builds remain host-native.

## Validation

- `npm run lint`
- `actionlint -ignore 'SC2129' .github/workflows/photos-desktop-build.yml`
- native N-API release build with no Zig on `PATH`
- Linux x64 and ARM64 Zig cross-builds, with the resulting binaries verified at a glibc 2.28 floor
