### PR TITLE
[mob][photos] Resolve current user avatars

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -767,7 +767,10 @@ class CollectionsService {
     return favorites + pinned + rest;
   }
 
-  User getFileOwner(int userID, int? collectionID) {
+  User resolveUserIdentity(int userID, int? collectionID) {
+    if (userID == _config.getUserID()) {
+      return User(id: userID, email: _config.getEmail()!);
+    }
     if (_cachedUserIdToUser.containsKey(userID)) {
       return _cachedUserIdToUser[userID]!;
     }

--- a/mobile/apps/photos/lib/services/social_notification_coordinator.dart
+++ b/mobile/apps/photos/lib/services/social_notification_coordinator.dart
@@ -367,7 +367,7 @@ class SocialNotificationCoordinator {
         fallback: anonID,
       );
     }
-    final user = _collectionsService.getFileOwner(
+    final user = _collectionsService.resolveUserIdentity(
       userID,
       candidate.collectionID,
     );

--- a/mobile/apps/photos/lib/ui/social/comment_likes_bottom_sheet.dart
+++ b/mobile/apps/photos/lib/ui/social/comment_likes_bottom_sheet.dart
@@ -98,7 +98,7 @@ class _CommentLikesBottomSheetState extends State<CommentLikesBottomSheet> {
       );
     }
 
-    return CollectionsService.instance.getFileOwner(
+    return CollectionsService.instance.resolveUserIdentity(
       reaction.userID,
       widget.collectionID,
     );

--- a/mobile/apps/photos/lib/ui/social/comments_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/comments_screen.dart
@@ -554,7 +554,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       comment: comment,
       anonDisplayNames: _anonDisplayNames,
       registeredUserResolver: (userID) => CollectionsService.instance
-          .getFileOwner(userID, _selectedCollectionID),
+          .resolveUserIdentity(userID, _selectedCollectionID),
     );
   }
 

--- a/mobile/apps/photos/lib/ui/social/likes_bottom_sheet.dart
+++ b/mobile/apps/photos/lib/ui/social/likes_bottom_sheet.dart
@@ -383,7 +383,7 @@ class _LikesList extends StatelessWidget {
       );
     }
 
-    return CollectionsService.instance.getFileOwner(
+    return CollectionsService.instance.resolveUserIdentity(
       reaction.userID,
       selectedCollectionID,
     );

--- a/mobile/apps/photos/lib/ui/social/widgets/feed_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/feed_item_widget.dart
@@ -481,7 +481,7 @@ class _StackedAvatars extends StatelessWidget {
         );
       } else {
         // Get user from collections service
-        final user = CollectionsService.instance.getFileOwner(
+        final user = CollectionsService.instance.resolveUserIdentity(
           userID,
           feedItem.collectionID,
         );
@@ -709,7 +709,7 @@ class _FeedTextContent extends StatelessWidget {
       return User(id: userID, email: "$anonID@unknown.com", name: displayName);
     }
 
-    return CollectionsService.instance.getFileOwner(
+    return CollectionsService.instance.resolveUserIdentity(
       userID,
       feedItem.collectionID,
     );

--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -189,7 +189,7 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
           comment: latestComment,
           anonDisplayNames: anonDisplayNames,
           registeredUserResolver: (userID) => CollectionsService.instance
-              .getFileOwner(userID, latestComment.collectionID),
+              .resolveUserIdentity(userID, latestComment.collectionID),
         );
       }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -220,7 +220,7 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       }
       if (shouldShowOwnerAvatar) {
         if (!widget.file.isOwner) {
-          final owner = CollectionsService.instance.getFileOwner(
+          final owner = CollectionsService.instance.resolveUserIdentity(
             widget.file.ownerID!,
             widget.file.collectionID,
           );

--- a/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/added_by_widget.dart
@@ -28,7 +28,7 @@ class AddedByWidget extends StatelessWidget {
       if (file.ownerID == null) {
         return const SizedBox.shrink();
       }
-      final fileOwner = CollectionsService.instance.getFileOwner(
+      final fileOwner = CollectionsService.instance.resolveUserIdentity(
         file.ownerID!,
         file.collectionID,
       );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/gallery_file_widget.dart
@@ -106,7 +106,7 @@ class _GalleryFileWidgetState extends State<GalleryFileWidget> {
         widget.file.isUploaded &&
         widget.file.ownerID != null &&
         widget.file.ownerID != widget.currentUserID) {
-      final owner = CollectionsService.instance.getFileOwner(
+      final owner = CollectionsService.instance.resolveUserIdentity(
         widget.file.ownerID!,
         widget.file.collectionID,
       );

--- a/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
+++ b/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
@@ -377,7 +377,7 @@ List<ContactsFilter> _curateContactsFilter(List<EnteFile> files) {
   }
 
   for (int id in ownerIdToOccurrence.keys) {
-    final user = CollectionsService.instance.getFileOwner(id, null);
+    final user = CollectionsService.instance.resolveUserIdentity(id, null);
     contactsFilters.add(
       ContactsFilter(user: user, occurrence: ownerIdToOccurrence[id]!),
     );


### PR DESCRIPTION
## What changed

- Rename `getFileOwner()` to `resolveUserIdentity()` across all callers.
- Return the configured account identity immediately when resolving the logged-in user.

## Why

The method resolves commenters, likers, collection participants, and file owners, so its old name was misleading. Owned collection records can also omit the current user's email, causing avatar resolution to fall back to "Someone" and preventing lookup of a linked person face.


