### PR TITLE
[mobile] Harden Photos library sharing recipients

### DIFF
--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -94,6 +94,8 @@ class SharingNotPermittedForFreeAccountsError extends Error {}
 
 class RecipientIdentityMismatchError extends Error {}
 
+class AutomaticShareRecipientNotEligibleError extends Error {}
+
 class LinkEditNotAllowedError extends Error {}
 
 class NoMediaLocationAccessError extends Error {}

--- a/mobile/apps/photos/lib/core/errors.dart
+++ b/mobile/apps/photos/lib/core/errors.dart
@@ -92,6 +92,8 @@ class SrpSetupNotCompleteError extends Error {}
 
 class SharingNotPermittedForFreeAccountsError extends Error {}
 
+class RecipientIdentityMismatchError extends Error {}
+
 class LinkEditNotAllowedError extends Error {}
 
 class NoMediaLocationAccessError extends Error {}

--- a/mobile/apps/photos/lib/gateways/collections/collection_share_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/collections/collection_share_gateway.dart
@@ -83,6 +83,7 @@ class CollectionShareGateway {
 
   Future<List<CollectionShareResult>> shareBulk({
     required int recipientUserID,
+    required String recipientEmail,
     required CollectionShareSource source,
     required List<BulkCollectionShareItem> collections,
   }) async {
@@ -90,6 +91,7 @@ class CollectionShareGateway {
       "/collections/share/bulk",
       data: {
         "recipientUserID": recipientUserID,
+        "recipientEmail": recipientEmail,
         "source": source.name,
         "collections": collections.map((item) => item.toJson()).toList(),
       },

--- a/mobile/apps/photos/lib/gateways/users/users_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/users/users_gateway.dart
@@ -88,21 +88,11 @@ class UsersGateway {
   /// Returns null if the email is not associated with an Ente account.
   ///
   /// Endpoint: GET /users/public-key
-  Future<String?> getPublicKey(String email) => _getPublicKey({"email": email});
-
-  /// Get the user's public key by user ID.
-  ///
-  /// Returns null if the user does not exist or has no public key.
-  ///
-  /// Endpoint: GET /users/public-key
-  Future<String?> getPublicKeyByUserID(int userID) =>
-      _getPublicKey({"userID": userID});
-
-  Future<String?> _getPublicKey(Map<String, Object> queryParameters) async {
+  Future<String?> getPublicKey(String email) async {
     try {
       final response = await _enteDio.get(
         "/users/public-key",
-        queryParameters: queryParameters,
+        queryParameters: {"email": email},
       );
       return response.data["publicKey"] as String?;
     } on DioException catch (e) {

--- a/mobile/apps/photos/lib/services/account/user_service.dart
+++ b/mobile/apps/photos/lib/services/account/user_service.dart
@@ -60,7 +60,7 @@ class UserService {
   static const kIsEmailMFAEnabled = "is_email_mfa_enabled";
 
   final SRP6GroupParameters kDefaultSrpGroup = SRP6StandardGroups.rfc5054_4096;
-  final _publicKeyCache = TimedCache<Object, String>(
+  final _publicKeyCache = TimedCache<String, String>(
     duration: const Duration(seconds: 10),
   );
 
@@ -208,23 +208,14 @@ class UserService {
 
   // getPublicKey returns null value if email id is not
   // associated with another ente account
-  Future<String?> getPublicKey(String email) =>
-      _getPublicKey(email, () => _gateway.getPublicKey(email));
-
-  Future<String?> getPublicKeyByUserID(int userID) =>
-      _getPublicKey(userID, () => _gateway.getPublicKeyByUserID(userID));
-
-  Future<String?> _getPublicKey(
-    Object cacheKey,
-    Future<String?> Function() fetch,
-  ) async {
-    final String? cachedPubKey = _publicKeyCache.get(cacheKey);
+  Future<String?> getPublicKey(String email) async {
+    final String? cachedPubKey = _publicKeyCache.get(email);
     if (cachedPubKey != null) {
       return cachedPubKey;
     }
-    final publicKey = await fetch();
+    final publicKey = await _gateway.getPublicKey(email);
     if (publicKey != null) {
-      _publicKeyCache.set(cacheKey, publicKey);
+      _publicKeyCache.set(email, publicKey);
     }
     return publicKey;
   }

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -924,6 +924,10 @@ class CollectionsService {
       if (e.response?.data?['code'] == 'RECIPIENT_IDENTITY_MISMATCH') {
         throw RecipientIdentityMismatchError();
       }
+      if (e.response?.data?['code'] ==
+          'AUTOMATIC_SHARE_RECIPIENT_NOT_ELIGIBLE') {
+        throw AutomaticShareRecipientNotEligibleError();
+      }
       rethrow;
     }
   }

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -905,6 +905,7 @@ class CollectionsService {
     try {
       final results = await collectionShareGateway.shareBulk(
         recipientUserID: recipientUserID,
+        recipientEmail: recipientEmail,
         source: source,
         collections: items,
       );
@@ -919,6 +920,9 @@ class CollectionsService {
     } on DioException catch (e) {
       if (e.response?.statusCode == 402) {
         throw SharingNotPermittedForFreeAccountsError();
+      }
+      if (e.response?.data?['code'] == 'RECIPIENT_IDENTITY_MISMATCH') {
+        throw RecipientIdentityMismatchError();
       }
       rethrow;
     }

--- a/mobile/apps/photos/lib/services/library_sharing_service.dart
+++ b/mobile/apps/photos/lib/services/library_sharing_service.dart
@@ -12,6 +12,7 @@ import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/library_sharing/library_sharing_recipient.dart';
 import 'package:photos/models/metadata/collection_magic.dart';
 import 'package:photos/models/metadata/common_keys.dart';
+import 'package:photos/models/user_details.dart';
 import 'package:photos/services/account/user_service.dart';
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/library_sharing_local_store.dart';
@@ -345,7 +346,14 @@ class LibrarySharingService implements LibrarySharingRepository {
               !activeFamilyMemberUserIDs.contains(latest.recipientUserID)) {
             await _writeConfig(ownerUserID, latest.copyWith(enabled: false));
           } else {
-            await _reconcileConfig(ownerUserID, latest);
+            try {
+              await _reconcileConfig(ownerUserID, latest);
+            } on AutomaticShareRecipientNotEligibleError {
+              await _refreshFamilyAndHandleIneligibleRecipient(
+                ownerUserID,
+                latest,
+              );
+            }
           }
         });
       } catch (error, stackTrace) {
@@ -462,6 +470,8 @@ class LibrarySharingService implements LibrarySharingRepository {
         );
       } on RecipientIdentityMismatchError {
         rethrow;
+      } on AutomaticShareRecipientNotEligibleError {
+        rethrow;
       } catch (error, stackTrace) {
         _logger.warning('Bulk library share failed', error, stackTrace);
       }
@@ -563,10 +573,38 @@ class LibrarySharingService implements LibrarySharingRepository {
         (throw StateError('No email found for library sharing recipient'));
   }
 
-  Set<int>? _activeFamilyMemberUserIDs() {
+  Future<void> _refreshFamilyAndHandleIneligibleRecipient(
+    int ownerUserID,
+    LibrarySharingLocalConfig config,
+  ) async {
+    UserDetails userDetails;
+    try {
+      userDetails = await _userService.getUserDetailsV2(memoryCount: false);
+    } catch (refreshError, refreshStackTrace) {
+      _logger.warning(
+        'Could not refresh family details after automatic share rejection for '
+        '${config.recipientUserID}',
+        refreshError,
+        refreshStackTrace,
+      );
+      return;
+    }
+    if (_activeFamilyMemberUserIDs(
+      userDetails,
+    )!.contains(config.recipientUserID)) {
+      _logger.warning(
+        'Automatic share rejected for active family member '
+        '${config.recipientUserID}',
+      );
+      return;
+    }
+    await _writeConfig(ownerUserID, config.copyWith(enabled: false));
+  }
+
+  Set<int>? _activeFamilyMemberUserIDs([UserDetails? userDetails]) {
     // Temporary best-effort guard while Library Sharing is family-scoped;
     // cached details can lag membership changes made on another client.
-    final userDetails = _userService.getCachedUserDetails();
+    userDetails ??= _userService.getCachedUserDetails();
     if (userDetails == null) {
       return null;
     }

--- a/mobile/apps/photos/lib/services/library_sharing_service.dart
+++ b/mobile/apps/photos/lib/services/library_sharing_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/core/configuration.dart';
+import 'package:photos/core/errors.dart';
 import 'package:photos/core/event_bus.dart';
 import 'package:photos/events/collection_updated_event.dart';
 import 'package:photos/events/user_details_changed_event.dart';
@@ -135,7 +136,7 @@ class LibrarySharingService implements LibrarySharingRepository {
     required Map<int, CollectionParticipantRole> roles,
   }) => _operationLock.synchronized(() async {
     final ownerUserID = _currentOwnerUserID();
-    final publicKey = await _requirePublicKey(recipient.userID);
+    final publicKey = await _requirePublicKey(recipient.email);
     final statuses = await _shareInBatches(
       ownerUserID: ownerUserID,
       recipientUserID: recipient.userID,
@@ -250,7 +251,7 @@ class LibrarySharingService implements LibrarySharingRepository {
       throw ArgumentError.value(role, 'role');
     }
     final ownerUserID = _currentOwnerUserID();
-    final publicKey = await _requirePublicKey(recipient.userID);
+    final publicKey = await _requirePublicKey(recipient.email);
     final existing = await _localStore.read(ownerUserID, recipient.userID);
     var config =
         (existing ??
@@ -374,7 +375,7 @@ class LibrarySharingService implements LibrarySharingRepository {
         ownerUserID: ownerUserID,
         recipientUserID: config.recipientUserID,
         recipientEmail: recipientEmail,
-        publicKey: await _requirePublicKey(config.recipientUserID),
+        publicKey: await _requirePublicKey(recipientEmail),
         roles: roles,
         source: CollectionShareSource.automatic,
       );
@@ -459,6 +460,8 @@ class LibrarySharingService implements LibrarySharingRepository {
             source: source,
           ),
         );
+      } on RecipientIdentityMismatchError {
+        rethrow;
       } catch (error, stackTrace) {
         _logger.warning('Bulk library share failed', error, stackTrace);
       }
@@ -541,8 +544,8 @@ class LibrarySharingService implements LibrarySharingRepository {
     await _localStore.write(ownerUserID, config);
   }
 
-  Future<String> _requirePublicKey(int userID) async {
-    final publicKey = await _userService.getPublicKeyByUserID(userID);
+  Future<String> _requirePublicKey(String email) async {
+    final publicKey = await _userService.getPublicKey(email);
     if (publicKey == null || publicKey.isEmpty) {
       throw StateError('No Ente public key found for recipient');
     }

--- a/mobile/apps/photos/test/services/library_sharing_service_test.dart
+++ b/mobile/apps/photos/test/services/library_sharing_service_test.dart
@@ -134,6 +134,57 @@ void main() {
 
     expect(fixture.collectionsService.shareBatchSizes, [100]);
   });
+
+  test(
+    'refreshes only for ineligible recipients and disables after removal',
+    () async {
+      final albums = [librarySharingTestAlbum(1)];
+      final fixture = await _Fixture.create(
+        albums,
+        activeFamilyMemberUserIDs: {librarySharingTestRecipient.userID},
+      );
+      await fixture.service.enableAutomaticSharing(
+        recipient: librarySharingTestRecipient,
+        role: CollectionParticipantRole.viewer,
+      );
+      albums.addAll([
+        for (var id = 2; id <= 102; id++) librarySharingTestAlbum(id),
+      ]);
+
+      fixture.collectionsService.shareError = StateError('ordinary failure');
+      await fixture.service.reconcile();
+      expect(fixture.userService.userDetailsFetches, 0);
+
+      fixture.collectionsService.shareError =
+          AutomaticShareRecipientNotEligibleError();
+      fixture.userService.refreshedActiveFamilyMemberUserIDs = {
+        librarySharingTestRecipient.userID,
+      };
+      await fixture.service.reconcile();
+      expect(fixture.userService.userDetailsFetches, 1);
+      expect(await fixture.isAutomaticSharingEnabled(), isTrue);
+
+      fixture.userService.userDetailsError = StateError('refresh failed');
+      await fixture.service.reconcile();
+      expect(fixture.userService.userDetailsFetches, 2);
+      expect(await fixture.isAutomaticSharingEnabled(), isTrue);
+
+      fixture.userService.userDetailsError = null;
+      fixture.userService.refreshedActiveFamilyMemberUserIDs = {};
+      await fixture.service.reconcile();
+      expect(fixture.userService.userDetailsFetches, 3);
+      expect(await fixture.isAutomaticSharingEnabled(), isFalse);
+      expect(fixture.collectionsService.shareBatchSizes, [
+        1,
+        100,
+        1,
+        100,
+        100,
+        100,
+      ]);
+      expect(albums.last.sharees, isEmpty);
+    },
+  );
 }
 
 class _Fixture {
@@ -179,6 +230,9 @@ class _Fixture {
 
   Future<LibrarySharingLocalConfig> readConfig() async =>
       (await store.read(1, librarySharingTestRecipient.userID))!;
+
+  Future<bool> isAutomaticSharingEnabled() =>
+      service.isAutomaticSharingEnabled(librarySharingTestRecipient.userID);
 }
 
 class _FakeCollectionsService extends Mock implements CollectionsService {
@@ -186,7 +240,7 @@ class _FakeCollectionsService extends Mock implements CollectionsService {
 
   final List<Collection> albums;
   final Set<int> blockedIDs;
-  final Object? shareError;
+  Object? shareError;
   final List<int> shareBatchSizes = [];
   final List<String> recipientEmails = [];
   final List<int> shareAttempts = [];
@@ -271,6 +325,9 @@ class _FakeUserService extends Mock implements UserService {
   _FakeUserService(this.activeFamilyMemberUserIDs);
 
   Set<int>? activeFamilyMemberUserIDs;
+  Set<int>? refreshedActiveFamilyMemberUserIDs;
+  Object? userDetailsError;
+  int userDetailsFetches = 0;
   final List<String> publicKeyEmails = [];
 
   @override
@@ -291,6 +348,23 @@ class _FakeUserService extends Mock implements UserService {
   UserDetails? getCachedUserDetails() {
     final userIDs = activeFamilyMemberUserIDs;
     return userIDs == null ? null : _FakeUserDetails(userIDs);
+  }
+
+  @override
+  Future<UserDetails> getUserDetailsV2({
+    bool memoryCount = true,
+    bool shouldCache = true,
+  }) async {
+    userDetailsFetches++;
+    if (userDetailsError != null) {
+      throw userDetailsError!;
+    }
+    final userIDs =
+        refreshedActiveFamilyMemberUserIDs ??
+        activeFamilyMemberUserIDs ??
+        const {};
+    activeFamilyMemberUserIDs = userIDs;
+    return _FakeUserDetails(userIDs);
   }
 }
 

--- a/mobile/apps/photos/test/services/library_sharing_service_test.dart
+++ b/mobile/apps/photos/test/services/library_sharing_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:photos/core/configuration.dart';
+import 'package:photos/core/errors.dart';
 import 'package:photos/gateways/collections/models/collection_share.dart';
 import 'package:photos/models/api/collection/user.dart';
 import 'package:photos/models/collection/collection.dart';
@@ -35,6 +36,13 @@ void main() {
     expect(result.failedIDs, isEmpty);
     expect(result.previouslyUnsharedIDs, {100, 101});
     expect(fixture.collectionsService.shareBatchSizes, [100, 1]);
+    expect(fixture.collectionsService.recipientEmails, [
+      librarySharingTestRecipient.email,
+      librarySharingTestRecipient.email,
+    ]);
+    expect(fixture.userService.publicKeyEmails, [
+      librarySharingTestRecipient.email,
+    ]);
     expect(
       fixture.collectionsService.sharedRoles[101],
       CollectionParticipantRole.viewer,
@@ -106,6 +114,26 @@ void main() {
       expect(albums.last.sharees, isEmpty);
     },
   );
+
+  test('stops bulk sharing on a recipient identity mismatch', () async {
+    final albums = [
+      for (var id = 1; id <= 101; id++) librarySharingTestAlbum(id),
+    ];
+    final fixture = await _Fixture.create(
+      albums,
+      shareError: RecipientIdentityMismatchError(),
+    );
+
+    await expectLater(
+      fixture.service.enableAutomaticSharing(
+        recipient: librarySharingTestRecipient,
+        role: CollectionParticipantRole.viewer,
+      ),
+      throwsA(isA<RecipientIdentityMismatchError>()),
+    );
+
+    expect(fixture.collectionsService.shareBatchSizes, [100]);
+  });
 }
 
 class _Fixture {
@@ -125,10 +153,15 @@ class _Fixture {
     List<Collection> albums, {
     Set<int> blockedIDs = const {},
     Set<int>? activeFamilyMemberUserIDs,
+    Object? shareError,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final preferences = await SharedPreferences.getInstance();
-    final collectionsService = _FakeCollectionsService(albums, blockedIDs);
+    final collectionsService = _FakeCollectionsService(
+      albums,
+      blockedIDs,
+      shareError,
+    );
     final store = LibrarySharingLocalStore(preferences);
     final userService = _FakeUserService(activeFamilyMemberUserIDs);
     return _Fixture(
@@ -149,11 +182,13 @@ class _Fixture {
 }
 
 class _FakeCollectionsService extends Mock implements CollectionsService {
-  _FakeCollectionsService(this.albums, this.blockedIDs);
+  _FakeCollectionsService(this.albums, this.blockedIDs, this.shareError);
 
   final List<Collection> albums;
   final Set<int> blockedIDs;
+  final Object? shareError;
   final List<int> shareBatchSizes = [];
+  final List<String> recipientEmails = [];
   final List<int> shareAttempts = [];
   final List<int> unshareAttempts = [];
   final Map<int, CollectionParticipantRole> sharedRoles = {};
@@ -182,6 +217,10 @@ class _FakeCollectionsService extends Mock implements CollectionsService {
     required CollectionShareSource source,
   }) async {
     shareBatchSizes.add(roles.length);
+    recipientEmails.add(recipientEmail);
+    if (shareError != null) {
+      throw shareError!;
+    }
     shareAttempts.addAll(roles.keys);
     sharedRoles.addAll(roles);
     for (final entry in roles.entries) {
@@ -232,10 +271,13 @@ class _FakeUserService extends Mock implements UserService {
   _FakeUserService(this.activeFamilyMemberUserIDs);
 
   Set<int>? activeFamilyMemberUserIDs;
+  final List<String> publicKeyEmails = [];
 
   @override
-  Future<String?> getPublicKeyByUserID(int userID) async =>
-      userID == librarySharingTestRecipient.userID ? 'public-key' : null;
+  Future<String?> getPublicKey(String email) async {
+    publicKeyEmails.add(email);
+    return email == librarySharingTestRecipient.email ? 'public-key' : null;
+  }
 
   @override
   List<User> getRelevantContacts() => [


### PR DESCRIPTION
- Use authenticated email lookup for recipient public keys and bind recipient email and user ID in bulk-share requests.
- On the dedicated automatic-share eligibility error, refresh family details once and disable local library sharing only after confirmed removal.
- Validation: flutter analyze --no-pub; flutter test --no-pub (369 Photos tests); mobile workspace checks and Rust clippy.