### PR TITLE
[server] Add v3 file URL endpoints

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -606,9 +606,11 @@ func main() {
 	storageAPI.POST("/files/upload-url", fileHandler.GetUploadURLV2)
 	storageAPI.POST("/files/multipart-upload-url", fileHandler.GetMultipartUploadURLV2)
 	storageAPI.GET("/files/download/:fileID", fileHandler.Get)
-	storageAPI.GET("/files/download/v2/:fileID", fileHandler.GetV2)
+	storageAPI.GET("/files/download/v2/:fileID", fileHandler.GetURL)
+	storageAPI.GET("/files/download/v3/:fileID", fileHandler.GetURLV3)
 	storageAPI.GET("/files/preview/:fileID", fileHandler.GetThumbnail)
-	storageAPI.GET("/files/preview/v2/:fileID", fileHandler.GetThumbnailV2)
+	storageAPI.GET("/files/preview/v2/:fileID", fileHandler.GetThumbnailURL)
+	storageAPI.GET("/files/thumbnail/v3/:fileID", fileHandler.GetThumbnailURLV3)
 
 	storageAPI.POST("/files/share-url", fileHandler.ShareUrl)
 	storageAPI.GET("/files/share-url", fileHandler.GetUrls)

--- a/server/pkg/api/file.go
+++ b/server/pkg/api/file.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -223,12 +225,23 @@ func (h *FileHandler) Get(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, url)
 }
 
-// GetV2 returns the URL of the file to the client
-func (h *FileHandler) GetV2(c *gin.Context) {
+// GetURL returns the URL of the file to the client.
+func (h *FileHandler) GetURL(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
 	url, err := h.Controller.GetFileURL(c, userID, fileID)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"url": url})
+}
+
+// GetURLV3 returns the URL of the file and reserves HTTP 404 for an unavailable endpoint.
+func (h *FileHandler) GetURLV3(c *gin.Context) {
+	userID, fileID := getUserAndFileIDs(c)
+	url, err := h.Controller.GetFileURL(c, userID, fileID)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(fileURLV3Error(err), ""))
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"url": url})
@@ -246,8 +259,8 @@ func (h *FileHandler) GetThumbnail(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, url)
 }
 
-// GetThumbnailV2 returns the URL of the thumbnail to the client
-func (h *FileHandler) GetThumbnailV2(c *gin.Context) {
+// GetThumbnailURL returns the URL of the thumbnail to the client.
+func (h *FileHandler) GetThumbnailURL(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
 	url, err := h.Controller.GetThumbnailURL(c, userID, fileID)
 	if err != nil {
@@ -255,6 +268,27 @@ func (h *FileHandler) GetThumbnailV2(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"url": url})
+}
+
+// GetThumbnailURLV3 returns the thumbnail URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *FileHandler) GetThumbnailURLV3(c *gin.Context) {
+	userID, fileID := getUserAndFileIDs(c)
+	url, err := h.Controller.GetThumbnailURL(c, userID, fileID)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(fileURLV3Error(err), ""))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"url": url})
+}
+
+func fileURLV3Error(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return ente.NewBadRequestError(&ente.ApiErrorParams{
+			Code:    ente.NotFoundError,
+			Message: "requested object was not found",
+		})
+	}
+	return err
 }
 
 // Trash moves the given files to the trash bin

--- a/server/pkg/api/file_test.go
+++ b/server/pkg/api/file_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ente/stacktrace"
+	"github.com/gin-gonic/gin"
+
+	"github.com/ente/museum/ente"
+	apiHandler "github.com/ente/museum/pkg/utils/handler"
+)
+
+func TestFileURLV3MissingObjectReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/files/download/v3/1", nil)
+
+	apiHandler.Error(ctx, stacktrace.Propagate(fileURLV3Error(sql.ErrNoRows), ""))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	var response ente.ApiError
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != ente.NotFoundError {
+		t.Fatalf("code = %q, want %q", response.Code, ente.NotFoundError)
+	}
+}

--- a/server/pkg/middleware/rate_limit.go
+++ b/server/pkg/middleware/rate_limit.go
@@ -213,7 +213,8 @@ func isSpaceViewerReadURLPath(reqPath string) bool {
 // getLimiter, based on reqPath & reqMethod, return instance of limiter.Limiter which needs to
 // be applied for a request. It returns nil if the request is not rate limited
 func (r *RateLimitMiddleware) getLimiter(reqPath string, reqMethod string) *limiter.Limiter {
-	if strings.HasPrefix(reqPath, "/files/preview/") {
+	if strings.HasPrefix(reqPath, "/files/preview/") ||
+		strings.HasPrefix(reqPath, "/files/thumbnail/") {
 		return r.limit700ReqPerSec
 	}
 	if reqPath == "/space/public/by-slug/:spaceSlug" ||


### PR DESCRIPTION
- Add explicit v3 file and thumbnail endpoints that return signed URLs without redirecting.
- Return 400 with NOT_FOUND for missing objects so clients can distinguish unsupported servers.

Validation: ./scripts/lint.sh; ./scripts/test-with-postgres.sh docker