### PR TITLE
Recognize ente.com internal accounts

### DIFF
--- a/mobile/apps/auth/lib/services/flagservice.dart
+++ b/mobile/apps/auth/lib/services/flagservice.dart
@@ -12,7 +12,9 @@ class FeatureFlagService {
       return false;
     }
 
-    return email.endsWith("@ente.io") || (userID <= 6);
+    return email.endsWith("@ente.io") ||
+        email.endsWith("@ente.com") ||
+        (userID <= 6);
   }
 
   static bool isLocalBackupEnabled() {

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -531,7 +531,9 @@ func (c *UserController) AddTokenAndNotify(ctx *gin.Context, userID int64, app e
 		templateData := map[string]interface{}{
 			"Date": t.Now().UTC().Format("02 Jan, 2006 15:04"),
 		}
-		if strings.HasSuffix(emailUtil.NormalizeEmail(user.Email), "@ente.io") {
+		normalizedEmail := emailUtil.NormalizeEmail(user.Email)
+		if strings.HasSuffix(normalizedEmail, "@ente.io") ||
+			strings.HasSuffix(normalizedEmail, "@ente.com") {
 			appDisplayNames := map[ente.App]string{
 				ente.Photos: "Ente Photos",
 				ente.Auth:   "Ente Auth",

--- a/server/pkg/repo/passkey/passkey.go
+++ b/server/pkg/repo/passkey/passkey.go
@@ -241,8 +241,10 @@ func (r *Repository) CreateBeginRegistrationData(user *ente.User) (options *prot
 	// This is necessary for Android to show third-party password managers (1Password, Bitwarden, etc.)
 	// in the Credential Manager UI during passkey registration. Without this, Android falls back to
 	// the legacy FIDO2 API which only offers Google Password Manager.
-	// This feature is currently enabled only for internal users (@ente.io email addresses).
-	if strings.HasSuffix(emailUtil.NormalizeEmail(user.Email), "@ente.io") {
+	// This feature is currently enabled only for internal users with Ente email addresses.
+	normalizedEmail := emailUtil.NormalizeEmail(user.Email)
+	if strings.HasSuffix(normalizedEmail, "@ente.io") ||
+		strings.HasSuffix(normalizedEmail, "@ente.com") {
 		authSelection := protocol.AuthenticatorSelection{
 			ResidentKey:        protocol.ResidentKeyRequirementRequired,
 			RequireResidentKey: protocol.ResidentKeyRequired(),


### PR DESCRIPTION
Recognize `@ente.com` accounts as internal wherever `@ente.io` accounts are currently recognized.
