### PR TITLE
Use Clang for Linux N-API publishing

### DIFF
--- a/.github/workflows/photos-desktop-build.yml
+++ b/.github/workflows/photos-desktop-build.yml
@@ -162,6 +162,9 @@ jobs:
                   if [ "${RUNNER_OS}" = "macOS" ]; then
                       export CSC_LINK="${MAC_OS_CERTIFICATE}"
                       export CSC_KEY_PASSWORD="${MAC_OS_CERTIFICATE_PASSWORD}"
+                  elif [ "${RUNNER_OS}" = "Linux" ]; then
+                      export TARGET_CC=clang
+                      export TARGET_CXX=clang++
                   fi
 
                   platform=${{ startsWith(matrix.os, 'macos') && 'mac' || startsWith(matrix.os, 'windows') && 'windows' || 'linux' }}


### PR DESCRIPTION
## Summary

- use Clang for Linux desktop N-API publishing builds
- keep the existing downloaded sysroot and linker configuration intact

## Why

The ARM64 cross-build needs Clang to compile `ring`; without an explicit target compiler, the N-API rebuild selects an incompatible compiler. As recommended [by napi-rs](https://napi.rs/docs/more/faq#rustls-%2F-aws-lc-sys-fails-with---use-napi-cross-on-aarch64).

## Impact

Only the Linux publish step changes. macOS and Windows builds are unaffected.

## Validation

- `git diff --check`
- `actionlint -ignore 'SC2129' .github/workflows/photos-desktop-build.yml`
