### PR TITLE
[mob][photos] Revert update in-app purchases

### DIFF
--- a/mobile/apps/photos/changes/update-google-play-billing.md
+++ b/mobile/apps/photos/changes/update-google-play-billing.md
@@ -1,1 +1,0 @@
-- Update to newer version of Google Play Billing Library to avoid updates from getting rejected after Aug 31st. iOS storekit had to be updated too, so need to test if there are any regressions in the buying subscriptions via both stores

--- a/mobile/apps/photos/fdroid/overlay/lib/services/account/purchase_update_listener.dart
+++ b/mobile/apps/photos/fdroid/overlay/lib/services/account/purchase_update_listener.dart
@@ -1,5 +1,3 @@
-Future<void> initializeStorePurchases() async {}
-
 void listenForPurchaseUpdates({
   required bool Function() isOnSubscriptionPage,
   required Future<void> Function(String productID, String verificationData)

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -505,7 +505,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
-  in_app_purchase_storekit: 22cca7d08eebca9babdf4d07d0baccb73325d3c8
+  in_app_purchase_storekit: d1a48cb0f8b29dbf5f85f782f5dd79b21b90a5e6
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   launcher_icon_switcher: 84c218d233505aa7d8655d8fa61a3ba802c022da

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -40,7 +40,6 @@ import "package:photos/locale.dart";
 import 'package:photos/module/upload/service/file_uploader.dart';
 import 'package:photos/module/upload/service/local_file_update_service.dart';
 import "package:photos/service_locator.dart";
-import "package:photos/services/account/store_purchase_integration.dart";
 import "package:photos/services/account/user_service.dart";
 import 'package:photos/services/app_lifecycle_service.dart';
 import 'package:photos/services/collections_service.dart';
@@ -89,7 +88,6 @@ enum ForegroundStartupMode { normal, picker }
 void main() async {
   debugRepaintRainbowEnabled = false;
   WidgetsFlutterBinding.ensureInitialized();
-  await initializeStorePurchases();
   ente_ui.AppThemeConfig.initialize(ente_ui.EnteApp.photos);
   await initIsIPad();
   if (isIPad) {

--- a/mobile/apps/photos/lib/services/account/billing_service.dart
+++ b/mobile/apps/photos/lib/services/account/billing_service.dart
@@ -10,7 +10,7 @@ import 'package:photos/gateways/billing/models/billing_plan.dart';
 import 'package:photos/gateways/billing/models/subscription.dart';
 import 'package:photos/models/user_details.dart';
 import "package:photos/service_locator.dart";
-import "package:photos/services/account/store_purchase_integration.dart";
+import "package:photos/services/account/purchase_update_listener.dart";
 import 'package:photos/ui/family/family_plan_page.dart';
 import 'package:photos/utils/dialog_util.dart';
 

--- a/mobile/apps/photos/lib/services/account/purchase_update_listener.dart
+++ b/mobile/apps/photos/lib/services/account/purchase_update_listener.dart
@@ -1,23 +1,6 @@
 import "dart:io";
 
 import "package:in_app_purchase/in_app_purchase.dart";
-import "package:in_app_purchase_storekit/in_app_purchase_storekit.dart";
-
-Future<void> initializeStorePurchases() async {
-  if (!Platform.isIOS) {
-    return;
-  }
-
-  // This must run during app initialization, before any code reads
-  // InAppPurchase.instance.purchaseStream. Flutter registers StoreKit 2 before
-  // main(), so switch to StoreKit 1 and re-register the Dart implementation
-  // early enough for its transaction observer to be initialized.
-  // TODO: Remove this fallback after the server supports StoreKit 2 JWS
-  // verification.
-  // ignore: deprecated_member_use
-  await InAppPurchaseStoreKitPlatform.enableStoreKit1();
-  InAppPurchaseStoreKitPlatform.registerPlatform();
-}
 
 void listenForPurchaseUpdates({
   required bool Function() isOnSubscriptionPage,

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -143,8 +143,7 @@ dependencies:
   http: 1.6.0
   hugeicons: 1.1.7
   image: 4.7.0
-  in_app_purchase: 3.3.0
-  in_app_purchase_storekit: 0.4.11
+  in_app_purchase: 3.2.1
   intl: 0.20.2
   just_audio: 0.10.5
   latlong2: 0.9.1

--- a/mobile/apps/photos/scripts/prepare_fdroid_source.sh
+++ b/mobile/apps/photos/scripts/prepare_fdroid_source.sh
@@ -10,9 +10,9 @@ fail() {
 
 remove_direct_dependencies() {
     local count
-    count=$(rg -c "^  (firebase_core|firebase_messaging|in_app_purchase_storekit|in_app_purchase):" pubspec.yaml || true)
-    [[ "$count" == "4" ]] || fail "expected four restricted dependencies in pubspec.yaml"
-    perl -0pi -e 's/^  (firebase_core|firebase_messaging|in_app_purchase_storekit|in_app_purchase):[^\n]*\n//mg' pubspec.yaml
+    count=$(rg -c "^  (firebase_core|firebase_messaging|in_app_purchase):" pubspec.yaml || true)
+    [[ "$count" == "3" ]] || fail "expected three restricted dependencies in pubspec.yaml"
+    perl -0pi -e 's/^  (firebase_core|firebase_messaging|in_app_purchase):[^\n]*\n//mg' pubspec.yaml
 }
 
 remove_playstore_sources() {
@@ -24,7 +24,7 @@ copy_fdroid_overlay() {
 }
 
 assert_fdroid_source() {
-    if rg -n "package:(firebase_core|firebase_messaging|in_app_purchase_storekit|in_app_purchase)" lib pubspec.yaml; then
+    if rg -n "package:(firebase_core|firebase_messaging|in_app_purchase)" lib pubspec.yaml; then
         fail "restricted package imports or direct dependencies remain"
     fi
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1409,18 +1409,18 @@ packages:
     dependency: transitive
     description:
       name: in_app_purchase
-      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
+      sha256: "11a40f148eeb4f681a0572003e2b33432e110c90c1bbb4f9ef83b81ec0c4f737"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.2.1"
   in_app_purchase_android:
     dependency: transitive
     description:
       name: in_app_purchase_android
-      sha256: b8af1b6f0e57076b5da5ede71e3af2d727017c0416ad2a41017c6ed2b102381d
+      sha256: "518b48a385dfc1aa278080472969c6cee0c3d41ef8b9511b0071dd015473ecf1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.4.0+11"
   in_app_purchase_platform_interface:
     dependency: transitive
     description:
@@ -1433,10 +1433,10 @@ packages:
     dependency: transitive
     description:
       name: in_app_purchase_storekit
-      sha256: "702a23c3d2ddc177b075d521d264900e82f01663881e4ef3ce17775de298c0e3"
+      sha256: "6ce1361278cacc0481508989ba419b2c9f46a2b0dc54b3fe54f5ee63c2718fef"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.11"
+    version: "0.3.22+1"
   integration_test:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
Reverts #11730 to restore the previous in-app purchase dependencies and StoreKit behavior.

Validated with Flutter analysis, locked dependency resolution, F-Droid source preparation, and Android and iOS builds.
