### PR TITLE
[mobile] Use v3 file URL endpoints

### DIFF
--- a/mobile/apps/locker/lib/services/files/download/file_downloader.dart
+++ b/mobile/apps/locker/lib/services/files/download/file_downloader.dart
@@ -7,6 +7,7 @@ import 'package:ente_network/network.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:locker/services/configuration.dart';
 import 'package:locker/services/db/locker_db.dart';
+import 'package:locker/services/files/download/file_url.dart';
 import 'package:locker/services/files/download/models/task.dart';
 import 'package:locker/services/files/download/service_locator.dart';
 import 'package:locker/services/files/offline/offline_file_storage.dart';
@@ -64,12 +65,19 @@ Future<File> ensureEncryptedOfflineCopy(
     } else {
       late final Response response;
       try {
+        final headers = <String, dynamic>{
+          "X-Auth-Token": Configuration.instance.getToken(),
+        };
+        final signedUrl = await FileUrl.tryGetV3Url(
+          Network.instance.enteDio,
+          file.uploadedFileID!,
+          FileUrlType.download,
+          headers: headers,
+        );
         response = await Network.instance.getDio().download(
-          file.downloadUrl,
+          signedUrl ?? file.downloadUrl,
           tempEncryptedFilePath,
-          options: Options(
-            headers: {"X-Auth-Token": Configuration.instance.getToken()},
-          ),
+          options: Options(headers: signedUrl == null ? headers : null),
           onReceiveProgress: progressCallback,
         );
       } catch (e) {
@@ -265,12 +273,19 @@ Future<File?> downloadAndDecrypt(
           return null;
         }
       } else {
+        final headers = <String, dynamic>{
+          "X-Auth-Token": Configuration.instance.getToken(),
+        };
+        final signedUrl = await FileUrl.tryGetV3Url(
+          Network.instance.enteDio,
+          file.uploadedFileID!,
+          FileUrlType.download,
+          headers: headers,
+        );
         final response = await Network.instance.getDio().download(
-          file.downloadUrl,
+          signedUrl ?? file.downloadUrl,
           tempEncryptedFilePath,
-          options: Options(
-            headers: {"X-Auth-Token": Configuration.instance.getToken()},
-          ),
+          options: Options(headers: signedUrl == null ? headers : null),
           onReceiveProgress: (a, b) {
             progressCallback?.call(a, b);
           },

--- a/mobile/apps/locker/lib/services/files/download/file_url.dart
+++ b/mobile/apps/locker/lib/services/files/download/file_url.dart
@@ -1,5 +1,9 @@
+import "package:dio/dio.dart";
 import "package:locker/core/constants.dart";
 import "package:locker/services/configuration.dart";
+
+const _v3RetryDelay = Duration(hours: 1);
+DateTime? _v3RetryAfter;
 
 enum FileUrlType {
   download,
@@ -10,7 +14,38 @@ enum FileUrlType {
 }
 
 class FileUrl {
-  static String getUrl(int fileID, FileUrlType type) {
+  static Future<String?> tryGetV3Url(
+    Dio dio,
+    int fileID,
+    FileUrlType type, {
+    required Map<String, dynamic> headers,
+    CancelToken? cancelToken,
+  }) async {
+    final usesWorker =
+        type != FileUrlType.directDownload &&
+        Configuration.instance.getHttpEndpoint() == kDefaultProductionEndpoint;
+    if (usesWorker || (_v3RetryAfter?.isAfter(DateTime.now()) ?? false)) {
+      return null;
+    }
+
+    final response = await dio.get<Map<String, dynamic>>(
+      _v3Path(fileID, type),
+      options: Options(
+        headers: headers,
+        validateStatus: (status) => status == 200 || status == 404,
+      ),
+      cancelToken: cancelToken,
+    );
+    if (response.statusCode == 404) {
+      // TODO(migration): Remove the legacy fallback once all supported Museum
+      // versions provide the v3 file URL endpoints. Started 4 Aug 2026.
+      _v3RetryAfter = DateTime.now().add(_v3RetryDelay);
+      return null;
+    }
+    return response.data!["url"] as String;
+  }
+
+  static String getLegacyUrl(int fileID, FileUrlType type) {
     final endpoint = Configuration.instance.getHttpEndpoint();
     final disableWorker = endpoint != kDefaultProductionEndpoint;
 
@@ -36,6 +71,20 @@ class FileUrl {
         return disableWorker
             ? "$endpoint/public-collection/files/preview/$fileID"
             : "https://public-albums.ente.com/preview/?fileID=$fileID";
+    }
+  }
+
+  static String _v3Path(int fileID, FileUrlType type) {
+    switch (type) {
+      case FileUrlType.download:
+      case FileUrlType.directDownload:
+        return "/files/download/v3/$fileID";
+      case FileUrlType.publicDownload:
+        return "/public-collection/files/download/v3/$fileID";
+      case FileUrlType.thumbnail:
+        return "/files/thumbnail/v3/$fileID";
+      case FileUrlType.publicThumbnail:
+        return "/public-collection/files/thumbnail/v3/$fileID";
     }
   }
 }

--- a/mobile/apps/locker/lib/services/files/download/manager.dart
+++ b/mobile/apps/locker/lib/services/files/download/manager.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:io";
 
 import "package:dio/dio.dart";
+import "package:ente_network/network.dart";
 import "package:locker/services/configuration.dart";
 import "package:locker/services/files/download/file_url.dart";
 import "package:locker/services/files/download/models/task.dart";
@@ -164,10 +165,19 @@ class DownloadManager {
       _logger.info(
         'Resuming download for ${task.filename} (${task.bytesDownloaded}/${task.totalBytes} bytes)',
       );
+      String? downloadUrl;
       for (int i = 0; i < totalChunks; i++) {
         if (existingChunks[i] || cancelToken.isCancelled) continue;
         _logger.info('Downloading chunk ${i + 1} of $totalChunks');
-        await _downloadChunk(task, basePath, i, totalChunks, cancelToken);
+        downloadUrl ??= await _resolveDownloadUrl(task.id, cancelToken);
+        await _downloadChunk(
+          task,
+          basePath,
+          i,
+          totalChunks,
+          cancelToken,
+          downloadUrl,
+        );
         existingChunks[i] = true;
       }
 
@@ -259,6 +269,7 @@ class DownloadManager {
     int chunkIndex,
     int totalChunks,
     CancelToken cancelToken,
+    String downloadUrl,
   ) async {
     final chunkPath = _getChunkPath(basePath, chunkIndex + 1);
     final startByte = chunkIndex * downloadChunkSize;
@@ -267,13 +278,10 @@ class DownloadManager {
         : (startByte + downloadChunkSize) - 1;
 
     await _dio.download(
-      FileUrl.getUrl(task.id, FileUrlType.directDownload),
+      downloadUrl,
       chunkPath,
       options: Options(
-        headers: {
-          "X-Auth-Token": Configuration.instance.getToken(),
-          "Range": "bytes=$startByte-$endByte",
-        },
+        headers: {HttpHeaders.rangeHeader: "bytes=$startByte-$endByte"},
       ),
       cancelToken: cancelToken,
       onReceiveProgress: (received, total) async {
@@ -289,6 +297,45 @@ class DownloadManager {
       bytesDownloaded: (chunkIndex) * downloadChunkSize + chunkFileSize,
     );
     _updateTask(task);
+  }
+
+  Future<String> _resolveDownloadUrl(
+    int fileID,
+    CancelToken cancelToken,
+  ) async {
+    final signedUrl = await FileUrl.tryGetV3Url(
+      Network.instance.enteDio,
+      fileID,
+      FileUrlType.directDownload,
+      headers: {"X-Auth-Token": Configuration.instance.getToken()},
+      cancelToken: cancelToken,
+    );
+    if (signedUrl != null) {
+      return signedUrl;
+    }
+
+    final response = await _dio.get<void>(
+      FileUrl.getLegacyUrl(fileID, FileUrlType.directDownload),
+      options: Options(
+        followRedirects: false,
+        receiveDataWhenStatusError: false,
+        headers: {"X-Auth-Token": Configuration.instance.getToken()},
+        validateStatus: (status) {
+          return status != null &&
+              status >= HttpStatus.multipleChoices &&
+              status < HttpStatus.badRequest;
+        },
+      ),
+      cancelToken: cancelToken,
+    );
+    final location = response.headers.value(HttpHeaders.locationHeader);
+    if (location == null || location.isEmpty) {
+      throw StateError(
+        'Missing redirect location for file $fileID '
+        '(status ${response.statusCode})',
+      );
+    }
+    return location;
   }
 
   Future<String> _combineChunks(String basePath, int totalChunks) async {

--- a/mobile/apps/locker/lib/services/files/sync/models/file.dart
+++ b/mobile/apps/locker/lib/services/files/sync/models/file.dart
@@ -77,7 +77,7 @@ class EnteFile {
   }
 
   String get downloadUrl =>
-      FileUrl.getUrl(uploadedFileID!, FileUrlType.download);
+      FileUrl.getLegacyUrl(uploadedFileID!, FileUrlType.download);
 
   String? get caption {
     return pubMagicMetadata.caption;

--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -146,7 +146,7 @@ class EnteFile {
   }
 
   String get downloadUrl =>
-      FileUrl.getUrl(uploadedFileID!, FileUrlType.download);
+      FileUrl.getLegacyUrl(uploadedFileID!, FileUrlType.download);
 
   String? get caption {
     return pubMagicMetadata?.caption;

--- a/mobile/apps/photos/lib/module/download/decrypt.dart
+++ b/mobile/apps/photos/lib/module/download/decrypt.dart
@@ -53,10 +53,23 @@ Future<File?> _downloadAndDecryptPublicFile(
     final headers = CollectionsService.instance.publicCollectionHeaders(
       file.collectionID!,
     );
+    final signedUrl = await FileUrl.tryGetV3Url(
+      NetworkClient.instance.enteDio,
+      file.uploadedFileID!,
+      FileUrlType.publicDownload,
+      headers: headers,
+    );
     final response = await NetworkClient.instance.downloadDio.download(
-      FileUrl.getUrl(file.uploadedFileID!, FileUrlType.publicDownload),
+      signedUrl ??
+          FileUrl.getLegacyUrl(
+            file.uploadedFileID!,
+            FileUrlType.publicDownload,
+          ),
       encryptedFilePath,
-      options: Options(headers: headers, responseType: ResponseType.bytes),
+      options: Options(
+        headers: signedUrl == null ? headers : null,
+        responseType: ResponseType.bytes,
+      ),
       onReceiveProgress: (received, total) {
         progressCallback?.call(received, total);
       },
@@ -147,12 +160,19 @@ Future<File?> downloadAndDecrypt(
         return null;
       }
     } else {
+      final headers = <String, dynamic>{
+        'X-Auth-Token': Configuration.instance.getToken(),
+      };
+      final signedUrl = await FileUrl.tryGetV3Url(
+        NetworkClient.instance.enteDio,
+        file.uploadedFileID!,
+        FileUrlType.download,
+        headers: headers,
+      );
       final response = await NetworkClient.instance.downloadDio.download(
-        file.downloadUrl,
+        signedUrl ?? file.downloadUrl,
         encryptedFilePath,
-        options: Options(
-          headers: {'X-Auth-Token': Configuration.instance.getToken()},
-        ),
+        options: Options(headers: signedUrl == null ? headers : null),
         onReceiveProgress: (received, total) {
           progressCallback?.call(received, total);
         },

--- a/mobile/apps/photos/lib/module/download/file_url.dart
+++ b/mobile/apps/photos/lib/module/download/file_url.dart
@@ -1,5 +1,9 @@
+import "package:dio/dio.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/service_locator.dart";
+
+const _v3RetryDelay = Duration(hours: 1);
+DateTime? _v3RetryAfter;
 
 enum FileUrlType {
   download,
@@ -10,7 +14,39 @@ enum FileUrlType {
 }
 
 class FileUrl {
-  static String getUrl(int fileID, FileUrlType type) {
+  static Future<String?> tryGetV3Url(
+    Dio dio,
+    int fileID,
+    FileUrlType type, {
+    required Map<String, dynamic> headers,
+    CancelToken? cancelToken,
+  }) async {
+    final usesWorker =
+        type != FileUrlType.directDownload &&
+        endpointConfig.endpoint == kDefaultProductionEndpoint &&
+        !flagService.disableCFWorker;
+    if (usesWorker || (_v3RetryAfter?.isAfter(DateTime.now()) ?? false)) {
+      return null;
+    }
+
+    final response = await dio.get<Map<String, dynamic>>(
+      _v3Path(fileID, type),
+      options: Options(
+        headers: headers,
+        validateStatus: (status) => status == 200 || status == 404,
+      ),
+      cancelToken: cancelToken,
+    );
+    if (response.statusCode == 404) {
+      // TODO(migration): Remove the legacy fallback once all supported Museum
+      // versions provide the v3 file URL endpoints. Started 4 Aug 2026.
+      _v3RetryAfter = DateTime.now().add(_v3RetryDelay);
+      return null;
+    }
+    return response.data!["url"] as String;
+  }
+
+  static String getLegacyUrl(int fileID, FileUrlType type) {
     final endpoint = endpointConfig.endpoint;
     final disableWorker =
         endpoint != kDefaultProductionEndpoint || flagService.disableCFWorker;
@@ -37,6 +73,20 @@ class FileUrl {
         return disableWorker
             ? "$endpoint/public-collection/files/preview/$fileID"
             : "https://public-albums.ente.com/preview/?fileID=$fileID";
+    }
+  }
+
+  static String _v3Path(int fileID, FileUrlType type) {
+    switch (type) {
+      case FileUrlType.download:
+      case FileUrlType.directDownload:
+        return "/files/download/v3/$fileID";
+      case FileUrlType.publicDownload:
+        return "/public-collection/files/download/v3/$fileID";
+      case FileUrlType.thumbnail:
+        return "/files/thumbnail/v3/$fileID";
+      case FileUrlType.publicThumbnail:
+        return "/public-collection/files/thumbnail/v3/$fileID";
     }
   }
 }

--- a/mobile/apps/photos/lib/module/download/manager.dart
+++ b/mobile/apps/photos/lib/module/download/manager.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "package:dio/dio.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/configuration.dart";
+import "package:photos/core/network/network.dart";
 
 import "package:photos/module/download/file_url.dart";
 import "package:photos/module/download/task.dart";
@@ -218,7 +219,7 @@ class DownloadManager {
           _logger.info('Download cancelled for ${task.filename}');
           break;
         }
-        downloadUrl ??= await _resolveDownloadRedirect(task.id, cancelToken);
+        downloadUrl ??= await _resolveDownloadUrl(task.id, cancelToken);
         await _downloadChunk(
           task,
           basePath,
@@ -361,12 +362,23 @@ class DownloadManager {
     _updateTask(task);
   }
 
-  Future<String> _resolveDownloadRedirect(
+  Future<String> _resolveDownloadUrl(
     int fileID,
     CancelToken cancelToken,
   ) async {
+    final signedUrl = await FileUrl.tryGetV3Url(
+      NetworkClient.instance.enteDio,
+      fileID,
+      FileUrlType.directDownload,
+      headers: {"X-Auth-Token": Configuration.instance.getToken()},
+      cancelToken: cancelToken,
+    );
+    if (signedUrl != null) {
+      return signedUrl;
+    }
+
     final response = await _dio.get<void>(
-      FileUrl.getUrl(fileID, FileUrlType.directDownload),
+      FileUrl.getLegacyUrl(fileID, FileUrlType.directDownload),
       options: Options(
         followRedirects: false,
         receiveDataWhenStatusError: false,

--- a/mobile/apps/photos/lib/module/download/thumbnail.dart
+++ b/mobile/apps/photos/lib/module/download/thumbnail.dart
@@ -308,15 +308,39 @@ Future<void> _downloadAndDecryptThumbnail(_ThumbnailDownload item) async {
       final headers = CollectionsService.instance.publicCollectionHeaders(
         file.collectionID!,
       );
+      final signedUrl = await FileUrl.tryGetV3Url(
+        NetworkClient.instance.enteDio,
+        file.uploadedFileID!,
+        FileUrlType.publicThumbnail,
+        headers: headers,
+      );
       encryptedThumbnail = (await NetworkClient.instance.downloadDio.get(
-        FileUrl.getUrl(file.uploadedFileID!, FileUrlType.publicThumbnail),
-        options: Options(headers: headers, responseType: ResponseType.bytes),
+        signedUrl ??
+            FileUrl.getLegacyUrl(
+              file.uploadedFileID!,
+              FileUrlType.publicThumbnail,
+            ),
+        options: Options(
+          headers: signedUrl == null ? headers : null,
+          responseType: ResponseType.bytes,
+        ),
       )).data;
     } else {
+      final headers = <String, dynamic>{
+        "X-Auth-Token": Configuration.instance.getToken(),
+      };
+      final signedUrl = await FileUrl.tryGetV3Url(
+        NetworkClient.instance.enteDio,
+        file.uploadedFileID!,
+        FileUrlType.thumbnail,
+        headers: headers,
+        cancelToken: item.cancelToken,
+      );
       encryptedThumbnail = (await NetworkClient.instance.downloadDio.get(
-        FileUrl.getUrl(file.uploadedFileID!, FileUrlType.thumbnail),
+        signedUrl ??
+            FileUrl.getLegacyUrl(file.uploadedFileID!, FileUrlType.thumbnail),
         options: Options(
-          headers: {"X-Auth-Token": Configuration.instance.getToken()},
+          headers: signedUrl == null ? headers : null,
           responseType: ResponseType.bytes,
         ),
         cancelToken: item.cancelToken,


### PR DESCRIPTION
- Resolve v3 download and thumbnail endpoints to signed URLs in Photos and Locker.
- Fall back to legacy endpoints for older Museum versions, retrying v3 after one hour.

Validation: mobile lint workflow commands and all Flutter workspace tests.