### PR TITLE
[mobile][photos] Refine library sharing selection

### DIFF
--- a/mobile/apps/photos/lib/ui/collections/flex_grid_view.dart
+++ b/mobile/apps/photos/lib/ui/collections/flex_grid_view.dart
@@ -52,7 +52,6 @@ class AlbumGridLayout {
 }
 
 typedef AlbumSelectionCallbacks = ({
-  bool isSelectionModeActive,
   bool Function(Collection) isSelected,
   ValueChanged<Collection> toggle,
 });
@@ -146,7 +145,7 @@ class _CollectionsFlexiGridViewWidgetState
   }
 
   bool get _togglesSelectionOnTap =>
-      (widget.selectionCallbacks?.isSelectionModeActive ?? false) ||
+      widget.selectionCallbacks != null ||
       isAnyAlbumSelected ||
       widget.onlyAllowSelection;
 
@@ -160,7 +159,7 @@ class _CollectionsFlexiGridViewWidgetState
 
   void _handleCollectionLongPress(Collection collection) {
     if (widget.selectionCallbacks != null) {
-      unawaited(_toggleAlbumSelection(collection));
+      unawaited(_navigateToCollectionPage(collection));
       return;
     }
     unawaited(

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_controller.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_controller.dart
@@ -47,7 +47,6 @@ class LibrarySharingController extends ChangeNotifier {
       !_isLoading &&
       _loadError == null &&
       (_selectionMode != null || isFirstTime);
-  bool get selectsAlbumsOnTap => _selectionMode != null || hasSelection;
   bool get hasSelection => _selectedRoles.isNotEmpty;
   int get selectedCount => _selectedRoles.length;
   int get selectedActiveShareCount =>

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_page.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_page.dart
@@ -227,11 +227,10 @@ class _LibrarySharingPageState extends State<LibrarySharingPage> {
         albums,
         tag: 'library_sharing_${_recipient.userID}',
         selectionCallbacks: (
-          isSelectionModeActive: _controller.selectsAlbumsOnTap,
           isSelected: _controller.isSelected,
           toggle: _toggleAlbumSelection,
         ),
-        enableSelectionMode: true,
+        enableSelectionMode: !_controller.isMutating,
         gridTopLeftOverlayBuilder: _roleOverlay,
         topPadding: Spacing.sm,
         bottomPadding: _gridBottomPadding,

--- a/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_selection_sheet.dart
+++ b/mobile/apps/photos/lib/ui/sharing/library_sharing/library_sharing_selection_sheet.dart
@@ -50,7 +50,7 @@ class LibrarySharingSelectionSheet extends StatelessWidget {
             isDisabled: !controller.canApply,
             onTap: onApply,
           ),
-          if (isExpanded && controller.canStopSharing) ...[
+          if (controller.canStopSharing) ...[
             const SizedBox(height: Spacing.md),
             ButtonComponent(
               label: LibrarySharingStrings.stopSharing,

--- a/mobile/apps/photos/test/ui/sharing/library_sharing_controller_test.dart
+++ b/mobile/apps/photos/test/ui/sharing/library_sharing_controller_test.dart
@@ -7,25 +7,6 @@ import 'package:photos/ui/sharing/library_sharing/library_sharing_controller.dar
 import 'library_sharing_test_helpers.dart';
 
 void main() {
-  test('first-time tap selection starts after an album is selected', () async {
-    final repository = FakeLibrarySharingRepository([
-      librarySharingTestAlbum(1),
-    ]);
-    final controller = LibrarySharingController(
-      recipient: librarySharingTestRecipient,
-      repository: repository,
-    );
-    await controller.load();
-
-    expect(controller.selectsAlbumsOnTap, isFalse);
-
-    controller.toggleSelection(repository.albums.single);
-    expect(controller.selectsAlbumsOnTap, isTrue);
-
-    controller.clearSelection();
-    expect(controller.selectsAlbumsOnTap, isFalse);
-  });
-
   test('shares a new album and returns to the shared overview', () async {
     final repository = FakeLibrarySharingRepository([
       librarySharingTestAlbum(

--- a/mobile/apps/photos/test/ui/sharing/library_sharing_page_test.dart
+++ b/mobile/apps/photos/test/ui/sharing/library_sharing_page_test.dart
@@ -396,7 +396,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(isExpanded(), isFalse);
     expect(find.text('Role'), findsNothing);
-    expect(find.text('Stop sharing'), findsNothing);
+    expect(find.text('Stop sharing'), findsOneWidget);
     expect(find.text('Save'), findsOneWidget);
 
     await tester.drag(selectionSheet, const Offset(0, -100));


### PR DESCRIPTION
- Tap albums to select or unselect them; long-press to open.
- Keep Stop sharing visible when selection controls collapse.

Validation: focused Library Sharing tests and targeted analysis