### PR TITLE
[server] Add v3 public file URL endpoints

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -784,11 +784,15 @@ func main() {
 	fileLinkApi.GET("/info", fileHandler.LinkInfo)
 	fileLinkApi.GET("/pass-info", fileHandler.PasswordInfo)
 	fileLinkApi.GET("/thumbnail", fileHandler.LinkThumbnail)
+	fileLinkApi.GET("/thumbnail/v3", fileHandler.LinkThumbnailURLV3)
 	fileLinkApi.GET("/file", fileHandler.LinkFile)
+	fileLinkApi.GET("/file/v3", fileHandler.LinkFileURLV3)
 	fileLinkApi.POST("/verify-password", fileHandler.VerifyPassword)
 
 	publicCollectionAPI.GET("/files/preview/:fileID", publicCollectionHandler.GetThumbnail)
+	publicCollectionAPI.GET("/files/thumbnail/v3/:fileID", publicCollectionHandler.GetThumbnailURLV3)
 	publicCollectionAPI.GET("/files/download/:fileID", publicCollectionHandler.GetFile)
+	publicCollectionAPI.GET("/files/download/v3/:fileID", publicCollectionHandler.GetFileURLV3)
 	publicCollectionAPI.GET("/files/data/fetch", publicCollectionHandler.GetFileData)
 	publicCollectionAPI.GET("/files/data/preview", publicCollectionHandler.GetPreviewURL)
 	publicCollectionAPI.GET("/diff", publicCollectionHandler.GetDiff)
@@ -825,7 +829,9 @@ func main() {
 	publicMemoryAPI.GET("/info", publicMemoryShareHandler.GetInfo)
 	publicMemoryAPI.GET("/files", publicMemoryShareHandler.GetFiles)
 	publicMemoryAPI.GET("/files/preview/:fileID", publicMemoryShareHandler.GetThumbnail)
+	publicMemoryAPI.GET("/files/thumbnail/v3/:fileID", publicMemoryShareHandler.GetThumbnailURLV3)
 	publicMemoryAPI.GET("/files/download/:fileID", publicMemoryShareHandler.GetFile)
+	publicMemoryAPI.GET("/files/download/v3/:fileID", publicMemoryShareHandler.GetFileURLV3)
 	publicMemoryAPI.GET("/file-data", publicMemoryShareHandler.GetFileData)
 	publicMemoryAPI.GET("/files/data/preview", publicMemoryShareHandler.GetPreviewURL)
 
@@ -861,7 +867,9 @@ func main() {
 	storageAPI.DELETE("/cast/revoke-all-tokens/", castHandler.RevokeAllToken)
 
 	castAPI.GET("/files/preview/:fileID", castHandler.GetThumbnail)
+	castAPI.GET("/files/thumbnail/v3/:fileID", castHandler.GetThumbnailURLV3)
 	castAPI.GET("/files/download/:fileID", castHandler.GetFile)
+	castAPI.GET("/files/download/v3/:fileID", castHandler.GetFileURLV3)
 	castAPI.GET("/diff", castHandler.GetDiff)
 	castAPI.GET("/info", castHandler.GetCollection)
 	familyHandler := &api.FamilyHandler{

--- a/server/pkg/api/cast.go
+++ b/server/pkg/api/cast.go
@@ -131,6 +131,18 @@ func (h *CastHandler) GetThumbnail(c *gin.Context) {
 	h.getFileForType(c, ente.THUMBNAIL)
 }
 
+// GetFileURLV3 returns the file URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *CastHandler) GetFileURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.FILE)
+	writeFileURLV3(c, url, err)
+}
+
+// GetThumbnailURLV3 returns the thumbnail URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *CastHandler) GetThumbnailURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.THUMBNAIL)
+	writeFileURLV3(c, url, err)
+}
+
 // GetCollection redirects the request to the collection location
 func (h *CastHandler) GetCollection(c *gin.Context) {
 	collection, err := h.CollectionCtrl.GetCastCollection(c)
@@ -166,16 +178,23 @@ func getDeviceCode(c *gin.Context) string {
 }
 
 func (h *CastHandler) getFileForType(c *gin.Context, objectType ente.ObjectType) {
-	fileID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
-	if err != nil {
-		handler.Error(c, stacktrace.Propagate(ente.ErrBadRequest, ""))
-		return
-	}
-	castCtx := auth.GetCastCtx(c)
-	url, err := h.FileCtrl.GetPublicOrCastFileURL(c, fileID, objectType, castCtx.CollectionID)
+	url, err := h.getFileURL(c, objectType)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
 	}
 	c.Redirect(http.StatusTemporaryRedirect, url)
+}
+
+func (h *CastHandler) getFileURL(c *gin.Context, objectType ente.ObjectType) (string, error) {
+	fileID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
+	if err != nil {
+		return "", stacktrace.Propagate(ente.ErrBadRequest, "")
+	}
+	castCtx := auth.GetCastCtx(c)
+	url, err := h.FileCtrl.GetPublicOrCastFileURL(c, fileID, objectType, castCtx.CollectionID)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
+	return url, nil
 }

--- a/server/pkg/api/file.go
+++ b/server/pkg/api/file.go
@@ -240,11 +240,7 @@ func (h *FileHandler) GetURL(c *gin.Context) {
 func (h *FileHandler) GetURLV3(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
 	url, err := h.Controller.GetFileURL(c, userID, fileID)
-	if err != nil {
-		handler.Error(c, stacktrace.Propagate(fileURLV3Error(err), ""))
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"url": url})
+	writeFileURLV3(c, url, err)
 }
 
 // GetThumbnail redirects the request to the file's thumbnail location
@@ -274,6 +270,10 @@ func (h *FileHandler) GetThumbnailURL(c *gin.Context) {
 func (h *FileHandler) GetThumbnailURLV3(c *gin.Context) {
 	userID, fileID := getUserAndFileIDs(c)
 	url, err := h.Controller.GetThumbnailURL(c, userID, fileID)
+	writeFileURLV3(c, url, err)
+}
+
+func writeFileURLV3(c *gin.Context, url string, err error) {
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(fileURLV3Error(err), ""))
 		return
@@ -282,7 +282,10 @@ func (h *FileHandler) GetThumbnailURLV3(c *gin.Context) {
 }
 
 func fileURLV3Error(err error) error {
-	if errors.Is(err, sql.ErrNoRows) {
+	var apiErr *ente.ApiError
+	if errors.Is(err, sql.ErrNoRows) ||
+		errors.Is(err, ente.ErrNotFound) ||
+		(errors.As(err, &apiErr) && apiErr.Code == ente.NotFoundError) {
 		return ente.NewBadRequestError(&ente.ApiErrorParams{
 			Code:    ente.NotFoundError,
 			Message: "requested object was not found",

--- a/server/pkg/api/file_link.go
+++ b/server/pkg/api/file_link.go
@@ -79,6 +79,20 @@ func (h *FileHandler) LinkFile(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, url)
 }
 
+// LinkThumbnailURLV3 returns the thumbnail URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *FileHandler) LinkThumbnailURLV3(c *gin.Context) {
+	linkCtx := auth.MustGetFileLinkAccessContext(c)
+	url, err := h.Controller.GetThumbnailURLForOwner(c, linkCtx.OwnerID, linkCtx.FileID)
+	writeFileURLV3(c, url, err)
+}
+
+// LinkFileURLV3 returns the file URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *FileHandler) LinkFileURLV3(c *gin.Context) {
+	linkCtx := auth.MustGetFileLinkAccessContext(c)
+	url, err := h.Controller.GetFileURLForOwner(c, linkCtx.OwnerID, linkCtx.FileID)
+	writeFileURLV3(c, url, err)
+}
+
 func (h *FileHandler) DisableUrl(c *gin.Context) {
 	cID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
 	if err != nil {

--- a/server/pkg/api/file_test.go
+++ b/server/pkg/api/file_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,25 +12,104 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/ente/museum/ente"
-	apiHandler "github.com/ente/museum/pkg/utils/handler"
 )
 
-func TestFileURLV3MissingObjectReturnsBadRequest(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(http.MethodGet, "/files/download/v3/1", nil)
+func TestWriteFileURLV3ReturnsJSONWithoutRedirect(t *testing.T) {
+	recorder, ctx := newFileURLV3TestContext("/files/download/v3/1")
 
-	apiHandler.Error(ctx, stacktrace.Propagate(fileURLV3Error(sql.ErrNoRows), ""))
+	writeFileURLV3(ctx, "https://objects.example/file", nil)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if location := recorder.Header().Get("Location"); location != "" {
+		t.Fatalf("Location = %q, want empty", location)
+	}
+	var response struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.URL != "https://objects.example/file" {
+		t.Fatalf("url = %q, want %q", response.URL, "https://objects.example/file")
+	}
+}
+
+func TestWriteFileURLV3MapsNotFoundErrorsToBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "sql no rows", err: stacktrace.Propagate(sql.ErrNoRows, "lookup object")},
+		{name: "not found sentinel", err: stacktrace.Propagate(ente.ErrNotFound, "lookup memory file")},
+		{name: "not found API error", err: stacktrace.Propagate(ente.ErrNotFoundError.NewErr("missing object"), "lookup file")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder, ctx := newFileURLV3TestContext("/files/download/v3/1")
+
+			writeFileURLV3(ctx, "", test.err)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+			var response ente.ApiError
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.Code != ente.NotFoundError {
+				t.Fatalf("code = %q, want %q", response.Code, ente.NotFoundError)
+			}
+		})
+	}
+}
+
+func TestWriteFileURLV3PreservesNonNotFoundErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "bad request", err: ente.ErrBadRequest, wantStatus: http.StatusBadRequest},
+		{name: "permission denied", err: ente.ErrPermissionDenied, wantStatus: http.StatusForbidden},
+		{name: "internal error", err: errors.New("storage unavailable"), wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder, ctx := newFileURLV3TestContext("/files/download/v3/1")
+
+			writeFileURLV3(ctx, "", test.err)
+
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, test.wantStatus)
+			}
+			if recorder.Code == http.StatusNotFound {
+				t.Fatal("HTTP 404 is reserved for an unavailable v3 route")
+			}
+		})
+	}
+}
+
+func TestPublicCollectionFileURLV3InvalidFileIDReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/public-collection/files/download/v3/:fileID", (&PublicCollectionHandler{}).GetFileURLV3)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/public-collection/files/download/v3/invalid", nil))
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
 	}
-	var response ente.ApiError
-	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if response.Code != ente.NotFoundError {
-		t.Fatalf("code = %q, want %q", response.Code, ente.NotFoundError)
-	}
+}
+
+func newFileURLV3TestContext(path string) (*httptest.ResponseRecorder, *gin.Context) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, path, nil)
+	return recorder, ctx
 }

--- a/server/pkg/api/public_collection.go
+++ b/server/pkg/api/public_collection.go
@@ -39,6 +39,18 @@ func (h *PublicCollectionHandler) GetFile(c *gin.Context) {
 	h.getFileForType(c, ente.FILE)
 }
 
+// GetThumbnailURLV3 returns the thumbnail URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *PublicCollectionHandler) GetThumbnailURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.THUMBNAIL)
+	writeFileURLV3(c, url, err)
+}
+
+// GetFileURLV3 returns the file URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *PublicCollectionHandler) GetFileURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.FILE)
+	writeFileURLV3(c, url, err)
+}
+
 func (h *PublicCollectionHandler) GetPreviewURL(c *gin.Context) {
 	var req fileData.GetPreviewURLRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -224,16 +236,23 @@ func (h *PublicCollectionHandler) GetDiff(c *gin.Context) {
 }
 
 func (h *PublicCollectionHandler) getFileForType(c *gin.Context, objectType ente.ObjectType) {
-	fileID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
-	if err != nil {
-		handler.Error(c, stacktrace.Propagate(ente.ErrBadRequest, ""))
-		return
-	}
-	accessContext := auth.MustGetPublicAccessContext(c)
-	url, err := h.FileCtrl.GetPublicOrCastFileURL(c, fileID, objectType, accessContext.CollectionID)
+	url, err := h.getFileURL(c, objectType)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
 	}
 	c.Redirect(http.StatusTemporaryRedirect, url)
+}
+
+func (h *PublicCollectionHandler) getFileURL(c *gin.Context, objectType ente.ObjectType) (string, error) {
+	fileID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
+	if err != nil {
+		return "", stacktrace.Propagate(ente.ErrBadRequest, "")
+	}
+	accessContext := auth.MustGetPublicAccessContext(c)
+	url, err := h.FileCtrl.GetPublicOrCastFileURL(c, fileID, objectType, accessContext.CollectionID)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "")
+	}
+	return url, nil
 }

--- a/server/pkg/api/public_memory_share.go
+++ b/server/pkg/api/public_memory_share.go
@@ -58,6 +58,18 @@ func (h *PublicMemoryShareHandler) GetFile(c *gin.Context) {
 	h.getFileForType(c, ente.FILE)
 }
 
+// GetThumbnailURLV3 returns the thumbnail URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *PublicMemoryShareHandler) GetThumbnailURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.THUMBNAIL)
+	writeFileURLV3(c, url, err)
+}
+
+// GetFileURLV3 returns the file URL and reserves HTTP 404 for an unavailable endpoint.
+func (h *PublicMemoryShareHandler) GetFileURLV3(c *gin.Context) {
+	url, err := h.getFileURL(c, ente.FILE)
+	writeFileURLV3(c, url, err)
+}
+
 // GetFileData returns HLS playlist data for video streaming
 func (h *PublicMemoryShareHandler) GetFileData(c *gin.Context) {
 	var req fileData.GetFileData
@@ -113,19 +125,25 @@ func (h *PublicMemoryShareHandler) GetPreviewURL(c *gin.Context) {
 }
 
 func (h *PublicMemoryShareHandler) getFileForType(c *gin.Context, objType ente.ObjectType) {
+	url, err := h.getFileURL(c, objType)
+	if err != nil {
+		handler.Error(c, stacktrace.Propagate(err, "failed to get file URL"))
+		return
+	}
+	c.Redirect(http.StatusTemporaryRedirect, url)
+}
+
+func (h *PublicMemoryShareHandler) getFileURL(c *gin.Context, objType ente.ObjectType) (string, error) {
 	fileID, err := strconv.ParseInt(c.Param("fileID"), 10, 64)
 	if err != nil {
-		handler.Error(c, stacktrace.Propagate(ente.ErrBadRequest, "invalid file ID"))
-		return
+		return "", stacktrace.Propagate(ente.ErrBadRequest, "invalid file ID")
 	}
 
 	accessCtx := auth.MustGetMemoryShareAccessContext(c)
 
 	url, err := h.PublicCtrl.GetPublicFileURL(c, accessCtx.ShareID, fileID, objType)
 	if err != nil {
-		handler.Error(c, stacktrace.Propagate(err, "failed to get file URL"))
-		return
+		return "", stacktrace.Propagate(err, "")
 	}
-
-	c.Redirect(http.StatusTemporaryRedirect, url)
+	return url, nil
 }


### PR DESCRIPTION
- Add v3 URL resolvers for public collections, memory shares, cast, and file links.
- Reserve HTTP 404 for unavailable routes by returning 400 `NOT_FOUND` for missing accessible storage objects.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh docker`