### PR TITLE
[cli] Use v3 file URL endpoints

### DIFF
--- a/cli/internal/api/files.go
+++ b/cli/internal/api/files.go
@@ -2,35 +2,73 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/ente/cli/utils/constants"
 	"github.com/spf13/viper"
-	"strconv"
-	"strings"
 )
 
-var (
-	downloadHost = "https://files.ente.com/?fileID="
-)
+const downloadHost = "https://files.ente.com/?fileID="
 
-func downloadUrl(fileID int64) string {
+type fileURLResponse struct {
+	URL string `json:"url"`
+}
+
+func useDownloadProxy() bool {
 	apiEndpoint := viper.GetString("endpoint.api")
-	if apiEndpoint == "" || strings.Compare(apiEndpoint, constants.EnteApiUrl) == 0 {
-		return downloadHost + strconv.FormatInt(fileID, 10)
+	return apiEndpoint == "" || apiEndpoint == constants.EnteApiUrl
+}
+
+func (c *Client) getFileURL(ctx context.Context, fileID int64) (string, error) {
+	result := fileURLResponse{}
+	r, err := c.restClient.R().
+		SetContext(ctx).
+		SetResult(&result).
+		Get(fmt.Sprintf("/files/download/v3/%d", fileID))
+	if err != nil {
+		return "", err
 	}
-	return apiEndpoint + "/files/download/" + strconv.FormatInt(fileID, 10)
+	if r.IsError() {
+		message := r.String()
+		if r.StatusCode() == http.StatusNotFound {
+			message = "file URL endpoint not found; please upgrade your Ente server and try again"
+		}
+		return "", &ApiError{
+			StatusCode: r.StatusCode(),
+			Message:    message,
+		}
+	}
+	return result.URL, nil
 }
 
 func (c *Client) DownloadFile(ctx context.Context, fileID int64, absolutePath string) error {
 	req := c.downloadClient.R().
 		SetContext(ctx).
 		SetOutput(absolutePath)
-	attachToken(req)
-	r, err := req.Get(downloadUrl(fileID))
+
+	var downloadURL string
+	if useDownloadProxy() {
+		downloadURL = downloadHost + strconv.FormatInt(fileID, 10)
+		attachToken(req)
+	} else {
+		var err error
+		downloadURL, err = c.getFileURL(ctx, fileID)
+		if err != nil {
+			return err
+		}
+	}
+
+	r, err := req.Get(downloadURL)
+	if err != nil {
+		return err
+	}
 	if r.IsError() {
 		return &ApiError{
 			StatusCode: r.StatusCode(),
 			Message:    r.String(),
 		}
 	}
-	return err
+	return nil
 }

--- a/rust/apps/cli/src/api/methods.rs
+++ b/rust/apps/cli/src/api/methods.rs
@@ -123,7 +123,7 @@ impl<'a> ApiMethods<'a> {
     async fn get_signed_file_url(&self, file_id: i64) -> Result<String> {
         let api = self.client.api();
         let response: GetFileUrlResponse = http::retry(|| async {
-            api.get(&format!("/files/download/v2/{file_id}"))
+            api.get(&format!("/files/download/v3/{file_id}"))
                 .send()
                 .await?
                 .error_for_code()
@@ -138,7 +138,7 @@ impl<'a> ApiMethods<'a> {
     async fn get_signed_thumbnail_url(&self, file_id: i64) -> Result<String> {
         let api = self.client.api();
         let response: GetThumbnailUrlResponse = http::retry(|| async {
-            api.get(&format!("/files/preview/v2/{file_id}"))
+            api.get(&format!("/files/thumbnail/v3/{file_id}"))
                 .send()
                 .await?
                 .error_for_code()
@@ -227,7 +227,7 @@ mod tests {
         let mut server = Server::new_async().await;
         let signed_url = format!("{}/object", server.url());
         let url_mock = server
-            .mock("GET", "/files/download/v2/12345")
+            .mock("GET", "/files/download/v3/12345")
             .match_header("x-auth-token", "token")
             .match_header("x-client-package", "io.ente.locker")
             .with_body(format!(r#"{{"url":"{signed_url}"}}"#))


### PR DESCRIPTION
Use v3 file URL endpoints in both CLIs. The Go CLI now resolves a signed URL for custom servers and suggests upgrading Museum when the endpoint returns 404; production proxy behavior is unchanged.