### PR TITLE
[mobile][photos] Compute ML index status from indexer's own eligibility logic

### DIFF
--- a/mobile/apps/photos/lib/db/ml/base.dart
+++ b/mobile/apps/photos/lib/db/ml/base.dart
@@ -131,4 +131,6 @@ abstract class IMLDataDB<T> {
   Future<Map<int, int>> petIndexedFileIds({int minimumMlVersion});
   Future<int> getPetIndexedFileCount({int minimumMlVersion});
   Future<void> deletePetDataForFiles(List<int> fileIDs);
+
+  Future<Set<int>> getFullyIndexedFileIds({required bool includePets});
 }

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -2487,6 +2487,22 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
   }
 
   @override
+  Future<Set<int>> getFullyIndexedFileIds({required bool includePets}) async {
+    final db = await asyncDB;
+    String query =
+        'SELECT $fileIDColumn FROM $facesTable WHERE $mlVersionColumn >= $faceMlVersion '
+        'INTERSECT '
+        'SELECT $fileIDColumn FROM $clipTable WHERE $mlVersionColumn >= $clipMlVersion';
+    if (includePets) {
+      query +=
+          ' INTERSECT '
+          'SELECT $fileIDColumn FROM $petFacesTable WHERE $mlVersionColumn >= $petMlVersion';
+    }
+    final List<Map<String, dynamic>> maps = await db.getAll(query);
+    return {for (final map in maps) map[fileIDColumn] as int};
+  }
+
+  @override
   Future<void> deletePetDataForFiles(List<int> fileIDs) async {
     if (fileIDs.isEmpty) return;
     final db = await asyncDB;

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -1,5 +1,5 @@
 import "dart:io" show File, Platform;
-import "dart:math" as math show min, max;
+import "dart:math" as math show min;
 
 import "package:dio/dio.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
@@ -98,32 +98,73 @@ class _OnlineMLIndexingCandidates {
   });
 }
 
+/// Counts indexing progress using the same eligibility predicates as the
+/// indexing candidate enumeration below, so the shown number always matches
+/// what the indexer would actually process.
 Future<IndexStatus> getIndexStatus() async {
   try {
-    final MLMode mode = isLocalGalleryMode
-        ? MLMode.localGallery
-        : MLMode.enteGallery;
-    final mlDataDB = mode == MLMode.localGallery
+    final bool localGallery = isLocalGalleryMode;
+    final mlDataDB = localGallery
         ? MLDataDB.localGalleryInstance
         : MLDataDB.instance;
-    final int indexableFiles = await _getIndexableFileCount(mode: mode);
-    final int facesIndexedFiles = await mlDataDB.getFaceIndexedFileCount();
-    final int clipIndexedFiles = await mlDataDB.getClipIndexedFileCount();
-    int indexedFiles = math.min(facesIndexedFiles, clipIndexedFiles);
-    if (flagService.petEnabled &&
+    final bool petActive =
+        flagService.petEnabled &&
         localSettings.petRecognitionEnabled &&
-        localSettings.isMLLocalIndexingEnabled) {
-      final int petIndexedFiles = await mlDataDB.getPetIndexedFileCount();
-      indexedFiles = math.min(indexedFiles, petIndexedFiles);
+        (localGallery || localSettings.isMLLocalIndexingEnabled);
+    final Set<int> indexedFileKeys = await mlDataDB.getFullyIndexedFileIds(
+      includePets: petActive,
+    );
+    final enteFiles = await SearchService.instance.getAllFilesForSearch();
+    final Set<int> seenKeys = {};
+    int total = 0;
+    int indexed = 0;
+    if (localGallery) {
+      final localIds = <String>[];
+      for (final EnteFile enteFile in enteFiles) {
+        if (enteFile.fileType == FileType.other) {
+          continue;
+        }
+        if ((enteFile.localID ?? '').isEmpty ||
+            (enteFile.uploadedFileID != null &&
+                enteFile.uploadedFileID != -1)) {
+          continue;
+        }
+        localIds.add(enteFile.localID!);
+      }
+      final localIdToIntId = await OfflineFilesDB.instance.ensureLocalIntIds(
+        localIds,
+      );
+      for (final localId in localIds) {
+        final localIntId = localIdToIntId[localId];
+        if (localIntId == null || !seenKeys.add(localIntId)) {
+          continue;
+        }
+        total++;
+        if (indexedFileKeys.contains(localIntId)) {
+          indexed++;
+        }
+      }
+    } else {
+      final hiddenFiles = await SearchService.instance.getHiddenFiles();
+      for (final EnteFile enteFile in enteFiles.followedBy(hiddenFiles)) {
+        if (enteFile.skipIndex) {
+          continue;
+        }
+        final id = enteFile.uploadedFileID;
+        if (id == null || id == -1 || !seenKeys.add(id)) {
+          continue;
+        }
+        total++;
+        if (indexedFileKeys.contains(id)) {
+          indexed++;
+        }
+      }
     }
-
-    final showIndexedFiles = math.min(indexedFiles, indexableFiles);
-    final showPendingFiles = math.max(indexableFiles - indexedFiles, 0);
     final hasWifiEnabled = await canUseHighBandwidth();
     _logger.info(
-      "Shown IndexStatus: indexedFiles: $showIndexedFiles, pendingFiles: $showPendingFiles, hasWifiEnabled: $hasWifiEnabled, ifOffline: $isLocalGalleryMode. Real values: indexedFiles: $indexedFiles (faces: $facesIndexedFiles, clip: $clipIndexedFiles), indexableFiles: $indexableFiles",
+      "IndexStatus: $indexed indexed of $total total (localGallery: $localGallery, petActive: $petActive, hasWifiEnabled: $hasWifiEnabled)",
     );
-    return IndexStatus(showIndexedFiles, showPendingFiles, hasWifiEnabled);
+    return IndexStatus(indexed, total - indexed, hasWifiEnabled);
   } catch (e, s) {
     _logger.severe('Error getting ML status', e, s);
     rethrow;
@@ -672,21 +713,6 @@ bool _shouldDiscardRemoteEmbedding(FileDataEntity fileML) {
 
 Future<int> getIndexableFileCount() async {
   return FilesDB.instance.remoteFileCount();
-}
-
-Future<int> _getIndexableFileCount({required MLMode mode}) async {
-  if (mode == MLMode.localGallery) {
-    final files = await SearchService.instance.getAllFilesForSearch();
-    return files
-        .where(
-          (file) =>
-              (file.localID ?? '').isNotEmpty &&
-              (file.uploadedFileID == null || file.uploadedFileID == -1) &&
-              file.fileType != FileType.other,
-        )
-        .length;
-  }
-  return getIndexableFileCount();
 }
 
 Future<String> getImagePathForML(EnteFile enteFile) async {


### PR DESCRIPTION
## What

Rewrites `getIndexStatus()` so the ML progress shown in the ML settings page and the ML banner matches what the indexer would actually process.

## Why

The status was previously derived from per-model counts (`min(faces, clip, pets)` against `remoteFileCount()`), which uses different eligibility logic than the indexer's candidate enumeration. The shown percentage could disagree with actual indexing completion and needed clamping to 0/100.

## How

- New `MLDataDB.getFullyIndexedFileIds()`: a single version-filtered `INTERSECT` query across the faces, clip, and (when pet indexing is active) pet tables — the SQL equivalent of the `_shouldRunIndexing` version checks.
- `getIndexStatus()` walks the cached `getAllFilesForSearch()` list (plus hidden files in online mode) applying the same eligibility predicates as the candidate enumeration (`skipIndex`, uploaded-ID checks, dedup by key; local-gallery filters and local int ID mapping), counting total and fully indexed files.
- No UI changes: the existing 10-second visible-only polling now gets a correct and cheaper answer (one indexed-set query plus an in-memory pass, instead of three count queries with mismatched semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)