### PR TITLE
[mobile][photos] Open video metadata to all users

### DIFF
--- a/mobile/apps/photos/changes/video-metadata.md
+++ b/mobile/apps/photos/changes/video-metadata.md
@@ -1,0 +1,1 @@
+- Made video metadata available in file details for everyone.

--- a/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
@@ -115,7 +115,7 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
             _exifData["exposureTime"] != null ||
             _exifData["ISO"] != null;
       });
-    } else if (flagService.internalUser && widget.file.isVideo) {
+    } else if (widget.file.isVideo) {
       getMediaInfo();
     }
     getExif(widget.file).then((exif) {
@@ -300,11 +300,10 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
             _exifData,
             _currentUserID,
           ),
-        if (flagService.internalUser)
-          ValueListenableBuilder(
-            valueListenable: _videoMetadataNotifier,
-            builder: (context, value, _) => VideoExifRowItem(file, value),
-          ),
+        ValueListenableBuilder(
+          valueListenable: _videoMetadataNotifier,
+          builder: (context, value, _) => VideoExifRowItem(file, value),
+        ),
       ];
       if (items.isNotEmpty) {
         fileDetailsTiles.addAll([


### PR DESCRIPTION
## What changed

- Load video metadata in file details for every user.
- Show the video info row without checking the internal-user flag.
- Add a Photos release note.

## Why

Video metadata was ready in the file details sheet, but both metadata loading and the matching UI row were still behind the internal-user gate. This made the feature unavailable to most users.

## User impact

All Photos mobile users can now view video metadata from file details. Image EXIF access is unchanged because it was already open to everyone.

## Checks

- `fvm dart format --output=none --set-exit-if-changed lib/ui/viewer/file/file_details_widget.dart`
- `fvm flutter gen-l10n` (local generated output only)
- `fvm flutter analyze lib/ui/viewer/file/file_details_widget.dart`