### PR TITLE
[web] Use v3 URLs for public file downloads

### DIFF
--- a/web/apps/albums/src/public-album/download/services/download-manager.ts
+++ b/web/apps/albums/src/public-album/download/services/download-manager.ts
@@ -7,9 +7,9 @@ import {
     playableVideoURL,
     renderableImageBlob,
 } from "@/public-album/media/processing/convert";
+import { fetchPublicCollectionFile } from "ente-base/file-download";
 import {
     authenticatedPublicAlbumsRequestHeaders,
-    publicRequestHeaders,
     retryEnsuringHTTPOk,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
@@ -147,18 +147,9 @@ const publicAlbums_downloadThumbnail = async (
 ) => {
     const customOrigin = await customAPIOrigin();
 
-    const getThumbnail = async () => {
+    const getThumbnail = () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken, accessTokenJWT } = credentials;
-            const params = new URLSearchParams({
-                accessToken,
-                ...(accessTokenJWT && { accessTokenJWT }),
-            });
-            return fetch(
-                `${customOrigin}/public-collection/files/preview/${file.id}?${params.toString()}`,
-                { headers: publicRequestHeaders() },
-            );
+            return fetchPublicCollectionFile(file.id, "thumbnail", credentials);
         } else {
             return fetch(
                 `https://public-albums.ente.com/preview/?fileID=${file.id}`,
@@ -182,15 +173,7 @@ const publicAlbums_downloadFile = async (
 
     const getFile = () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken, accessTokenJWT } = credentials;
-            const params = new URLSearchParams({
-                accessToken,
-                ...(accessTokenJWT && { accessTokenJWT }),
-            });
-            return fetch(
-                `${customOrigin}/public-collection/files/download/${file.id}?${params.toString()}`,
-            );
+            return fetchPublicCollectionFile(file.id, "file", credentials);
         } else {
             return fetch(
                 `https://public-albums.ente.com/download/?fileID=${file.id}`,

--- a/web/apps/albums/src/public-album/media/thumbnails/thumbnail-manager.ts
+++ b/web/apps/albums/src/public-album/media/thumbnails/thumbnail-manager.ts
@@ -4,9 +4,9 @@ import {
     setPublicAlbumsCredentials,
 } from "@/public-album/data/auth/public-link-credentials";
 import { blobCache, type BlobCache } from "ente-base/blob-cache";
+import { fetchPublicCollectionFile } from "ente-base/file-download";
 import {
     authenticatedPublicAlbumsRequestHeaders,
-    publicRequestHeaders,
     retryEnsuringHTTPOk,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
@@ -136,17 +136,9 @@ const publicAlbums_downloadThumbnail = async (
 ) => {
     const customOrigin = await customAPIOrigin();
 
-    const getThumbnail = async () => {
+    const getThumbnail = () => {
         if (customOrigin) {
-            const { accessToken, accessTokenJWT } = credentials;
-            const params = new URLSearchParams({
-                accessToken,
-                ...(accessTokenJWT && { accessTokenJWT }),
-            });
-            return fetch(
-                `${customOrigin}/public-collection/files/preview/${file.id}?${params.toString()}`,
-                { headers: publicRequestHeaders() },
-            );
+            return fetchPublicCollectionFile(file.id, "thumbnail", credentials);
         } else {
             return fetch(
                 `https://public-albums.ente.com/preview/?fileID=${file.id}`,

--- a/web/apps/cast/src/services/render.ts
+++ b/web/apps/cast/src/services/render.ts
@@ -1,6 +1,7 @@
 import type { CastData } from "@/services/cast-data";
 import { detectMediaMIMEType } from "@/services/detect-type";
 import { decryptStreamBytes } from "ente-base/crypto";
+import { fetchCastFile } from "ente-base/file-download";
 import { nameAndExtension } from "ente-base/file-name";
 import { ensureOk, isHTTP401Error, publicRequestHeaders } from "ente-base/http";
 import log from "ente-base/log";
@@ -251,14 +252,11 @@ const downloadFile = async (
 
     const getFile = () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const params = new URLSearchParams({ castToken });
-            const baseURL = shouldUseThumbnail
-                ? `${customOrigin}/cast/files/preview/${file.id}`
-                : `${customOrigin}/cast/files/download/${file.id}`;
-            return fetch(`${baseURL}?${params.toString()}`, {
-                headers: publicRequestHeaders(),
-            });
+            return fetchCastFile(
+                file.id,
+                shouldUseThumbnail ? "thumbnail" : "file",
+                castToken,
+            );
         } else {
             const url = shouldUseThumbnail
                 ? `https://cast-albums.ente.com/preview/?fileID=${file.id}`

--- a/web/apps/share/src/services/collection-share.ts
+++ b/web/apps/share/src/services/collection-share.ts
@@ -4,6 +4,7 @@ import {
     decryptStreamBytes,
     deriveKey,
 } from "ente-base/crypto";
+import { fetchPublicCollectionFile } from "ente-base/file-download";
 import {
     authenticatedPublicAlbumsDeviceLimitRequestHeaders,
     authenticatedPublicAlbumsInfoRequestHeaders,
@@ -12,7 +13,7 @@ import {
     linkDeviceTokenFromResponse,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
-import { apiOrigin, apiURL } from "ente-base/origins";
+import { apiURL } from "ente-base/origins";
 import {
     decryptRemoteCollection,
     RemoteCollection,
@@ -351,10 +352,11 @@ export const downloadPublicCollectionFile = async (
     fileDecryptionHeader: string,
     onProgress?: (progress: DownloadProgress) => void,
 ): Promise<void> => {
-    const url = `${await apiOrigin()}/public-collection/files/download/${fileID}`;
-    const response = await fetch(url, {
-        headers: authenticatedPublicAlbumsRequestHeaders(credentials),
-    });
+    const response = await fetchPublicCollectionFile(
+        fileID,
+        "file",
+        credentials,
+    );
     ensureOk(response);
 
     const totalHeader = response.headers.get("content-length");

--- a/web/apps/share/src/services/file-share.ts
+++ b/web/apps/share/src/services/file-share.ts
@@ -7,6 +7,7 @@ import {
     fromHex,
     toB64,
 } from "ente-base/crypto";
+import { fetchFileLinkFile } from "ente-base/file-download";
 import {
     linkDeviceTokenFromResponse,
     linkDeviceTokenRequestHeader,
@@ -433,12 +434,8 @@ export const downloadFile = async (
     fileDecryptionHeader?: string,
     fileNonce?: string,
 ): Promise<void> => {
-    const url = `${await apiOrigin()}/file-link/file`;
-
     // Fetch the encrypted file from the server
-    const response = await fetch(url, {
-        headers: { "X-Auth-Access-Token": accessToken },
-    });
+    const response = await fetchFileLinkFile(accessToken);
 
     if (!response.ok) {
         if (await isDeviceLimitExceededResponse(response)) {

--- a/web/packages/base/file-download.ts
+++ b/web/packages/base/file-download.ts
@@ -1,34 +1,154 @@
 import { z } from "zod";
 import {
+    authenticatedPublicAlbumsRequestHeaders,
     authenticatedRequestHeaders,
     ensureOk,
     publicRequestHeaders,
+    type PublicAlbumsCredentials,
 } from "./http";
-import { apiURL } from "./origins";
+import { apiURL, customAPIOrigin } from "./origins";
+import {
+    authenticatedPublicMemoryRequestHeaders,
+    type PublicMemoryCredentials,
+} from "./public-memory";
 import { ensureAuthToken } from "./token";
 
 const FileURLResponse = z.object({ url: z.string() });
 const V3_RETRY_DELAY_MS = 60 * 60 * 1000;
 let v3RetryAfter = 0;
 
-export const fetchFile = async (fileID: number, kind: "file" | "thumbnail") => {
-    if (v3RetryAfter <= Date.now()) {
-        const path = kind == "file" ? "download" : "thumbnail";
-        const res = await fetch(await apiURL(`/files/${path}/v3/${fileID}`), {
-            headers: await authenticatedRequestHeaders(),
-        });
-        if (res.status !== 404) {
-            ensureOk(res);
-            const { url } = FileURLResponse.parse(await res.json());
-            return fetch(url);
-        }
+const tryFetchFileUsingV3 = async (
+    path: string,
+    headers: HeadersInit,
+): Promise<Response | undefined> => {
+    if (v3RetryAfter > Date.now()) {
+        return undefined;
+    }
+
+    const response = await fetch(await apiURL(path), { headers });
+    if (response.status === 404) {
         v3RetryAfter = Date.now() + V3_RETRY_DELAY_MS;
+        return undefined;
+    }
+
+    ensureOk(response);
+    const { url } = FileURLResponse.parse(await response.json());
+    return fetch(url);
+};
+
+type FileKind = "file" | "thumbnail";
+
+const filePath = (kind: FileKind) =>
+    kind == "file" ? "download" : "thumbnail";
+
+const legacyFilePath = (kind: FileKind) =>
+    kind == "file" ? "download" : "preview";
+
+export const fetchFile = async (fileID: number, kind: FileKind) => {
+    const response = await tryFetchFileUsingV3(
+        `/files/${filePath(kind)}/v3/${fileID}`,
+        await authenticatedRequestHeaders(),
+    );
+    if (response) {
+        return response;
     }
 
     // migration : 3 aug 2026
     const token = await ensureAuthToken();
-    const path = kind == "file" ? "download" : "preview";
-    return fetch(await apiURL(`/files/${path}/${fileID}`, { token }), {
-        headers: publicRequestHeaders(),
+    return fetch(
+        await apiURL(`/files/${legacyFilePath(kind)}/${fileID}`, { token }),
+        { headers: publicRequestHeaders() },
+    );
+};
+
+export const fetchPublicCollectionFile = async (
+    fileID: number,
+    kind: FileKind,
+    credentials: PublicAlbumsCredentials,
+) => {
+    const response = await tryFetchFileUsingV3(
+        `/public-collection/files/${filePath(kind)}/v3/${fileID}`,
+        authenticatedPublicAlbumsRequestHeaders(credentials),
+    );
+    if (response) {
+        return response;
+    }
+
+    const path = `/public-collection/files/${legacyFilePath(kind)}/${fileID}`;
+    if (await customAPIOrigin()) {
+        const { accessToken, accessTokenJWT } = credentials;
+        return fetch(
+            await apiURL(path, {
+                accessToken,
+                ...(accessTokenJWT && { accessTokenJWT }),
+            }),
+            kind == "thumbnail"
+                ? { headers: publicRequestHeaders() }
+                : undefined,
+        );
+    }
+    return fetch(await apiURL(path), {
+        headers: authenticatedPublicAlbumsRequestHeaders(credentials),
+    });
+};
+
+export const fetchPublicMemoryFile = async (
+    fileID: number,
+    kind: FileKind,
+    credentials: PublicMemoryCredentials,
+) => {
+    const response = await tryFetchFileUsingV3(
+        `/public-memory/files/${filePath(kind)}/v3/${fileID}`,
+        authenticatedPublicMemoryRequestHeaders(credentials),
+    );
+    if (response) {
+        return response;
+    }
+
+    const path = `/public-memory/files/${legacyFilePath(kind)}/${fileID}`;
+    if (await customAPIOrigin()) {
+        return fetch(
+            await apiURL(path, { accessToken: credentials.accessToken }),
+            kind == "thumbnail"
+                ? { headers: publicRequestHeaders() }
+                : undefined,
+        );
+    }
+    return fetch(await apiURL(path), {
+        headers: authenticatedPublicMemoryRequestHeaders(credentials),
+    });
+};
+
+export const fetchCastFile = async (
+    fileID: number,
+    kind: FileKind,
+    castToken: string,
+) => {
+    const response = await tryFetchFileUsingV3(
+        `/cast/files/${filePath(kind)}/v3/${fileID}`,
+        { ...publicRequestHeaders(), "X-Cast-Access-Token": castToken },
+    );
+    if (response) {
+        return response;
+    }
+
+    return fetch(
+        await apiURL(`/cast/files/${legacyFilePath(kind)}/${fileID}`, {
+            castToken,
+        }),
+        { headers: publicRequestHeaders() },
+    );
+};
+
+export const fetchFileLinkFile = async (accessToken: string) => {
+    const response = await tryFetchFileUsingV3("/file-link/file/v3", {
+        "X-Auth-Access-Token": accessToken,
+    });
+    if (response) {
+        return response;
+    }
+
+    return fetch(await apiURL("/file-link/file"), {
+        headers: { "X-Auth-Access-Token": accessToken },
     });
 };

--- a/web/packages/gallery/services/download.ts
+++ b/web/packages/gallery/services/download.ts
@@ -1,16 +1,16 @@
-import { fetchFile } from "ente-base/file-download";
+import {
+    fetchFile,
+    fetchPublicCollectionFile,
+    fetchPublicMemoryFile,
+} from "ente-base/file-download";
 import {
     authenticatedPublicAlbumsRequestHeaders,
     authenticatedRequestHeaders,
-    publicRequestHeaders,
     retryEnsuringHTTPOk,
     type PublicAlbumsCredentials,
 } from "ente-base/http";
-import { apiURL, customAPIOrigin } from "ente-base/origins";
-import {
-    authenticatedPublicMemoryRequestHeaders,
-    type PublicMemoryCredentials,
-} from "ente-base/public-memory";
+import { customAPIOrigin } from "ente-base/origins";
+import type { PublicMemoryCredentials } from "ente-base/public-memory";
 import type { EnteFile } from "ente-media/file";
 import { playableVideoURL, renderableImageBlob } from "./convert";
 import {
@@ -233,8 +233,7 @@ const photos_downloadFile = async (
     //
     // Older Museum versions redirect from the legacy endpoint. Browsers
     // preserve request headers across that redirect, so the legacy fallback
-    // has to put the token in the query string instead. Public share routes
-    // still use their legacy query credentials for the same reason.
+    // has to put the token in the query string instead.
     //
     // Ente's own interactive requests use a proxy instead of directly
     // connecting to object storage.
@@ -279,18 +278,9 @@ const publicAlbums_downloadThumbnail = async (
 ) => {
     const customOrigin = await customAPIOrigin();
 
-    const getThumbnail = async () => {
+    const getThumbnail = () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken, accessTokenJWT } = credentials;
-            const params = new URLSearchParams({
-                accessToken,
-                ...(accessTokenJWT && { accessTokenJWT }),
-            });
-            return fetch(
-                `${customOrigin}/public-collection/files/preview/${file.id}?${params.toString()}`,
-                { headers: publicRequestHeaders() },
-            );
+            return fetchPublicCollectionFile(file.id, "thumbnail", credentials);
         } else {
             return fetch(
                 `https://public-albums.ente.com/preview/?fileID=${file.id}`,
@@ -314,15 +304,7 @@ const publicAlbums_downloadFile = async (
 
     const getFile = () => {
         if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken, accessTokenJWT } = credentials;
-            const params = new URLSearchParams({
-                accessToken,
-                ...(accessTokenJWT && { accessTokenJWT }),
-            });
-            return fetch(
-                `${customOrigin}/public-collection/files/download/${file.id}?${params.toString()}`,
-            );
+            return fetchPublicCollectionFile(file.id, "file", credentials);
         } else {
             return fetch(
                 `https://public-albums.ente.com/download/?fileID=${file.id}`,
@@ -345,27 +327,8 @@ const publicMemory_downloadThumbnail = async (
     file: EnteFile,
     credentials: PublicMemoryCredentials,
 ) => {
-    const customOrigin = await customAPIOrigin();
-
-    const getThumbnail = async () => {
-        if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken } = credentials;
-            const params = new URLSearchParams({ accessToken });
-            return fetch(
-                `${customOrigin}/public-memory/files/preview/${file.id}?${params.toString()}`,
-                { headers: publicRequestHeaders() },
-            );
-        } else {
-            return fetch(
-                await apiURL(`/public-memory/files/preview/${file.id}`),
-                {
-                    headers:
-                        authenticatedPublicMemoryRequestHeaders(credentials),
-                },
-            );
-        }
-    };
+    const getThumbnail = () =>
+        fetchPublicMemoryFile(file.id, "thumbnail", credentials);
 
     const res = await retryEnsuringHTTPOk(getThumbnail);
     return new Uint8Array(await res.arrayBuffer());
@@ -375,26 +338,7 @@ const publicMemory_downloadFile = async (
     file: EnteFile,
     credentials: PublicMemoryCredentials,
 ) => {
-    const customOrigin = await customAPIOrigin();
-
-    const getFile = async () => {
-        if (customOrigin) {
-            // See: [Note: Passing credentials for self-hosted file fetches]
-            const { accessToken } = credentials;
-            const params = new URLSearchParams({ accessToken });
-            return fetch(
-                `${customOrigin}/public-memory/files/download/${file.id}?${params.toString()}`,
-            );
-        } else {
-            return fetch(
-                await apiURL(`/public-memory/files/download/${file.id}`),
-                {
-                    headers:
-                        authenticatedPublicMemoryRequestHeaders(credentials),
-                },
-            );
-        }
-    };
+    const getFile = () => fetchPublicMemoryFile(file.id, "file", credentials);
 
     return retryEnsuringHTTPOk(getFile);
 };


### PR DESCRIPTION
- Resolve public collection, memory, cast, and file-link downloads through the v3 URL endpoints.
- Retain worker-backed production paths and the old-server fallback.

Validation: `npm ci`, `npm audit --audit-level critical`, `npm run build:wasm`, `npm run build:space-wasm`, `npm run lint`, `npm test`