### PR TITLE
[server] Harden sharing recipient identity lookup

### DIFF
--- a/server/ente/collection.go
+++ b/server/ente/collection.go
@@ -137,6 +137,7 @@ type BulkCollectionShareItem struct {
 
 type BulkCollectionShareRequest struct {
 	RecipientUserID int64                     `json:"recipientUserID" binding:"required"`
+	RecipientEmail  string                    `json:"recipientEmail" binding:"required"`
 	Source          CollectionShareSource     `json:"source" binding:"required"`
 	Collections     []BulkCollectionShareItem `json:"collections" binding:"required"`
 }

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -202,6 +202,12 @@ var ErrUserNotFound = &ApiError{
 	HttpStatusCode: http.StatusNotFound,
 }
 
+var ErrRecipientIdentityMismatch = &ApiError{
+	Code:           "RECIPIENT_IDENTITY_MISMATCH",
+	Message:        "Recipient identity does not match",
+	HttpStatusCode: http.StatusConflict,
+}
+
 var ErrMaxPasskeysReached = ApiError{
 	Code:           MaxPasskeysReached,
 	Message:        "Max passkeys limit reached",

--- a/server/ente/errors.go
+++ b/server/ente/errors.go
@@ -208,6 +208,12 @@ var ErrRecipientIdentityMismatch = &ApiError{
 	HttpStatusCode: http.StatusConflict,
 }
 
+var ErrAutomaticShareRecipientNotEligible = &ApiError{
+	Code:           "AUTOMATIC_SHARE_RECIPIENT_NOT_ELIGIBLE",
+	Message:        "Automatic share recipient is not eligible",
+	HttpStatusCode: http.StatusForbidden,
+}
+
 var ErrMaxPasskeysReached = ApiError{
 	Code:           MaxPasskeysReached,
 	Message:        "Max passkeys limit reached",

--- a/server/pkg/api/user.go
+++ b/server/pkg/api/user.go
@@ -149,18 +149,10 @@ func (h *UserHandler) SetRecoveryKey(c *gin.Context) {
 
 // GetPublicKey returns the public key of a user
 func (h *UserHandler) GetPublicKey(c *gin.Context) {
-	var publicKey string
-	var err error
-	if userID := c.Query("userID"); userID != "" {
-		targetUserID, parseErr := strconv.ParseInt(userID, 10, 64)
-		if parseErr != nil || targetUserID <= 0 {
-			handler.Error(c, stacktrace.Propagate(ente.ErrBadRequest, "invalid userID"))
-			return
-		}
-		publicKey, err = h.UserController.GetPublicKeyByUserID(targetUserID)
-	} else {
-		publicKey, err = h.UserController.GetPublicKey(auth.GetUserID(c.Request.Header), c.Query("email"))
-	}
+	publicKey, err := h.UserController.GetPublicKey(
+		auth.GetUserID(c.Request.Header),
+		c.Query("email"),
+	)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/api/user_test.go
+++ b/server/pkg/api/user_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/internal/testutil"
+	museumcontroller "github.com/ente/museum/pkg/controller"
 	usercontroller "github.com/ente/museum/pkg/controller/user"
 	"github.com/ente/museum/pkg/repo"
 	"github.com/gin-gonic/gin"
@@ -52,33 +53,31 @@ func TestSetAttributesHandlerRejectsLowMemoryLimit(t *testing.T) {
 	assertAPIErrorResponse(t, recorder, http.StatusBadRequest, ente.BadRequest, "memory limit must be at least 128MB")
 }
 
-func TestGetPublicKeyHandlerLooksUpUserByID(t *testing.T) {
+func TestGetPublicKeyHandlerUsesEmailLookup(t *testing.T) {
 	handler, db := setupUserHandlerTest(t)
+	requesterUserID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       102,
+		Email:        "public-key-requester@ente.com",
+		CreationTime: 1,
+	})
 
 	targetUserID := testutil.InsertUser(t, db, testutil.UserFixture{
 		UserID:       103,
 		Email:        "public-key-target@ente.com",
 		CreationTime: 1,
 	})
-	keyAttributes := ente.KeyAttributes{
-		KEKSalt:                  "kek-salt",
-		KEKHash:                  "kek-hash",
-		EncryptedKey:             "encrypted-key",
-		KeyDecryptionNonce:       "key-decryption-nonce",
-		PublicKey:                "target-public-key",
-		EncryptedSecretKey:       "encrypted-secret-key",
-		SecretKeyDecryptionNonce: "secret-key-decryption-nonce",
-		MemLimit:                 128 * 1024 * 1024,
-		OpsLimit:                 32,
-	}
-	if err := handler.UserController.UserRepo.SetKeyAttributes(targetUserID, keyAttributes); err != nil {
-		t.Fatalf("failed to set key attributes: %v", err)
-	}
+	keyAttributes := setPublicKeyTestAttributes(t, handler, targetUserID)
 
-	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/users/public-key?userID="+strconv.FormatInt(targetUserID, 10), nil)
 	router := gin.New()
 	router.GET("/users/public-key", handler.GetPublicKey)
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/users/public-key?email=public-key-target%40ente.com",
+		nil,
+	)
+	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(requesterUserID, 10))
 	router.ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -93,6 +92,51 @@ func TestGetPublicKeyHandlerLooksUpUserByID(t *testing.T) {
 	if response.PublicKey != keyAttributes.PublicKey {
 		t.Fatalf("unexpected public key: got %q want %q", response.PublicKey, keyAttributes.PublicKey)
 	}
+}
+
+func TestGetPublicKeyHandlerDoesNotLookupByUserID(t *testing.T) {
+	handler, db := setupUserHandlerTest(t)
+	requesterUserID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       101,
+		Email:        "public-key-requester@ente.com",
+		CreationTime: 1,
+	})
+	targetUserID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       102,
+		Email:        "public-key-target@ente.com",
+		CreationTime: 1,
+	})
+	setPublicKeyTestAttributes(t, handler, targetUserID)
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/users/public-key?userID=102", nil)
+	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(requesterUserID, 10))
+	router := gin.New()
+	router.GET("/users/public-key", handler.GetPublicKey)
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("unexpected status code: got %d want %d; body=%s", recorder.Code, http.StatusNotFound, recorder.Body.String())
+	}
+}
+
+func setPublicKeyTestAttributes(t *testing.T, handler *UserHandler, userID int64) ente.KeyAttributes {
+	t.Helper()
+	keyAttributes := ente.KeyAttributes{
+		KEKSalt:                  "kek-salt",
+		KEKHash:                  "kek-hash",
+		EncryptedKey:             "encrypted-key",
+		KeyDecryptionNonce:       "key-decryption-nonce",
+		PublicKey:                "target-public-key",
+		EncryptedSecretKey:       "encrypted-secret-key",
+		SecretKeyDecryptionNonce: "secret-key-decryption-nonce",
+		MemLimit:                 128 * 1024 * 1024,
+		OpsLimit:                 32,
+	}
+	if err := handler.UserController.UserRepo.SetKeyAttributes(userID, keyAttributes); err != nil {
+		t.Fatalf("failed to set key attributes: %v", err)
+	}
+	return keyAttributes
 }
 
 func setupUserHandlerTest(t *testing.T) (*UserHandler, *sql.DB) {
@@ -114,7 +158,8 @@ func setupUserHandlerTest(t *testing.T) (*UserHandler, *sql.DB) {
 
 	return &UserHandler{
 		UserController: &usercontroller.UserController{
-			UserRepo: userRepo,
+			UserRepo:   userRepo,
+			UserLookup: museumcontroller.NewUserLookupController(userRepo, nil),
 		},
 	}, db
 }

--- a/server/pkg/controller/collections/share.go
+++ b/server/pkg/controller/collections/share.go
@@ -72,6 +72,13 @@ func (c *CollectionController) BulkShare(
 	if err := validateBulkShareRecipient(fromUserID, req.RecipientUserID); err != nil {
 		return nil, err
 	}
+	if err := c.UserLookup.VerifyUserID(
+		fromUserID,
+		req.RecipientEmail,
+		req.RecipientUserID,
+	); err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
 
 	results := make([]ente.BulkCollectionShareResult, 0, len(req.Collections))
 	for _, item := range req.Collections {

--- a/server/pkg/controller/collections/share.go
+++ b/server/pkg/controller/collections/share.go
@@ -79,6 +79,19 @@ func (c *CollectionController) BulkShare(
 	); err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
+	if req.Source == ente.AutomaticShare {
+		sameFamily, err := c.UserRepo.AreUsersInSameFamily(
+			ctx.Request.Context(),
+			fromUserID,
+			req.RecipientUserID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !sameFamily {
+			return nil, stacktrace.Propagate(ente.ErrAutomaticShareRecipientNotEligible, "")
+		}
+	}
 
 	results := make([]ente.BulkCollectionShareResult, 0, len(req.Collections))
 	for _, item := range req.Collections {

--- a/server/pkg/controller/collections/share_test.go
+++ b/server/pkg/controller/collections/share_test.go
@@ -102,6 +102,17 @@ func setupCollectionShareTest(
 	return db, newShareTestCollectionRepo(db), ownerID, shareeID
 }
 
+func setShareTestFamilyAdmin(t *testing.T, db *sql.DB, userID int64, familyAdminID any) {
+	t.Helper()
+	if _, err := db.Exec(
+		`UPDATE users SET family_admin_id = $1 WHERE user_id = $2`,
+		familyAdminID,
+		userID,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func requireCollectionShareStatus(
 	t *testing.T,
 	status, want ente.CollectionShareStatus,
@@ -468,6 +479,8 @@ func TestUncategorizedCollectionsOnlyAllowViewerShares(t *testing.T) {
 
 func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 	db, collectionRepo, ownerID, shareeID := setupCollectionShareTest(t)
+	setShareTestFamilyAdmin(t, db, ownerID, ownerID)
+	setShareTestFamilyAdmin(t, db, shareeID, ownerID)
 	albumID := createShareTestCollection(t, collectionRepo, ownerID)
 	neverSharedID := createShareTestCollection(t, collectionRepo, ownerID)
 	uncategorizedID := createShareTestCollectionOfType(
@@ -479,6 +492,7 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 	controller := &CollectionController{
 		CollectionRepo: collectionRepo,
 		CastRepo:       &castRepo.Repository{DB: db},
+		UserRepo:       &repo.UserRepository{DB: db},
 		UserLookup:     newShareTestUserLookup(db),
 	}
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
@@ -522,6 +536,59 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 	if unshareResults[0].Status != ente.CollectionUnshared ||
 		unshareResults[1].Status != ente.CollectionNotShared {
 		t.Fatalf("bulk unshare results = %+v", unshareResults)
+	}
+}
+
+func TestBulkShareAutomaticRecipientMustBeInSameFamily(t *testing.T) {
+	db, collectionRepo, ownerID, shareeID := setupCollectionShareTest(t)
+	controller := &CollectionController{
+		CollectionRepo: collectionRepo,
+		UserRepo:       &repo.UserRepository{DB: db},
+		UserLookup:     newShareTestUserLookup(db),
+	}
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/collections/share/bulk", nil)
+	ctx.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(ownerID, 10))
+	share := func(collectionID int64, source ente.CollectionShareSource) error {
+		_, err := controller.BulkShare(ctx, ente.BulkCollectionShareRequest{
+			RecipientUserID: shareeID,
+			RecipientEmail:  "sharee@example.com",
+			Source:          source,
+			Collections: []ente.BulkCollectionShareItem{{
+				CollectionID: collectionID,
+				EncryptedKey: b64OfLen(sealedCollectionKeyLen),
+				Role:         ente.VIEWER,
+			}},
+		})
+		return err
+	}
+
+	setShareTestFamilyAdmin(t, db, ownerID, ownerID)
+	setShareTestFamilyAdmin(t, db, shareeID, shareeID)
+	if err := share(createShareTestCollection(t, collectionRepo, ownerID), ente.AutomaticShare); !errors.Is(err, ente.ErrAutomaticShareRecipientNotEligible) {
+		t.Fatalf("unrelated automatic share error = %v, want %v", err, ente.ErrAutomaticShareRecipientNotEligible)
+	}
+
+	setShareTestFamilyAdmin(t, db, shareeID, nil)
+	if err := share(createShareTestCollection(t, collectionRepo, ownerID), ente.AutomaticShare); !errors.Is(err, ente.ErrAutomaticShareRecipientNotEligible) {
+		t.Fatalf("former family member automatic share error = %v, want %v", err, ente.ErrAutomaticShareRecipientNotEligible)
+	}
+
+	var shareCount int
+	if err := db.QueryRow(`SELECT count(*) FROM collection_shares`).Scan(&shareCount); err != nil {
+		t.Fatal(err)
+	}
+	if shareCount != 0 {
+		t.Fatalf("collection shares after rejected requests = %d, want 0", shareCount)
+	}
+
+	if err := share(createShareTestCollection(t, collectionRepo, ownerID), ente.ManualShare); err != nil {
+		t.Fatalf("manual share error = %v", err)
+	}
+
+	setShareTestFamilyAdmin(t, db, shareeID, ownerID)
+	if err := share(createShareTestCollection(t, collectionRepo, ownerID), ente.AutomaticShare); err != nil {
+		t.Fatalf("same-family automatic share error = %v", err)
 	}
 }
 

--- a/server/pkg/controller/collections/share_test.go
+++ b/server/pkg/controller/collections/share_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/internal/testutil"
+	museumcontroller "github.com/ente/museum/pkg/controller"
 	"github.com/ente/museum/pkg/repo"
 	castRepo "github.com/ente/museum/pkg/repo/cast"
 	publicRepo "github.com/ente/museum/pkg/repo/public"
@@ -22,6 +23,10 @@ func (panicUserLookup) LookupUserID(int64, string) (int64, error) {
 	panic("user lookup must not be called while revoking collection access")
 }
 
+func (panicUserLookup) VerifyUserID(int64, string, int64) error {
+	panic("user lookup must not be called while revoking collection access")
+}
+
 type fixedUserLookup struct {
 	userID int64
 }
@@ -30,12 +35,23 @@ func (l fixedUserLookup) LookupUserID(int64, string) (int64, error) {
 	return l.userID, nil
 }
 
+func (fixedUserLookup) VerifyUserID(int64, string, int64) error {
+	return nil
+}
+
 func newShareTestCollectionRepo(db *sql.DB) *repo.CollectionRepository {
 	return &repo.CollectionRepository{
 		DB:                  db,
 		CollectionLinkRepo:  publicRepo.NewCollectionLinkRepository(db, ""),
 		SecretEncryptionKey: testutil.SecretEncryptionKey(),
 	}
+}
+
+func newShareTestUserLookup(db *sql.DB) *museumcontroller.UserLookupController {
+	return museumcontroller.NewUserLookupController(&repo.UserRepository{
+		DB:         db,
+		HashingKey: testutil.HashingKey(),
+	}, nil)
 }
 
 func createShareTestCollection(t *testing.T, collectionRepo *repo.CollectionRepository, ownerID int64) int64 {
@@ -463,6 +479,7 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 	controller := &CollectionController{
 		CollectionRepo: collectionRepo,
 		CastRepo:       &castRepo.Repository{DB: db},
+		UserLookup:     newShareTestUserLookup(db),
 	}
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	ctx.Request = httptest.NewRequest("POST", "/collections/share/bulk", nil)
@@ -470,6 +487,7 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 
 	results, err := controller.BulkShare(ctx, ente.BulkCollectionShareRequest{
 		RecipientUserID: shareeID,
+		RecipientEmail:  "sharee@example.com",
 		Source:          ente.AutomaticShare,
 		Collections: []ente.BulkCollectionShareItem{
 			{
@@ -492,6 +510,7 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 		t.Fatalf("bulk share results = %+v", results)
 	}
 
+	controller.UserLookup = panicUserLookup{}
 	unshareResults, err := controller.BulkUnShare(ctx, ente.BulkCollectionUnshareRequest{
 		RecipientUserID: shareeID,
 		Source:          ente.AutomaticShare,
@@ -503,6 +522,43 @@ func TestBulkShareAndUnshareReturnPerCollectionStatuses(t *testing.T) {
 	if unshareResults[0].Status != ente.CollectionUnshared ||
 		unshareResults[1].Status != ente.CollectionNotShared {
 		t.Fatalf("bulk unshare results = %+v", unshareResults)
+	}
+}
+
+func TestBulkShareRejectsRecipientIdentityMismatchBeforeMutation(t *testing.T) {
+	db, collectionRepo, ownerID, shareeID := setupCollectionShareTest(t)
+	collectionID := createShareTestCollection(t, collectionRepo, ownerID)
+	controller := &CollectionController{
+		CollectionRepo: collectionRepo,
+		UserLookup:     newShareTestUserLookup(db),
+	}
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/collections/share/bulk", nil)
+	ctx.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(ownerID, 10))
+
+	_, err := controller.BulkShare(ctx, ente.BulkCollectionShareRequest{
+		RecipientUserID: shareeID + 1,
+		RecipientEmail:  "sharee@example.com",
+		Source:          ente.AutomaticShare,
+		Collections: []ente.BulkCollectionShareItem{{
+			CollectionID: collectionID,
+			EncryptedKey: b64OfLen(sealedCollectionKeyLen),
+			Role:         ente.VIEWER,
+		}},
+	})
+	if !errors.Is(err, ente.ErrRecipientIdentityMismatch) {
+		t.Fatalf("bulk share error = %v, want %v", err, ente.ErrRecipientIdentityMismatch)
+	}
+
+	var shareCount int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM collection_shares WHERE collection_id = $1`,
+		collectionID,
+	).Scan(&shareCount); err != nil {
+		t.Fatal(err)
+	}
+	if shareCount != 0 {
+		t.Fatalf("collection shares after rejected request = %d, want 0", shareCount)
 	}
 }
 

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -242,11 +242,6 @@ func (c *UserController) GetPublicKey(requesterUserID int64, email string) (stri
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}
-	return c.GetPublicKeyByUserID(userID)
-}
-
-// GetPublicKeyByUserID returns the public key of a user.
-func (c *UserController) GetPublicKeyByUserID(userID int64) (string, error) {
 	key, err := c.UserRepo.GetPublicKey(userID)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")

--- a/server/pkg/controller/user_lookup.go
+++ b/server/pkg/controller/user_lookup.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"database/sql"
 	"errors"
+	"strconv"
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/pkg/repo"
@@ -22,6 +23,7 @@ type potentialAbuseNotifier interface {
 // UserLookup applies the shared authenticated email-discovery policy.
 type UserLookup interface {
 	LookupUserID(requesterUserID int64, email string) (int64, error)
+	VerifyUserID(requesterUserID int64, email string, expectedUserID int64) error
 }
 
 // UserLookupController limits email discovery before querying the user repository.
@@ -42,12 +44,38 @@ func NewUserLookupController(userRepo *repo.UserRepository, notifier potentialAb
 }
 
 func (c *UserLookupController) LookupUserID(requesterUserID int64, email string) (int64, error) {
+	return c.lookupUserID(requesterUserID, email, nil)
+}
+
+// VerifyUserID applies the shared lookup policy and verifies that email still
+// identifies expectedUserID.
+func (c *UserLookupController) VerifyUserID(
+	requesterUserID int64,
+	email string,
+	expectedUserID int64,
+) error {
+	_, err := c.lookupUserID(requesterUserID, email, &expectedUserID)
+	return err
+}
+
+func (c *UserLookupController) lookupUserID(
+	requesterUserID int64,
+	email string,
+	expectedUserID *int64,
+) (int64, error) {
 	if requesterUserID <= 0 {
 		return -1, stacktrace.Propagate(ente.ErrAuthenticationRequired, "")
 	}
+	if expectedUserID != nil && *expectedUserID <= 0 {
+		return -1, stacktrace.Propagate(ente.ErrBadRequest, "invalid expected user ID")
+	}
 
 	normalizedEmail := emailUtil.NormalizeEmail(email)
-	targetHash, err := crypto.GetHash(normalizedEmail, c.hashingKey)
+	limitTarget := normalizedEmail
+	if expectedUserID != nil {
+		limitTarget = "email-user-id\x00" + normalizedEmail + "\x00" + strconv.FormatInt(*expectedUserID, 10)
+	}
+	targetHash, err := crypto.GetHash(limitTarget, c.hashingKey)
 	if err != nil {
 		return -1, stacktrace.Propagate(err, "")
 	}
@@ -58,9 +86,14 @@ func (c *UserLookupController) LookupUserID(requesterUserID int64, email string)
 	}
 
 	userID, err := c.userRepo.GetUserIDWithEmailUnrestricted(normalizedEmail)
-	decision = c.lookupLimit.Finish(attempt, errors.Is(err, sql.ErrNoRows))
+	identityMismatch := errors.Is(err, sql.ErrNoRows) ||
+		(err == nil && expectedUserID != nil && userID != *expectedUserID)
+	decision = c.lookupLimit.Finish(attempt, identityMismatch)
 	if !decision.allowed {
 		return -1, c.limitExceeded(decision)
+	}
+	if expectedUserID != nil && identityMismatch {
+		return -1, stacktrace.Propagate(ente.ErrRecipientIdentityMismatch, "")
 	}
 	return userID, err
 }

--- a/server/pkg/controller/user_lookup_test.go
+++ b/server/pkg/controller/user_lookup_test.go
@@ -91,6 +91,58 @@ func TestUserLookupNormalizesAndAlwaysQueriesRepository(t *testing.T) {
 	}
 }
 
+func TestUserLookupVerifiesNormalizedEmailAndExpectedUserID(t *testing.T) {
+	now := time.Unix(1000, 0)
+	repository := &userLookupRepositoryStub{userID: 42}
+	controller := newUserLookupControllerForTest(repository, nil, func() time.Time { return now })
+
+	err := controller.VerifyUserID(1, "  Person@Example.COM ", 42)
+	if err != nil {
+		t.Fatalf("verify returned error: %v", err)
+	}
+	if got := repository.emails[0]; got != "person@example.com" {
+		t.Fatalf("repository email = %q, want normalized email", got)
+	}
+}
+
+func TestUserLookupVerifyReturnsSameErrorForMissingEmailAndMismatchedUserID(t *testing.T) {
+	now := time.Unix(1000, 0)
+	repository := &userLookupRepositoryStub{userID: 42}
+	controller := newUserLookupControllerForTest(repository, nil, func() time.Time { return now })
+
+	mismatchErr := controller.VerifyUserID(1, "person@example.com", 43)
+	if !errors.Is(mismatchErr, ente.ErrRecipientIdentityMismatch) {
+		t.Fatalf("mismatch error = %v, want %v", mismatchErr, ente.ErrRecipientIdentityMismatch)
+	}
+
+	repository.setResult(-1, sql.ErrNoRows)
+	missingErr := controller.VerifyUserID(1, "missing@example.com", 44)
+	if !errors.Is(missingErr, ente.ErrRecipientIdentityMismatch) {
+		t.Fatalf("missing email error = %v, want %v", missingErr, ente.ErrRecipientIdentityMismatch)
+	}
+}
+
+func TestUserLookupVerifyLimitsDistinctIDsForSameEmailAsMissingTargets(t *testing.T) {
+	now := time.Unix(1000, 0)
+	repository := &userLookupRepositoryStub{userID: 42}
+	controller := newUserLookupControllerForTest(repository, nil, func() time.Time { return now })
+
+	for i := 0; i < defaultUserLookupNotFoundMinuteLimit; i++ {
+		err := controller.VerifyUserID(7, "known@example.com", int64(100+i))
+		if !errors.Is(err, ente.ErrRecipientIdentityMismatch) {
+			t.Fatalf("mismatch %d error = %v, want %v", i, err, ente.ErrRecipientIdentityMismatch)
+		}
+	}
+
+	err := controller.VerifyUserID(7, "known@example.com", 999)
+	if !errors.Is(err, ente.ErrTooManyBadRequest) {
+		t.Fatalf("next mismatch error = %v, want %v", err, ente.ErrTooManyBadRequest)
+	}
+	if got := repository.callCount(); got != defaultUserLookupNotFoundMinuteLimit {
+		t.Fatalf("repository calls = %d, want %d", got, defaultUserLookupNotFoundMinuteLimit)
+	}
+}
+
 func TestUserLookupRejectsUnauthenticatedRequesterBeforeRepository(t *testing.T) {
 	now := time.Unix(1000, 0)
 	repository := &userLookupRepositoryStub{}

--- a/server/pkg/repo/contact/contact.go
+++ b/server/pkg/repo/contact/contact.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	contactmodel "github.com/ente/museum/ente/contact"
+	"github.com/ente/museum/pkg/repo"
 	"github.com/ente/museum/pkg/utils/crypto"
 	"github.com/ente/stacktrace"
 	"github.com/lib/pq"
@@ -107,24 +108,11 @@ func (r *Repository) hasActiveEmergencyRelationship(ctx context.Context, actorUs
 }
 
 func (r *Repository) hasSharedActiveFamily(ctx context.Context, actorUserID int64, contactUserID int64) (bool, error) {
-	var exists bool
-	err := r.DB.QueryRowContext(
+	return (&repo.UserRepository{DB: r.DB}).AreUsersInSameFamily(
 		ctx,
-		`SELECT EXISTS(
-			SELECT 1
-			FROM users actor
-			JOIN users contact ON actor.family_admin_id = contact.family_admin_id
-			WHERE actor.user_id = $1
-			  AND contact.user_id = $2
-			  AND actor.family_admin_id IS NOT NULL
-		)`,
 		actorUserID,
 		contactUserID,
-	).Scan(&exists)
-	if err != nil {
-		return false, err
-	}
-	return exists, nil
+	)
 }
 
 func (r *Repository) hasCommonSharedCollection(ctx context.Context, actorUserID int64, contactUserID int64) (bool, error) {

--- a/server/pkg/repo/user.go
+++ b/server/pkg/repo/user.go
@@ -126,6 +126,19 @@ func (repo *UserRepository) GetFamilyAdminID(userID int64) (*int64, error) {
 	return familyAdminID, nil
 }
 
+func (repo *UserRepository) AreUsersInSameFamily(ctx context.Context, firstUserID, secondUserID int64) (bool, error) {
+	var sameFamily bool
+	err := repo.DB.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1
+		FROM users first_user
+		JOIN users second_user ON first_user.family_admin_id = second_user.family_admin_id
+		WHERE first_user.user_id = $1
+		  AND second_user.user_id = $2
+		  AND first_user.family_admin_id IS NOT NULL
+	)`, firstUserID, secondUserID).Scan(&sameFamily)
+	return sameFamily, stacktrace.Propagate(err, "")
+}
+
 // GetUserByEmailHash returns a user indicated by the emailHash
 func (repo *UserRepository) GetUserByEmailHash(emailHash string) (ente.User, error) {
 	var user ente.User


### PR DESCRIPTION
- Restore public-key lookup to the authenticated email-only flow and require bulk shares to bind recipient email and user ID before any writes.
- Reject automatic bulk shares before processing when owner and recipient do not share the same non-null family admin, using a dedicated 403 error code.
- The request contract changes are safe to coordinate because these APIs are consumed only by Ente internal clients.
- Validation: cd server && ./scripts/lint.sh && ./scripts/test-with-postgres.sh host; cd rust && cargo test --locked --features museum,ente-photos/ml-assets.