### PR TITLE
[server] Add collection self-share repair endpoint

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -984,6 +984,7 @@ func main() {
 	adminAPI.PUT("/user/subscription", adminHandler.UpdateSubscription)
 	adminAPI.POST("/queue/re-queue", adminHandler.ReQueueItem)
 	adminAPI.POST("/user/bonus", adminHandler.UpdateBonus)
+	adminAPI.POST("/collection-shares/repair-owner-self-shares", adminHandler.RepairCollectionSelfShares)
 
 	userEntityController := &userEntityCtrl.Controller{Repo: userEntityRepo}
 	userEntityHandler := &api.UserEntityHandler{Controller: userEntityController}

--- a/server/pkg/api/admin.go
+++ b/server/pkg/api/admin.go
@@ -546,6 +546,38 @@ func (h *AdminHandler) UpdateBonus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{})
 }
 
+func (h *AdminHandler) RepairCollectionSelfShares(c *gin.Context) {
+	var request struct {
+		CollectionID int64 `json:"collectionID"`
+		UserID       int64 `json:"userID"`
+	}
+	if err := handler.BindJSON(c, &request); err != nil {
+		handler.Error(c, stacktrace.Propagate(err, "Bad request"))
+		return
+	}
+	if request.CollectionID <= 0 {
+		handler.Error(c, stacktrace.Propagate(ente.NewBadRequestWithMessage("collectionID must be positive"), ""))
+		return
+	}
+	if request.UserID <= 0 {
+		handler.Error(c, stacktrace.Propagate(ente.NewBadRequestWithMessage("userID must be positive"), ""))
+		return
+	}
+	updationTime := time.Microseconds()
+	repaired, err := h.CollectionRepo.RepairCollectionSelfShare(c, request.CollectionID, request.UserID, updationTime)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	adminID := auth.GetUserID(c.Request.Header)
+	h.notifyAdminAction(adminID, "repairing owner self-share row for collection %d and user %d", request.CollectionID, request.UserID)
+	c.JSON(http.StatusOK, gin.H{
+		"collectionID": request.CollectionID,
+		"repaired":     repaired,
+		"updationTime": updationTime,
+	})
+}
+
 func (h *AdminHandler) RecoverAccount(c *gin.Context) {
 
 	var request ente.RecoverAccountRequest

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -611,6 +611,75 @@ func (repo *CollectionRepository) UnShare(collectionID int64, toUserID int64) er
 	return stacktrace.Propagate(err, "")
 }
 
+func (repo *CollectionRepository) RepairCollectionSelfShare(ctx context.Context, collectionID int64, userID int64, updationTime int64) (bool, error) {
+	tx, err := repo.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+		WITH target AS (
+			SELECT cs.collection_id, c.owner_id
+			FROM collection_shares cs
+			INNER JOIN collections c
+				ON c.collection_id = cs.collection_id
+			WHERE cs.is_deleted = FALSE
+				AND cs.collection_id = $1
+				AND c.owner_id = $2
+				AND cs.from_user_id = $2
+				AND cs.to_user_id = $2
+			GROUP BY cs.collection_id, c.owner_id
+		),
+		deleted_shares AS (
+			DELETE FROM collection_shares cs
+			USING target
+			WHERE cs.collection_id = target.collection_id
+				AND cs.from_user_id = target.owner_id
+				AND cs.to_user_id = target.owner_id
+				AND cs.is_deleted = FALSE
+			RETURNING cs.collection_id
+		),
+		updated_collections AS (
+			UPDATE collections c
+			SET updation_time = $3
+			FROM target
+			WHERE c.collection_id = target.collection_id
+				AND EXISTS (
+					SELECT 1
+					FROM deleted_shares ds
+					WHERE ds.collection_id = c.collection_id
+				)
+			RETURNING c.collection_id, c.owner_id, c.updation_time
+		)
+		SELECT collection_id
+		FROM updated_collections
+		ORDER BY collection_id
+	`, collectionID, userID, updationTime)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+
+	repaired := false
+	for rows.Next() {
+		var repairedCollectionID int64
+		if err := rows.Scan(&repairedCollectionID); err != nil {
+			return false, stacktrace.Propagate(err, "")
+		}
+		repaired = true
+	}
+	if err := rows.Err(); err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	if err := rows.Close(); err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	if err := tx.Commit(); err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	return repaired, nil
+}
+
 // AddFiles adds files to a collection
 func (repo *CollectionRepository) AddFiles(
 	collectionID int64,

--- a/server/pkg/repo/collection_self_shares_test.go
+++ b/server/pkg/repo/collection_self_shares_test.go
@@ -1,0 +1,151 @@
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ente/museum/internal/testutil"
+)
+
+func TestRepairCollectionSelfShares(t *testing.T) {
+	_, db := setupAccessibleObjectTest(t)
+	repository := &CollectionRepository{DB: db}
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owner@example.com",
+		CreationTime: 1,
+	})
+	shareeID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       2,
+		Email:        "sharee@example.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	insertObjectTestCollectionShare(t, db, collectionID, ownerID, ownerID)
+	insertObjectTestCollectionShare(t, db, collectionID, ownerID, shareeID)
+	insertObjectTestCollectionShare(t, db, collectionID, shareeID, ownerID)
+
+	repaired, err := repository.RepairCollectionSelfShare(context.Background(), collectionID, ownerID, 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repaired {
+		t.Fatal("repair returned false, want true")
+	}
+
+	var ownerShareCount int
+	err = db.QueryRow(
+		`SELECT count(*)
+		 FROM collection_shares
+		 WHERE collection_id = $1 AND from_user_id = $2 AND to_user_id = $2`,
+		collectionID,
+		ownerID,
+	).Scan(&ownerShareCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownerShareCount != 0 {
+		t.Fatalf("owner self-share count = %d, want 0", ownerShareCount)
+	}
+
+	var validShareDeleted bool
+	err = db.QueryRow(
+		`SELECT is_deleted
+		 FROM collection_shares
+		 WHERE collection_id = $1 AND to_user_id = $2`,
+		collectionID,
+		shareeID,
+	).Scan(&validShareDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if validShareDeleted {
+		t.Fatal("valid sharee row was deleted")
+	}
+
+	var reverseShareCount int
+	err = db.QueryRow(
+		`SELECT count(*)
+		 FROM collection_shares
+		 WHERE collection_id = $1 AND from_user_id = $2 AND to_user_id = $3`,
+		collectionID,
+		shareeID,
+		ownerID,
+	).Scan(&reverseShareCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reverseShareCount != 1 {
+		t.Fatalf("reverse share count = %d, want 1", reverseShareCount)
+	}
+
+	var collectionUpdationTime int64
+	err = db.QueryRow(
+		`SELECT updation_time FROM collections WHERE collection_id = $1`,
+		collectionID,
+	).Scan(&collectionUpdationTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if collectionUpdationTime != 200 {
+		t.Fatalf("collection updation_time = %d, want 200", collectionUpdationTime)
+	}
+
+	repaired, err = repository.RepairCollectionSelfShare(context.Background(), collectionID, ownerID, 300)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repaired {
+		t.Fatal("second repair returned true, want false")
+	}
+}
+
+func TestRepairCollectionSelfShareRequiresMatchingUser(t *testing.T) {
+	_, db := setupAccessibleObjectTest(t)
+	repository := &CollectionRepository{DB: db}
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "owner@example.com",
+		CreationTime: 1,
+	})
+	firstCollectionID := insertObjectTestCollection(t, db, ownerID)
+	secondCollectionID := insertObjectTestCollection(t, db, ownerID)
+	insertObjectTestCollectionShare(t, db, firstCollectionID, ownerID, ownerID)
+	insertObjectTestCollectionShare(t, db, secondCollectionID, ownerID, ownerID)
+
+	repaired, err := repository.RepairCollectionSelfShare(context.Background(), secondCollectionID, ownerID+1, 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repaired {
+		t.Fatal("repair with mismatched user returned true, want false")
+	}
+	repaired, err = repository.RepairCollectionSelfShare(context.Background(), secondCollectionID, ownerID, 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repaired {
+		t.Fatal("repair with matching user returned false, want true")
+	}
+
+	var firstCount, secondCount int
+	err = db.QueryRow(
+		`SELECT count(*) FROM collection_shares WHERE collection_id = $1 AND to_user_id = $2`,
+		firstCollectionID,
+		ownerID,
+	).Scan(&firstCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.QueryRow(
+		`SELECT count(*) FROM collection_shares WHERE collection_id = $1 AND to_user_id = $2`,
+		secondCollectionID,
+		ownerID,
+	).Scan(&secondCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstCount != 1 || secondCount != 0 {
+		t.Fatalf("self-share counts: first=%d second=%d, want 1/0", firstCount, secondCount)
+	}
+}


### PR DESCRIPTION
Adds a temporary admin endpoint to remove an active owner self-share row for an exact collection/user pair and bump the collection sync timestamp.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh host`. Rust workflow-equivalent `cargo test --locked --features museum,ente-photos/ml-assets` failed locally in `ente-space` external upload integration with B2 connection refused.