### PR TITLE
[web] Use v3 URLs for authenticated file downloads

### DIFF
--- a/web/apps/locker/src/services/remote-read.ts
+++ b/web/apps/locker/src/services/remote-read.ts
@@ -7,14 +7,10 @@ import {
     ensureLocalUser,
     ensureUserKeyPair,
 } from "ente-accounts-rs/services/user";
-import {
-    authenticatedRequestHeaders,
-    ensureOk,
-    publicRequestHeaders,
-} from "ente-base/http";
+import { fetchFile } from "ente-base/file-download";
+import { authenticatedRequestHeaders, ensureOk } from "ente-base/http";
 import log from "ente-base/log";
 import { apiURL, customAPIOrigin } from "ente-base/origins";
-import { ensureAuthToken } from "ente-base/token";
 import { z } from "zod";
 import {
     boxSealOpen,
@@ -1046,9 +1042,7 @@ export const downloadLockerFile = async (
     let response: Response;
     try {
         if (customOrigin) {
-            const token = await ensureAuthToken();
-            const url = await apiURL(`/files/download/${fileID}`, { token });
-            response = await fetch(url, { headers: publicRequestHeaders() });
+            response = await fetchFile(fileID, "file");
         } else {
             response = await fetch(`https://files.ente.com/?fileID=${fileID}`, {
                 headers: await authenticatedRequestHeaders(),

--- a/web/packages/base/file-download.ts
+++ b/web/packages/base/file-download.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import {
+    authenticatedRequestHeaders,
+    ensureOk,
+    publicRequestHeaders,
+} from "./http";
+import { apiURL } from "./origins";
+import { ensureAuthToken } from "./token";
+
+const FileURLResponse = z.object({ url: z.string() });
+const V3_RETRY_DELAY_MS = 60 * 60 * 1000;
+let v3RetryAfter = 0;
+
+export const fetchFile = async (fileID: number, kind: "file" | "thumbnail") => {
+    if (v3RetryAfter <= Date.now()) {
+        const path = kind == "file" ? "download" : "thumbnail";
+        const res = await fetch(await apiURL(`/files/${path}/v3/${fileID}`), {
+            headers: await authenticatedRequestHeaders(),
+        });
+        if (res.status !== 404) {
+            ensureOk(res);
+            const { url } = FileURLResponse.parse(await res.json());
+            return fetch(url);
+        }
+        v3RetryAfter = Date.now() + V3_RETRY_DELAY_MS;
+    }
+
+    // migration : 3 aug 2026
+    const token = await ensureAuthToken();
+    const path = kind == "file" ? "download" : "preview";
+    return fetch(await apiURL(`/files/${path}/${fileID}`, { token }), {
+        headers: publicRequestHeaders(),
+    });
+};

--- a/web/packages/gallery/services/download.ts
+++ b/web/packages/gallery/services/download.ts
@@ -1,3 +1,4 @@
+import { fetchFile } from "ente-base/file-download";
 import {
     authenticatedPublicAlbumsRequestHeaders,
     authenticatedRequestHeaders,
@@ -10,7 +11,6 @@ import {
     authenticatedPublicMemoryRequestHeaders,
     type PublicMemoryCredentials,
 } from "ente-base/public-memory";
-import { ensureAuthToken } from "ente-base/token";
 import type { EnteFile } from "ente-media/file";
 import { playableVideoURL, renderableImageBlob } from "./convert";
 import {
@@ -201,13 +201,7 @@ const photos_downloadThumbnail = async (file: EnteFile) => {
 
     const getThumbnail = async () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const token = await ensureAuthToken();
-            const params = new URLSearchParams({ token });
-            return fetch(
-                `${customOrigin}/files/preview/${file.id}?${params.toString()}`,
-                { headers: publicRequestHeaders() },
-            );
+            return fetchFile(file.id, "thumbnail");
         } else {
             return fetch(`https://thumbnails.ente.com/?fileID=${file.id}`, {
                 headers: await authenticatedRequestHeaders(),
@@ -232,31 +226,18 @@ const photos_downloadFile = async (
 
     // [Note: Passing credentials for self-hosted file fetches]
     //
-    // Fetching files (or thumbnails) in the default self-hosted Ente
-    // configuration involves a redirection:
+    // Current Museum versions return a pre-signed object URL after
+    // authenticating the request with the X-Auth-Token header. The browser can
+    // then fetch that URL without forwarding Ente credentials to object
+    // storage.
     //
-    // 1. The browser makes a HTTP GET to a museum with credentials. Museum
-    //    inspects the credentials, in this case the auth token, and if they're
-    //    valid, returns a HTTP 307 redirect to the pre-signed S3 URL that to
-    //    the file in the configured S3 bucket.
+    // Older Museum versions redirect from the legacy endpoint. Browsers
+    // preserve request headers across that redirect, so the legacy fallback
+    // has to put the token in the query string instead. Public share routes
+    // still use their legacy query credentials for the same reason.
     //
-    // 2. The browser follows the redirect to get the actual file. The URL is
-    //    pre-signed, i.e. already has all credentials needed to prove to the S3
-    //    object storage that it should serve this response.
-    //
-    // For the first step normally we'd pass the auth the token via the
-    // "X-Auth-Token" HTTP header. In this case though, that would be
-    // problematic because the browser preserves the request headers when it
-    // follows the HTTP 307 redirect, and the "X-Auth-Token" header also gets
-    // sent to the redirected S3 request made in second step.
-    //
-    // To avoid this, we pass the token as a query parameter. Generally this is
-    // not a good idea, but in this case (a) the URL is not a user visible one
-    // and (b) even if it gets logged, it'll be in the self-hosters own service.
-    //
-    // Note that Ente's own servers don't have these concerns because we use a
-    // slightly different flow involving a proxy instead of directly connecting
-    // to the S3 storage.
+    // Ente's own interactive requests use a proxy instead of directly
+    // connecting to object storage.
     //
     // 1. The web browser makes a HTTP GET request to a proxy passing it the
     //    credentials in the "X-Auth-Token".
@@ -277,9 +258,7 @@ const photos_downloadFile = async (
 
     const getFile = async () => {
         if (customOrigin || background) {
-            const token = await ensureAuthToken();
-            const url = await apiURL(`/files/download/${file.id}`, { token });
-            return fetch(url, { headers: publicRequestHeaders() });
+            return fetchFile(file.id, "file");
         } else {
             return fetch(`https://files.ente.com/?fileID=${file.id}`, {
                 headers: await authenticatedRequestHeaders(),


### PR DESCRIPTION
Uses the v3 endpoints added in #11896.

- Resolve Locker and Photos direct downloads with header authentication.
- Use the v3 thumbnail URL endpoint for custom-origin Photos requests.
- Fall back to legacy query-token routes for one hour when v3 is unavailable.

Validation: npm audit --audit-level critical; npm run build:wasm; npm run build:space-wasm; npm run lint; npm test; npm run build