### PR TITLE
[rust][photos] Bound ML detections and fuse pet crop transforms

### DIFF
--- a/rust/crates/photos/src/ml/face/detect.rs
+++ b/rust/crates/photos/src/ml/face/detect.rs
@@ -1,6 +1,7 @@
 use crate::ml::{
     error::{MlError, MlResult},
     onnx,
+    postprocess::MAX_DETECTIONS_PER_IMAGE,
     preprocess::{YOLO_INPUT_SIZE, YoloInput},
     runtime::MlRuntimeView,
     types::FaceDetection,
@@ -99,37 +100,31 @@ fn postprocess_face_tensor<T: onnx::FloatTensorData>(
         });
     }
 
-    Ok(naive_non_max_suppression(detections, IOU_THRESHOLD))
+    Ok(greedy_non_max_suppression(detections, IOU_THRESHOLD))
 }
 
-fn naive_non_max_suppression(
+fn greedy_non_max_suppression(
     mut detections: Vec<FaceDetection>,
     iou_threshold: f32,
 ) -> Vec<FaceDetection> {
     detections.sort_by(|a, b| b.score.total_cmp(&a.score));
 
-    let mut suppressed = vec![false; detections.len()];
-    for i in 0..detections.len() {
-        if suppressed[i] {
+    let mut retained = Vec::with_capacity(detections.len().min(MAX_DETECTIONS_PER_IMAGE));
+    for detection in detections {
+        if retained
+            .iter()
+            .any(|existing| calculate_iou(existing, &detection) >= iou_threshold)
+        {
             continue;
         }
 
-        for j in (i + 1)..detections.len() {
-            if suppressed[j] {
-                continue;
-            }
-            let iou = calculate_iou(&detections[i], &detections[j]);
-            if iou >= iou_threshold {
-                suppressed[j] = true;
-            }
+        retained.push(detection);
+        if retained.len() == MAX_DETECTIONS_PER_IMAGE {
+            break;
         }
     }
 
-    detections
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, detection)| (!suppressed[index]).then_some(detection))
-        .collect()
+    retained
 }
 
 fn calculate_iou(a: &FaceDetection, b: &FaceDetection) -> f32 {
@@ -155,4 +150,55 @@ fn calculate_iou(a: &FaceDetection, b: &FaceDetection) -> f32 {
         return 0.0;
     }
     intersection_area / union_area
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FaceDetection, IOU_THRESHOLD, MAX_DETECTIONS_PER_IMAGE, greedy_non_max_suppression,
+    };
+
+    #[test]
+    fn face_nms_retains_the_highest_scoring_hundred_detections() {
+        let detections = (0..=MAX_DETECTIONS_PER_IMAGE)
+            .map(|index| FaceDetection {
+                score: index as f32,
+                box_xyxy: separated_box(index),
+                keypoints: [[0.0; 2]; 5],
+            })
+            .collect();
+
+        let retained = greedy_non_max_suppression(detections, IOU_THRESHOLD);
+
+        assert_eq!(retained.len(), MAX_DETECTIONS_PER_IMAGE);
+        assert_eq!(retained.first().unwrap().score, 100.0);
+        assert_eq!(retained.last().unwrap().score, 1.0);
+    }
+
+    #[test]
+    fn face_nms_suppresses_lower_scoring_overlaps() {
+        let retained = greedy_non_max_suppression(
+            vec![
+                FaceDetection {
+                    score: 0.8,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    keypoints: [[0.0; 2]; 5],
+                },
+                FaceDetection {
+                    score: 0.9,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    keypoints: [[0.0; 2]; 5],
+                },
+            ],
+            IOU_THRESHOLD,
+        );
+
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].score, 0.9);
+    }
+
+    fn separated_box(index: usize) -> [f32; 4] {
+        let x = index as f32 * 2.0;
+        [x, 0.0, x + 1.0, 1.0]
+    }
 }

--- a/rust/crates/photos/src/ml/pet/align.rs
+++ b/rust/crates/photos/src/ml/pet/align.rs
@@ -1,7 +1,5 @@
-use image::{Rgb, RgbImage};
-
 use crate::ml::{
-    error::{MlError, MlResult},
+    error::MlResult,
     types::{DecodedImage, PetAlignmentResult, PetFaceDetection, PetFaceResult, to_face_id},
 };
 
@@ -71,7 +69,15 @@ pub(crate) fn run_pet_face_alignment(
             if crop_w == 0 || crop_h == 0 {
                 continue;
             }
-            crop_and_resize_decoded(&mut crop_resizer, decoded, cx1, cy1, crop_w, crop_h)?
+            crop_resizer.resize(
+                decoded,
+                PixelCrop {
+                    x: cx1,
+                    y: cy1,
+                    width: crop_w,
+                    height: crop_h,
+                },
+            )?
         } else {
             let bw = (box_x2 - box_x1) as f32;
             let bh = (box_y2 - box_y1) as f32;
@@ -87,8 +93,6 @@ pub(crate) fn run_pet_face_alignment(
                 continue;
             }
 
-            let region = RgbRegion::new(decoded, region_x1, region_y1, region_w, region_h)?;
-
             let local_cx = (box_x1 + box_x2) as f64 / 2.0 - region_x1 as f64;
             let local_cy = (box_y1 + box_y2) as f64 / 2.0 - region_y1 as f64;
 
@@ -103,19 +107,23 @@ pub(crate) fn run_pet_face_alignment(
             if crop_w == 0 || crop_h == 0 {
                 continue;
             }
-            let rotated_crop = rotate_crop_around_center(
-                &region,
-                angle_rad as f64,
-                local_cx,
-                local_cy,
+            crop_resizer.resize_rotated(
+                decoded,
+                PixelCrop {
+                    x: region_x1,
+                    y: region_y1,
+                    width: region_w,
+                    height: region_h,
+                },
                 PixelCrop {
                     x: nx1,
                     y: ny1,
                     width: crop_w,
                     height: crop_h,
                 },
-            );
-            crop_and_resize_rgb(&mut crop_resizer, &rotated_crop, 0, 0, crop_w, crop_h)?
+                angle_rad as f64,
+                [local_cx, local_cy],
+            )?
         };
 
         let result_index = face_results.len();
@@ -148,216 +156,4 @@ pub(crate) fn run_pet_face_alignment(
     }
 
     Ok((aligned_inputs, face_results))
-}
-
-fn rotate_crop_around_center(
-    source: &RgbRegion<'_>,
-    angle_rad: f64,
-    cx: f64,
-    cy: f64,
-    crop: PixelCrop,
-) -> RgbImage {
-    let cos_a = angle_rad.cos();
-    let sin_a = angle_rad.sin();
-
-    let mut output = RgbImage::new(crop.width, crop.height);
-    let w_f = source.width as f64;
-    let h_f = source.height as f64;
-
-    for crop_y in 0..crop.height {
-        let out_y = crop.y + crop_y;
-        for crop_x in 0..crop.width {
-            let out_x = crop.x + crop_x;
-            let dx = out_x as f64 - cx;
-            let dy = out_y as f64 - cy;
-            let src_x = cos_a * dx + sin_a * dy + cx;
-            let src_y = -sin_a * dx + cos_a * dy + cy;
-
-            let sx = src_x.max(0.0).min(w_f - 1.0);
-            let sy = src_y.max(0.0).min(h_f - 1.0);
-
-            let x0 = sx.floor() as u32;
-            let y0 = sy.floor() as u32;
-            let x1 = (x0 + 1).min(source.width - 1);
-            let y1 = (y0 + 1).min(source.height - 1);
-            let fx = (sx - sx.floor()) as f32;
-            let fy = (sy - sy.floor()) as f32;
-
-            let p00 = source.get_pixel(x0, y0);
-            let p10 = source.get_pixel(x1, y0);
-            let p01 = source.get_pixel(x0, y1);
-            let p11 = source.get_pixel(x1, y1);
-
-            let mut px = [0u8; 3];
-            for c in 0..3 {
-                let v = p00[c] as f32 * (1.0 - fx) * (1.0 - fy)
-                    + p10[c] as f32 * fx * (1.0 - fy)
-                    + p01[c] as f32 * (1.0 - fx) * fy
-                    + p11[c] as f32 * fx * fy;
-                px[c] = v.round().clamp(0.0, 255.0) as u8;
-            }
-            output.put_pixel(crop_x, crop_y, Rgb(px));
-        }
-    }
-
-    output
-}
-
-fn crop_and_resize_rgb<'a>(
-    resizer: &'a mut RgbCropResizer,
-    source: &RgbImage,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-) -> MlResult<&'a [u8]> {
-    let src_w = source.width();
-    let src_h = source.height();
-    let clamped_w = w.min(src_w.saturating_sub(x));
-    let clamped_h = h.min(src_h.saturating_sub(y));
-    if clamped_w == 0 || clamped_h == 0 {
-        return Err(MlError::Image(
-            "crop_and_resize_rgb: crop region extends beyond source image".to_string(),
-        ));
-    }
-    resize_crop(
-        resizer,
-        source.as_raw(),
-        src_w,
-        src_h,
-        PixelCrop {
-            x,
-            y,
-            width: clamped_w,
-            height: clamped_h,
-        },
-    )
-}
-
-/// Crop directly from decoded image bytes and resize — avoids building a
-/// full-size RgbImage when no rotation is needed.
-fn crop_and_resize_decoded<'a>(
-    resizer: &'a mut RgbCropResizer,
-    decoded: &DecodedImage,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-) -> MlResult<&'a [u8]> {
-    resize_crop(
-        resizer,
-        &decoded.rgb,
-        decoded.dimensions.width,
-        decoded.dimensions.height,
-        PixelCrop {
-            x,
-            y,
-            width: w,
-            height: h,
-        },
-    )
-}
-
-fn resize_crop<'a>(
-    resizer: &'a mut RgbCropResizer,
-    rgb: &[u8],
-    source_width: u32,
-    source_height: u32,
-    crop: PixelCrop,
-) -> MlResult<&'a [u8]> {
-    resizer.resize(rgb, source_width, source_height, crop)
-}
-
-struct RgbRegion<'a> {
-    rgb: &'a [u8],
-    image_width: usize,
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
-}
-
-impl<'a> RgbRegion<'a> {
-    fn new(decoded: &'a DecodedImage, x: u32, y: u32, width: u32, height: u32) -> MlResult<Self> {
-        if width == 0
-            || height == 0
-            || x > decoded.dimensions.width.saturating_sub(width)
-            || y > decoded.dimensions.height.saturating_sub(height)
-        {
-            return Err(MlError::Image(
-                "RGB region extends beyond decoded image".to_string(),
-            ));
-        }
-        let expected_len = (decoded.dimensions.width as usize)
-            .checked_mul(decoded.dimensions.height as usize)
-            .and_then(|pixels| pixels.checked_mul(3))
-            .ok_or_else(|| MlError::Image("decoded RGB dimensions overflow".to_string()))?;
-        if decoded.rgb.len() < expected_len {
-            return Err(MlError::Image(
-                "decoded RGB buffer is shorter than its dimensions".to_string(),
-            ));
-        }
-
-        Ok(Self {
-            rgb: &decoded.rgb,
-            image_width: decoded.dimensions.width as usize,
-            x,
-            y,
-            width,
-            height,
-        })
-    }
-
-    #[inline]
-    fn get_pixel(&self, x: u32, y: u32) -> [u8; 3] {
-        let pixel = ((self.y + y) as usize * self.image_width + (self.x + x) as usize) * 3;
-        [self.rgb[pixel], self.rgb[pixel + 1], self.rgb[pixel + 2]]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{PixelCrop, RgbRegion, rotate_crop_around_center};
-    use crate::ml::types::{DecodedImage, Dimensions};
-
-    #[test]
-    fn cropped_rotation_matches_the_same_region_of_a_full_rotation() {
-        let decoded = DecodedImage {
-            dimensions: Dimensions {
-                width: 11,
-                height: 9,
-            },
-            rgb: (0..11 * 9 * 3).map(|value| (value % 251) as u8).collect(),
-        };
-        let source = RgbRegion::new(&decoded, 1, 1, 9, 7).unwrap();
-        let crop = PixelCrop {
-            x: 2,
-            y: 1,
-            width: 5,
-            height: 4,
-        };
-
-        let full = rotate_crop_around_center(
-            &source,
-            0.37,
-            4.25,
-            3.75,
-            PixelCrop {
-                x: 0,
-                y: 0,
-                width: source.width,
-                height: source.height,
-            },
-        );
-        let cropped = rotate_crop_around_center(&source, 0.37, 4.25, 3.75, crop);
-
-        for y in 0..crop.height {
-            for x in 0..crop.width {
-                assert_eq!(
-                    cropped.get_pixel(x, y),
-                    full.get_pixel(crop.x + x, crop.y + y)
-                );
-            }
-        }
-    }
 }

--- a/rust/crates/photos/src/ml/pet/detect.rs
+++ b/rust/crates/photos/src/ml/pet/detect.rs
@@ -1,6 +1,7 @@
 use crate::ml::{
     error::{MlError, MlResult},
     onnx,
+    postprocess::MAX_DETECTIONS_PER_IMAGE,
     preprocess::{YOLO_INPUT_SIZE, YoloInput},
     runtime::MlRuntimeView,
     types::{PetBodyDetection, PetFaceDetection},
@@ -163,7 +164,7 @@ fn postprocess_pet_face_tensor<T: onnx::FloatTensorData>(
         });
     }
 
-    Ok(naive_nms_pet_face(detections, PET_FACE_IOU_THRESHOLD))
+    Ok(greedy_nms_pet_face(detections, PET_FACE_IOU_THRESHOLD))
 }
 
 pub(crate) fn run_pet_body_detection(
@@ -233,7 +234,7 @@ fn postprocess_pet_body_tensor<T: onnx::FloatTensorData>(
         });
     }
 
-    Ok(naive_nms_pet_body(detections, BODY_IOU_THRESHOLD))
+    Ok(greedy_nms_pet_body(detections, BODY_IOU_THRESHOLD))
 }
 
 fn winning_pet_body_class<T: onnx::FloatTensorData>(
@@ -291,69 +292,152 @@ fn calculate_iou_4(a: &[f32; 4], b: &[f32; 4]) -> f32 {
     if union <= 0.0 { 0.0 } else { inter / union }
 }
 
-fn naive_nms_pet_face(
+fn greedy_nms_pet_face(
     mut detections: Vec<PetFaceDetection>,
     iou_threshold: f32,
 ) -> Vec<PetFaceDetection> {
     detections.sort_by(|a, b| b.score.total_cmp(&a.score));
-    let n = detections.len();
-    let mut suppressed = vec![false; n];
-    for i in 0..n {
-        if suppressed[i] {
+
+    let mut retained = Vec::with_capacity(detections.len().min(MAX_DETECTIONS_PER_IMAGE));
+    for detection in detections {
+        if retained.iter().any(|existing: &PetFaceDetection| {
+            existing.class_id == detection.class_id
+                && calculate_iou_4(&existing.box_xyxy, &detection.box_xyxy) >= iou_threshold
+        }) {
             continue;
         }
-        for j in (i + 1)..n {
-            if suppressed[j] {
-                continue;
-            }
-            if detections[i].class_id == detections[j].class_id
-                && calculate_iou_4(&detections[i].box_xyxy, &detections[j].box_xyxy)
-                    >= iou_threshold
-            {
-                suppressed[j] = true;
-            }
+
+        retained.push(detection);
+        if retained.len() == MAX_DETECTIONS_PER_IMAGE {
+            break;
         }
     }
-    detections
-        .into_iter()
-        .zip(suppressed)
-        .filter_map(|(d, s)| if s { None } else { Some(d) })
-        .collect()
+
+    retained
 }
 
-fn naive_nms_pet_body(
+fn greedy_nms_pet_body(
     mut detections: Vec<PetBodyDetection>,
     iou_threshold: f32,
 ) -> Vec<PetBodyDetection> {
     detections.sort_by(|a, b| b.score.total_cmp(&a.score));
-    let n = detections.len();
-    let mut suppressed = vec![false; n];
-    for i in 0..n {
-        if suppressed[i] {
+
+    let mut retained = Vec::with_capacity(detections.len().min(MAX_DETECTIONS_PER_IMAGE));
+    for detection in detections {
+        if retained.iter().any(|existing: &PetBodyDetection| {
+            existing.coco_class == detection.coco_class
+                && calculate_iou_4(&existing.box_xyxy, &detection.box_xyxy) >= iou_threshold
+        }) {
             continue;
         }
-        for j in (i + 1)..n {
-            if suppressed[j] {
-                continue;
-            }
-            if detections[i].coco_class == detections[j].coco_class
-                && calculate_iou_4(&detections[i].box_xyxy, &detections[j].box_xyxy)
-                    >= iou_threshold
-            {
-                suppressed[j] = true;
-            }
+
+        retained.push(detection);
+        if retained.len() == MAX_DETECTIONS_PER_IMAGE {
+            break;
         }
     }
-    detections
-        .into_iter()
-        .zip(suppressed)
-        .filter_map(|(d, s)| if s { None } else { Some(d) })
-        .collect()
+
+    retained
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BODY_MIN_SCORE, COCO_CAT, COCO_DOG, winning_pet_body_class};
+    use super::{
+        BODY_IOU_THRESHOLD, BODY_MIN_SCORE, COCO_CAT, COCO_DOG, MAX_DETECTIONS_PER_IMAGE,
+        PET_FACE_IOU_THRESHOLD, PET_SPECIES_CAT, PET_SPECIES_DOG, PetBodyDetection,
+        PetFaceDetection, greedy_nms_pet_body, greedy_nms_pet_face, winning_pet_body_class,
+    };
+
+    #[test]
+    fn pet_nms_retains_the_highest_scoring_hundred_detections() {
+        let faces = (0..=MAX_DETECTIONS_PER_IMAGE)
+            .map(|index| PetFaceDetection {
+                score: index as f32,
+                box_xyxy: separated_box(index),
+                keypoints: [[0.0; 2]; 3],
+                class_id: PET_SPECIES_DOG,
+            })
+            .collect();
+        let bodies = (0..=MAX_DETECTIONS_PER_IMAGE)
+            .map(|index| PetBodyDetection {
+                score: index as f32,
+                box_xyxy: separated_box(index),
+                coco_class: COCO_DOG,
+            })
+            .collect();
+
+        let retained_faces = greedy_nms_pet_face(faces, PET_FACE_IOU_THRESHOLD);
+        let retained_bodies = greedy_nms_pet_body(bodies, BODY_IOU_THRESHOLD);
+
+        assert_eq!(retained_faces.len(), MAX_DETECTIONS_PER_IMAGE);
+        assert_eq!(retained_faces.first().unwrap().score, 100.0);
+        assert_eq!(retained_faces.last().unwrap().score, 1.0);
+        assert_eq!(retained_bodies.len(), MAX_DETECTIONS_PER_IMAGE);
+        assert_eq!(retained_bodies.first().unwrap().score, 100.0);
+        assert_eq!(retained_bodies.last().unwrap().score, 1.0);
+    }
+
+    #[test]
+    fn pet_nms_only_suppresses_overlaps_within_the_same_class() {
+        let retained_faces = greedy_nms_pet_face(
+            vec![
+                PetFaceDetection {
+                    score: 0.8,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    keypoints: [[0.0; 2]; 3],
+                    class_id: PET_SPECIES_DOG,
+                },
+                PetFaceDetection {
+                    score: 0.9,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    keypoints: [[0.0; 2]; 3],
+                    class_id: PET_SPECIES_DOG,
+                },
+                PetFaceDetection {
+                    score: 0.7,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    keypoints: [[0.0; 2]; 3],
+                    class_id: PET_SPECIES_CAT,
+                },
+            ],
+            PET_FACE_IOU_THRESHOLD,
+        );
+        let retained_bodies = greedy_nms_pet_body(
+            vec![
+                PetBodyDetection {
+                    score: 0.8,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    coco_class: COCO_DOG,
+                },
+                PetBodyDetection {
+                    score: 0.9,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    coco_class: COCO_DOG,
+                },
+                PetBodyDetection {
+                    score: 0.7,
+                    box_xyxy: [0.0, 0.0, 1.0, 1.0],
+                    coco_class: COCO_CAT,
+                },
+            ],
+            BODY_IOU_THRESHOLD,
+        );
+
+        assert_eq!(
+            retained_faces
+                .iter()
+                .map(|detection| (detection.score, detection.class_id))
+                .collect::<Vec<_>>(),
+            vec![(0.9, PET_SPECIES_DOG), (0.7, PET_SPECIES_CAT)]
+        );
+        assert_eq!(
+            retained_bodies
+                .iter()
+                .map(|detection| (detection.score, detection.coco_class))
+                .collect::<Vec<_>>(),
+            vec![(0.9, COCO_DOG), (0.7, COCO_CAT)]
+        );
+    }
 
     #[test]
     fn pet_body_class_prefilter_matches_full_scan() {
@@ -410,5 +494,10 @@ mod tests {
 
         let score = best_logit * row[4];
         (score >= BODY_MIN_SCORE).then_some((best_class, score))
+    }
+
+    fn separated_box(index: usize) -> [f32; 4] {
+        let x = index as f32 * 2.0;
+        [x, 0.0, x + 1.0, 1.0]
     }
 }

--- a/rust/crates/photos/src/ml/pet/preprocess.rs
+++ b/rust/crates/photos/src/ml/pet/preprocess.rs
@@ -1,8 +1,3 @@
-use fast_image_resize::{
-    FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer,
-    images::{CroppedImage, Image as FirImage, ImageRef as FirImageRef},
-};
-
 use crate::ml::{
     error::{MlError, MlResult},
     types::DecodedImage,
@@ -83,12 +78,7 @@ impl PetEmbeddingPreprocessor {
         output: &mut Vec<f32>,
     ) -> MlResult<()> {
         let crop = relative_crop(decoded, box_xyxy)?;
-        let resized = self.crop_resizer.resize(
-            &decoded.rgb,
-            decoded.dimensions.width,
-            decoded.dimensions.height,
-            crop,
-        )?;
+        let resized = self.crop_resizer.resize(decoded, crop)?;
         append_imagenet_tensor(resized, output);
         Ok(())
     }
@@ -129,48 +119,178 @@ fn relative_crop(decoded: &DecodedImage, box_xyxy: &[f32; 4]) -> MlResult<PixelC
 }
 
 pub(super) struct RgbCropResizer {
-    resizer: Resizer,
-    resized: FirImage<'static>,
-    options: ResizeOptions,
+    output_size: u32,
+    resized: Vec<u8>,
 }
 
 impl RgbCropResizer {
     pub(super) fn new(output_size: u32) -> Self {
+        assert!(output_size > 0);
+        let output_len = (output_size as usize)
+            .checked_mul(output_size as usize)
+            .and_then(|pixels| pixels.checked_mul(3))
+            .expect("RGB crop output dimensions overflow");
         Self {
-            resizer: Resizer::new(),
-            resized: FirImage::new(output_size, output_size, PixelType::U8x3),
-            options: ResizeOptions::new()
-                .resize_alg(ResizeAlg::Interpolation(FilterType::Bilinear)),
+            output_size,
+            resized: vec![0; output_len],
         }
     }
 
-    pub(super) fn resize(
+    pub(super) fn resize(&mut self, decoded: &DecodedImage, crop: PixelCrop) -> MlResult<&[u8]> {
+        let source = RgbRegion::new(
+            decoded,
+            PixelCrop {
+                x: 0,
+                y: 0,
+                width: decoded.dimensions.width,
+                height: decoded.dimensions.height,
+            },
+        )?;
+        self.render(&source, crop, |x, y| (x, y))
+    }
+
+    pub(super) fn resize_rotated(
         &mut self,
-        rgb: &[u8],
-        source_width: u32,
-        source_height: u32,
+        decoded: &DecodedImage,
+        region: PixelCrop,
         crop: PixelCrop,
+        angle_rad: f64,
+        center: [f64; 2],
     ) -> MlResult<&[u8]> {
+        let source = RgbRegion::new(decoded, region)?;
+        let cos = angle_rad.cos();
+        let sin = angle_rad.sin();
+        self.render(&source, crop, |x, y| {
+            let dx = x - center[0];
+            let dy = y - center[1];
+            (
+                cos * dx + sin * dy + center[0],
+                -sin * dx + cos * dy + center[1],
+            )
+        })
+    }
+
+    fn render<'a>(
+        &'a mut self,
+        source: &RgbRegion<'_>,
+        crop: PixelCrop,
+        transform: impl Fn(f64, f64) -> (f64, f64),
+    ) -> MlResult<&'a [u8]> {
+        source.validate_crop(crop)?;
+
+        let output_size = self.output_size;
+        let x_scale = f64::from(crop.width) / f64::from(output_size);
+        let y_scale = f64::from(crop.height) / f64::from(output_size);
+        let min_x = f64::from(crop.x);
+        let min_y = f64::from(crop.y);
+        let max_x = min_x + f64::from(crop.width - 1);
+        let max_y = min_y + f64::from(crop.height - 1);
+
+        for output_y in 0..output_size {
+            let crop_y = (min_y + (f64::from(output_y) + 0.5) * y_scale - 0.5).clamp(min_y, max_y);
+            for output_x in 0..output_size {
+                let crop_x =
+                    (min_x + (f64::from(output_x) + 0.5) * x_scale - 0.5).clamp(min_x, max_x);
+                let (source_x, source_y) = transform(crop_x, crop_y);
+                let pixel = source.sample_bilinear(source_x, source_y);
+                let output_index =
+                    (output_y as usize * output_size as usize + output_x as usize) * 3;
+                self.resized[output_index..output_index + 3].copy_from_slice(&pixel);
+            }
+        }
+
+        Ok(&self.resized)
+    }
+}
+
+struct RgbRegion<'a> {
+    rgb: &'a [u8],
+    image_width: usize,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+impl<'a> RgbRegion<'a> {
+    fn new(decoded: &'a DecodedImage, region: PixelCrop) -> MlResult<Self> {
+        let image_width = decoded.dimensions.width;
+        let image_height = decoded.dimensions.height;
+        if region.width == 0
+            || region.height == 0
+            || region.width > image_width
+            || region.height > image_height
+            || region.x > image_width - region.width
+            || region.y > image_height - region.height
+        {
+            return Err(MlError::Image(
+                "RGB region extends beyond source image".to_string(),
+            ));
+        }
+        let expected_len = (image_width as usize)
+            .checked_mul(image_height as usize)
+            .and_then(|pixels| pixels.checked_mul(3))
+            .ok_or_else(|| MlError::Image("RGB source dimensions overflow".to_string()))?;
+        if decoded.rgb.len() < expected_len {
+            return Err(MlError::Image(
+                "RGB source buffer is shorter than its dimensions".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            rgb: &decoded.rgb,
+            image_width: image_width as usize,
+            x: region.x,
+            y: region.y,
+            width: region.width,
+            height: region.height,
+        })
+    }
+
+    fn validate_crop(&self, crop: PixelCrop) -> MlResult<()> {
         if crop.width == 0 || crop.height == 0 {
             return Err(MlError::Image("crop dimensions cannot be zero".to_string()));
         }
-        if crop.x > source_width.saturating_sub(crop.width)
-            || crop.y > source_height.saturating_sub(crop.height)
+        if crop.width > self.width
+            || crop.height > self.height
+            || crop.x > self.width - crop.width
+            || crop.y > self.height - crop.height
         {
             return Err(MlError::Image(
                 "crop region extends beyond source image".to_string(),
             ));
         }
+        Ok(())
+    }
 
-        let source = FirImageRef::new(source_width, source_height, rgb, PixelType::U8x3)
-            .map_err(|e| MlError::Image(format!("failed to create FIR source image: {e}")))?;
-        let source = CroppedImage::new(&source, crop.x, crop.y, crop.width, crop.height)
-            .map_err(|e| MlError::Image(format!("failed to create FIR crop view: {e}")))?;
-        self.resizer
-            .resize(&source, &mut self.resized, Some(&self.options))
-            .map_err(|e| MlError::Image(format!("failed to resize RGB crop: {e}")))?;
+    fn sample_bilinear(&self, x: f64, y: f64) -> [u8; 3] {
+        let x = x.clamp(0.0, f64::from(self.width - 1));
+        let y = y.clamp(0.0, f64::from(self.height - 1));
+        let x0 = x.floor() as u32;
+        let y0 = y.floor() as u32;
+        let x1 = (x0 + 1).min(self.width - 1);
+        let y1 = (y0 + 1).min(self.height - 1);
+        let x_weight = (x - x.floor()) as f32;
+        let y_weight = (y - y.floor()) as f32;
 
-        Ok(self.resized.buffer())
+        let top_left = self.get_pixel(x0, y0);
+        let top_right = self.get_pixel(x1, y0);
+        let bottom_left = self.get_pixel(x0, y1);
+        let bottom_right = self.get_pixel(x1, y1);
+        let mut output = [0; 3];
+        for channel in 0..3 {
+            let value = top_left[channel] as f32 * (1.0 - x_weight) * (1.0 - y_weight)
+                + top_right[channel] as f32 * x_weight * (1.0 - y_weight)
+                + bottom_left[channel] as f32 * (1.0 - x_weight) * y_weight
+                + bottom_right[channel] as f32 * x_weight * y_weight;
+            output[channel] = value.round().clamp(0.0, 255.0) as u8;
+        }
+        output
+    }
+
+    fn get_pixel(&self, x: u32, y: u32) -> [u8; 3] {
+        let pixel = ((self.y + y) as usize * self.image_width + (self.x + x) as usize) * 3;
+        [self.rgb[pixel], self.rgb[pixel + 1], self.rgb[pixel + 2]]
     }
 }
 
@@ -192,15 +312,24 @@ pub(super) fn append_imagenet_tensor(resized: &[u8], output: &mut Vec<f32>) {
 
 #[cfg(test)]
 mod tests {
+    use fast_image_resize::{
+        FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer,
+        images::{CroppedImage, Image as FirImage, ImageRef as FirImageRef},
+    };
+
     use super::{PixelCrop, RgbCropResizer};
+    use crate::ml::types::{DecodedImage, Dimensions};
 
     #[test]
-    fn cropped_view_resize_matches_a_materialized_crop() {
+    fn crop_resize_matches_a_materialized_crop() {
         let width = 6u32;
         let height = 5u32;
-        let rgb = (0..(width * height * 3))
-            .map(|value| (value % 251) as u8)
-            .collect::<Vec<_>>();
+        let decoded = DecodedImage {
+            dimensions: Dimensions { width, height },
+            rgb: (0..(width * height * 3))
+                .map(|value| (value % 251) as u8)
+                .collect(),
+        };
         let crop = PixelCrop {
             x: 1,
             y: 1,
@@ -209,7 +338,7 @@ mod tests {
         };
 
         let direct = RgbCropResizer::new(7)
-            .resize(&rgb, width, height, crop)
+            .resize(&decoded, crop)
             .unwrap()
             .to_vec();
 
@@ -217,13 +346,18 @@ mod tests {
         for row in crop.y..crop.y + crop.height {
             let start = ((row * width + crop.x) * 3) as usize;
             let end = start + (crop.width * 3) as usize;
-            materialized.extend_from_slice(&rgb[start..end]);
+            materialized.extend_from_slice(&decoded.rgb[start..end]);
         }
+        let materialized = DecodedImage {
+            dimensions: Dimensions {
+                width: crop.width,
+                height: crop.height,
+            },
+            rgb: materialized,
+        };
         let baseline = RgbCropResizer::new(7)
             .resize(
                 &materialized,
-                crop.width,
-                crop.height,
                 PixelCrop {
                     x: 0,
                     y: 0,
@@ -235,5 +369,273 @@ mod tests {
             .to_vec();
 
         assert_eq!(direct, baseline);
+    }
+
+    #[test]
+    fn crop_resize_stays_close_to_fir() {
+        for (width, height, output_size, crop) in [
+            (
+                19,
+                13,
+                7,
+                PixelCrop {
+                    x: 2,
+                    y: 3,
+                    width: 14,
+                    height: 8,
+                },
+            ),
+            (
+                7,
+                5,
+                13,
+                PixelCrop {
+                    x: 1,
+                    y: 1,
+                    width: 5,
+                    height: 3,
+                },
+            ),
+            (
+                101,
+                3,
+                17,
+                PixelCrop {
+                    x: 1,
+                    y: 0,
+                    width: 99,
+                    height: 3,
+                },
+            ),
+        ] {
+            let decoded = test_image(width, height);
+            let actual = RgbCropResizer::new(output_size)
+                .resize(&decoded, crop)
+                .unwrap()
+                .to_vec();
+            let expected = fir_resize(&decoded.rgb, width, height, crop, output_size);
+            assert_max_delta(&actual, &expected, 1);
+        }
+    }
+
+    #[test]
+    fn zero_angle_region_matches_global_crop() {
+        let width = 23;
+        let height = 17;
+        let decoded = test_image(width, height);
+        let region = PixelCrop {
+            x: 3,
+            y: 2,
+            width: 17,
+            height: 13,
+        };
+        let local_crop = PixelCrop {
+            x: 4,
+            y: 3,
+            width: 9,
+            height: 7,
+        };
+        let global_crop = PixelCrop {
+            x: region.x + local_crop.x,
+            y: region.y + local_crop.y,
+            ..local_crop
+        };
+
+        let direct = RgbCropResizer::new(11)
+            .resize(&decoded, global_crop)
+            .unwrap()
+            .to_vec();
+        let rotated = RgbCropResizer::new(11)
+            .resize_rotated(&decoded, region, local_crop, 0.0, [8.5, 6.5])
+            .unwrap()
+            .to_vec();
+
+        assert_eq!(direct, rotated);
+    }
+
+    #[test]
+    fn fused_rotation_stays_close_to_two_pass_pipeline() {
+        let width = 41;
+        let height = 31;
+        let decoded = smooth_test_image(width, height);
+        let region = PixelCrop {
+            x: 4,
+            y: 3,
+            width: 33,
+            height: 25,
+        };
+        let crop = PixelCrop {
+            x: 8,
+            y: 6,
+            width: 17,
+            height: 13,
+        };
+        let angle = 0.27;
+        let center_x = 16.5;
+        let center_y = 12.5;
+
+        let actual = RgbCropResizer::new(19)
+            .resize_rotated(&decoded, region, crop, angle, [center_x, center_y])
+            .unwrap()
+            .to_vec();
+        let rotated =
+            materialize_rotated_crop(&decoded.rgb, width, region, crop, angle, center_x, center_y);
+        let expected = fir_resize(
+            &rotated,
+            crop.width,
+            crop.height,
+            PixelCrop {
+                x: 0,
+                y: 0,
+                width: crop.width,
+                height: crop.height,
+            },
+            19,
+        );
+
+        assert_max_delta(&actual, &expected, 1);
+    }
+
+    #[test]
+    fn extreme_aspect_ratio_has_fixed_output() {
+        let width = 100_000;
+        let decoded = test_image(width, 1);
+        let mut resizer = RgbCropResizer::new(224);
+        let capacity = resizer.resized.capacity();
+        let resized = resizer
+            .resize(
+                &decoded,
+                PixelCrop {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height: 1,
+                },
+            )
+            .unwrap()
+            .to_vec();
+
+        assert_eq!(resized.len(), 224 * 224 * 3);
+        assert_eq!(resizer.resized.capacity(), capacity);
+    }
+
+    fn fir_resize(
+        rgb: &[u8],
+        width: u32,
+        height: u32,
+        crop: PixelCrop,
+        output_size: u32,
+    ) -> Vec<u8> {
+        let source = FirImageRef::new(width, height, rgb, PixelType::U8x3).unwrap();
+        let source = CroppedImage::new(&source, crop.x, crop.y, crop.width, crop.height).unwrap();
+        let mut output = FirImage::new(output_size, output_size, PixelType::U8x3);
+        let options =
+            ResizeOptions::new().resize_alg(ResizeAlg::Interpolation(FilterType::Bilinear));
+        Resizer::new()
+            .resize(&source, &mut output, Some(&options))
+            .unwrap();
+        output.into_vec()
+    }
+
+    fn materialize_rotated_crop(
+        rgb: &[u8],
+        image_width: u32,
+        region: PixelCrop,
+        crop: PixelCrop,
+        angle: f64,
+        center_x: f64,
+        center_y: f64,
+    ) -> Vec<u8> {
+        let cos = angle.cos();
+        let sin = angle.sin();
+        let mut output = Vec::with_capacity((crop.width * crop.height * 3) as usize);
+        for y in crop.y..crop.y + crop.height {
+            for x in crop.x..crop.x + crop.width {
+                let dx = f64::from(x) - center_x;
+                let dy = f64::from(y) - center_y;
+                let source_x = cos * dx + sin * dy + center_x;
+                let source_y = -sin * dx + cos * dy + center_y;
+                output.extend_from_slice(&sample_region(
+                    rgb,
+                    image_width,
+                    region,
+                    source_x,
+                    source_y,
+                ));
+            }
+        }
+        output
+    }
+
+    fn sample_region(rgb: &[u8], image_width: u32, region: PixelCrop, x: f64, y: f64) -> [u8; 3] {
+        let x = x.clamp(0.0, f64::from(region.width - 1));
+        let y = y.clamp(0.0, f64::from(region.height - 1));
+        let x0 = x.floor() as u32;
+        let y0 = y.floor() as u32;
+        let x1 = (x0 + 1).min(region.width - 1);
+        let y1 = (y0 + 1).min(region.height - 1);
+        let x_weight = (x - x.floor()) as f32;
+        let y_weight = (y - y.floor()) as f32;
+        let pixel = |x: u32, y: u32| {
+            let index = (((region.y + y) * image_width + region.x + x) * 3) as usize;
+            [rgb[index], rgb[index + 1], rgb[index + 2]]
+        };
+        let top_left = pixel(x0, y0);
+        let top_right = pixel(x1, y0);
+        let bottom_left = pixel(x0, y1);
+        let bottom_right = pixel(x1, y1);
+        let mut output = [0; 3];
+        for channel in 0..3 {
+            let value = top_left[channel] as f32 * (1.0 - x_weight) * (1.0 - y_weight)
+                + top_right[channel] as f32 * x_weight * (1.0 - y_weight)
+                + bottom_left[channel] as f32 * (1.0 - x_weight) * y_weight
+                + bottom_right[channel] as f32 * x_weight * y_weight;
+            output[channel] = value.round().clamp(0.0, 255.0) as u8;
+        }
+        output
+    }
+
+    fn test_image(width: u32, height: u32) -> DecodedImage {
+        let mut rgb = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                rgb.push(((x * 17 + y * 29) % 256) as u8);
+                rgb.push(((x * 47 + y * 11 + 31) % 256) as u8);
+                rgb.push(((x * 7 + y * 53 + 97) % 256) as u8);
+            }
+        }
+        DecodedImage {
+            dimensions: Dimensions { width, height },
+            rgb,
+        }
+    }
+
+    fn smooth_test_image(width: u32, height: u32) -> DecodedImage {
+        let mut rgb = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                rgb.push((x * 2 + y * 3) as u8);
+                rgb.push((x * 3 + y * 2 + 7) as u8);
+                rgb.push((x + y * 4 + 11) as u8);
+            }
+        }
+        DecodedImage {
+            dimensions: Dimensions { width, height },
+            rgb,
+        }
+    }
+
+    fn assert_max_delta(actual: &[u8], expected: &[u8], allowed: u8) {
+        assert_eq!(actual.len(), expected.len());
+        let max_delta = actual
+            .iter()
+            .zip(expected)
+            .map(|(&actual, &expected)| actual.abs_diff(expected))
+            .max()
+            .unwrap_or(0);
+        assert!(
+            max_delta <= allowed,
+            "maximum pixel delta {max_delta} exceeds {allowed}"
+        );
     }
 }

--- a/rust/crates/photos/src/ml/postprocess.rs
+++ b/rust/crates/photos/src/ml/postprocess.rs
@@ -1,3 +1,5 @@
+pub(crate) const MAX_DETECTIONS_PER_IMAGE: usize = 100;
+
 pub(crate) fn l2_normalize(embedding: &mut [f32], zero_threshold: f32) {
     let mut norm = 0.0f32;
     for value in embedding.iter() {


### PR DESCRIPTION
## Summary

- cap face and pet detections at 100 after greedy non-max suppression
- fuse pet crop rotation and resizing into a fixed-size bilinear render pass
- cover suppression, resize compatibility, rotation, and extreme aspect ratios