### PR TITLE
[mobile] Replace email validator dependency

### DIFF
--- a/mobile/packages/ente_pure_utils/lib/src/email_validator.dart
+++ b/mobile/packages/ente_pure_utils/lib/src/email_validator.dart
@@ -1,5 +1,128 @@
-import 'package:email_validator/email_validator.dart';
+const _maxEmailLength = 254;
+const _maxLocalPartLength = 64;
+const _maxDomainLabelLength = 63;
+const _apostrophe = 0x27;
+const _dot = 0x2E;
+const _hyphen = 0x2D;
+const _lowercaseN = 0x6E;
+const _lowercaseX = 0x78;
+const _plus = 0x2B;
+const _underscore = 0x5F;
 
+/// Whether [email] uses Ente's supported public internet email syntax.
+///
+/// Quoted local parts, domain literals, comments, and non-ASCII input are not
+/// supported. Internationalized domains must be converted to their ASCII form
+/// before validation.
 bool isValidEmail(String email) {
-  return EmailValidator.validate(email);
+  if (email.isEmpty || email.length > _maxEmailLength) {
+    return false;
+  }
+
+  final separatorIndex = email.indexOf('@');
+  if (separatorIndex <= 0 ||
+      separatorIndex > _maxLocalPartLength ||
+      separatorIndex != email.lastIndexOf('@') ||
+      separatorIndex == email.length - 1) {
+    return false;
+  }
+
+  return _isValidLocalPart(email, separatorIndex) &&
+      _isValidDomain(email, separatorIndex + 1);
+}
+
+bool _isValidLocalPart(String email, int end) {
+  var previousWasDot = true;
+  for (var index = 0; index < end; index++) {
+    final codeUnit = email.codeUnitAt(index);
+    if (codeUnit == _dot) {
+      if (previousWasDot) {
+        return false;
+      }
+      previousWasDot = true;
+    } else {
+      if (!_isLocalAtomCodeUnit(codeUnit)) {
+        return false;
+      }
+      previousWasDot = false;
+    }
+  }
+  return !previousWasDot;
+}
+
+bool _isValidDomain(String email, int start) {
+  var labelStart = start;
+  var hasDot = false;
+  for (var index = start; index <= email.length; index++) {
+    final atEnd = index == email.length;
+    if (!atEnd) {
+      final codeUnit = email.codeUnitAt(index);
+      if (codeUnit != _dot) {
+        if (!_isAsciiLetter(codeUnit) &&
+            !_isAsciiDigit(codeUnit) &&
+            codeUnit != _hyphen) {
+          return false;
+        }
+        continue;
+      }
+    }
+
+    final labelLength = index - labelStart;
+    if (labelLength == 0 ||
+        labelLength > _maxDomainLabelLength ||
+        email.codeUnitAt(labelStart) == _hyphen ||
+        email.codeUnitAt(index - 1) == _hyphen) {
+      return false;
+    }
+
+    if (atEnd) {
+      return hasDot && _isValidTopLevelDomain(email, labelStart, index);
+    }
+    hasDot = true;
+    labelStart = index + 1;
+  }
+  return false;
+}
+
+bool _isValidTopLevelDomain(String email, int start, int end) {
+  if (end - start < 2) {
+    return false;
+  }
+  for (var index = start; index < end; index++) {
+    if (!_isAsciiLetter(email.codeUnitAt(index))) {
+      return end - start > 4 &&
+          _equalsAsciiIgnoreCase(email.codeUnitAt(start), _lowercaseX) &&
+          _equalsAsciiIgnoreCase(email.codeUnitAt(start + 1), _lowercaseN) &&
+          email.codeUnitAt(start + 2) == _hyphen &&
+          email.codeUnitAt(start + 3) == _hyphen &&
+          _isAsciiLetterOrDigit(email.codeUnitAt(start + 4));
+    }
+  }
+  return true;
+}
+
+bool _isLocalAtomCodeUnit(int codeUnit) {
+  return _isAsciiLetter(codeUnit) ||
+      _isAsciiDigit(codeUnit) ||
+      codeUnit == _apostrophe ||
+      codeUnit == _plus ||
+      codeUnit == _hyphen ||
+      codeUnit == _underscore;
+}
+
+bool _isAsciiLetter(int codeUnit) {
+  return (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
+      (codeUnit >= 0x61 && codeUnit <= 0x7A);
+}
+
+bool _isAsciiDigit(int codeUnit) {
+  return codeUnit >= 0x30 && codeUnit <= 0x39;
+}
+
+bool _isAsciiLetterOrDigit(int codeUnit) {
+  return _isAsciiLetter(codeUnit) || _isAsciiDigit(codeUnit);
+}
+
+bool _equalsAsciiIgnoreCase(int codeUnit, int lowercaseCodeUnit) {
+  return codeUnit == lowercaseCodeUnit || codeUnit == lowercaseCodeUnit - 0x20;
 }

--- a/mobile/packages/ente_pure_utils/pubspec.yaml
+++ b/mobile/packages/ente_pure_utils/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
   collection: 1.19.1
   convert: 3.1.2
   crypto: 3.0.7
-  email_validator: 3.0.0
   flutter:
     sdk: flutter
   intl: 0.20.2

--- a/mobile/packages/ente_pure_utils/test/email_validator_test.dart
+++ b/mobile/packages/ente_pure_utils/test/email_validator_test.dart
@@ -1,0 +1,107 @@
+import 'package:ente_pure_utils/ente_pure_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isValidEmail', () {
+    test('accepts practical internet email addresses', () {
+      const validEmails = [
+        'user@example.com',
+        'USER@EXAMPLE.COM',
+        'first.last+tag@sub-domain.example',
+        "o'hara@example.com",
+        'user_name@example.com',
+        'a@b.co',
+        'user@xn--bcher-kva.de',
+        'user@example.xn--p1ai',
+      ];
+
+      for (final email in validEmails) {
+        expect(isValidEmail(email), isTrue, reason: email);
+      }
+    });
+
+    test('rejects missing or ambiguous address parts', () {
+      const invalidEmails = [
+        '',
+        'user',
+        '@example.com',
+        'user@',
+        'user@@example.com',
+      ];
+
+      for (final email in invalidEmails) {
+        expect(isValidEmail(email), isFalse, reason: email);
+      }
+    });
+
+    test('rejects whitespace and unsupported local-part forms', () {
+      const invalidEmails = [
+        ' user@example.com',
+        'user@example.com ',
+        'user name@example.com',
+        '.user@example.com',
+        'user.@example.com',
+        'user..name@example.com',
+        r'"user name"@example.com',
+        r'user\name@example.com',
+        'user:name@example.com',
+        'user!name@example.com',
+        'user#name@example.com',
+        r'user$name@example.com',
+        'user/name@example.com',
+        'user=name@example.com',
+        'user~name@example.com',
+      ];
+
+      for (final email in invalidEmails) {
+        expect(isValidEmail(email), isFalse, reason: email);
+      }
+    });
+
+    test('rejects non-public or malformed domains', () {
+      const invalidEmails = [
+        'user@localhost',
+        'user@example.c',
+        'user@example.123',
+        'user@example.a1',
+        'user@example.xn--',
+        'user@example.xn---invalid',
+        'user@-example.com',
+        'user@example-.com',
+        'user@example..com',
+        'user@example_com',
+        'user@example.com.',
+        'user@[127.0.0.1]',
+      ];
+
+      for (final email in invalidEmails) {
+        expect(isValidEmail(email), isFalse, reason: email);
+      }
+    });
+
+    test('enforces email and DNS length limits', () {
+      final localPartAtLimit = 'a' * 64;
+      final localPartOverLimit = 'a' * 65;
+      final domainLabelAtLimit = 'b' * 63;
+      final domainLabelOverLimit = 'b' * 64;
+      final emailAtLimit = '${'a' * 64}@${'b' * 63}.${'c' * 63}.${'d' * 61}';
+      final emailOverLimit = '${'a' * 64}@${'b' * 63}.${'c' * 63}.${'d' * 62}';
+
+      expect(isValidEmail('$localPartAtLimit@example.com'), isTrue);
+      expect(isValidEmail('$localPartOverLimit@example.com'), isFalse);
+      expect(isValidEmail('user@$domainLabelAtLimit.com'), isTrue);
+      expect(isValidEmail('user@$domainLabelOverLimit.com'), isFalse);
+      expect(emailAtLimit.length, 254);
+      expect(isValidEmail(emailAtLimit), isTrue);
+      expect(emailOverLimit.length, 255);
+      expect(isValidEmail(emailOverLimit), isFalse);
+    });
+
+    test('rejects Unicode until EAI and IDNA canonicalization are owned', () {
+      expect(isValidEmail('josé@example.com'), isFalse);
+      expect(isValidEmail('user@例え.jp'), isFalse);
+      expect(isValidEmail('😀@example.com'), isFalse);
+      expect(isValidEmail('user@exam\u200Bple.com'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
- Replace `email_validator` inside `ente_pure_utils` with an owned validator and tests.
- Raw Unicode remains rejected pending EAI/IDNA canonicalization. Local-part behavior aligns with web; Punycode-TLD and trailing-hyphen domain parity remain follow-up.

Validation: mobile lint workflow checks and full Flutter test matrix.